### PR TITLE
Remove unnecessary maxHeartbeats overrides

### DIFF
--- a/EvmAsm/Evm64/Add.lean
+++ b/EvmAsm/Evm64/Add.lean
@@ -16,7 +16,6 @@ namespace EvmAsm.Rv64
 abbrev evm_add_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_add
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM ADD: composes 4 per-limb ADD specs + ADDI sp adjustment.
     30 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A + B to sp+32..sp+56, advances sp by 32.

--- a/EvmAsm/Evm64/And.lean
+++ b/EvmAsm/Evm64/And.lean
@@ -17,7 +17,6 @@ namespace EvmAsm.Rv64
 abbrev evm_and_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_and
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM AND: composes 4 per-limb AND specs + sp adjustment.
     17 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A &&& B to sp+32..sp+56, advances sp by 32. -/
@@ -45,7 +44,6 @@ theorem evm_and_spec (sp base : Addr)
 -- Stack-level AND spec
 -- ============================================================================
 
-set_option maxHeartbeats 6400000 in
 /-- Stack-level 256-bit EVM AND: operates on two EvmWords via evmWordIs. -/
 theorem evm_and_stack_spec (sp base : Addr)
     (a b : EvmWord) (v7 v6 : Word)

--- a/EvmAsm/Evm64/DivModCompose.lean
+++ b/EvmAsm/Evm64/DivModCompose.lean
@@ -79,7 +79,6 @@ private theorem divK_phaseA_code_sub_divCode (base : Addr) :
   unfold divCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 1600000 in
 /-- Zero path code (5 instructions, block 11) is subsumed by divCode. -/
 private theorem divK_zeroPath_code_sub_divCode (base : Addr) :
     ∀ a i, (divK_zeroPath_code (base + 1044)) a = some i → (divCode base) a = some i := by
@@ -218,7 +217,6 @@ private theorem phB_sp24_32 (sp : Addr) : (sp + (24 : Addr) + (32 : Addr)) = sp 
 -- ============================================================================
 
 set_option maxRecDepth 2048 in
-set_option maxHeartbeats 12800000 in
 /-- When b = 0 (all limbs zero), evm_div writes zeros and advances sp.
     Execution path: phaseA body (7 instrs), BEQ taken, zeroPath (5 instrs). -/
 theorem evm_div_bzero_spec (sp base : Addr)
@@ -280,7 +278,6 @@ theorem evm_div_bzero_spec (sp base : Addr)
 -- ============================================================================
 
 set_option maxRecDepth 2048 in
-set_option maxHeartbeats 12800000 in
 /-- When b ≠ 0, evm_div falls through Phase A to Phase B at base+32.
     Execution path: phaseA body (7 instrs), BEQ not taken. -/
 theorem evm_div_phaseA_ntaken_spec (sp base : Addr)
@@ -328,8 +325,8 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Addr)
 -- init1 → init2 → ADDI x5=4 → BNE x10(taken) → tail
 -- ============================================================================
 
-set_option maxRecDepth 4096 in
 set_option maxHeartbeats 51200000 in
+set_option maxRecDepth 4096 in
 /-- Phase B when b[3] ≠ 0 (n=4): zero scratch, load b[1..2], cascade BNE taken, load leading limb.
     Execution path: init1 (7 instrs) + init2 (2) + ADDI (1) + BNE taken (1) + tail (5) = 16 instrs.
     Exit at base+116 (start of CLZ). x5 = b[3] (leading limb), x6 = b[1], x7 = b[2], n = 4. -/
@@ -453,8 +450,8 @@ theorem evm_div_phaseB_n4_spec (sp base : Addr)
 -- base → base+116 (entry to CLZ)
 -- ============================================================================
 
-set_option maxRecDepth 2048 in
 set_option maxHeartbeats 25600000 in
+set_option maxRecDepth 2048 in
 /-- When b ≠ 0 and b[3] ≠ 0, evm_div executes Phase A (ntaken) then Phase B (n=4).
     Execution: 8 + 16 = 24 instructions, base → base+116 (start of CLZ).
     Pre/postcondition shapes reflect frame structure from composition. -/
@@ -543,7 +540,6 @@ private theorem divK_phaseA_code_sub_modCode (base : Addr) :
   unfold modCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 1600000 in
 private theorem divK_zeroPath_code_sub_modCode (base : Addr) :
     ∀ a i, (divK_zeroPath_code (base + 1044)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
@@ -566,7 +562,6 @@ private theorem beq_singleton_sub_modCode (base : Addr) :
 -- ============================================================================
 
 set_option maxRecDepth 2048 in
-set_option maxHeartbeats 12800000 in
 /-- When b = 0 (all limbs zero), evm_mod writes zeros and advances sp.
     Execution path: phaseA body (7 instrs), BEQ taken, zeroPath (5 instrs). -/
 theorem evm_mod_bzero_spec (sp base : Addr)
@@ -624,7 +619,6 @@ theorem evm_mod_bzero_spec (sp base : Addr)
 -- ============================================================================
 
 set_option maxRecDepth 2048 in
-set_option maxHeartbeats 12800000 in
 /-- When b ≠ 0, evm_mod falls through Phase A to Phase B at base+32.
     Execution path: phaseA body (7 instrs), BEQ not taken. -/
 theorem evm_mod_phaseA_ntaken_spec (sp base : Addr)

--- a/EvmAsm/Evm64/DivModSpec.lean
+++ b/EvmAsm/Evm64/DivModSpec.lean
@@ -79,7 +79,6 @@ theorem divK_phaseA_body_spec (sp : Addr) (base : Addr)
 -- Phase A: full cpsBranch (body + BEQ)
 -- ============================================================================
 
-set_option maxHeartbeats 1600000 in
 /-- Phase A: OR-reduce b then BEQ to zero path. -/
 theorem divK_phaseA_spec (sp : Addr) (base : Addr)
     (b0 b1 b2 b3 v5 v10 : Word)
@@ -643,7 +642,6 @@ theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
 -- Phase C2 full: body + BEQ (shift = 0 branch). cpsBranch.
 -- ============================================================================
 
-set_option maxHeartbeats 1600000 in
 set_option maxRecDepth 1024 in
 /-- Phase C2: store shift, compute anti_shift, BEQ if shift=0.
     Taken: shift = 0, skip normalization.
@@ -810,7 +808,6 @@ theorem divK_loopSetup_body_spec (sp n v1 v5 : Word)
     (signExtend12 (4 : BitVec 12)) n (base + 8) (by nofun) (by nofun)
   runBlock I0 I1 I2
 
-set_option maxHeartbeats 1600000 in
 /-- Loop setup: load n, compute m = 4-n, BLT if m < 0 (skip loop).
     Taken: m < 0 (n > 4, impossible in practice but handled).
     Not taken: m >= 0, proceed to loop. -/
@@ -2502,8 +2499,8 @@ theorem divK_div128_prodcheck2_merged_spec
 --   + LD+MUL+SLLI+OR+BLTU+JAL+ADDI+ADD (product check 1).
 -- ============================================================================
 
-set_option maxRecDepth 2048 in
 set_option maxHeartbeats 4000000 in
+set_option maxRecDepth 2048 in
 /-- div128 step 1: trial division q1, clamp, product check. Instrs [10]-[24].
     Input: u_hi in x7, d_hi in x6, un1 in x11, dlo in memory.
     Output: refined q1 in x10, refined rhat in x7. -/
@@ -2645,8 +2642,8 @@ theorem divK_div128_step1_spec
 --   + LD+MUL+SLLI+LD+OR+BLTU+JAL+ADDI (product check 2).
 -- ============================================================================
 
-set_option maxRecDepth 2048 in
 set_option maxHeartbeats 4000000 in
+set_option maxRecDepth 2048 in
 /-- div128 step 2: trial division q0, clamp, product check. Instrs [30]-[44].
     Input: un21 in x7, d_hi in x6, dlo/un0 in memory.
     Output: refined q0 in x5. -/

--- a/EvmAsm/Evm64/Eq.lean
+++ b/EvmAsm/Evm64/Eq.lean
@@ -16,7 +16,6 @@ namespace EvmAsm.Rv64
 abbrev evm_eq_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_eq
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM EQ: EQ(a, b) = 1 iff a == b (unsigned).
     XOR each limb pair, OR-reduce, SLTIU to boolean.
     Pops 2 stack words (A at sp, B at sp+32),

--- a/EvmAsm/Evm64/Gt.lean
+++ b/EvmAsm/Evm64/Gt.lean
@@ -17,7 +17,6 @@ namespace EvmAsm.Rv64
 abbrev evm_gt_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_gt
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM GT: GT(a, b) = 1 iff a > b (unsigned).
     Computed as borrow chain of (b - a), same circuit as LT(b, a).
     Pops 2 stack words (A at sp, B at sp+32),

--- a/EvmAsm/Evm64/Lt.lean
+++ b/EvmAsm/Evm64/Lt.lean
@@ -16,7 +16,6 @@ namespace EvmAsm.Rv64
 abbrev evm_lt_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_lt
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM LT: LT(a, b) = 1 iff a < b (unsigned).
     Borrow chain across 4 limbs, then store result.
     Pops 2 stack words (A at sp, B at sp+32),

--- a/EvmAsm/Evm64/MultiplySpec.lean
+++ b/EvmAsm/Evm64/MultiplySpec.lean
@@ -53,7 +53,6 @@ theorem mul_col3_spec (sp : Addr) (base : Addr)
 abbrev mul_col2_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base mul_col2
 
-set_option maxHeartbeats 1600000 in
 /-- Column 2: multiply b[2] × {a[0],a[1]}, finalize r[2], update r[3] accumulator.
     13 instructions. Input: x11 = r2 acc, sp+16 = r3 partial.
     Output: x10 = r3 total, sp+48 = r2 stored. -/
@@ -109,7 +108,6 @@ abbrev mul_col1_partA_code (base : Addr) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 32) (.ADD .x11 .x11 .x6))
   (CodeReq.singleton (base + 36) (.SLTU .x10 .x11 .x6))))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Column 1 part A: load b1, multiply a0×b1, store r1, begin r2 accumulation.
     10 instructions at base..base+36. -/
 theorem mul_col1_partA_spec (sp : Addr) (base : Addr)
@@ -161,7 +159,6 @@ abbrev mul_col1_partB_code (base : Addr) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 84) (.ADD .x10 .x10 .x6))
   (CodeReq.singleton (base + 88) (.SD .x12 .x10 16)))))))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Column 1 part B: multiply a1×b1, a2×b1, accumulate r2/r3, store r3 spill.
     13 instructions at base+40..base+88. -/
 theorem mul_col1_partB_spec (sp : Addr) (base : Addr)
@@ -202,7 +199,6 @@ theorem mul_col1_partB_spec (sp : Addr) (base : Addr)
 abbrev mul_col1_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base mul_col1
 
-set_option maxHeartbeats 1600000 in
 /-- Column 1: multiply b[1] × {a[0],a[1],a[2]}, finalize r[1], update r[2]/r[3].
     23 instructions. Input: x10 = r1 acc, x11 = r2 acc, sp+24 = r3 partial from col0.
     Output: x11 = r2 acc, sp+16 = r3 partial, sp+40 = r1 stored. -/
@@ -259,7 +255,6 @@ abbrev mul_col0_partA_code (base : Addr) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 36) (.SLTU .x6 .x10 .x7))
   (CodeReq.singleton (base + 40) (.ADD .x11 .x11 .x6)))))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Column 0 part A: load b0, multiply a0×b0 and a1×b0, store r0, begin r1/r2 accumulation.
     11 instructions at base..base+40. -/
 theorem mul_col0_partA_spec (sp : Addr) (base : Addr)
@@ -308,7 +303,6 @@ abbrev mul_col0_partB_code (base : Addr) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 76) (.ADD .x6 .x6 .x7))
   (CodeReq.singleton (base + 80) (.SD .x12 .x6 24))))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Column 0 part B: multiply a2×b0 and a3×b0, accumulate r2, store r3 partial.
     10 instructions at base+44..base+80. -/
 theorem mul_col0_partB_spec (sp : Addr) (base : Addr)
@@ -344,7 +338,6 @@ theorem mul_col0_partB_spec (sp : Addr) (base : Addr)
 abbrev mul_col0_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base mul_col0
 
-set_option maxHeartbeats 1600000 in
 /-- Column 0: multiply b[0] × {a[0],a[1],a[2],a[3]}, store r[0], spill r[3] partial.
     21 instructions. Output: x10 = r1 acc, x11 = r2 acc, sp+24 = r3p, sp+32 = r0. -/
 theorem mul_col0_spec (sp : Addr) (base : Addr)
@@ -387,7 +380,6 @@ theorem mul_col0_spec (sp : Addr) (base : Addr)
 abbrev evm_mul_code01 (base : Addr) : CodeReq :=
   CodeReq.union (mul_col0_code base) (mul_col1_code (base + 84))
 
-set_option maxHeartbeats 6400000 in
 /-- Intermediate: compose col0 + col1. 44 instructions at base..base+176. -/
 theorem evm_mul_cols01_spec (sp : Addr) (base : Addr)
     (a0 a1 a2 a3 b0 b1 : Word)
@@ -445,7 +437,6 @@ abbrev evm_mul_cols23ep_code (base : Addr) : CodeReq :=
   (CodeReq.union (mul_col3_code (base + 228))
   (CodeReq.singleton (base + 248) (.ADDI .x12 .x12 32)))
 
-set_option maxHeartbeats 1600000 in
 /-- Intermediate: compose col2 + col3 + epilogue. 19 instructions at base+176..base+252. -/
 theorem evm_mul_cols23ep_spec (sp : Addr) (base : Addr)
     (a0 a1 b2 b3 r2_in r3p_in v5 v6 v7 v10 : Word)
@@ -483,7 +474,6 @@ abbrev evm_mul_code (base : Addr) : CodeReq :=
       (CodeReq.union (mul_col3_code (base + 228))
         (CodeReq.singleton (base + 248) (.ADDI .x12 .x12 32)))))
 
-set_option maxHeartbeats 12800000 in
 /-- Full 256-bit EVM MUL: composes cols01 + cols23ep intermediate triples.
     63 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes (A * B) mod 2^256 to sp+32..sp+56, advances sp by 32. -/

--- a/EvmAsm/Evm64/Not.lean
+++ b/EvmAsm/Evm64/Not.lean
@@ -19,7 +19,6 @@ namespace EvmAsm.Rv64
 abbrev evm_not_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_not
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM NOT: composes 4 per-limb NOT specs.
     12 instructions total. Unary: complements each limb in-place, sp unchanged. -/
 theorem evm_not_spec (sp base : Addr)
@@ -49,7 +48,6 @@ theorem evm_not_spec (sp base : Addr)
 theorem signExtend12_neg1_eq_allOnes : signExtend12 (-1 : BitVec 12) = BitVec.allOnes 64 := by
   native_decide
 
-set_option maxHeartbeats 6400000 in
 /-- Stack-level 256-bit EVM NOT: complements an EvmWord in-place. -/
 theorem evm_not_stack_spec (sp base : Addr)
     (a : EvmWord) (v7 : Word)

--- a/EvmAsm/Evm64/Or.lean
+++ b/EvmAsm/Evm64/Or.lean
@@ -13,7 +13,6 @@ namespace EvmAsm.Rv64
 abbrev evm_or_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_or
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM OR: composes 4 per-limb OR specs + sp adjustment. -/
 theorem evm_or_spec (sp base : Addr)
     (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
@@ -33,7 +32,6 @@ theorem evm_or_spec (sp base : Addr)
   have LADDI := addi_spec_gen_same .x12 sp 32 (base + 64) (by nofun)
   runBlock L0 L1 L2 L3 LADDI
 
-set_option maxHeartbeats 6400000 in
 /-- Stack-level 256-bit EVM OR. -/
 theorem evm_or_stack_spec (sp base : Addr)
     (a b : EvmWord) (v7 v6 : Word)

--- a/EvmAsm/Evm64/Sgt.lean
+++ b/EvmAsm/Evm64/Sgt.lean
@@ -21,7 +21,6 @@ namespace EvmAsm.Rv64
 abbrev evm_sgt_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_sgt
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM SGT: SGT(a, b) = 1 iff a >s b (signed).
     Computed as SLT(b, a): signed compare MSB limbs (b3 vs a3),
     if equal, unsigned borrow chain on lower 3 limbs (b - a).

--- a/EvmAsm/Evm64/SignExtendSpec.lean
+++ b/EvmAsm/Evm64/SignExtendSpec.lean
@@ -19,7 +19,6 @@ open EvmAsm.Rv64.Tactics
 
 namespace EvmAsm.Rv64
 
-set_option maxHeartbeats 800000
 
 -- ============================================================================
 -- Per-body Helper: Sign-extend in-place (4 instructions)
@@ -137,7 +136,6 @@ abbrev signext_body_1_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 24) (.SD .x12 .x10 56))
    (CodeReq.singleton (base + 28) (.JAL .x0 jal_off))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Body 1: limb_idx=1, sign-extend limb 1 at sp+40, fill limbs 2-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + JAL. -/
 theorem signext_body_1_spec (sp : Word)
@@ -182,7 +180,6 @@ abbrev signext_body_0_code (base : Addr) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 24) (.SD .x12 .x10 48))
    (CodeReq.singleton (base + 28) (.SD .x12 .x10 56))))))))
 
-set_option maxHeartbeats 1600000 in
 /-- Body 0: limb_idx=0, sign-extend limb 0 at sp+32, fill limbs 1-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + SD. Falls through to done. -/
 theorem signext_body_0_spec (sp : Word)
@@ -236,7 +233,6 @@ theorem signext_done_spec (sp : Word) (base : Addr) :
 abbrev signext_phase_b_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base signext_phase_b
 
-set_option maxHeartbeats 1600000 in
 /-- Phase B spec: compute sign-extension parameters.
     ANDI x10,x5,7; SLLI x10,x10,3; ADDI x6,x0,56;
     SUB x6,x6,x10; SRLI x5,x5,3.

--- a/EvmAsm/Evm64/Slt.lean
+++ b/EvmAsm/Evm64/Slt.lean
@@ -20,7 +20,6 @@ namespace EvmAsm.Rv64
 abbrev evm_slt_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_slt
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM SLT: SLT(a, b) = 1 iff a <s b (signed).
     If MSB limbs differ, uses RV64 SLT (signed comparison).
     If MSB limbs equal, uses unsigned borrow chain on lower 3 limbs.

--- a/EvmAsm/Evm64/Sub.lean
+++ b/EvmAsm/Evm64/Sub.lean
@@ -16,7 +16,6 @@ namespace EvmAsm.Rv64
 abbrev evm_sub_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_sub
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM SUB: composes 4 per-limb SUB specs + ADDI sp adjustment.
     30 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A - B to sp+32..sp+56, advances sp by 32.

--- a/EvmAsm/Evm64/Xor.lean
+++ b/EvmAsm/Evm64/Xor.lean
@@ -13,7 +13,6 @@ namespace EvmAsm.Rv64
 abbrev evm_xor_code (base : Addr) : CodeReq :=
   CodeReq.ofProg base evm_xor
 
-set_option maxHeartbeats 6400000 in
 /-- Full 256-bit EVM XOR: composes 4 per-limb XOR specs + sp adjustment. -/
 theorem evm_xor_spec (sp base : Addr)
     (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
@@ -33,7 +32,6 @@ theorem evm_xor_spec (sp base : Addr)
   have LADDI := addi_spec_gen_same .x12 sp 32 (base + 64) (by nofun)
   runBlock L0 L1 L2 L3 LADDI
 
-set_option maxHeartbeats 6400000 in
 /-- Stack-level 256-bit EVM XOR. -/
 theorem evm_xor_stack_spec (sp base : Addr)
     (a b : EvmWord) (v7 v6 : Word)


### PR DESCRIPTION
## Summary
- Removed 38 of 42 per-file `set_option maxHeartbeats` settings that compile fine with the default (200000)
- Only 4 remain in `DivModSpec.lean` (2× 4000000) and `DivModCompose.lean` (51200000, 25600000) where proofs genuinely require elevated limits
- 15 files touched, net -38 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)