### PR TITLE
Refactor shift codes as unionAll of per-phase ofProg blocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,10 +63,10 @@ When adding or modifying proofs:
 
 ## Critical Rules
 
-- **Do NOT add `set_option maxHeartbeats` to any file** unless you are in `Evm64/Shift/` composition files (Compose, ShlCompose, SarCompose) or subsumption lemmas where `native_decide` on large programs (90-95 instructions) requires it. Heartbeat limits are configured globally in `lakefile.toml`.
+- **Do NOT add `set_option maxHeartbeats` to any file** unless you are in `Evm64/Shift/` composition files (Compose, ShlCompose, SarCompose) for body/path composition proofs. Heartbeat limits are configured globally in `lakefile.toml`.
 - **Do NOT add `set_option maxRecDepth` to any file.** Recursion depth is configured globally in `lakefile.toml`.
 - If a proof times out or hits recursion limits, restructure the proof (e.g., split into smaller lemmas, use intermediate `have` bindings) rather than increasing limits.
-- **Exception for Shift composition files**: `set_option maxHeartbeats 4000000` (or up to 8000000) is acceptable for subsumption lemmas using `native_decide` on 90-95 instruction programs, and `set_option maxHeartbeats 6400000` for body composition proofs.
+- **Exception for Shift composition files**: `set_option maxHeartbeats` up to 6400000 is acceptable for body/path composition proofs (Section 4+) which are bottlenecked by `xperm_hyp` permutation on large atom chains. Subsumption lemmas (Section 2) should NOT need heartbeat overrides — they use structural `unionAll` reasoning.
 
 ## Common Pitfalls
 
@@ -139,8 +139,8 @@ Each EVM opcode follows a three-level proof hierarchy:
 
 1. **Limb-level specs** (`LimbSpec.lean`, `ShlSpec.lean`, `SarSpec.lean`): Per-instruction specs composed with `runBlock`. These operate on raw 64-bit memory cells (`↦ₘ`).
 2. **Composition** (`Compose.lean`, `ShlCompose.lean`, `SarCompose.lean`): Hierarchical composition of limb specs into full-program theorems. Includes:
-   - `xyzCode` definition (`CodeReq.ofProg base evm_xyz`)
-   - Subsumption lemmas (prove each sub-spec's code is contained in the full program)
+   - `xyzCode` definition (`CodeReq.unionAll` of per-phase `CodeReq.ofProg` blocks)
+   - Subsumption lemmas (structural `skipBlock` + `union_mono_left`, no `native_decide` on full programs)
    - Address normalization lemmas (`bv_omega` proofs)
    - Path composition (zero-path/sign-fill for shift >= 256, body-path for shift < 256)
    - Bridge lemmas connecting per-limb results to `getLimb (result) i`
@@ -149,8 +149,8 @@ Each EVM opcode follows a three-level proof hierarchy:
 ### Composition File Pattern (for shift opcodes)
 
 Each shift Compose file (~1000-1200 lines) follows this structure:
-1. **Section 1**: `xyzCode` definition + helpers (`singleton_sub_xyzCode`, `CodeReq_union_sub_both`, `regIs_to_regOwn`)
-2. **Section 2**: Subsumption lemmas — prove each phase/body/path code is subsumed by the full program using `CodeReq.ofProg_mono_sub` or `singleton_sub_xyzCode`
+1. **Section 1**: `xyzCode` definition as `CodeReq.unionAll` of per-phase `ofProg` blocks + length lemmas + `skipBlock` macro + helpers (`singleton_sub_ofProg`, `CodeReq_union_sub_both`, `regIs_to_regOwn`)
+2. **Section 2**: Subsumption lemmas — structural reasoning via `skipBlock` + `union_mono_left` (following the DivMod pattern). For union-chain `_code` definitions (Phase A, Phase C, sign-fill), split into bridge sub-lemma (`chain_code ⊆ ofProg small_block`) + structural sub-lemma (`ofProg small_block ⊆ xyzCode`)
 3. **Section 3**: Address normalization — `bv_omega` proofs for all offset arithmetic
 4. **Section 4**: Zero-path or sign-fill composition — instruction-by-instruction Phase A chain + branch elimination + path composition
 5. **Section 5**: Phase C dispatch — `cpsNBranch` with cascade steps
@@ -168,7 +168,8 @@ Bridge lemmas in `Evm64/Basic.lean` connect per-limb arithmetic to 256-bit opera
 
 - **SAR sign-fill path** uses `sar_sign_fill_path_spec` which takes `.x5` and `.x10` in its precondition (unlike `shr_zero_path_spec` which only takes `.x12`). This means the frame for sign-fill is smaller than for zero-path.
 - **Address normalization direction matters**: The sign-fill path spec uses `sp + 40` directly, not `(sp + 32) + 8`. Don't apply `ha40 : sp + 40 = (sp + 32) + 8` in permutation callbacks if the assertions already use `sp + 40`. Use `xperm_hyp` directly — it handles both forms.
-- **Subsumption for large programs (90-95 instrs)**: Individual `singleton_sub_xyzCode` calls with `native_decide` can timeout. For 7+ instruction blocks, use `CodeReq.ofProg_mono_sub` which batches the proof. For union chains, use `CodeReq_union_sub_both` to decompose.
+- **Subsumption via unionAll (preferred pattern)**: Define `xyzCode` as `CodeReq.unionAll` of per-phase `ofProg` blocks (not a flat `ofProg base evm_xyz`). Then subsumption is structural: `skipBlock` skips disjoint blocks, `union_mono_left` matches the target block. For union-chain `_code` definitions, add a bridge sub-lemma using `singleton_sub_ofProg`/`ofProg_mono_sub` on the **small** sub-program (5-25 elements). Never use `native_decide` on the full 90-95 instruction program — that's the old pattern and requires 4-8M heartbeats. See `DivMod/Compose.lean` for the canonical reference.
+- **`local macro` for file-scoped tactics**: When defining `skipBlock` (or similar) in multiple Compose files, use `local macro` not `macro`. Without `local`, importing multiple files causes "environment already contains" errors.
 - **`sshiftRight (sshiftRight x n) 63 = sshiftRight x 63`**: This identity (sign extension is idempotent under further shifting by 63) requires a case split on `63 + j < 64` and `BitVec.msb_sshiftRight`.
 - **Phase C for SAR**: Same structure as SHR/SHL Phase C but with different BEQ/cascade offsets. The `shr_cascade_step_code`/`shr_cascade_step_spec` are parameterized and reusable. Only the initial BEQ offset and the `phase_c_code` definition need SAR-specific versions.
 - **`native_decide` cannot handle free variables**: For `getLimb_fromLimbs_const`, use `match i with | ⟨0, _⟩ => ...; bv_decide | ⟨1, _⟩ => ...` instead of `fin_cases i <;> bv_decide`.

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -18,8 +18,37 @@ namespace EvmAsm.Rv64
 -- Section 1: shrCode definition and helpers
 -- ============================================================================
 
-/-- The full evm_shr code as a single CodeReq.ofProg block (90 instructions). -/
-abbrev shrCode (base : Addr) : CodeReq := CodeReq.ofProg base evm_shr
+-- Sub-program length lemmas (cheap native_decide on small lists)
+private theorem shr_phase_a_len : shr_phase_a.length = 9 := by native_decide
+private theorem shr_phase_b_len : shr_phase_b.length = 7 := by native_decide
+private theorem shr_phase_c_len : shr_phase_c.length = 5 := by native_decide
+private theorem shr_body_3_prog_len : (shr_body_3_prog 252).length = 7 := by native_decide
+private theorem shr_body_2_prog_len : (shr_body_2_prog 200).length = 13 := by native_decide
+private theorem shr_body_1_prog_len : (shr_body_1_prog 124).length = 19 := by native_decide
+private theorem shr_body_0_prog_len : (shr_body_0_prog 24).length = 25 := by native_decide
+private theorem shr_zero_path_len : shr_zero_path.length = 5 := by native_decide
+
+/-- Skip one ofProg block in a right-nested union via range disjointness. -/
+local macro "skipBlock" : tactic =>
+  `(tactic| apply CodeReq.mono_union_right
+      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+        simp only [shr_phase_a_len, shr_phase_b_len, shr_phase_c_len,
+          shr_body_3_prog_len, shr_body_2_prog_len, shr_body_1_prog_len,
+          shr_body_0_prog_len, shr_zero_path_len] at hk1 hk2
+        bv_omega)))
+
+/-- The full evm_shr code split into 8 per-phase CodeReq.ofProg blocks. -/
+abbrev shrCode (base : Addr) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base shr_phase_a,                      -- block 0: 9 instrs at +0
+    CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1: 7 instrs at +36
+    CodeReq.ofProg (base + 64) shr_phase_c,               -- block 2: 5 instrs at +64
+    CodeReq.ofProg (base + 84) (shr_body_3_prog 252),     -- block 3: 7 instrs at +84
+    CodeReq.ofProg (base + 112) (shr_body_2_prog 200),    -- block 4: 13 instrs at +112
+    CodeReq.ofProg (base + 164) (shr_body_1_prog 124),    -- block 5: 19 instrs at +164
+    CodeReq.ofProg (base + 240) (shr_body_0_prog 24),     -- block 6: 25 instrs at +240
+    CodeReq.ofProg (base + 340) shr_zero_path              -- block 7: 5 instrs at +340
+  ]
 
 /-- Weaken concrete register to existential ownership. -/
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
@@ -36,172 +65,191 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | none => simp [h1a] at h; exact h2 a i h
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
-/-- A singleton at instruction k of evm_shr is subsumed by shrCode. -/
-private theorem singleton_sub_shrCode (base addr : Addr) (instr : Instr) (k : Nat)
-    (hk : k < evm_shr.length)
+/-- A singleton at instruction k of a small program is subsumed by its ofProg.
+    Same pattern as the old singleton_sub_shrCode but parametric over any program. -/
+private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+    (hk : k < prog.length)
+    (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
-    (h_instr : evm_shr.get ⟨k, hk⟩ = instr) :
-    ∀ a i, CodeReq.singleton addr instr a = some i → shrCode base a = some i :=
-  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base evm_shr k addr hk
-    (by native_decide) h_addr)
+    (h_instr : prog.get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i → (CodeReq.ofProg base prog) a = some i :=
+  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base prog k addr hk hbound h_addr)
 
 -- ============================================================================
--- Section 2: Subsumption lemmas
+-- Section 2: Subsumption lemmas (via unionAll structural reasoning)
+--
+-- Strategy: shrCode is a unionAll of 8 ofProg blocks. Each sub-block code
+-- is proved subsumed by first bridging to the matching ofProg block (cheap
+-- native_decide on small lists), then using structural union monotonicity.
 -- ============================================================================
 
-/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shrCode. -/
-private theorem phase_a_sub_shrCode (base : Addr) :
-    ∀ a i, shr_phase_a_code base a = some i → shrCode base a = some i := by
-  unfold shr_phase_a_code
+-- Bridge: shr_phase_a_code (union chain) ⊆ ofProg shr_phase_a (9-element list)
+private theorem phase_a_code_sub_ofProg (base : Addr) :
+    ∀ a i, shr_phase_a_code base a = some i →
+      (CodeReq.ofProg base shr_phase_a) a = some i := by
+  unfold shr_phase_a_code shr_ld_or_acc_code
   apply CodeReq_union_sub_both
-  · -- singleton base (.LD .x5 .x12 8) → instr 0
-    exact singleton_sub_shrCode base base (.LD .x5 .x12 8) 0
-      (by native_decide) (by bv_omega) (by native_decide)
+  · exact singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
   · apply CodeReq_union_sub_both
-    · -- shr_ld_or_acc_code 16 (base+4) → instrs 1-2
-      unfold shr_ld_or_acc_code
-      exact CodeReq.ofProg_mono_sub base (base + 4) evm_shr (shr_ld_or_acc_prog 16) 1
+    · exact CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
     · apply CodeReq_union_sub_both
-      · -- shr_ld_or_acc_code 24 (base+12) → instrs 3-4
-        unfold shr_ld_or_acc_code
-        exact CodeReq.ofProg_mono_sub base (base + 12) evm_shr (shr_ld_or_acc_prog 24) 3
+      · exact CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
           (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
       · apply CodeReq_union_sub_both
-        · -- singleton (base+20) (.BNE .x5 .x0 320) → instr 5
-          exact singleton_sub_shrCode base (base + 20) (.BNE .x5 .x0 320) 5
-            (by native_decide) (by bv_omega) (by native_decide)
+        · exact singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
+            (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
         · apply CodeReq_union_sub_both
-          · -- singleton (base+24) (.LD .x5 .x12 0) → instr 6
-            exact singleton_sub_shrCode base (base + 24) (.LD .x5 .x12 0) 6
-              (by native_decide) (by bv_omega) (by native_decide)
+          · exact singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
+              (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
           · apply CodeReq_union_sub_both
-            · -- singleton (base+28) (.SLTIU .x10 .x5 256) → instr 7
-              exact singleton_sub_shrCode base (base + 28) (.SLTIU .x10 .x5 256) 7
-                (by native_decide) (by bv_omega) (by native_decide)
-            · -- singleton (base+32) (.BEQ .x10 .x0 308) → instr 8
-              exact singleton_sub_shrCode base (base + 32) (.BEQ .x10 .x0 308) 8
-                (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
 
-/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shrCode. -/
+/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shrCode (block 0). -/
+private theorem phase_a_sub_shrCode (base : Addr) :
+    ∀ a i, shr_phase_a_code base a = some i → shrCode base a = some i := by
+  intro a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i (phase_a_code_sub_ofProg base a i h)
+
+/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shrCode (block 1). -/
 private theorem phase_b_sub_shrCode (base : Addr) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shrCode base a = some i := by
-  unfold shr_phase_b_code
-  exact CodeReq.ofProg_mono_sub base (base + 36) evm_shr shr_phase_b 9
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_phase_b_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-private theorem cascade_17_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 68) (shr_cascade_step_prog 1 92) a = some i → shrCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 68) evm_shr (shr_cascade_step_prog 1 92) 17
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+-- Bridge: shr_phase_c_code (union chain) ⊆ ofProg shr_phase_c (5-element list)
+private theorem phase_c_code_sub_ofProg (base : Addr) :
+    ∀ a i, shr_phase_c_code base a = some i →
+      (CodeReq.ofProg base shr_phase_c) a = some i := by
+  unfold shr_phase_c_code shr_cascade_step_code
+  apply CodeReq_union_sub_both
+  · exact singleton_sub_ofProg base base shr_phase_c (.BEQ .x5 .x0 176) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+  · apply CodeReq_union_sub_both
+    · exact CodeReq.ofProg_mono_sub base (base + 4) shr_phase_c (shr_cascade_step_prog 1 92) 1
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+    · exact CodeReq.ofProg_mono_sub base (base + 12) shr_phase_c (shr_cascade_step_prog 2 32) 3
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-set_option maxHeartbeats 4000000 in
-private theorem cascade_19_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 76) (shr_cascade_step_prog 2 32) a = some i → shrCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 76) evm_shr (shr_cascade_step_prog 2 32) 19
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+/-- ofProg shr_phase_c (block 2) is subsumed by shrCode. -/
+private theorem ofProg_phase_c_sub_shrCode (base : Addr) :
+    ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shrCode base a = some i := by
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Phase C code (union chain, 5 instrs at +64) is subsumed by shrCode. -/
+/-- Phase C code (union chain, 5 instrs at +64) is subsumed by shrCode (block 2). -/
 private theorem phase_c_sub_shrCode (base : Addr) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shrCode base a = some i := by
-  unfold shr_phase_c_code
-  apply CodeReq_union_sub_both
-  · -- singleton (base+64) (.BEQ .x5 .x0 176) → instr 16
-    exact singleton_sub_shrCode base (base + 64) (.BEQ .x5 .x0 176) 16
-      (by native_decide) (by bv_omega) (by native_decide)
-  · apply CodeReq_union_sub_both
-    · -- shr_cascade_step_code 1 92 (base+68) → instrs 17-18
-      unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 4 = base + 68 := by bv_omega
-      rw [this]
-      exact cascade_17_sub_shrCode base
-    · -- shr_cascade_step_code 2 32 (base+76) → instrs 19-20
-      unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 12 = base + 76 := by bv_omega
-      rw [this]
-      exact cascade_19_sub_shrCode base
+  intro a i h
+  exact ofProg_phase_c_sub_shrCode base a i (phase_c_code_sub_ofProg (base + 64) a i h)
 
-/-- Body 3 code (ofProg, 7 instrs at +84) is subsumed by shrCode. -/
+/-- Body 3 code (ofProg, 7 instrs at +84) is subsumed by shrCode (block 3). -/
 private theorem body_3_sub_shrCode (base : Addr) :
     ∀ a i, shr_body_3_code 252 (base + 84) a = some i → shrCode base a = some i := by
-  unfold shr_body_3_code
-  exact CodeReq.ofProg_mono_sub base (base + 84) evm_shr (shr_body_3_prog 252) 21
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_body_3_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Body 2 code (ofProg, 13 instrs at +112) is subsumed by shrCode. -/
+/-- Body 2 code (ofProg, 13 instrs at +112) is subsumed by shrCode (block 4). -/
 private theorem body_2_sub_shrCode (base : Addr) :
     ∀ a i, shr_body_2_code 200 (base + 112) a = some i → shrCode base a = some i := by
-  unfold shr_body_2_code
-  exact CodeReq.ofProg_mono_sub base (base + 112) evm_shr (shr_body_2_prog 200) 28
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_body_2_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Body 1 code (ofProg, 19 instrs at +164) is subsumed by shrCode. -/
+/-- Body 1 code (ofProg, 19 instrs at +164) is subsumed by shrCode (block 5). -/
 private theorem body_1_sub_shrCode (base : Addr) :
     ∀ a i, shr_body_1_code 124 (base + 164) a = some i → shrCode base a = some i := by
-  unfold shr_body_1_code
-  exact CodeReq.ofProg_mono_sub base (base + 164) evm_shr (shr_body_1_prog 124) 41
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_body_1_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Body 0 code (ofProg, 25 instrs at +240) is subsumed by shrCode. -/
+/-- Body 0 code (ofProg, 25 instrs at +240) is subsumed by shrCode (block 6). -/
 private theorem body_0_sub_shrCode (base : Addr) :
     ∀ a i, shr_body_0_code 24 (base + 240) a = some i → shrCode base a = some i := by
-  unfold shr_body_0_code
-  exact CodeReq.ofProg_mono_sub base (base + 240) evm_shr (shr_body_0_prog 24) 60
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_body_0_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shrCode. -/
+/-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shrCode (block 7). -/
 private theorem zero_path_sub_shrCode (base : Addr) :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shrCode base a = some i := by
-  unfold shr_zero_path_code
-  exact CodeReq.ofProg_mono_sub base (base + 340) evm_shr shr_zero_path 85
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_zero_path_code shrCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
+-- Each bridges singleton → ofProg shr_phase_a (9-element) → shrCode block 0
 
 /-- LD x5 x12 8 singleton at base is subsumed by shrCode. -/
 private theorem ld_s1_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shrCode base a = some i :=
-  singleton_sub_shrCode base base (.LD .x5 .x12 8) 0
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shrCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD/OR acc at base+4 (2 instrs) is subsumed by shrCode. -/
 private theorem ld_or_16_sub_shrCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shrCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 4) evm_shr (shr_ld_or_acc_prog 16) 1
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD/OR acc at base+12 (2 instrs) is subsumed by shrCode. -/
 private theorem ld_or_24_sub_shrCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shrCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 12) evm_shr (shr_ld_or_acc_prog 24) 3
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- BNE singleton at base+20 is subsumed by shrCode. -/
 private theorem bne_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shrCode base a = some i :=
-  singleton_sub_shrCode base (base + 20) (.BNE .x5 .x0 320) 5
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shrCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD x5 x12 0 singleton at base+24 is subsumed by shrCode. -/
 private theorem ld_s0_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shrCode base a = some i :=
-  singleton_sub_shrCode base (base + 24) (.LD .x5 .x12 0) 6
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shrCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- SLTIU singleton at base+28 is subsumed by shrCode. -/
 private theorem sltiu_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shrCode base a = some i :=
-  singleton_sub_shrCode base (base + 28) (.SLTIU .x10 .x5 256) 7
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shrCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 /-- BEQ singleton at base+32 is subsumed by shrCode. -/
 private theorem beq_sub_shrCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shrCode base a = some i :=
-  singleton_sub_shrCode base (base + 32) (.BEQ .x10 .x0 308) 8
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shrCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shrCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 -- ============================================================================
 -- Section 3: Address normalization lemmas

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -20,8 +20,37 @@ namespace EvmAsm.Rv64
 -- Section 1: sarCode definition and helpers
 -- ============================================================================
 
-/-- The full evm_sar code as a single CodeReq.ofProg block (95 instructions). -/
-abbrev sarCode (base : Addr) : CodeReq := CodeReq.ofProg base evm_sar
+-- Sub-program length lemmas (cheap native_decide on small lists)
+private theorem sar_phase_a_len : sar_phase_a.length = 9 := by native_decide
+private theorem shr_phase_b_len : shr_phase_b.length = 7 := by native_decide
+private theorem sar_phase_c_len : sar_phase_c.length = 5 := by native_decide
+private theorem sar_body_3_prog_len : (sar_body_3_prog 268).length = 8 := by native_decide
+private theorem sar_body_2_prog_len : (sar_body_2_prog 212).length = 14 := by native_decide
+private theorem sar_body_1_prog_len : (sar_body_1_prog 132).length = 20 := by native_decide
+private theorem sar_body_0_prog_len : (sar_body_0_prog 32).length = 25 := by native_decide
+private theorem sar_sign_fill_path_len : sar_sign_fill_path.length = 7 := by native_decide
+
+/-- Skip one ofProg block in a right-nested union via range disjointness. -/
+local macro "skipBlock" : tactic =>
+  `(tactic| apply CodeReq.mono_union_right
+      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+        simp only [sar_phase_a_len, shr_phase_b_len, sar_phase_c_len,
+          sar_body_3_prog_len, sar_body_2_prog_len, sar_body_1_prog_len,
+          sar_body_0_prog_len, sar_sign_fill_path_len] at hk1 hk2
+        bv_omega)))
+
+/-- The full evm_sar code split into 8 per-phase CodeReq.ofProg blocks. -/
+abbrev sarCode (base : Addr) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base sar_phase_a,                      -- block 0: 9 instrs at +0
+    CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1: 7 instrs at +36
+    CodeReq.ofProg (base + 64) sar_phase_c,               -- block 2: 5 instrs at +64
+    CodeReq.ofProg (base + 84) (sar_body_3_prog 268),     -- block 3: 8 instrs at +84
+    CodeReq.ofProg (base + 116) (sar_body_2_prog 212),    -- block 4: 14 instrs at +116
+    CodeReq.ofProg (base + 172) (sar_body_1_prog 132),    -- block 5: 20 instrs at +172
+    CodeReq.ofProg (base + 252) (sar_body_0_prog 32),     -- block 6: 25 instrs at +252
+    CodeReq.ofProg (base + 352) sar_sign_fill_path         -- block 7: 7 instrs at +352
+  ]
 
 /-- Weaken concrete register to existential ownership. -/
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
@@ -38,84 +67,83 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | none => simp [h1a] at h; exact h2 a i h
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
-/-- A singleton at instruction k of evm_sar is subsumed by sarCode. -/
-private theorem singleton_sub_sarCode (base addr : Addr) (instr : Instr) (k : Nat)
-    (hk : k < evm_sar.length)
+private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+    (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
-    (h_instr : evm_sar.get ⟨k, hk⟩ = instr) :
-    ∀ a i, CodeReq.singleton addr instr a = some i → sarCode base a = some i :=
-  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base evm_sar k addr hk
-    (by native_decide) h_addr)
+    (h_instr : prog.get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i → (CodeReq.ofProg base prog) a = some i :=
+  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base prog k addr hk hbound h_addr)
 
 -- ============================================================================
--- Section 2: Subsumption lemmas
+-- Section 2: Subsumption lemmas (via unionAll structural reasoning)
 -- ============================================================================
 
--- Phase A individual instruction subsumption
+-- Phase A individual instruction subsumption (via ofProg sar_phase_a, 9-element list)
 
 private theorem ld_s1_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base base (.LD .x5 .x12 8) 0
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → sarCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base base sar_phase_a (.LD .x5 .x12 8) 0
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_or_16_sub_sarCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → sarCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 4) evm_sar (shr_ld_or_acc_prog 16) 1
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 4) sar_phase_a (shr_ld_or_acc_prog 16) 1
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_or_24_sub_sarCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → sarCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 12) evm_sar (shr_ld_or_acc_prog 24) 3
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 12) sar_phase_a (shr_ld_or_acc_prog 24) 3
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem bne_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 332) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base (base + 20) (.BNE .x5 .x0 332) 5
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 332) a = some i → sarCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 20) sar_phase_a (.BNE .x5 .x0 332) 5
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_s0_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base (base + 24) (.LD .x5 .x12 0) 6
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → sarCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 24) sar_phase_a (.LD .x5 .x12 0) 6
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem sltiu_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base (base + 28) (.SLTIU .x10 .x5 256) 7
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → sarCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 28) sar_phase_a (.SLTIU .x10 .x5 256) 7
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem beq_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 320) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base (base + 32) (.BEQ .x10 .x0 320) 8
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 320) a = some i → sarCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 32) sar_phase_a (.BEQ .x10 .x0 320) 8
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
-/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by sarCode. -/
+/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by sarCode (block 1). -/
 private theorem phase_b_sub_sarCode (base : Addr) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → sarCode base a = some i := by
-  unfold shr_phase_b_code
-  exact CodeReq.ofProg_mono_sub base (base + 36) evm_sar shr_phase_b 9
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_phase_b_code sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock
+  exact CodeReq.union_mono_left _ _
 
 -- Phase C subsumption (SAR-specific offsets)
-
-set_option maxHeartbeats 4000000 in
-private theorem cascade_17_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 68) (shr_cascade_step_prog 1 100) a = some i → sarCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 68) evm_sar (shr_cascade_step_prog 1 100) 17
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
-
-set_option maxHeartbeats 4000000 in
-private theorem cascade_19_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 76) (shr_cascade_step_prog 2 36) a = some i → sarCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 76) evm_sar (shr_cascade_step_prog 2 36) 19
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
-
-/-- Phase C: BEQ singleton at base+64 with offset 188 (SAR-specific). -/
-private theorem beq_ls0_sub_sarCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 64) (.BEQ .x5 .x0 188) a = some i → sarCode base a = some i :=
-  singleton_sub_sarCode base (base + 64) (.BEQ .x5 .x0 188) 16
-    (by native_decide) (by bv_omega) (by native_decide)
 
 /-- SAR Phase C code (union chain, 5 instrs at +64). -/
 abbrev sar_phase_c_code (base : Addr) : CodeReq :=
@@ -123,84 +151,99 @@ abbrev sar_phase_c_code (base : Addr) : CodeReq :=
   (CodeReq.union (shr_cascade_step_code 1 100 (base + 4))
   (shr_cascade_step_code 2 36 (base + 12)))
 
-/-- SAR Phase C code is subsumed by sarCode. -/
+-- Bridge: sar_phase_c_code (union chain) ⊆ ofProg sar_phase_c (5-element list)
+private theorem sar_phase_c_code_sub_ofProg (base : Addr) :
+    ∀ a i, sar_phase_c_code base a = some i →
+      (CodeReq.ofProg base sar_phase_c) a = some i := by
+  unfold sar_phase_c_code shr_cascade_step_code
+  apply CodeReq_union_sub_both
+  · exact singleton_sub_ofProg base base sar_phase_c (.BEQ .x5 .x0 188) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+  · apply CodeReq_union_sub_both
+    · exact CodeReq.ofProg_mono_sub base (base + 4) sar_phase_c (shr_cascade_step_prog 1 100) 1
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+    · exact CodeReq.ofProg_mono_sub base (base + 12) sar_phase_c (shr_cascade_step_prog 2 36) 3
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+
+private theorem ofProg_phase_c_sub_sarCode (base : Addr) :
+    ∀ a i, (CodeReq.ofProg (base + 64) sar_phase_c) a = some i → sarCode base a = some i := by
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
+
+/-- SAR Phase C code is subsumed by sarCode (block 2). -/
 private theorem sar_phase_c_sub_sarCode (base : Addr) :
     ∀ a i, sar_phase_c_code (base + 64) a = some i → sarCode base a = some i := by
-  unfold sar_phase_c_code
-  apply CodeReq_union_sub_both
-  · exact beq_ls0_sub_sarCode base
-  · apply CodeReq_union_sub_both
-    · unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 4 = base + 68 := by bv_omega
-      rw [this]
-      exact cascade_17_sub_sarCode base
-    · unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 12 = base + 76 := by bv_omega
-      rw [this]
-      exact cascade_19_sub_sarCode base
+  intro a i h
+  exact ofProg_phase_c_sub_sarCode base a i (sar_phase_c_code_sub_ofProg (base + 64) a i h)
 
 -- Body subsumption lemmas
 
-set_option maxHeartbeats 4000000 in
-/-- SAR Body 3 code (8 instrs at +84) is subsumed by sarCode. -/
+/-- SAR Body 3 code (8 instrs at +84) is subsumed by sarCode (block 3). -/
 private theorem sar_body_3_sub_sarCode (base : Addr) :
     ∀ a i, sar_body_3_code (base + 84) 268 a = some i → sarCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 84) evm_sar (sar_body_3_prog 268) 21
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold sar_body_3_code sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SAR Body 2 code (14 instrs at +116) is subsumed by sarCode. -/
+/-- SAR Body 2 code (14 instrs at +116) is subsumed by sarCode (block 4). -/
 private theorem sar_body_2_sub_sarCode (base : Addr) :
     ∀ a i, sar_body_2_code (base + 116) 212 a = some i → sarCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 116) evm_sar (sar_body_2_prog 212) 29
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold sar_body_2_code sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SAR Body 1 code (20 instrs at +172) is subsumed by sarCode. -/
+/-- SAR Body 1 code (20 instrs at +172) is subsumed by sarCode (block 5). -/
 private theorem sar_body_1_sub_sarCode (base : Addr) :
     ∀ a i, sar_body_1_code (base + 172) 132 a = some i → sarCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 172) evm_sar (sar_body_1_prog 132) 43
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold sar_body_1_code sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SAR Body 0 code (25 instrs at +252) is subsumed by sarCode. -/
+/-- SAR Body 0 code (25 instrs at +252) is subsumed by sarCode (block 6). -/
 private theorem sar_body_0_sub_sarCode (base : Addr) :
     ∀ a i, sar_body_0_code (base + 252) 32 a = some i → sarCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 252) evm_sar (sar_body_0_prog 32) 63
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold sar_body_0_code sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 8000000 in
-/-- Sign-fill path code (7 instrs at +352) is subsumed by sarCode. -/
-private theorem sign_fill_sub_sarCode (base : Addr) :
-    ∀ a i, sar_sign_fill_path_code (base + 352) a = some i → sarCode base a = some i := by
+-- Bridge: sar_sign_fill_path_code (union chain) ⊆ ofProg sar_sign_fill_path (7-element list)
+private theorem sign_fill_code_sub_ofProg (base : Addr) :
+    ∀ a i, sar_sign_fill_path_code base a = some i →
+      (CodeReq.ofProg base sar_sign_fill_path) a = some i := by
   unfold sar_sign_fill_path_code
   apply CodeReq_union_sub_both
-  · -- singleton (base+352) (.LD .x5 .x12 56) → instr 88
-    exact singleton_sub_sarCode base (base + 352) (.LD .x5 .x12 56) 88
-      (by native_decide) (by bv_omega) (by native_decide)
+  · exact singleton_sub_ofProg base base sar_sign_fill_path (.LD .x5 .x12 56) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
   · apply CodeReq_union_sub_both
-    · -- singleton (base+356) (.SRAI .x5 .x5 63) → instr 89
-      exact singleton_sub_sarCode base ((base + 352) + 4) (.SRAI .x5 .x5 63) 89
-        (by native_decide) (by bv_omega) (by native_decide)
+    · exact singleton_sub_ofProg base (base + 4) sar_sign_fill_path (.SRAI .x5 .x5 63) 1
+        (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
     · apply CodeReq_union_sub_both
-      · -- singleton (base+360) (.ADDI .x12 .x12 32) → instr 90
-        exact singleton_sub_sarCode base ((base + 352) + 8) (.ADDI .x12 .x12 32) 90
-          (by native_decide) (by bv_omega) (by native_decide)
+      · exact singleton_sub_ofProg base (base + 8) sar_sign_fill_path (.ADDI .x12 .x12 32) 2
+          (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
       · apply CodeReq_union_sub_both
-        · -- singleton (base+364) (.SD .x12 .x5 0) → instr 91
-          exact singleton_sub_sarCode base ((base + 352) + 12) (.SD .x12 .x5 0) 91
-            (by native_decide) (by bv_omega) (by native_decide)
+        · exact singleton_sub_ofProg base (base + 12) sar_sign_fill_path (.SD .x12 .x5 0) 3
+            (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
         · apply CodeReq_union_sub_both
-          · -- singleton (base+368) (.SD .x12 .x5 8) → instr 92
-            exact singleton_sub_sarCode base ((base + 352) + 16) (.SD .x12 .x5 8) 92
-              (by native_decide) (by bv_omega) (by native_decide)
+          · exact singleton_sub_ofProg base (base + 16) sar_sign_fill_path (.SD .x12 .x5 8) 4
+              (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
           · apply CodeReq_union_sub_both
-            · -- singleton (base+372) (.SD .x12 .x5 16) → instr 93
-              exact singleton_sub_sarCode base ((base + 352) + 20) (.SD .x12 .x5 16) 93
-                (by native_decide) (by bv_omega) (by native_decide)
-            · -- singleton (base+376) (.SD .x12 .x5 24) → instr 94
-              exact singleton_sub_sarCode base ((base + 352) + 24) (.SD .x12 .x5 24) 94
-                (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 20) sar_sign_fill_path (.SD .x12 .x5 16) 5
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 24) sar_sign_fill_path (.SD .x12 .x5 24) 6
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+
+private theorem ofProg_sign_fill_sub_sarCode (base : Addr) :
+    ∀ a i, (CodeReq.ofProg (base + 352) sar_sign_fill_path) a = some i → sarCode base a = some i := by
+  unfold sarCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
+
+/-- Sign-fill path code (7 instrs at +352) is subsumed by sarCode (block 7). -/
+private theorem sign_fill_sub_sarCode (base : Addr) :
+    ∀ a i, sar_sign_fill_path_code (base + 352) a = some i → sarCode base a = some i := by
+  intro a i h
+  exact ofProg_sign_fill_sub_sarCode base a i (sign_fill_code_sub_ofProg (base + 352) a i h)
 
 -- ============================================================================
 -- Section 3: Address normalization lemmas

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -20,8 +20,37 @@ namespace EvmAsm.Rv64
 -- Section 1: shlCode definition and helpers
 -- ============================================================================
 
-/-- The full evm_shl code as a single CodeReq.ofProg block (90 instructions). -/
-abbrev shlCode (base : Addr) : CodeReq := CodeReq.ofProg base evm_shl
+-- Sub-program length lemmas (cheap native_decide on small lists)
+private theorem shr_phase_a_len : shr_phase_a.length = 9 := by native_decide
+private theorem shr_phase_b_len : shr_phase_b.length = 7 := by native_decide
+private theorem shr_phase_c_len : shr_phase_c.length = 5 := by native_decide
+private theorem shl_body_3_prog_len : (shl_body_3_prog 252).length = 7 := by native_decide
+private theorem shl_body_2_prog_len : (shl_body_2_prog 200).length = 13 := by native_decide
+private theorem shl_body_1_prog_len : (shl_body_1_prog 124).length = 19 := by native_decide
+private theorem shl_body_0_prog_len : (shl_body_0_prog 24).length = 25 := by native_decide
+private theorem shr_zero_path_len : shr_zero_path.length = 5 := by native_decide
+
+/-- Skip one ofProg block in a right-nested union via range disjointness. -/
+local macro "skipBlock" : tactic =>
+  `(tactic| apply CodeReq.mono_union_right
+      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+        simp only [shr_phase_a_len, shr_phase_b_len, shr_phase_c_len,
+          shl_body_3_prog_len, shl_body_2_prog_len, shl_body_1_prog_len,
+          shl_body_0_prog_len, shr_zero_path_len] at hk1 hk2
+        bv_omega)))
+
+/-- The full evm_shl code split into 8 per-phase CodeReq.ofProg blocks. -/
+abbrev shlCode (base : Addr) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base shr_phase_a,                      -- block 0 (shared with SHR)
+    CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1 (shared)
+    CodeReq.ofProg (base + 64) shr_phase_c,               -- block 2 (shared)
+    CodeReq.ofProg (base + 84) (shl_body_3_prog 252),     -- block 3
+    CodeReq.ofProg (base + 112) (shl_body_2_prog 200),    -- block 4
+    CodeReq.ofProg (base + 164) (shl_body_1_prog 124),    -- block 5
+    CodeReq.ofProg (base + 240) (shl_body_0_prog 24),     -- block 6
+    CodeReq.ofProg (base + 340) shr_zero_path              -- block 7 (shared)
+  ]
 
 /-- Weaken concrete register to existential ownership. -/
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
@@ -38,155 +67,175 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | none => simp [h1a] at h; exact h2 a i h
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
-/-- A singleton at instruction k of evm_shl is subsumed by shlCode. -/
-private theorem singleton_sub_shlCode (base addr : Addr) (instr : Instr) (k : Nat)
-    (hk : k < evm_shl.length)
+private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+    (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
-    (h_instr : evm_shl.get ⟨k, hk⟩ = instr) :
-    ∀ a i, CodeReq.singleton addr instr a = some i → shlCode base a = some i :=
-  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base evm_shl k addr hk
-    (by native_decide) h_addr)
+    (h_instr : prog.get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i → (CodeReq.ofProg base prog) a = some i :=
+  CodeReq.singleton_mono (h_instr ▸ CodeReq.ofProg_lookup_addr base prog k addr hk hbound h_addr)
 
 -- ============================================================================
--- Section 2: Subsumption lemmas
+-- Section 2: Subsumption lemmas (via unionAll structural reasoning)
 -- ============================================================================
 
-/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shlCode. -/
-private theorem phase_a_sub_shlCode (base : Addr) :
-    ∀ a i, shr_phase_a_code base a = some i → shlCode base a = some i := by
-  unfold shr_phase_a_code
+-- Bridge: shr_phase_a_code (union chain) ⊆ ofProg shr_phase_a (9-element list)
+private theorem phase_a_code_sub_ofProg (base : Addr) :
+    ∀ a i, shr_phase_a_code base a = some i →
+      (CodeReq.ofProg base shr_phase_a) a = some i := by
+  unfold shr_phase_a_code shr_ld_or_acc_code
   apply CodeReq_union_sub_both
-  · exact singleton_sub_shlCode base base (.LD .x5 .x12 8) 0
-      (by native_decide) (by bv_omega) (by native_decide)
+  · exact singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
   · apply CodeReq_union_sub_both
-    · unfold shr_ld_or_acc_code
-      exact CodeReq.ofProg_mono_sub base (base + 4) evm_shl (shr_ld_or_acc_prog 16) 1
+    · exact CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
     · apply CodeReq_union_sub_both
-      · unfold shr_ld_or_acc_code
-        exact CodeReq.ofProg_mono_sub base (base + 12) evm_shl (shr_ld_or_acc_prog 24) 3
+      · exact CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
           (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
       · apply CodeReq_union_sub_both
-        · exact singleton_sub_shlCode base (base + 20) (.BNE .x5 .x0 320) 5
-            (by native_decide) (by bv_omega) (by native_decide)
+        · exact singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
+            (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
         · apply CodeReq_union_sub_both
-          · exact singleton_sub_shlCode base (base + 24) (.LD .x5 .x12 0) 6
-              (by native_decide) (by bv_omega) (by native_decide)
+          · exact singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
+              (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
           · apply CodeReq_union_sub_both
-            · exact singleton_sub_shlCode base (base + 28) (.SLTIU .x10 .x5 256) 7
-                (by native_decide) (by bv_omega) (by native_decide)
-            · exact singleton_sub_shlCode base (base + 32) (.BEQ .x10 .x0 308) 8
-                (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+            · exact singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
+                (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
 
-/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shlCode. -/
+/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shlCode (block 0). -/
+private theorem phase_a_sub_shlCode (base : Addr) :
+    ∀ a i, shr_phase_a_code base a = some i → shlCode base a = some i := by
+  intro a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i (phase_a_code_sub_ofProg base a i h)
+
+/-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shlCode (block 1). -/
 private theorem phase_b_sub_shlCode (base : Addr) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shlCode base a = some i := by
-  unfold shr_phase_b_code
-  exact CodeReq.ofProg_mono_sub base (base + 36) evm_shl shr_phase_b 9
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_phase_b_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-private theorem cascade_17_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 68) (shr_cascade_step_prog 1 92) a = some i → shlCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 68) evm_shl (shr_cascade_step_prog 1 92) 17
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+-- Bridge: shr_phase_c_code (union chain) ⊆ ofProg shr_phase_c (5-element list)
+private theorem phase_c_code_sub_ofProg (base : Addr) :
+    ∀ a i, shr_phase_c_code base a = some i →
+      (CodeReq.ofProg base shr_phase_c) a = some i := by
+  unfold shr_phase_c_code shr_cascade_step_code
+  apply CodeReq_union_sub_both
+  · exact singleton_sub_ofProg base base shr_phase_c (.BEQ .x5 .x0 176) 0
+      (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
+  · apply CodeReq_union_sub_both
+    · exact CodeReq.ofProg_mono_sub base (base + 4) shr_phase_c (shr_cascade_step_prog 1 92) 1
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+    · exact CodeReq.ofProg_mono_sub base (base + 12) shr_phase_c (shr_cascade_step_prog 2 32) 3
+        (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-set_option maxHeartbeats 4000000 in
-private theorem cascade_19_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.ofProg (base + 76) (shr_cascade_step_prog 2 32) a = some i → shlCode base a = some i :=
-  CodeReq.ofProg_mono_sub base (base + 76) evm_shl (shr_cascade_step_prog 2 32) 19
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+private theorem ofProg_phase_c_sub_shlCode (base : Addr) :
+    ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shlCode base a = some i := by
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Phase C code (union chain, 5 instrs at +64) is subsumed by shlCode. -/
+/-- Phase C code (union chain, 5 instrs at +64) is subsumed by shlCode (block 2). -/
 private theorem phase_c_sub_shlCode (base : Addr) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shlCode base a = some i := by
-  unfold shr_phase_c_code
-  apply CodeReq_union_sub_both
-  · exact singleton_sub_shlCode base (base + 64) (.BEQ .x5 .x0 176) 16
-      (by native_decide) (by bv_omega) (by native_decide)
-  · apply CodeReq_union_sub_both
-    · unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 4 = base + 68 := by bv_omega
-      rw [this]
-      exact cascade_17_sub_shlCode base
-    · unfold shr_cascade_step_code
-      have : (base + 64 : Addr) + 12 = base + 76 := by bv_omega
-      rw [this]
-      exact cascade_19_sub_shlCode base
+  intro a i h
+  exact ofProg_phase_c_sub_shlCode base a i (phase_c_code_sub_ofProg (base + 64) a i h)
 
-set_option maxHeartbeats 4000000 in
-/-- SHL Body 3 code (7 instrs at +84) is subsumed by shlCode. -/
+/-- SHL Body 3 code (7 instrs at +84) is subsumed by shlCode (block 3). -/
 private theorem shl_body_3_sub_shlCode (base : Addr) :
     ∀ a i, shl_body_3_code (base + 84) 252 a = some i → shlCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 84) evm_shl (shl_body_3_prog 252) 21
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shl_body_3_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SHL Body 2 code (13 instrs at +112) is subsumed by shlCode. -/
+/-- SHL Body 2 code (13 instrs at +112) is subsumed by shlCode (block 4). -/
 private theorem shl_body_2_sub_shlCode (base : Addr) :
     ∀ a i, shl_body_2_code (base + 112) 200 a = some i → shlCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 112) evm_shl (shl_body_2_prog 200) 28
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shl_body_2_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SHL Body 1 code (19 instrs at +164) is subsumed by shlCode. -/
+/-- SHL Body 1 code (19 instrs at +164) is subsumed by shlCode (block 5). -/
 private theorem shl_body_1_sub_shlCode (base : Addr) :
     ∀ a i, shl_body_1_code (base + 164) 124 a = some i → shlCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 164) evm_shl (shl_body_1_prog 124) 41
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shl_body_1_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-set_option maxHeartbeats 4000000 in
-/-- SHL Body 0 code (25 instrs at +240) is subsumed by shlCode. -/
+/-- SHL Body 0 code (25 instrs at +240) is subsumed by shlCode (block 6). -/
 private theorem shl_body_0_sub_shlCode (base : Addr) :
     ∀ a i, shl_body_0_code (base + 240) 24 a = some i → shlCode base a = some i := by
-  exact CodeReq.ofProg_mono_sub base (base + 240) evm_shl (shl_body_0_prog 24) 60
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shl_body_0_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
-/-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shlCode. -/
+/-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shlCode (block 7). -/
 private theorem zero_path_sub_shlCode (base : Addr) :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shlCode base a = some i := by
-  unfold shr_zero_path_code
-  exact CodeReq.ofProg_mono_sub base (base + 340) evm_shl shr_zero_path 85
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  unfold shr_zero_path_code shlCode; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
 
 private theorem ld_s1_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shlCode base a = some i :=
-  singleton_sub_shlCode base base (.LD .x5 .x12 8) 0
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shlCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_or_16_sub_shlCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shlCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 4) evm_shl (shr_ld_or_acc_prog 16) 1
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_or_24_sub_shlCode (base : Addr) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shlCode base a = some i := by
-  unfold shr_ld_or_acc_code
-  exact CodeReq.ofProg_mono_sub base (base + 12) evm_shl (shr_ld_or_acc_prog 24) 3
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
+  intro a i h; unfold shr_ld_or_acc_code at h
+  have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
+    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem bne_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shlCode base a = some i :=
-  singleton_sub_shlCode base (base + 20) (.BNE .x5 .x0 320) 5
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shlCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem ld_s0_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shlCode base a = some i :=
-  singleton_sub_shlCode base (base + 24) (.LD .x5 .x12 0) 6
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shlCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem sltiu_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shlCode base a = some i :=
-  singleton_sub_shlCode base (base + 28) (.SLTIU .x10 .x5 256) 7
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shlCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 private theorem beq_sub_shlCode (base : Addr) :
-    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shlCode base a = some i :=
-  singleton_sub_shlCode base (base + 32) (.BEQ .x10 .x0 308) 8
-    (by native_decide) (by bv_omega) (by native_decide)
+    ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shlCode base a = some i := by
+  intro a i h
+  have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
+    (by native_decide) (by native_decide) (by bv_omega) (by native_decide) a i h
+  unfold shlCode; simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left _ _ a i h1
 
 -- ============================================================================
 -- Section 3: Address normalization lemmas


### PR DESCRIPTION
## Summary
- Fixes #76: Reduce maxHeartbeats in Shift composition files
- Replaces flat `CodeReq.ofProg base evm_shr/shl/sar` (90-95 instruction lists) with `CodeReq.unionAll` of 8 per-phase `ofProg` blocks, following the established DivMod pattern
- Subsumption proofs become structural (`skipBlock` + `union_mono_left`) instead of `native_decide` on full program lists
- Eliminates 15 `set_option maxHeartbeats` from subsumption sections (including the 8M sign_fill proof)

## Changes
| File | maxHeartbeats removed |
|------|----------------------|
| Compose.lean (SHR) | 2: cascade 4M×2 |
| ShlCompose.lean (SHL) | 6: cascade 4M×2, bodies 4M×4 |
| SarCompose.lean (SAR) | 7: cascade 4M×2, bodies 4M×4, sign_fill **8M** |

For union-chain `_code` definitions (Phase A, Phase C, sign-fill), bridge sub-lemmas decompose the proof into:
1. `chain_code ⊆ ofProg small_prog` — `native_decide` on 5-9 element lists (cheap)
2. `ofProg small_prog ⊆ *Code` — structural via `skipBlock` + `union_mono_left` (zero cost)

## Test plan
- [x] `lake build EvmAsm.Evm64.Shift` succeeds (all 89 jobs)
- [x] All downstream files (Semantic, ShlSemantic, SarSemantic) compile unchanged
- [x] Zero errors in all three modified files via LSP diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)