### PR TITLE
Fix duplicate CI builds on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   push:
+    branches: [main]
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
## Summary
- Limit `push` trigger to `main` branch only, so PR branches don't get two identical builds (one from `push`, one from `pull_request`)

## Test plan
- [x] Verify this PR itself only has one build job (not two)

🤖 Generated with [Claude Code](https://claude.com/claude-code)