### PR TITLE
Update README to reflect current opcode spec status

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,19 +106,13 @@ EvmAsm/
     Multiply/                 --   MUL (Program + LimbSpec, schoolbook 4x4 limb)
     DivMod/                   --   DIV/MOD (Program + LimbSpec + Compose, Knuth Algorithm D)
     SignExtend/               --   SIGNEXTEND (Program + LimbSpec)
-    Shift/                    --   SHR/SHL/SAR (Program only, specs pending)
-    Byte/                     --   BYTE (Program only, specs pending)
+    Shift/                    --   SHR/SHL/SAR (Program + LimbSpec + ShlSpec + SarSpec + Compose)
+    Byte/                     --   BYTE (Program + LimbSpec + Spec)
     zkvm-standards/           --   Submodule: zkVM RISC-V target standards
 EvmAsm.lean                  -- Top-level module hub
 EvmAsm/Rv64.lean             -- Rv64 module hub
 EvmAsm/Evm64.lean            -- Evm64 module hub
-execution-specs/              -- Submodule: Ethereum execution specs (uninitialized)
-```
-
-## Lean Toolchain
-
-```
-leanprover/lean4:v4.29.0-rc1
+execution-specs/              -- Submodule: Ethereum execution specs
 ```
 
 ## Building
@@ -142,15 +136,15 @@ This is a **prototype** demonstrating the approach. Current state:
   triples, and automated tactics (`xperm`, `xcancel`, `seqFrame`, `liftSpec`,
   `runBlock` with `@[spec_gen]` auto-resolution).
 - **Evm64 (0 sorry)** — targets `riscv64im_zicclsm-unknown-none-elf`,
-  4x64-bit limbs, 20 fully-proved opcodes:
+  4x64-bit limbs, 22 fully-proved opcodes:
   AND, OR, XOR, NOT, ADD, SUB, MUL, DIV, MOD, SIGNEXTEND,
+  SHR, BYTE,
   LT, GT, EQ, ISZERO, SLT, SGT,
   POP, PUSH0, DUP1-16, SWAP1-16
-- **Programs without full specs**: SHR, SHL, SAR, BYTE (pending CodeReq
-  migration).
+- **Limb-level specs only** (no stack-level `evmWordIs` spec yet): SHL, SAR
 - **0 sorry across the entire codebase** (`lake build` clean).
-- **TODO**: EXP, ADDMOD, MULMOD, SDIV, SMOD, MLOAD, MSTORE, SHR/SHL/SAR/BYTE
-  spec re-creation, interpreter loop, state transition function, connect to
+- **TODO**: SHL/SAR stack-level specs, EXP, ADDMOD, MULMOD, SDIV, SMOD,
+  MLOAD, MSTORE, interpreter loop, state transition function, connect to
   sail-riscv-lean for RISC-V spec compliance, connect to EVM specs in Lean,
   testing.
 


### PR DESCRIPTION
## Summary
- Remove Lean toolchain section (not needed for users)
- Update Shift/ and Byte/ tree entries from "specs pending" to actual file sets
- Bump fully-proved opcode count from 20 → 22 (SHR + BYTE now have stack-level `evmWordIs` specs)
- List SHL/SAR as limb-level specs only, add to TODO
- Fix execution-specs submodule annotation (no longer uninitialized)

🤖 Generated with [Claude Code](https://claude.com/claude-code)