### PR TITLE
Add GitHub Actions CI with Mathlib cache

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: leanprover/lean-action@v1
+        with:
+          use-mathlib-cache: true
+          lake-package-directory: .


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` using `leanprover/lean-action@v1`
- Fetches Mathlib cache before building (`use-mathlib-cache: true`)
- Triggers on push, pull request, and manual dispatch

## Test plan
- [ ] Verify the workflow triggers on this PR
- [ ] Confirm `lake exe cache get` succeeds and build completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)