### PR TITLE
Recreate StackOps: POP, PUSH0, DUP1-16, SWAP1-16 specs

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -8,6 +8,12 @@
 import EvmAsm.Evm64.Basic
 import EvmAsm.Evm64.Stack
 
+-- Stack operations
+import EvmAsm.Evm64.Pop
+import EvmAsm.Evm64.Push0
+import EvmAsm.Evm64.Dup
+import EvmAsm.Evm64.Swap
+
 -- Bitwise operations
 import EvmAsm.Evm64.Bitwise
 import EvmAsm.Evm64.And

--- a/EvmAsm/Evm64/Dup.lean
+++ b/EvmAsm/Evm64/Dup.lean
@@ -1,0 +1,230 @@
+/-
+  EvmAsm.Evm64.Dup
+
+  256-bit EVM DUP1-16: generic duplication of nth stack element.
+  9 instructions (1 ADDI + 4 × (LD + SD)).
+-/
+
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definitions
+-- ============================================================================
+
+/-- One limb pair for DUP: LD x7 from source offset, SD x7 to destination offset. -/
+private def dup_one_limb (n i : Nat) : Program :=
+  LD .x7 .x12 (BitVec.ofNat 12 (n * 32 + i * 8)) ;;
+  SD .x12 .x7 (BitVec.ofNat 12 (i * 8))
+
+/-- Generic DUPn program (1-indexed): push copy of nth stack element on top.
+    n=1 copies the top, n=2 copies the second element, etc.
+    Uses 9 instructions: 1 ADDI + 4 × (LD + SD). -/
+def evm_dup (n : Nat) : Program :=
+  ADDI .x12 .x12 (-32) ;;
+  dup_one_limb n 0 ;; dup_one_limb n 1 ;; dup_one_limb n 2 ;; dup_one_limb n 3
+
+-- ============================================================================
+-- Per-limb helper
+-- ============================================================================
+
+/-- Two-instruction spec for DUP: LD x7 from source, SD x7 to destination.
+    Copies src_val from src address to dst address. -/
+theorem dup_pair_spec (sp : Addr)
+    (off_src off_dst : BitVec 12) (src_val dst_old v7 : Word) (base : Addr)
+    (hvalid_src : isValidDwordAccess (sp + signExtend12 off_src) = true)
+    (hvalid_dst : isValidDwordAccess (sp + signExtend12 off_dst) = true) :
+    cpsTriple base (base + 8)
+      (CodeReq.singleton base (.LD .x7 .x12 off_src) |>.union
+        (CodeReq.singleton (base + 4) (.SD .x12 .x7 off_dst)))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) **
+       ((sp + signExtend12 off_src) ↦ₘ src_val) ** ((sp + signExtend12 off_dst) ↦ₘ dst_old))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ src_val) **
+       ((sp + signExtend12 off_src) ↦ₘ src_val) ** ((sp + signExtend12 off_dst) ↦ₘ src_val)) := by
+  runBlock
+
+-- ============================================================================
+-- CodeReq for generic DUP (explicit union chain, not ofProg)
+-- ============================================================================
+
+/-- CodeReq for generic DUPn: 9 instructions = 36 bytes.
+    Built as an explicit union chain because symbolic n prevents ofProg reduction. -/
+abbrev evm_dup_code (base : Addr) (n : Nat) : CodeReq :=
+  CodeReq.singleton base (.ADDI .x12 .x12 (-32))
+  |>.union (CodeReq.singleton (base + 4)  (.LD .x7 .x12 (BitVec.ofNat 12 (n*32))))
+  |>.union (CodeReq.singleton (base + 8)  (.SD .x12 .x7 (BitVec.ofNat 12 0)))
+  |>.union (CodeReq.singleton (base + 12) (.LD .x7 .x12 (BitVec.ofNat 12 (n*32+8))))
+  |>.union (CodeReq.singleton (base + 16) (.SD .x12 .x7 (BitVec.ofNat 12 8)))
+  |>.union (CodeReq.singleton (base + 20) (.LD .x7 .x12 (BitVec.ofNat 12 (n*32+16))))
+  |>.union (CodeReq.singleton (base + 24) (.SD .x12 .x7 (BitVec.ofNat 12 16)))
+  |>.union (CodeReq.singleton (base + 28) (.LD .x7 .x12 (BitVec.ofNat 12 (n*32+24))))
+  |>.union (CodeReq.singleton (base + 32) (.SD .x12 .x7 (BitVec.ofNat 12 24)))
+
+-- ============================================================================
+-- Low-level generic DUP spec
+-- ============================================================================
+
+set_option maxHeartbeats 6400000 in
+/-- Generic DUPn spec (low level): copies 4 dword limbs from src (at nsp+n*32) to dst (at nsp).
+    Requires 1 ≤ n ≤ 16 (valid EVM DUP range). -/
+theorem evm_dup_spec (nsp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (s0 s1 s2 s3 : Word)
+    (d0 d1 d2 d3 : Word)
+    (v7 : Word)
+    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    cpsTriple base (base + 36) (evm_dup_code base n)
+      ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
+       (nsp ↦ₘ d0) ** ((nsp+8) ↦ₘ d1) ** ((nsp+16) ↦ₘ d2) ** ((nsp+24) ↦ₘ d3) **
+       ((nsp + BitVec.ofNat 64 (n*32))    ↦ₘ s0) **
+       ((nsp + BitVec.ofNat 64 (n*32+8))  ↦ₘ s1) **
+       ((nsp + BitVec.ofNat 64 (n*32+16)) ↦ₘ s2) **
+       ((nsp + BitVec.ofNat 64 (n*32+24)) ↦ₘ s3))
+      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ s3) **
+       (nsp ↦ₘ s0) ** ((nsp+8) ↦ₘ s1) ** ((nsp+16) ↦ₘ s2) ** ((nsp+24) ↦ₘ s3) **
+       ((nsp + BitVec.ofNat 64 (n*32))    ↦ₘ s0) **
+       ((nsp + BitVec.ofNat 64 (n*32+8))  ↦ₘ s1) **
+       ((nsp + BitVec.ofNat 64 (n*32+16)) ↦ₘ s2) **
+       ((nsp + BitVec.ofNat 64 (n*32+24)) ↦ₘ s3)) := by
+  -- signExtend12 normalizations for source offsets
+  have hse_s0 : signExtend12 (BitVec.ofNat 12 (n*32)) = BitVec.ofNat 64 (n*32) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s1 : signExtend12 (BitVec.ofNat 12 (n*32+8)) = BitVec.ofNat 64 (n*32+8) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s2 : signExtend12 (BitVec.ofNat 12 (n*32+16)) = BitVec.ofNat 64 (n*32+16) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s3 : signExtend12 (BitVec.ofNat 12 (n*32+24)) = BitVec.ofNat 64 (n*32+24) :=
+    signExtend12_ofNat_small _ (by omega)
+  -- signExtend12 normalizations for destination offsets
+  have hm0  : nsp + signExtend12 (BitVec.ofNat 12 0)  = nsp      := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm8  : nsp + signExtend12 (BitVec.ofNat 12 8)  = nsp + 8  := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm16 : nsp + signExtend12 (BitVec.ofNat 12 16) = nsp + 16 := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm24 : nsp + signExtend12 (BitVec.ofNat 12 24) = nsp + 24 := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  -- Memory validity from ValidMemRange for dst locations
+  have hv0  : isValidDwordAccess nsp       = true := by have := hvalid.get (i := 0) (by omega); simpa using this
+  have hv8  : isValidDwordAccess (nsp + 8)  = true := by have := hvalid.get (i := 1) (by omega); simpa using this
+  have hv16 : isValidDwordAccess (nsp + 16) = true := by have := hvalid.get (i := 2) (by omega); simpa using this
+  have hv24 : isValidDwordAccess (nsp + 24) = true := by have := hvalid.get (i := 3) (by omega); simpa using this
+  -- Memory validity from ValidMemRange for src locations
+  have hvs0 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32)) = true := by
+    have := hvalid.get (i := n*4) (by omega); rwa [show 8 * (n * 4) = n * 32 from by omega] at this
+  have hvs8 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+8)) = true := by
+    have := hvalid.get (i := n*4+1) (by omega); rwa [show 8 * (n * 4 + 1) = n * 32 + 8 from by omega] at this
+  have hvs16 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+16)) = true := by
+    have := hvalid.get (i := n*4+2) (by omega); rwa [show 8 * (n * 4 + 2) = n * 32 + 16 from by omega] at this
+  have hvs24 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+24)) = true := by
+    have := hvalid.get (i := n*4+3) (by omega); rwa [show 8 * (n * 4 + 3) = n * 32 + 24 from by omega] at this
+  -- ADDI spec
+  have sA := addi_spec_gen_same .x12 (nsp + 32) (-32) base (by nofun)
+  simp only [signExtend12_neg32] at sA
+  rw [show (nsp + 32 : Word) + (-32 : Word) = nsp from by bv_omega] at sA
+  -- Pair specs (LD + SD for each limb)
+  have P0 := dup_pair_spec nsp
+    (BitVec.ofNat 12 (n*32)) (BitVec.ofNat 12 0) s0 d0 v7 (base + 4)
+    (by rw [hse_s0]; exact hvs0) (by rw [hm0]; exact hv0)
+  rw [hse_s0, hm0] at P0
+  have P1 := dup_pair_spec nsp
+    (BitVec.ofNat 12 (n*32+8)) (BitVec.ofNat 12 8) s1 d1 s0 (base + 12)
+    (by rw [hse_s1]; exact hvs8) (by rw [hm8]; exact hv8)
+  rw [hse_s1, hm8] at P1
+  have P2 := dup_pair_spec nsp
+    (BitVec.ofNat 12 (n*32+16)) (BitVec.ofNat 12 16) s2 d2 s1 (base + 20)
+    (by rw [hse_s2]; exact hvs16) (by rw [hm16]; exact hv16)
+  rw [hse_s2, hm16] at P2
+  have P3 := dup_pair_spec nsp
+    (BitVec.ofNat 12 (n*32+24)) (BitVec.ofNat 12 24) s3 d3 s2 (base + 28)
+    (by rw [hse_s3]; exact hvs24) (by rw [hm24]; exact hv24)
+  rw [hse_s3, hm24] at P3
+  runBlock sA P0 P1 P2 P3
+
+-- ============================================================================
+-- EvmWord-level DUP spec
+-- ============================================================================
+
+set_option maxHeartbeats 3200000 in
+/-- DUPn spec at evmWordIs level: copies the nth stack element to new top position. -/
+theorem evm_dup_evmword_spec (nsp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (src dst : EvmWord) (v7 : Word)
+    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    cpsTriple base (base + 36) (evm_dup_code base n)
+      ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
+       evmWordIs nsp dst **
+       evmWordIs (nsp + BitVec.ofNat 64 (n * 32)) src)
+      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ src.getLimb 3) **
+       evmWordIs nsp src **
+       evmWordIs (nsp + BitVec.ofNat 64 (n * 32)) src) := by
+  -- Address normalizations for evmWordIs (nsp + BitVec.ofNat 64 (n*32))
+  have haddr8  : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 8  = nsp + BitVec.ofNat 64 (n*32+8)  := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have haddr16 : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 16 = nsp + BitVec.ofNat 64 (n*32+16) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have haddr24 : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 24 = nsp + BitVec.ofNat 64 (n*32+24) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have h_main := evm_dup_spec nsp base n hn1 hn16
+    (src.getLimb 0) (src.getLimb 1) (src.getLimb 2) (src.getLimb 3)
+    (dst.getLimb 0) (dst.getLimb 1) (dst.getLimb 2) (dst.getLimb 3)
+    v7 hvalid
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun _ hp => by
+      simp only [evmWordIs, haddr8, haddr16, haddr24] at hp
+      xperm_hyp hp)
+    (fun _ hq => by
+      simp only [evmWordIs, haddr8, haddr16, haddr24]
+      xperm_hyp hq)
+    h_main
+
+-- ============================================================================
+-- Stack-level DUP spec
+-- ============================================================================
+
+set_option maxHeartbeats 3200000 in
+/-- DUPn stack spec: copies the (n-1)-th element (0-indexed) from the stack
+    to a new top position, leaving the rest unchanged. -/
+theorem evm_dup_stack_spec (nsp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (stack : List EvmWord) (hlen : n ≤ stack.length)
+    (d : EvmWord) (v7 : Word)
+    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    let vn := stack[n - 1]'(by omega)
+    cpsTriple base (base + 36) (evm_dup_code base n)
+      ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
+       evmWordIs nsp d **
+       evmStackIs (nsp + 32) stack)
+      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ vn.getLimb 3) **
+       evmWordIs nsp vn **
+       evmStackIs (nsp + 32) stack) := by
+  intro vn
+  -- Split evmStackIs at position (n-1) to extract the target element
+  have hk : n - 1 < stack.length := by omega
+  have hsplit := evmStackIs_split_at (nsp + 32) stack (n - 1) hk
+  -- Address normalizations
+  have haddr_src : (nsp + 32 : Addr) + BitVec.ofNat 64 ((n - 1) * 32) =
+      nsp + BitVec.ofNat 64 (n * 32) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have haddr_rest : (nsp + 32 : Addr) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
+      nsp + BitVec.ofNat 64 (n * 32 + 32) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  rw [haddr_src, haddr_rest, show n - 1 + 1 = n from by omega] at hsplit
+  -- Frame the evm_dup_evmword_spec with the stack prefix and suffix
+  have h_main := cpsTriple_frame_left _ _ _ _ _
+    (evmStackIs (nsp + 32) (stack.take (n - 1)) **
+     evmStackIs (nsp + BitVec.ofNat 64 (n * 32 + 32)) (stack.drop n))
+    (by pcFree)
+    (evm_dup_evmword_spec nsp base n hn1 hn16 vn d v7 hvalid)
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun _ hp => by rw [hsplit] at hp; xperm_hyp hp)
+    (fun _ hq => by rw [hsplit]; xperm_hyp hq)
+    h_main
+
+end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Pop.lean
+++ b/EvmAsm/Evm64/Pop.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.Pop
+
+  256-bit EVM POP: discard top of stack, sp += 32.
+  1 instruction (ADDI x12 x12 32).
+-/
+
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+def evm_pop : Program := ADDI .x12 .x12 32
+
+-- ============================================================================
+-- CodeReq
+-- ============================================================================
+
+abbrev evm_pop_code (base : Addr) : CodeReq :=
+  CodeReq.ofProg base evm_pop
+
+-- ============================================================================
+-- POP spec
+-- ============================================================================
+
+/-- POP: advances stack pointer by 32 bytes (discards top 256-bit element).
+    1 instruction = 4 bytes. -/
+theorem evm_pop_spec (sp base : Addr) :
+    cpsTriple base (base + 4) (evm_pop_code base)
+      (.x12 ↦ᵣ sp)
+      (.x12 ↦ᵣ (sp + 32)) := by
+  have h := addi_spec_gen_same .x12 sp 32 base (by nofun)
+  simp only [signExtend12_32] at h
+  runBlock h
+
+/-- POP stack spec: discards top element, rest untouched. -/
+theorem evm_pop_stack_spec (sp base : Addr)
+    (a : EvmWord) (rest : List EvmWord) :
+    cpsTriple base (base + 4) (evm_pop_code base)
+      ((.x12 ↦ᵣ sp) ** evmWordIs sp a ** evmStackIs (sp + 32) rest)
+      ((.x12 ↦ᵣ (sp + 32)) ** evmWordIs sp a ** evmStackIs (sp + 32) rest) :=
+  cpsTriple_frame_left _ _ _ _ _
+    (evmWordIs sp a ** evmStackIs (sp + 32) rest)
+    (pcFree_sepConj (pcFree_evmWordIs sp a) (pcFree_evmStackIs (sp + 32) rest))
+    (evm_pop_spec sp base)
+
+end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Push0.lean
+++ b/EvmAsm/Evm64/Push0.lean
@@ -1,0 +1,75 @@
+/-
+  EvmAsm.Evm64.Push0
+
+  256-bit EVM PUSH0: push 0 onto stack, sp -= 32.
+  5 instructions (ADDI + 4 × SD x0).
+-/
+
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+def evm_push0 : Program :=
+  ADDI .x12 .x12 (-32) ;;
+  SD .x12 .x0 0 ;; SD .x12 .x0 8 ;; SD .x12 .x0 16 ;; SD .x12 .x0 24
+
+-- ============================================================================
+-- CodeReq
+-- ============================================================================
+
+abbrev evm_push0_code (base : Addr) : CodeReq :=
+  CodeReq.ofProg base evm_push0
+
+-- ============================================================================
+-- PUSH0 spec
+-- ============================================================================
+
+set_option maxHeartbeats 6400000 in
+/-- PUSH0: writes 4 zero limbs at nsp, moves SP backward by 32.
+    5 instructions = 20 bytes. nsp is the NEW stack pointer (after decrement). -/
+theorem evm_push0_spec (nsp base : Addr)
+    (d0 d1 d2 d3 : Word)
+    (hvalid : ValidMemRange nsp 4) :
+    let code := evm_push0_code base
+    cpsTriple base (base + 20) code
+      ((.x12 ↦ᵣ (nsp + 32)) **
+       (nsp ↦ₘ d0) ** ((nsp + 8) ↦ₘ d1) ** ((nsp + 16) ↦ₘ d2) ** ((nsp + 24) ↦ₘ d3))
+      ((.x12 ↦ᵣ nsp) **
+       (nsp ↦ₘ 0) ** ((nsp + 8) ↦ₘ 0) ** ((nsp + 16) ↦ₘ 0) ** ((nsp + 24) ↦ₘ 0)) := by
+  have LADDI := addi_spec_gen_same .x12 (nsp + 32) (-32) base (by nofun)
+  simp only [signExtend12_neg32] at LADDI
+  rw [show (nsp + 32 : Word) + (-32 : Word) = nsp from by bv_omega] at LADDI
+  have L0 := sd_x0_spec_gen .x12 nsp d0 0 (base + 4) (by validMem)
+  have L1 := sd_x0_spec_gen .x12 nsp d1 8 (base + 8) (by validMem)
+  have L2 := sd_x0_spec_gen .x12 nsp d2 16 (base + 12) (by validMem)
+  have L3 := sd_x0_spec_gen .x12 nsp d3 24 (base + 16) (by validMem)
+  runBlock LADDI L0 L1 L2 L3
+
+/-- PUSH0 stack spec: pushes EvmWord 0 onto stack. -/
+theorem evm_push0_stack_spec (nsp base : Addr)
+    (d0 d1 d2 d3 : Word) (rest : List EvmWord)
+    (hvalid : ValidMemRange nsp 4) :
+    let code := evm_push0_code base
+    cpsTriple base (base + 20) code
+      ((.x12 ↦ᵣ (nsp + 32)) **
+       (nsp ↦ₘ d0) ** ((nsp + 8) ↦ₘ d1) ** ((nsp + 16) ↦ₘ d2) ** ((nsp + 24) ↦ₘ d3) **
+       evmStackIs (nsp + 32) rest)
+      ((.x12 ↦ᵣ nsp) ** evmWordIs nsp 0 ** evmStackIs (nsp + 32) rest) :=
+  cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by simp only [evmWordIs, EvmWord.getLimb_zero]; xperm_hyp hq)
+    (cpsTriple_frame_left _ _ _ _ _
+      (evmStackIs (nsp + 32) rest)
+      (by exact pcFree_evmStackIs (nsp + 32) rest)
+      (evm_push0_spec nsp base d0 d1 d2 d3 hvalid))
+
+end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -48,4 +48,55 @@ theorem evmStackIs_cons (sp : Addr) (v : EvmWord) (vs : List EvmWord) :
 theorem evmStackIs_nil (sp : Addr) :
     evmStackIs sp [] = empAssertion := rfl
 
+-- ============================================================================
+-- Shared infrastructure for stack operation specs
+-- ============================================================================
+
+@[simp] theorem EvmWord.getLimb_zero (i : Fin 4) : (0 : EvmWord).getLimb i = 0 := by
+  have h : ∀ j : Fin 4, (0 : EvmWord).getLimb j = 0 := by native_decide
+  exact h i
+
+@[simp] theorem signExtend12_neg32 : signExtend12 (-32 : BitVec 12) = (-32 : Word) := by
+  native_decide
+
+/-- Sign-extend a small non-negative 12-bit value to 64 bits.
+    The MSB is clear when m < 2^11 = 2048, so signExtend = zeroExtend = identity. -/
+theorem signExtend12_ofNat_small (m : Nat) (hm : m < 2048) :
+    signExtend12 (BitVec.ofNat 12 m) = BitVec.ofNat 64 m := by
+  unfold signExtend12
+  rw [BitVec.signExtend_eq_setWidth_of_msb_false]
+  · exact BitVec.setWidth_ofNat_of_le_of_lt (by omega) (by omega)
+  · rw [BitVec.msb_eq_false_iff_two_mul_lt]; simp [BitVec.toNat_ofNat]; omega
+
+/-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
+theorem evmStackIs_split_at (sp : Addr) (stack : List EvmWord) (k : Nat)
+    (hk : k < stack.length) :
+    evmStackIs sp stack =
+      (evmStackIs sp (stack.take k) **
+       evmWordIs (sp + BitVec.ofNat 64 (k * 32)) (stack[k]'hk) **
+       evmStackIs (sp + BitVec.ofNat 64 ((k + 1) * 32)) (stack.drop (k + 1))) := by
+  induction k generalizing sp stack with
+  | zero =>
+    cases stack with
+    | nil => simp at hk
+    | cons v vs =>
+      simp only [Nat.zero_mul, List.take_zero,
+                 List.drop_succ_cons, List.drop_zero, List.getElem_cons_zero,
+                 evmStackIs_cons, evmStackIs_nil, sepConj_emp_left', BitVec.add_zero]
+      congr 1
+  | succ k ih =>
+    cases stack with
+    | nil => simp at hk
+    | cons v vs =>
+      have hk' : k < vs.length := by simp at hk; omega
+      have a1 : sp + (32 : Addr) + BitVec.ofNat 64 (k * 32) =
+                sp + BitVec.ofNat 64 ((k + 1) * 32) := by
+        apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+      have a2 : sp + (32 : Addr) + BitVec.ofNat 64 ((k + 1) * 32) =
+                sp + BitVec.ofNat 64 ((k + 2) * 32) := by
+        apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+      rw [evmStackIs_cons, ih (sp + 32) vs hk', a1, a2]
+      simp only [List.take_succ_cons, List.drop_succ_cons, List.getElem_cons_succ]
+      simp only [evmStackIs_cons, sepConj_assoc']
+
 end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Swap.lean
+++ b/EvmAsm/Evm64/Swap.lean
@@ -1,0 +1,253 @@
+/-
+  EvmAsm.Evm64.Swap
+
+  256-bit EVM SWAP1-16: generic swap of top with nth stack element.
+  16 instructions (4 × (LD + LD + SD + SD)).
+-/
+
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definitions
+-- ============================================================================
+
+/-- One limb quad for SWAP: LD x7 from top, LD x6 from nth, SD x6 to top, SD x7 to nth. -/
+private def swap_one_limb (n i : Nat) : Program :=
+  LD .x7 .x12 (BitVec.ofNat 12 (i * 8)) ;;
+  LD .x6 .x12 (BitVec.ofNat 12 (n * 32 + i * 8)) ;;
+  SD .x12 .x6 (BitVec.ofNat 12 (i * 8)) ;;
+  SD .x12 .x7 (BitVec.ofNat 12 (n * 32 + i * 8))
+
+/-- Generic SWAPn program (1-indexed): swap the top element with the nth stack element.
+    n=1 swaps top with 2nd, n=2 swaps top with 3rd, etc.
+    Uses 16 instructions: 4 × (LD + LD + SD + SD). -/
+def evm_swap (n : Nat) : Program :=
+  swap_one_limb n 0 ;; swap_one_limb n 1 ;; swap_one_limb n 2 ;; swap_one_limb n 3
+
+-- ============================================================================
+-- Per-limb helper
+-- ============================================================================
+
+/-- Four-instruction spec for SWAP per-limb: LD x7 from A, LD x6 from B,
+    SD x6 to A, SD x7 to B. Swaps values at offsets off_a and off_b. -/
+theorem swap_limb_spec (sp : Addr)
+    (off_a off_b : BitVec 12) (a_val b_val v7 v6 : Word) (base : Addr)
+    (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
+    (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
+    cpsTriple base (base + 16)
+      (CodeReq.singleton base (.LD .x7 .x12 off_a) |>.union
+        (CodeReq.singleton (base + 4) (.LD .x6 .x12 off_b) |>.union
+        (CodeReq.singleton (base + 8) (.SD .x12 .x6 off_a) |>.union
+         (CodeReq.singleton (base + 12) (.SD .x12 .x7 off_b)))))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       ((sp + signExtend12 off_a) ↦ₘ a_val) ** ((sp + signExtend12 off_b) ↦ₘ b_val))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ a_val) ** (.x6 ↦ᵣ b_val) **
+       ((sp + signExtend12 off_a) ↦ₘ b_val) ** ((sp + signExtend12 off_b) ↦ₘ a_val)) := by
+  runBlock
+
+-- ============================================================================
+-- CodeReq for generic SWAP (explicit union chain)
+-- ============================================================================
+
+/-- CodeReq for generic SWAPn: 16 instructions = 64 bytes.
+    Built as an explicit union chain because symbolic n prevents ofProg reduction. -/
+abbrev evm_swap_code (base : Addr) (n : Nat) : CodeReq :=
+  -- Limb 0
+  CodeReq.singleton base (.LD .x7 .x12 (BitVec.ofNat 12 0))
+  |>.union (CodeReq.singleton (base + 4)  (.LD .x6 .x12 (BitVec.ofNat 12 (n*32))))
+  |>.union (CodeReq.singleton (base + 8)  (.SD .x12 .x6 (BitVec.ofNat 12 0)))
+  |>.union (CodeReq.singleton (base + 12) (.SD .x12 .x7 (BitVec.ofNat 12 (n*32))))
+  -- Limb 1
+  |>.union (CodeReq.singleton (base + 16) (.LD .x7 .x12 (BitVec.ofNat 12 8)))
+  |>.union (CodeReq.singleton (base + 20) (.LD .x6 .x12 (BitVec.ofNat 12 (n*32+8))))
+  |>.union (CodeReq.singleton (base + 24) (.SD .x12 .x6 (BitVec.ofNat 12 8)))
+  |>.union (CodeReq.singleton (base + 28) (.SD .x12 .x7 (BitVec.ofNat 12 (n*32+8))))
+  -- Limb 2
+  |>.union (CodeReq.singleton (base + 32) (.LD .x7 .x12 (BitVec.ofNat 12 16)))
+  |>.union (CodeReq.singleton (base + 36) (.LD .x6 .x12 (BitVec.ofNat 12 (n*32+16))))
+  |>.union (CodeReq.singleton (base + 40) (.SD .x12 .x6 (BitVec.ofNat 12 16)))
+  |>.union (CodeReq.singleton (base + 44) (.SD .x12 .x7 (BitVec.ofNat 12 (n*32+16))))
+  -- Limb 3
+  |>.union (CodeReq.singleton (base + 48) (.LD .x7 .x12 (BitVec.ofNat 12 24)))
+  |>.union (CodeReq.singleton (base + 52) (.LD .x6 .x12 (BitVec.ofNat 12 (n*32+24))))
+  |>.union (CodeReq.singleton (base + 56) (.SD .x12 .x6 (BitVec.ofNat 12 24)))
+  |>.union (CodeReq.singleton (base + 60) (.SD .x12 .x7 (BitVec.ofNat 12 (n*32+24))))
+
+-- ============================================================================
+-- Low-level generic SWAP spec
+-- ============================================================================
+
+set_option maxHeartbeats 6400000 in
+/-- Generic SWAPn spec (low level): swaps 4 dword limbs at sp (top) with 4 at sp+n*32 (nth).
+    Requires 1 ≤ n ≤ 16 (valid EVM SWAP range). -/
+theorem evm_swap_spec (sp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (a0 a1 a2 a3 : Word)
+    (b0 b1 b2 b3 : Word)
+    (v7 v6 : Word)
+    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    cpsTriple base (base + 64) (evm_swap_code base n)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       (sp ↦ₘ a0) ** ((sp+8) ↦ₘ a1) ** ((sp+16) ↦ₘ a2) ** ((sp+24) ↦ₘ a3) **
+       ((sp + BitVec.ofNat 64 (n*32))    ↦ₘ b0) **
+       ((sp + BitVec.ofNat 64 (n*32+8))  ↦ₘ b1) **
+       ((sp + BitVec.ofNat 64 (n*32+16)) ↦ₘ b2) **
+       ((sp + BitVec.ofNat 64 (n*32+24)) ↦ₘ b3))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ a3) ** (.x6 ↦ᵣ b3) **
+       (sp ↦ₘ b0) ** ((sp+8) ↦ₘ b1) ** ((sp+16) ↦ₘ b2) ** ((sp+24) ↦ₘ b3) **
+       ((sp + BitVec.ofNat 64 (n*32))    ↦ₘ a0) **
+       ((sp + BitVec.ofNat 64 (n*32+8))  ↦ₘ a1) **
+       ((sp + BitVec.ofNat 64 (n*32+16)) ↦ₘ a2) **
+       ((sp + BitVec.ofNat 64 (n*32+24)) ↦ₘ a3)) := by
+  -- signExtend12 normalizations for n-dependent source offsets
+  have hse_s0 : signExtend12 (BitVec.ofNat 12 (n*32)) = BitVec.ofNat 64 (n*32) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s1 : signExtend12 (BitVec.ofNat 12 (n*32+8)) = BitVec.ofNat 64 (n*32+8) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s2 : signExtend12 (BitVec.ofNat 12 (n*32+16)) = BitVec.ofNat 64 (n*32+16) :=
+    signExtend12_ofNat_small _ (by omega)
+  have hse_s3 : signExtend12 (BitVec.ofNat 12 (n*32+24)) = BitVec.ofNat 64 (n*32+24) :=
+    signExtend12_ofNat_small _ (by omega)
+  -- signExtend12 normalizations for destination offsets (0,8,16,24)
+  have hm0  : sp + signExtend12 (BitVec.ofNat 12 0)  = sp      := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm8  : sp + signExtend12 (BitVec.ofNat 12 8)  = sp + 8  := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm16 : sp + signExtend12 (BitVec.ofNat 12 16) = sp + 16 := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  have hm24 : sp + signExtend12 (BitVec.ofNat 12 24) = sp + 24 := by
+    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+  -- Memory validity for destination locations (indices 0..3)
+  have hv0  : isValidDwordAccess sp       = true := by have := hvalid.get (i := 0) (by omega); simpa using this
+  have hv8  : isValidDwordAccess (sp + 8)  = true := by have := hvalid.get (i := 1) (by omega); simpa using this
+  have hv16 : isValidDwordAccess (sp + 16) = true := by have := hvalid.get (i := 2) (by omega); simpa using this
+  have hv24 : isValidDwordAccess (sp + 24) = true := by have := hvalid.get (i := 3) (by omega); simpa using this
+  -- Memory validity for source locations (indices n*4..n*4+3)
+  have hvs0 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32)) = true := by
+    have := hvalid.get (i := n*4) (by omega); rwa [show 8 * (n * 4) = n * 32 from by omega] at this
+  have hvs8 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+8)) = true := by
+    have := hvalid.get (i := n*4+1) (by omega); rwa [show 8 * (n * 4 + 1) = n * 32 + 8 from by omega] at this
+  have hvs16 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+16)) = true := by
+    have := hvalid.get (i := n*4+2) (by omega); rwa [show 8 * (n * 4 + 2) = n * 32 + 16 from by omega] at this
+  have hvs24 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+24)) = true := by
+    have := hvalid.get (i := n*4+3) (by omega); rwa [show 8 * (n * 4 + 3) = n * 32 + 24 from by omega] at this
+  -- Limb 0 swap
+  have L0 := swap_limb_spec sp
+    (BitVec.ofNat 12 0) (BitVec.ofNat 12 (n*32))
+    a0 b0 v7 v6 base (by rw [hm0]; exact hv0) (by rw [hse_s0]; exact hvs0)
+  rw [hm0, hse_s0] at L0
+  -- Limb 1 swap
+  have L1 := swap_limb_spec sp
+    (BitVec.ofNat 12 8) (BitVec.ofNat 12 (n*32+8))
+    a1 b1 a0 b0 (base + 16) (by rw [hm8]; exact hv8) (by rw [hse_s1]; exact hvs8)
+  rw [hm8, hse_s1] at L1
+  -- Limb 2 swap
+  have L2 := swap_limb_spec sp
+    (BitVec.ofNat 12 16) (BitVec.ofNat 12 (n*32+16))
+    a2 b2 a1 b1 (base + 32) (by rw [hm16]; exact hv16) (by rw [hse_s2]; exact hvs16)
+  rw [hm16, hse_s2] at L2
+  -- Limb 3 swap
+  have L3 := swap_limb_spec sp
+    (BitVec.ofNat 12 24) (BitVec.ofNat 12 (n*32+24))
+    a3 b3 a2 b2 (base + 48) (by rw [hm24]; exact hv24) (by rw [hse_s3]; exact hvs24)
+  rw [hm24, hse_s3] at L3
+  runBlock L0 L1 L2 L3
+
+-- ============================================================================
+-- EvmWord-level SWAP spec
+-- ============================================================================
+
+/-- SWAPn spec at evmWordIs level: swaps the top and nth stack elements. -/
+theorem evm_swap_evmword_spec (sp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (top nth : EvmWord) (v7 v6 : Word)
+    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    cpsTriple base (base + 64) (evm_swap_code base n)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       evmWordIs sp top **
+       evmWordIs (sp + BitVec.ofNat 64 (n * 32)) nth)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimb 3) ** (.x6 ↦ᵣ nth.getLimb 3) **
+       evmWordIs sp nth **
+       evmWordIs (sp + BitVec.ofNat 64 (n * 32)) top) := by
+  -- Address normalizations
+  have ha8  : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 8  = sp + BitVec.ofNat 64 (n*32+8)  := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have ha16 : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 16 = sp + BitVec.ofNat 64 (n*32+16) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have ha24 : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 24 = sp + BitVec.ofNat 64 (n*32+24) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by
+      simp only [evmWordIs, ha8, ha16, ha24] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      simp only [evmWordIs, ha8, ha16, ha24]
+      xperm_hyp hq)
+    (evm_swap_spec sp base n hn1 hn16
+      (top.getLimb 0) (top.getLimb 1) (top.getLimb 2) (top.getLimb 3)
+      (nth.getLimb 0) (nth.getLimb 1) (nth.getLimb 2) (nth.getLimb 3)
+      v7 v6 hvalid)
+
+-- ============================================================================
+-- Stack-level SWAP spec
+-- ============================================================================
+
+/-- SWAPn stack spec: swaps top with the nth element (1-indexed) of the stack. -/
+theorem evm_swap_stack_spec (sp base : Addr)
+    (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
+    (stack : List EvmWord) (hlen : n + 1 ≤ stack.length)
+    (v7 v6 : Word)
+    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    let top := stack[0]'(by omega)
+    let nth := stack[n]'(by omega)
+    cpsTriple base (base + 64) (evm_swap_code base n)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
+       evmStackIs sp stack)
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimb 3) ** (.x6 ↦ᵣ nth.getLimb 3) **
+       evmWordIs sp nth **
+       evmStackIs (sp + 32) ((stack.drop 1).take (n - 1)) **
+       evmWordIs (sp + BitVec.ofNat 64 (n * 32)) top **
+       evmStackIs (sp + BitVec.ofNat 64 ((n + 1) * 32)) ((stack.drop 1).drop n)) := by
+  intro top nth
+  -- Split evmStackIs sp stack at position 0 to extract top
+  have hk0 : 0 < stack.length := by omega
+  have hsplit0 := evmStackIs_split_at sp stack 0 hk0
+  -- Split the tail at position (n-1) to extract nth
+  have htail_len : n - 1 < (stack.drop 1).length := by simp; omega
+  have hsplit1 := evmStackIs_split_at (sp + 32) (stack.drop 1) (n - 1) htail_len
+  -- Address normalizations
+  have haddr_src : (sp + 32 : Addr) + BitVec.ofNat 64 ((n - 1) * 32) =
+      sp + BitVec.ofNat 64 (n * 32) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  have haddr_rest : (sp + 32 : Addr) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
+      sp + BitVec.ofNat 64 ((n + 1) * 32) := by
+    apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+  -- Simplify element access
+  have helem : (stack.drop 1)[n - 1]'htail_len = stack[n]'(by omega) := by
+    simp; congr 1; omega
+  rw [haddr_src, haddr_rest, show (n - 1) + 1 = n from by omega, helem] at hsplit1
+  -- Frame the swap spec with middle and rest stacks
+  have h_main := cpsTriple_frame_left _ _ _ _ _
+    (evmStackIs (sp + 32) ((stack.drop 1).take (n - 1)) **
+     evmStackIs (sp + BitVec.ofNat 64 ((n + 1) * 32)) ((stack.drop 1).drop n))
+    (by pcFree)
+    (evm_swap_evmword_spec sp base n hn1 hn16 top nth v7 v6 hvalid)
+  have haddr32 : (sp + BitVec.ofNat 64 (1 * 32) : Addr) = sp + 32 := by bv_omega
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by
+      rw [hsplit0] at hp
+      simp only [Nat.zero_mul, List.take_zero, evmStackIs_nil, sepConj_emp_left',
+                  BitVec.add_zero, haddr32] at hp
+      rw [hsplit1] at hp
+      xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h_main
+
+end EvmAsm.Rv64

--- a/PLAN.md
+++ b/PLAN.md
@@ -82,14 +82,14 @@ EVM stack: x12 is EVM stack pointer, stack grows upward, 32 bytes per element.
 | Shift | SHR, SHL, SAR | 90 / 90 / 95 | ⚠️ Programs + tests only (specs deleted) |
 | Comparison | ISZERO, LT, GT, EQ, SLT, SGT | 12 / 26 / 26 / 21 / 25 / 25 | ✅ Fully proved |
 | Byte/SignExt | BYTE, SIGNEXTEND | 45 / 48 | ⚠️ BYTE spec deleted; SIGNEXTEND proved |
-| Stack | POP, PUSH0, DUP1-16, SWAP1-16 | 1 / 5 / 9 / 16 | ⚠️ Specs deleted |
+| Stack | POP, PUSH0, DUP1-16, SWAP1-16 | 1 / 5 / 9 / 16 | ✅ Fully proved |
 
 **Deleted spec files** (incomplete CodeReq migration, easier to recreate):
 - `ShiftSpec.lean` — SHR per-limb + phase + body specs
 - `ShlSpec.lean` — SHL per-limb + body specs
 - `SarSpec.lean` — SAR per-limb + body + sign-fill specs
 - `ByteSpec.lean` — BYTE per-body + store + phase B specs
-- `StackOps.lean` — POP, PUSH0, DUP1-16, SWAP1-16 specs
+- ~~`StackOps.lean`~~ — ✅ Recreated as modular `Pop.lean`, `Push0.lean`, `Dup.lean`, `Swap.lean`
 
 See **Pending: Recreate Deleted Spec Files** below for recreation plan.
 
@@ -131,26 +131,20 @@ corresponding non-Spec files.
 
 ### Files to recreate (by priority)
 
-#### 1. StackOps.lean — POP, PUSH0, DUP1-16, SWAP1-16
+#### ~~1. StackOps.lean — POP, PUSH0, DUP1-16, SWAP1-16~~ ✅ DONE
 
-- **File**: `Evm64/StackOps.lean`
-- **Programs**: `evm_pop`, `evm_push0`, `evm_dup(n)`, `evm_swap(n)` are
-  generic Lean functions in the existing `Stack.lean` / program files.
-- **What was in the old file**:
-  - `evm_pop_spec` (1 instr): trivial ADDI — use `runBlock` or direct proof
-  - `evm_pop_stack_spec`: frame with evmWordIs/evmStackIs
-  - `evm_push0_spec` (5 instrs): 4× SD + ADDI — `runBlock` auto mode
-  - `evm_push0_stack_spec`: frame with evmStackIs
-  - `evm_dup_spec(n)` (9 instrs): ADDI + 4× LD/SD pairs — `runBlock` auto mode
-  - `evm_dup_stack_spec`: evmWordIs + evmStackIs abstraction
-  - `evm_swap_spec(n)` (16 instrs): 4× LD/SD + 4× LD/SD — `runBlock` auto mode
-  - `evm_swap_stack_spec`: evmStackIs abstraction
-- **Approach**: Per-limb specs via `runBlock` auto mode. Stack-level specs
-  via `cpsTriple_frame_left` + `cpsTriple_consequence` with `xperm_hyp`.
-  The old file's manual `cpsTriple_seq_with_perm` chains should be replaced
-  with `runBlock` (which handles CR extension automatically).
-- **Key pitfall**: `evm_dup(n)` and `evm_swap(n)` use generic `n : Nat`
-  offsets. `signExtend12_ofNat_small` is needed for `signExtend12 (BitVec.ofNat 12 (n*32+k))`.
+- **Files**: `Evm64/Pop.lean`, `Evm64/Push0.lean`, `Evm64/Dup.lean`, `Evm64/Swap.lean`
+  (modular split; shared infra in `Stack.lean`)
+- **Programs**: `evm_pop` (1 instr), `evm_push0` (5), `evm_dup(n)` (9), `evm_swap(n)` (16)
+- **Specs**: All fully proved (0 sorry). Three-level hierarchy per opcode:
+  low-level (explicit limbs) → EvmWord → stack (evmStackIs).
+- **Pattern**: POP/PUSH0 use `CodeReq.ofProg` + `runBlock`. DUP/SWAP use
+  explicit `CodeReq` union chains (symbolic `n` prevents `ofProg` whnf) with
+  `runBlock` manual mode handling monotonicity via `buildMonoProof`'s
+  union-split support. Per-limb helpers (`dup_pair_spec`, `swap_limb_spec`)
+  use `runBlock` auto mode.
+- **Shared infra** added to `Stack.lean`: `signExtend12_ofNat_small`,
+  `evmStackIs_split_at`, `EvmWord.getLimb_zero`, `signExtend12_neg32`.
 
 #### 2. ShiftSpec.lean — SHR per-limb, phase, body specs
 
@@ -272,14 +266,13 @@ All phases below target **Evm64** primarily. Files are under `EvmAsm/Evm64/`.
 
 ### Phase 3: Stack Extensions
 
-#### 3.1 DUP1-16 and SWAP1-16 (Generic) — ⚠️ specs deleted
-- **File**: `Evm64/StackOps.lean` — deleted in commit `1197924`.
-  Programs remain in `Stack.lean`.
+#### ~~3.1 DUP1-16 and SWAP1-16 (Generic)~~ ✅
+- **Files**: `Evm64/Pop.lean`, `Evm64/Push0.lean`, `Evm64/Dup.lean`, `Evm64/Swap.lean`
 - **Approach**: `evm_dup (n : Nat)` and `evm_swap (n : Nat)` as generic
   Lean functions producing `Program`. 9 instructions for DUP, 16 for SWAP.
   Full spec hierarchy: low-level (explicit limbs) → evmWordIs → evmStackIs.
-  Added `signExtend12_ofNat_small` and `evmStackIs_split_at` for Evm64.
-- Covers 32 opcodes with one proof each. Was fully proved; needs recreation.
+  Added `signExtend12_ofNat_small` and `evmStackIs_split_at` to `Stack.lean`.
+- Covers 34 opcodes (POP, PUSH0, DUP1-16, SWAP1-16) with one proof each. Fully proved.
 
 #### 3.2 PUSH1-32
 - **File**: `Evm64/StackOps.lean`
@@ -603,7 +596,7 @@ This is the heart of the STF — the inner loop that executes EVM bytecode.
 ## Priority Order
 
 **Immediate (recreate deleted specs):**
-1. Recreate `StackOps.lean` — POP, PUSH0, DUP1-16, SWAP1-16 specs
+1. ~~Recreate `StackOps.lean`~~ — ✅ Done (Pop.lean, Push0.lean, Dup.lean, Swap.lean)
 2. Recreate `ShiftSpec.lean` — SHR per-limb + phase + body specs
 3. Recreate `ShlSpec.lean`, `SarSpec.lean` — SHL/SAR specs (depend on ShiftSpec)
 4. Recreate `ByteSpec.lean` — BYTE specs (depends on ShiftSpec)


### PR DESCRIPTION
## Summary
- Recreates the deleted `StackOps.lean` as modular files: `Pop.lean`, `Push0.lean`, `Dup.lean`, `Swap.lean`
- Extends `Stack.lean` with shared infrastructure: `signExtend12_ofNat_small`, `evmStackIs_split_at`, `EvmWord.getLimb_zero`, `signExtend12_neg32`
- All specs use modern 5-arg `cpsTriple` with `CodeReq` (no `instrAt` atoms in P/Q)
- DUP/SWAP use explicit `CodeReq` union chains (symbolic `n` prevents `ofProg` reduction), with `runBlock` handling monotonicity automatically
- 0 sorry across all files, full project builds clean

## Spec hierarchy per opcode
| Level | POP | PUSH0 | DUP(n) | SWAP(n) |
|-------|-----|-------|--------|---------|
| Program | `evm_pop` (1 instr) | `evm_push0` (5) | `evm_dup n` (9) | `evm_swap n` (16) |
| Low-level | `evm_pop_spec` | `evm_push0_spec` | `evm_dup_spec` | `evm_swap_spec` |
| EvmWord | — | — | `evm_dup_evmword_spec` | `evm_swap_evmword_spec` |
| Stack | `evm_pop_stack_spec` | `evm_push0_stack_spec` | `evm_dup_stack_spec` | `evm_swap_stack_spec` |

🤖 Generated with [Claude Code](https://claude.com/claude-code)