### PR TITLE
XPerm AC reflection + getLimb→getLimbN migration for Expr identity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -234,6 +234,20 @@ Bridge lemmas in `Evm64/Basic.lean` connect per-limb arithmetic to 256-bit opera
 - **`ext j` for BitVec**: After `ext j`, the variable `j` is a `Nat` and `rename_i hj` gives the bound `hj : j < w`. Use `BitVec.getElem_extractLsb'`, `BitVec.getLsbD_sshiftRight`, `BitVec.getElem_sshiftRight` for simplification.
 - **`dif_pos`/`dif_neg` for dependent if**: When `simp` leaves a `dite` (dependent if-then-else), use `rw [dif_pos h]` or `rw [dif_neg h]` to eliminate it, not `simp only [dite_true]`.
 
+## XPerm AC Reflection and Atom Identity
+
+The `xperm` tactic uses AC reflection (`Lean.Meta.AC.buildNormProof`) for O(n log n) separation logic permutation proofs. This requires atoms on both sides to be **syntactically identical** (same `Expr.hash`). Common causes of hash mismatch:
+
+1. **Type alias differences**: `Word` vs `BitVec 64`. Fixed by defining `Word` as `notation` (not `abbrev`), so the elaborator always produces `BitVec 64`.
+
+2. **Let-binding indirection**: `regIs .x7 result` (fvar) vs `regIs .x7 (if ...)` (definition). Fixed by `zetaReduce` in `buildPermProof`.
+
+3. **OfNat instance differences**: `@OfNat.ofNat Word 8 inst₁` vs `@OfNat.ofNat (BitVec 64) 8 inst₂`. Fixed by recursive `withReducible whnf` normalization in `checkACEligible`.
+
+4. **Fin proof term differences**: `getLimb ⟨0, proof₁⟩` vs `getLimb ⟨0, proof₂⟩` where `proof₁` and `proof₂` are different terms for `0 < 4`. **Not yet fixed.** Workaround: use `getLimbN` (Nat index) instead of `getLimb` (Fin 4 index) in new code.
+
+**Rule for new code**: When writing theorem statements that go through `xperm_hyp`, ensure both sides of the permutation use identical expressions (not just isDefEq). Avoid `Fin` literals and use `Nat` indices where possible.
+
 ## Roadmap (PLAN.md)
 
 The project roadmap is maintained in `PLAN.md`. See `CLAUDE.md` for the

--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 /-- ADD limb 0 spec (5 instructions): LD, LD, ADD, SLTU, SD.
     Computes sum = a + b (mod 2^64) and carry = (sum < b ? 1 : 0). -/
 theorem add_limb0_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -39,7 +39,7 @@ theorem add_limb0_spec (off_a off_b : BitVec 12)
 /-- ADD carry limb phase 1 (4 instructions): LD, LD, ADD, SLTU.
     Loads a_limb and b_limb, computes psum = a + b, carry1 = (psum < b ? 1 : 0). -/
 theorem add_limb_carry_spec_phase1 (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -62,7 +62,7 @@ theorem add_limb_carry_spec_phase1 (off_a off_b : BitVec 12)
     Takes psum, carry1, carry_in, computes result = psum + carry_in,
     carry2 = (result < carry_in ? 1 : 0), carry_out = carry1 ||| carry2. -/
 theorem add_limb_carry_spec_phase2 (off_b : BitVec 12)
-    (sp psum b_limb carry_in carry1 a_limb : Word) (mem_a : Addr) (base : Addr)
+    (sp psum b_limb carry_in carry1 a_limb : Word) (mem_a : Word) (base : Word)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_b := sp + signExtend12 off_b
     let result := psum + carry_in
@@ -83,7 +83,7 @@ theorem add_limb_carry_spec_phase2 (off_b : BitVec 12)
 /-- ADD carry limb spec (8 instructions): LD, LD, ADD, SLTU, ADD, SLTU, OR, SD.
     Composed from phase1 and phase2. -/
 theorem add_limb_carry_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -68,10 +68,10 @@ theorem evm_add_spec (sp : Word) (base : Word)
 theorem evm_add_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
-    let a0 := a.getLimb 0; let b0 := b.getLimb 0
-    let a1 := a.getLimb 1; let b1 := b.getLimb 1
-    let a2 := a.getLimb 2; let b2 := b.getLimb 2
-    let a3 := a.getLimb 3; let b3 := b.getLimb 3
+    let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+    let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+    let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+    let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
     let sum0 := a0 + b0
     let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
     let psum1 := a1 + b1
@@ -100,21 +100,21 @@ theorem evm_add_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) (a + b)) := by
   intro a0 b0 a1 b1 a2 b2 a3 b3 sum0 carry0 psum1 carry1a result1 carry1b carry1 psum2 carry2a result2 carry2b carry2 psum3 carry3a result3 carry3b carry3
   have h_main := evm_add_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   -- Get the carry chain correctness
   have ⟨h0, h1, h2, h3⟩ := EvmWord.add_carry_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -107,18 +107,20 @@ theorem evm_add_stack_spec (sp base : Word)
   have ⟨h0, h1, h2, h3⟩ := EvmWord.add_carry_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
+      simp only [evmWordIs]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at h0 h1 h2 h3
       rw [h0, h1, h2, h3]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -14,14 +14,14 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM ADD operation.
     30 instructions = 120 bytes. 4 per-limb ADD blocks + ADDI sp adjustment. -/
-abbrev evm_add_code (base : Addr) : CodeReq :=
+abbrev evm_add_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_add
 
 /-- Full 256-bit EVM ADD: composes 4 per-limb ADD specs + ADDI sp adjustment.
     30 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A + B to sp+32..sp+56, advances sp by 32.
     Carry propagates through limbs via x5. -/
-theorem evm_add_spec (sp : Addr) (base : Addr)
+theorem evm_add_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -65,7 +65,7 @@ theorem evm_add_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM ADD: operates on two EvmWords via evmWordIs. -/
-theorem evm_add_stack_spec (sp base : Addr)
+theorem evm_add_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
@@ -108,16 +108,16 @@ theorem evm_add_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       rw [h0, h1, h2, h3]
       xperm_hyp hq)

--- a/EvmAsm/Evm64/And/LimbSpec.lean
+++ b/EvmAsm/Evm64/And/LimbSpec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 /-- Per-limb AND spec (4 instructions: LD x7, LD x6, AND x7 x7 x6, SD x12 x7).
     Loads A[i] and B[i], computes AND, stores result at B[i]'s location. -/
 theorem and_limb_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -54,22 +54,22 @@ theorem evm_and_stack_spec (sp base : Word)
        (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp a ** evmWordIs (sp + 32) b)
       (-- Registers + memory (updated)
-       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimb 3 &&& b.getLimb 3)) ** (.x6 ↦ᵣ b.getLimb 3) **
+       (.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimbN 3 &&& b.getLimbN 3)) ** (.x6 ↦ᵣ b.getLimbN 3) **
        evmWordIs sp a ** evmWordIs (sp + 32) (a &&& b)) := by
   have h_main := evm_and_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_and]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_and]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -62,14 +62,14 @@ theorem evm_and_stack_spec (sp base : Word)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_and]
+      simp only [evmWordIs, EvmWord.getLimbN_and]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -14,13 +14,13 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM AND operation.
     17 instructions = 68 bytes. 4 per-limb AND blocks + ADDI sp adjustment. -/
-abbrev evm_and_code (base : Addr) : CodeReq :=
+abbrev evm_and_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_and
 
 /-- Full 256-bit EVM AND: composes 4 per-limb AND specs + sp adjustment.
     17 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A &&& B to sp+32..sp+56, advances sp by 32. -/
-theorem evm_and_spec (sp base : Addr)
+theorem evm_and_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_and_code base
@@ -45,7 +45,7 @@ theorem evm_and_spec (sp base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM AND: operates on two EvmWords via evmWordIs. -/
-theorem evm_and_stack_spec (sp base : Addr)
+theorem evm_and_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_and_code base
@@ -63,16 +63,16 @@ theorem evm_and_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_and]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -145,6 +145,13 @@ theorem getLimb_eq_getLimbN (v : EvmWord) (i : Fin 4) :
     v.getLimb i = v.getLimbN i.val := by
   simp [getLimbN, i.isLt]
 
+/-- Convert `getLimb (k : Fin 4)` to `getLimbN k` for concrete indices.
+    Use `simp only [getLimb_as_getLimbN]` to batch-convert bridge lemma hypotheses. -/
+theorem getLimb_as_getLimbN_0 (v : EvmWord) : v.getLimb 0 = v.getLimbN 0 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_1 (v : EvmWord) : v.getLimb 1 = v.getLimbN 1 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_2 (v : EvmWord) : v.getLimb 2 = v.getLimbN 2 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_3 (v : EvmWord) : v.getLimb 3 = v.getLimbN 3 := by simp [getLimbN]
+
 -- getLimbN versions of operation lemmas (for xperm AC fast path consistency)
 theorem getLimbN_and (x y : EvmWord) (k : Nat) :
     (x &&& y).getLimbN k = x.getLimbN k &&& y.getLimbN k := by
@@ -167,6 +174,20 @@ theorem getLimbN_zero (k : Nat) :
   unfold getLimbN; split
   · simp [getLimb]
   · rfl
+
+theorem getLimbN_one (k : Nat) :
+    (1 : EvmWord).getLimbN k = if k = 0 then 1 else 0 := by
+  unfold getLimbN
+  split
+  · next h =>
+    have hfin : ∀ j : Fin 4, (1 : EvmWord).getLimb j = if j.val = 0 then 1 else 0 := by
+      native_decide
+    exact hfin ⟨k, h⟩
+  · next h => simp [show ¬(k = 0) from by omega]
+
+theorem getLimbN_ite (c : Prop) [Decidable c] (x y : EvmWord) (k : Nat) :
+    (if c then x else y).getLimbN k = if c then x.getLimbN k else y.getLimbN k := by
+  split <;> rfl
 
 private theorem extractLsb'_ge_width (v : BitVec 256) (s : Nat) (h : s ≥ 256) :
     BitVec.extractLsb' s 64 v = (0 : BitVec 64) := by
@@ -500,6 +521,13 @@ theorem getLimb_fromLimbs_const (w : Word) (i : Fin 4) :
   | ⟨2, _⟩ => simp [fromLimbs, getLimb]; bv_decide
   | ⟨3, _⟩ => simp [fromLimbs, getLimb]; bv_decide
   | ⟨n+4, h⟩ => exact absurd h (by omega)
+
+theorem getLimbN_fromLimbs_const (w : Word) (k : Nat) :
+    (fromLimbs (fun _ => w)).getLimbN k = if k < 4 then w else 0 := by
+  unfold getLimbN
+  split
+  · next h => simp [getLimb_fromLimbs_const]
+  · next h => simp_all
 
 end EvmWord
 

--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -139,6 +139,35 @@ theorem getLimbN_ge (v : EvmWord) (k : Nat) (h : k ≥ 4) :
     v.getLimbN k = 0 := by
   simp [getLimbN, show ¬(k < 4) from by omega]
 
+/-- Convert getLimb (Fin 4) to getLimbN (Nat). Use this simp lemma to normalize
+    all getLimb calls to getLimbN for consistent Expr.hash in xperm. -/
+theorem getLimb_eq_getLimbN (v : EvmWord) (i : Fin 4) :
+    v.getLimb i = v.getLimbN i.val := by
+  simp [getLimbN, i.isLt]
+
+-- getLimbN versions of operation lemmas (for xperm AC fast path consistency)
+theorem getLimbN_and (x y : EvmWord) (k : Nat) :
+    (x &&& y).getLimbN k = x.getLimbN k &&& y.getLimbN k := by
+  simp [getLimbN]; split <;> simp [getLimb, BitVec.extractLsb'_and]
+
+theorem getLimbN_or (x y : EvmWord) (k : Nat) :
+    (x ||| y).getLimbN k = x.getLimbN k ||| y.getLimbN k := by
+  simp [getLimbN]; split <;> simp [getLimb, BitVec.extractLsb'_or]
+
+theorem getLimbN_xor (x y : EvmWord) (k : Nat) :
+    (x ^^^ y).getLimbN k = x.getLimbN k ^^^ y.getLimbN k := by
+  simp [getLimbN]; split <;> simp [getLimb, BitVec.extractLsb'_xor]
+
+theorem getLimbN_not (x : EvmWord) (k : Nat) (hk : k < 4) :
+    (~~~ x).getLimbN k = ~~~ (x.getLimbN k) := by
+  simp only [getLimbN, hk, dif_pos, getLimb_not]
+
+theorem getLimbN_zero (k : Nat) :
+    (0 : EvmWord).getLimbN k = 0 := by
+  unfold getLimbN; split
+  · simp [getLimb]
+  · rfl
+
 private theorem extractLsb'_ge_width (v : BitVec 256) (s : Nat) (h : s ≥ 256) :
     BitVec.extractLsb' s 64 v = (0 : BitVec 64) := by
   ext j

--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -27,12 +27,12 @@ namespace EvmAsm.Rv64
 -- Uses full byte_phase_a code as CodeReq for composition.
 -- ============================================================================
 
-abbrev byte_phase_a_code (base : Addr) : CodeReq :=
+abbrev byte_phase_a_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_phase_a
 
 /-- Phase A OR-reduce body: LD idx[1], LD idx[2], OR, LD idx[3], OR.
     Produces x5 = idx1 ||| idx2 ||| idx3. Uses full phase_a code. -/
-theorem byte_phase_a_or_reduce_spec (sp v5 v10 idx1 idx2 idx3 : Word) (base : Addr)
+theorem byte_phase_a_or_reduce_spec (sp v5 v10 idx1 idx2 idx3 : Word) (base : Word)
     (hv1 : isValidDwordAccess (sp + signExtend12 (8 : BitVec 12)) = true)
     (hv2 : isValidDwordAccess (sp + signExtend12 (16 : BitVec 12)) = true)
     (hv3 : isValidDwordAccess (sp + signExtend12 (24 : BitVec 12)) = true) :
@@ -60,7 +60,7 @@ theorem byte_phase_a_or_reduce_spec (sp v5 v10 idx1 idx2 idx3 : Word) (base : Ad
 
 /-- Phase A low-check: LD idx[0] into x5, SLTIU x10 = (idx0 < 32).
     Located at offset 24 within byte_phase_a (after OR-reduce + BNE). -/
-theorem byte_phase_a_low_check_spec (sp v5 idx0 v10 : Word) (base : Addr)
+theorem byte_phase_a_low_check_spec (sp v5 idx0 v10 : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (0 : BitVec 12)) = true) :
     let cr := byte_phase_a_code base
     cpsTriple (base + 24) (base + 32) cr
@@ -78,14 +78,14 @@ theorem byte_phase_a_low_check_spec (sp v5 idx0 v10 : Word) (base : Addr)
 -- Same computation as SignExtend Phase B
 -- ============================================================================
 
-abbrev byte_phase_b_code (base : Addr) : CodeReq :=
+abbrev byte_phase_b_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_phase_b
 
 /-- Phase B spec: compute byte extraction parameters.
     ANDI x10,x5,7; SLLI x10,x10,3; ADDI x6,x0,56;
     SUB x6,x6,x10; SRLI x5,x5,3.
     Outputs: x6 = 56 - (idx%8)*8 (bit_shift), x5 = idx/8 (limb_from_msb). -/
-theorem byte_phase_b_spec (idx r6 r10 : Word) (base : Addr) :
+theorem byte_phase_b_spec (idx r6 r10 : Word) (base : Word) :
     let byte_in_limb := idx &&& signExtend12 (7 : BitVec 12)
     let byte_shift := byte_in_limb <<< (3 : BitVec 6).toNat
     let shift_amount := (56 : Word) - byte_shift
@@ -109,11 +109,11 @@ theorem byte_phase_b_spec (idx r6 r10 : Word) (base : Addr) :
 -- body_3: LD sp+32, SRL, ANDI 0xFF, JAL 48 (4 instrs)
 -- limb_from_msb = 3 → extract from limb 0 (LSB) at sp+32
 
-abbrev byte_body_3_code (base : Addr) : CodeReq :=
+abbrev byte_body_3_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_3
 
 /-- body_3 spec: load limb 0 from sp+32, extract byte, jump to store. -/
-theorem byte_body_3_spec (sp v5 shift_amount limb : Word) (base : Addr)
+theorem byte_body_3_spec (sp v5 shift_amount limb : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (32 : BitVec 12)) = true) :
     let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_3_code base
@@ -131,11 +131,11 @@ theorem byte_body_3_spec (sp v5 shift_amount limb : Word) (base : Addr)
 -- body_2: LD sp+40, SRL, ANDI 0xFF, JAL 32 (4 instrs)
 -- limb_from_msb = 2 → extract from limb 1 at sp+40
 
-abbrev byte_body_2_code (base : Addr) : CodeReq :=
+abbrev byte_body_2_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_2
 
 /-- body_2 spec: load limb 1 from sp+40, extract byte, jump to store. -/
-theorem byte_body_2_spec (sp v5 shift_amount limb : Word) (base : Addr)
+theorem byte_body_2_spec (sp v5 shift_amount limb : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (40 : BitVec 12)) = true) :
     let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_2_code base
@@ -153,11 +153,11 @@ theorem byte_body_2_spec (sp v5 shift_amount limb : Word) (base : Addr)
 -- body_1: LD sp+48, SRL, ANDI 0xFF, JAL 16 (4 instrs)
 -- limb_from_msb = 1 → extract from limb 2 at sp+48
 
-abbrev byte_body_1_code (base : Addr) : CodeReq :=
+abbrev byte_body_1_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_1
 
 /-- body_1 spec: load limb 2 from sp+48, extract byte, jump to store. -/
-theorem byte_body_1_spec (sp v5 shift_amount limb : Word) (base : Addr)
+theorem byte_body_1_spec (sp v5 shift_amount limb : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (48 : BitVec 12)) = true) :
     let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_1_code base
@@ -175,11 +175,11 @@ theorem byte_body_1_spec (sp v5 shift_amount limb : Word) (base : Addr)
 -- body_0: LD sp+56, SRL, ANDI 0xFF (3 instrs, falls through to store)
 -- limb_from_msb = 0 → extract from limb 3 (MSB) at sp+56
 
-abbrev byte_body_0_code (base : Addr) : CodeReq :=
+abbrev byte_body_0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_0
 
 /-- body_0 spec: load limb 3 from sp+56, extract byte. Falls through to store. -/
-theorem byte_body_0_spec (sp v5 shift_amount limb : Word) (base : Addr)
+theorem byte_body_0_spec (sp v5 shift_amount limb : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true) :
     let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_0_code base
@@ -197,12 +197,12 @@ theorem byte_body_0_spec (sp v5 shift_amount limb : Word) (base : Addr)
 -- Store: pop index word, write byte result + 3 zero limbs (6 instrs)
 -- ============================================================================
 
-abbrev byte_store_code (base : Addr) : CodeReq :=
+abbrev byte_store_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_store
 
 /-- Store spec: ADDI x12 32, SD result, SD 0×3, JAL 24.
     Pops the index word (sp → sp+32), writes result at sp+32 and zeros at sp+40..56. -/
-theorem byte_store_spec (sp result m0 m8 m16 m24 : Word) (base : Addr)
+theorem byte_store_spec (sp result m0 m8 m16 m24 : Word) (base : Word)
     (hvalid : ValidMemRange sp 8) :
     let nsp := sp + signExtend12 (32 : BitVec 12)
     let code := byte_store_code base
@@ -225,12 +225,12 @@ theorem byte_store_spec (sp result m0 m8 m16 m24 : Word) (base : Addr)
 -- Zero path: pop index word, write all zeros (5 instrs)
 -- ============================================================================
 
-abbrev byte_zero_path_code (base : Addr) : CodeReq :=
+abbrev byte_zero_path_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_zero_path
 
 /-- Zero path spec: ADDI x12 32, SD 0×4.
     Pops the index word (sp → sp+32), writes zeros at sp+32..56. -/
-theorem byte_zero_path_spec (sp m0 m8 m16 m24 : Word) (base : Addr)
+theorem byte_zero_path_spec (sp m0 m8 m16 m24 : Word) (base : Word)
     (hvalid : ValidMemRange sp 8) :
     let nsp := sp + signExtend12 (32 : BitVec 12)
     let code := byte_zero_path_code base
@@ -252,11 +252,11 @@ theorem byte_zero_path_spec (sp m0 m8 m16 m24 : Word) (base : Addr)
 -- Phase C: Cascade dispatch on limb_from_msb (5 instructions)
 -- ============================================================================
 
-abbrev byte_phase_c_code (base : Addr) : CodeReq :=
+abbrev byte_phase_c_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_phase_c
 
 /-- Each singleton instruction in byte_phase_c is subsumed by the full program CodeReq. -/
-private theorem byte_pc_instr_sub (base addr : Addr) (instr : Instr) (k : Nat)
+private theorem byte_pc_instr_sub (base addr : Word) (instr : Instr) (k : Nat)
     (hk : k < byte_phase_c.length)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
     (h_instr : byte_phase_c.get ⟨k, hk⟩ = instr) :
@@ -265,27 +265,27 @@ private theorem byte_pc_instr_sub (base addr : Addr) (instr : Instr) (k : Nat)
     (by native_decide) h_addr)
 
 -- Per-instruction subsumption lemmas (k = 0..4)
-private theorem byte_pc_sub_0 (base : Addr) :
+private theorem byte_pc_sub_0 (base : Word) :
     ∀ a i, CodeReq.singleton base (.BEQ .x5 .x0 68) a = some i →
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base base _ 0 (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem byte_pc_sub_1 (base : Addr) :
+private theorem byte_pc_sub_1 (base : Word) :
     ∀ a i, CodeReq.singleton (base + 4) (.ADDI .x10 .x0 1) a = some i →
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base (base + 4) _ 1 (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem byte_pc_sub_2 (base : Addr) :
+private theorem byte_pc_sub_2 (base : Word) :
     ∀ a i, CodeReq.singleton (base + 8) (.BEQ .x5 .x10 44) a = some i →
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base (base + 8) _ 2 (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem byte_pc_sub_3 (base : Addr) :
+private theorem byte_pc_sub_3 (base : Word) :
     ∀ a i, CodeReq.singleton (base + 12) (.ADDI .x10 .x0 2) a = some i →
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base (base + 12) _ 3 (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem byte_pc_sub_4 (base : Addr) :
+private theorem byte_pc_sub_4 (base : Word) :
     ∀ a i, CodeReq.singleton (base + 16) (.BEQ .x5 .x10 20) a = some i →
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base (base + 16) _ 4 (by native_decide) (by bv_omega) (by native_decide)
@@ -293,8 +293,8 @@ private theorem byte_pc_sub_4 (base : Addr) :
 set_option maxHeartbeats 6400000 in
 /-- Phase C cascade dispatch spec: branches on x5 (limb_from_msb) to 4 body entry points.
     Each exit postcondition includes pure constraints identifying which branch was taken. -/
-theorem byte_phase_c_spec (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 68 = e0)
     (he1 : (base + 8) + signExtend13 44 = e1)
     (he2 : (base + 16) + signExtend13 20 = e2)
@@ -327,14 +327,14 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Addr)
   have addi1f := cpsTriple_frame_left _ _ _ _ _
     (.x5 ↦ᵣ v5) (by pcFree) addi1_cr
   -- Normalize ADDI1 exit PC
-  have haddi1_exit : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have haddi1_exit : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [haddi1_exit] at addi1f
   -- Step 2: BEQ x5 x10 44 at base+8 (extend to cr, frame with x0)
   have beq1_raw := beq_spec_gen .x5 .x10 44 v5 ((0 : Word) + signExtend12 1) (base + 8)
   rw [he1] at beq1_raw
   have beq1_cr := cpsBranch_extend_code (byte_pc_sub_2 base) beq1_raw
   -- Normalize BEQ1 ntaken exit
-  have hbeq1_nf : (base + 8 : Addr) + 4 = base + 12 := by bv_omega
+  have hbeq1_nf : (base + 8 : Word) + 4 = base + 12 := by bv_omega
   rw [hbeq1_nf] at beq1_raw beq1_cr
   have beq1f := cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq1_cr
   -- Compose addi1 + beq1 (let Lean infer intermediate shapes)
@@ -376,14 +376,14 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Addr)
   have addi2f := cpsTriple_frame_left _ _ _ _ _
     (.x5 ↦ᵣ v5) (by pcFree) addi2_cr
   -- Normalize ADDI2 exit PC
-  have haddi2_exit : (base + 12 : Addr) + 4 = base + 16 := by bv_omega
+  have haddi2_exit : (base + 12 : Word) + 4 = base + 16 := by bv_omega
   rw [haddi2_exit] at addi2f
   -- Step 4: BEQ x5 x10 20 at base+16 (extend to cr, frame with x0)
   have beq2_raw := beq_spec_gen .x5 .x10 20 v5 ((0 : Word) + signExtend12 2) (base + 16)
   rw [he2] at beq2_raw
   have beq2_cr := cpsBranch_extend_code (byte_pc_sub_4 base) beq2_raw
   -- Normalize BEQ2 ntaken exit
-  have hbeq2_nf : (base + 16 : Addr) + 4 = base + 20 := by bv_omega
+  have hbeq2_nf : (base + 16 : Word) + 4 = base + 20 := by bv_omega
   rw [hbeq2_nf] at beq2_raw beq2_cr
   have beq2f := cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq2_cr
   -- Compose addi2 + beq2 (let Lean infer intermediate shapes)

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -569,6 +569,8 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
+        simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                   EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at hq
         unfold evmWordIs
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
@@ -1012,14 +1014,14 @@ theorem evm_byte_stack_spec (sp base : Word)
       -- getLimb k = (idx.toNat / 2^(k*64)) % 2^64
       -- For k >= 1, idx.toNat < 2^64 ⇒ idx.toNat / 2^(k*64) = 0
       have h1 : i1 = 0 := by
-        show idx.getLimbN 1 = 0; simp [EvmWord.getLimb]
+        show idx.getLimbN 1 = 0; simp [EvmWord.getLimbN, EvmWord.getLimb]
         apply BitVec.eq_of_toNat_eq; simp [BitVec.extractLsb'_toNat]; omega
       have h2 : i2 = 0 := by
         show idx.getLimbN 2 = 0; apply BitVec.eq_of_toNat_eq
-        simp [EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
+        simp [EvmWord.getLimbN, EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
       have h3 : i3 = 0 := by
         show idx.getLimbN 3 = 0; apply BitVec.eq_of_toNat_eq
-        simp [EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
+        simp [EvmWord.getLimbN, EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
       rw [h1, h2, h3]; simp
     rw [hbyte_zero]
     -- Use evm_byte_zero_high_spec at the limb level, then wrap with evmWordIs
@@ -1040,13 +1042,9 @@ theorem evm_byte_stack_spec (sp base : Word)
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
-                   show (0 : EvmWord).getLimbN 0 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimbN 1 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimbN 2 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimbN 3 = 0 from by simp [EvmWord.getLimb]]
-        have w := sepConj_mono_left (regIs_to_regOwn .x6 _) h
-          ((congrFun (show _ = _ from by xperm) h).mp hq)
-        exact (congrFun (show _ = _ from by xperm) h).mp w)
+                   EvmWord.getLimbN_zero]
+        have w := sepConj_mono_right (regIs_to_regOwn .x6 _) h hq
+        xperm_hyp w)
       h_framed
   · push_neg at hhigh
     -- hhigh : i1 ||| i2 ||| i3 = 0
@@ -1085,13 +1083,9 @@ theorem evm_byte_stack_spec (sp base : Word)
           simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                      show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                      show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
-                     show (0 : EvmWord).getLimbN 0 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimbN 1 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimbN 2 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimbN 3 = 0 from by simp [EvmWord.getLimb]]
-          have w := sepConj_mono_left (regIs_to_regOwn .x6 _) h
-            ((congrFun (show _ = _ from by xperm) h).mp hq)
-          exact (congrFun (show _ = _ from by xperm) h).mp w)
+                     EvmWord.getLimbN_zero]
+          have w := sepConj_mono_right (regIs_to_regOwn .x6 _) h hq
+          xperm_hyp w)
         h_framed
 
 end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -530,8 +530,8 @@ set_option maxHeartbeats 6400000 in
 theorem evm_byte_body_evmWord_spec (sp base : Word)
     (idx value : EvmWord) (r5 r6 r10 : Word)
     (hvalid : ValidMemRange sp 8)
-    (hhigh_zero : idx.getLimb 1 ||| idx.getLimb 2 ||| idx.getLimb 3 = 0)
-    (hlt_i0 : BitVec.ult (idx.getLimb 0) (signExtend12 (32 : BitVec 12)) = true)
+    (hhigh_zero : idx.getLimbN 1 ||| idx.getLimbN 2 ||| idx.getLimbN 3 = 0)
+    (hlt_i0 : BitVec.ult (idx.getLimbN 0) (signExtend12 (32 : BitVec 12)) = true)
     (hlt : idx.toNat < 32) :
     cpsTriple base (base + 180) (evm_byte_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x6 ↦ᵣ r6) **
@@ -541,14 +541,14 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
        (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        evmWordIs sp idx ** evmWordIs (sp + 32) (byte idx value)) := by
   -- Abbreviate limbs
-  set i0 := idx.getLimb 0
-  set i1 := idx.getLimb 1
-  set i2 := idx.getLimb 2
-  set i3 := idx.getLimb 3
-  set v0 := value.getLimb 0
-  set v1 := value.getLimb 1
-  set v2 := value.getLimb 2
-  set v3 := value.getLimb 3
+  set i0 := idx.getLimbN 0
+  set i1 := idx.getLimbN 1
+  set i2 := idx.getLimbN 2
+  set i3 := idx.getLimbN 3
+  set v0 := value.getLimbN 0
+  set v1 := value.getLimbN 1
+  set v2 := value.getLimbN 2
+  set v3 := value.getLimbN 3
   set result := byte idx value
   -- Reduce evmWordIs to raw memIs
   suffices h_raw : cpsTriple base (base + 180) (evm_byte_code base)
@@ -991,14 +991,14 @@ theorem evm_byte_stack_spec (sp base : Word)
        (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        evmWordIs sp idx ** evmWordIs (sp + 32) (EvmWord.byte idx val)) := by
   -- Abbreviate limbs
-  set i0 := idx.getLimb 0
-  set i1 := idx.getLimb 1
-  set i2 := idx.getLimb 2
-  set i3 := idx.getLimb 3
-  set v0 := val.getLimb 0
-  set v1 := val.getLimb 1
-  set v2 := val.getLimb 2
-  set v3 := val.getLimb 3
+  set i0 := idx.getLimbN 0
+  set i1 := idx.getLimbN 1
+  set i2 := idx.getLimbN 2
+  set i3 := idx.getLimbN 3
+  set v0 := val.getLimbN 0
+  set v1 := val.getLimbN 1
+  set v2 := val.getLimbN 2
+  set v3 := val.getLimbN 3
   -- Case split on three conditions
   by_cases hhigh : i1 ||| i2 ||| i3 ≠ 0
   · -- Case 1: high limbs nonzero → zero result
@@ -1012,13 +1012,13 @@ theorem evm_byte_stack_spec (sp base : Word)
       -- getLimb k = (idx.toNat / 2^(k*64)) % 2^64
       -- For k >= 1, idx.toNat < 2^64 ⇒ idx.toNat / 2^(k*64) = 0
       have h1 : i1 = 0 := by
-        show idx.getLimb 1 = 0; simp [EvmWord.getLimb]
+        show idx.getLimbN 1 = 0; simp [EvmWord.getLimb]
         apply BitVec.eq_of_toNat_eq; simp [BitVec.extractLsb'_toNat]; omega
       have h2 : i2 = 0 := by
-        show idx.getLimb 2 = 0; apply BitVec.eq_of_toNat_eq
+        show idx.getLimbN 2 = 0; apply BitVec.eq_of_toNat_eq
         simp [EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
       have h3 : i3 = 0 := by
-        show idx.getLimb 3 = 0; apply BitVec.eq_of_toNat_eq
+        show idx.getLimbN 3 = 0; apply BitVec.eq_of_toNat_eq
         simp [EvmWord.getLimb, BitVec.extractLsb'_toNat]; omega
       rw [h1, h2, h3]; simp
     rw [hbyte_zero]
@@ -1040,10 +1040,10 @@ theorem evm_byte_stack_spec (sp base : Word)
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
-                   show (0 : EvmWord).getLimb 0 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimb 1 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimb 2 = 0 from by simp [EvmWord.getLimb],
-                   show (0 : EvmWord).getLimb 3 = 0 from by simp [EvmWord.getLimb]]
+                   show (0 : EvmWord).getLimbN 0 = 0 from by simp [EvmWord.getLimb],
+                   show (0 : EvmWord).getLimbN 1 = 0 from by simp [EvmWord.getLimb],
+                   show (0 : EvmWord).getLimbN 2 = 0 from by simp [EvmWord.getLimb],
+                   show (0 : EvmWord).getLimbN 3 = 0 from by simp [EvmWord.getLimb]]
         have w := sepConj_mono_left (regIs_to_regOwn .x6 _) h
           ((congrFun (show _ = _ from by xperm) h).mp hq)
         exact (congrFun (show _ = _ from by xperm) h).mp w)
@@ -1085,10 +1085,10 @@ theorem evm_byte_stack_spec (sp base : Word)
           simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                      show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                      show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
-                     show (0 : EvmWord).getLimb 0 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimb 1 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimb 2 = 0 from by simp [EvmWord.getLimb],
-                     show (0 : EvmWord).getLimb 3 = 0 from by simp [EvmWord.getLimb]]
+                     show (0 : EvmWord).getLimbN 0 = 0 from by simp [EvmWord.getLimb],
+                     show (0 : EvmWord).getLimbN 1 = 0 from by simp [EvmWord.getLimb],
+                     show (0 : EvmWord).getLimbN 2 = 0 from by simp [EvmWord.getLimb],
+                     show (0 : EvmWord).getLimbN 3 = 0 from by simp [EvmWord.getLimb]]
           have w := sepConj_mono_left (regIs_to_regOwn .x6 _) h
             ((congrFun (show _ = _ from by xperm) h).mp hq)
           exact (congrFun (show _ = _ from by xperm) h).mp w)

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -26,7 +26,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 /-- Full BYTE program code as CodeReq.ofProg. -/
-abbrev evm_byte_code (base : Addr) : CodeReq :=
+abbrev evm_byte_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_byte
 
 -- Program length verification
@@ -46,56 +46,56 @@ private theorem evm_byte_len : evm_byte.length = 45 := by native_decide
 -- ============================================================================
 
 /-- Phase A code (9 instrs at offset 0) is subsumed by evm_byte_code. -/
-private theorem byte_phase_a_sub (base : Addr) :
+private theorem byte_phase_a_sub (base : Word) :
     ∀ a i, (byte_phase_a_code base) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_phase_a_code
   exact CodeReq.ofProg_mono_sub base base evm_byte byte_phase_a 0
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Phase B code (5 instrs at offset 36) is subsumed by evm_byte_code. -/
-private theorem byte_phase_b_sub (base : Addr) :
+private theorem byte_phase_b_sub (base : Word) :
     ∀ a i, (byte_phase_b_code (base + 36)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_phase_b_code
   exact CodeReq.ofProg_mono_sub base (base + 36) evm_byte byte_phase_b 9
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- body_3 code (4 instrs at offset 76) is subsumed by evm_byte_code. -/
-private theorem byte_body_3_sub (base : Addr) :
+private theorem byte_body_3_sub (base : Word) :
     ∀ a i, (byte_body_3_code (base + 76)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_body_3_code
   exact CodeReq.ofProg_mono_sub base (base + 76) evm_byte byte_body_3 19
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- body_2 code (4 instrs at offset 92) is subsumed by evm_byte_code. -/
-private theorem byte_body_2_sub (base : Addr) :
+private theorem byte_body_2_sub (base : Word) :
     ∀ a i, (byte_body_2_code (base + 92)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_body_2_code
   exact CodeReq.ofProg_mono_sub base (base + 92) evm_byte byte_body_2 23
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- body_1 code (4 instrs at offset 108) is subsumed by evm_byte_code. -/
-private theorem byte_body_1_sub (base : Addr) :
+private theorem byte_body_1_sub (base : Word) :
     ∀ a i, (byte_body_1_code (base + 108)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_body_1_code
   exact CodeReq.ofProg_mono_sub base (base + 108) evm_byte byte_body_1 27
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- body_0 code (3 instrs at offset 124) is subsumed by evm_byte_code. -/
-private theorem byte_body_0_sub (base : Addr) :
+private theorem byte_body_0_sub (base : Word) :
     ∀ a i, (byte_body_0_code (base + 124)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_body_0_code
   exact CodeReq.ofProg_mono_sub base (base + 124) evm_byte byte_body_0 31
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Store code (6 instrs at offset 136) is subsumed by evm_byte_code. -/
-private theorem byte_store_sub (base : Addr) :
+private theorem byte_store_sub (base : Word) :
     ∀ a i, (byte_store_code (base + 136)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_store_code
   exact CodeReq.ofProg_mono_sub base (base + 136) evm_byte byte_store 34
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Zero path code (5 instrs at offset 160) is subsumed by evm_byte_code. -/
-private theorem byte_zero_path_sub (base : Addr) :
+private theorem byte_zero_path_sub (base : Word) :
     ∀ a i, (byte_zero_path_code (base + 160)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_zero_path_code
   exact CodeReq.ofProg_mono_sub base (base + 160) evm_byte byte_zero_path 40
@@ -106,7 +106,7 @@ private theorem byte_zero_path_sub (base : Addr) :
 -- ============================================================================
 
 /-- Phase C code (5 instrs at offset 56) is subsumed by evm_byte_code. -/
-private theorem byte_phase_c_sub (base : Addr) :
+private theorem byte_phase_c_sub (base : Word) :
     ∀ a i, (byte_phase_c_code (base + 56)) a = some i → (evm_byte_code base) a = some i := by
   unfold evm_byte_code byte_phase_c_code
   exact CodeReq.ofProg_mono_sub base (base + 56) evm_byte byte_phase_c 14
@@ -117,7 +117,7 @@ private theorem byte_phase_c_sub (base : Addr) :
 -- ============================================================================
 
 /-- A singleton at instruction k of evm_byte is subsumed by evm_byte_code. -/
-private theorem singleton_sub_evm_byte (base addr : Addr) (instr : Instr) (k : Nat)
+private theorem singleton_sub_evm_byte (base addr : Word) (instr : Instr) (k : Nat)
     (hk : k < evm_byte.length)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
     (h_instr : evm_byte.get ⟨k, hk⟩ = instr) :
@@ -126,28 +126,28 @@ private theorem singleton_sub_evm_byte (base addr : Addr) (instr : Instr) (k : N
     (by native_decide) h_addr)
 
 /-- BNE x5 x0 140 singleton at base+20 is subsumed by evm_byte_code. -/
-private theorem byte_bne_sub (base : Addr) :
+private theorem byte_bne_sub (base : Word) :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 140) a = some i →
       (evm_byte_code base) a = some i :=
   singleton_sub_evm_byte base (base + 20) (.BNE .x5 .x0 140) 5
     (by native_decide) (by bv_omega) (by native_decide)
 
 /-- LD x5 x12 0 singleton at base+24 is subsumed by evm_byte_code. -/
-private theorem byte_ld0_sub (base : Addr) :
+private theorem byte_ld0_sub (base : Word) :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i →
       (evm_byte_code base) a = some i :=
   singleton_sub_evm_byte base (base + 24) (.LD .x5 .x12 0) 6
     (by native_decide) (by bv_omega) (by native_decide)
 
 /-- SLTIU x10 x5 32 singleton at base+28 is subsumed by evm_byte_code. -/
-private theorem byte_sltiu_sub (base : Addr) :
+private theorem byte_sltiu_sub (base : Word) :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 32) a = some i →
       (evm_byte_code base) a = some i :=
   singleton_sub_evm_byte base (base + 28) (.SLTIU .x10 .x5 32) 7
     (by native_decide) (by bv_omega) (by native_decide)
 
 /-- BEQ x10 x0 128 singleton at base+32 is subsumed by evm_byte_code. -/
-private theorem byte_beq_sub (base : Addr) :
+private theorem byte_beq_sub (base : Word) :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 128) a = some i →
       (evm_byte_code base) a = some i :=
   singleton_sub_evm_byte base (base + 32) (.BEQ .x10 .x0 128) 8
@@ -158,45 +158,45 @@ private theorem byte_beq_sub (base : Addr) :
 -- ============================================================================
 
 -- Phase A offsets
-private theorem byte_off_4 (base : Addr) : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-private theorem byte_off_12 (base : Addr) : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-private theorem byte_off_20 (base : Addr) : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-private theorem byte_off_24 (base : Addr) : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-private theorem byte_off_28 (base : Addr) : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-private theorem byte_off_32 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem byte_off_36_20 (base : Addr) : (base + 36 : Addr) + 20 = base + 56 := by bv_omega
-private theorem byte_off_56_20 (base : Addr) : (base + 56 : Addr) + 20 = base + 76 := by bv_omega
-private theorem byte_off_160_20 (base : Addr) : (base + 160 : Addr) + 20 = base + 180 := by bv_omega
+private theorem byte_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem byte_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem byte_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem byte_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem byte_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem byte_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem byte_off_36_20 (base : Word) : (base + 36 : Word) + 20 = base + 56 := by bv_omega
+private theorem byte_off_56_20 (base : Word) : (base + 56 : Word) + 20 = base + 76 := by bv_omega
+private theorem byte_off_160_20 (base : Word) : (base + 160 : Word) + 20 = base + 180 := by bv_omega
 
 -- BNE/BEQ branch targets
-private theorem byte_bne_target (base : Addr) : (base + 20 : Addr) + signExtend13 140 = base + 160 := by
+private theorem byte_bne_target (base : Word) : (base + 20 : Word) + signExtend13 140 = base + 160 := by
   rw [show signExtend13 (140 : BitVec 13) = (140 : Word) from by native_decide]; bv_omega
-private theorem byte_beq_target (base : Addr) : (base + 32 : Addr) + signExtend13 128 = base + 160 := by
+private theorem byte_beq_target (base : Word) : (base + 32 : Word) + signExtend13 128 = base + 160 := by
   rw [show signExtend13 (128 : BitVec 13) = (128 : Word) from by native_decide]; bv_omega
 
 -- Phase C exit addresses
-private theorem byte_c_e0 (base : Addr) : (base + 56 : Addr) + signExtend13 68 = base + 124 := by
+private theorem byte_c_e0 (base : Word) : (base + 56 : Word) + signExtend13 68 = base + 124 := by
   rw [show signExtend13 (68 : BitVec 13) = (68 : Word) from by native_decide]; bv_omega
-private theorem byte_c_e1 (base : Addr) : ((base + 56 : Addr) + 8) + signExtend13 44 = base + 108 := by
+private theorem byte_c_e1 (base : Word) : ((base + 56 : Word) + 8) + signExtend13 44 = base + 108 := by
   rw [show signExtend13 (44 : BitVec 13) = (44 : Word) from by native_decide]; bv_omega
-private theorem byte_c_e2 (base : Addr) : ((base + 56 : Addr) + 16) + signExtend13 20 = base + 92 := by
+private theorem byte_c_e2 (base : Word) : ((base + 56 : Word) + 16) + signExtend13 20 = base + 92 := by
   rw [show signExtend13 (20 : BitVec 13) = (20 : Word) from by native_decide]; bv_omega
-private theorem byte_c_e3 (base : Addr) : (base + 56 : Addr) + 20 = base + 76 := by bv_omega
+private theorem byte_c_e3 (base : Word) : (base + 56 : Word) + 20 = base + 76 := by bv_omega
 
 -- Body exit addresses (JAL targets → store at base+136)
-private theorem byte_body_3_exit_eq (base : Addr) :
+private theorem byte_body_3_exit_eq (base : Word) :
     (base + 76 + 12) + signExtend21 (48 : BitVec 21) = base + 136 := by
   rw [show signExtend21 (48 : BitVec 21) = (48 : Word) from by native_decide]; bv_omega
-private theorem byte_body_2_exit_eq (base : Addr) :
+private theorem byte_body_2_exit_eq (base : Word) :
     (base + 92 + 12) + signExtend21 (32 : BitVec 21) = base + 136 := by
   rw [show signExtend21 (32 : BitVec 21) = (32 : Word) from by native_decide]; bv_omega
-private theorem byte_body_1_exit_eq (base : Addr) :
+private theorem byte_body_1_exit_eq (base : Word) :
     (base + 108 + 12) + signExtend21 (16 : BitVec 21) = base + 136 := by
   rw [show signExtend21 (16 : BitVec 21) = (16 : Word) from by native_decide]; bv_omega
 -- body_0 is fallthrough: exits at base+124+12 = base+136 (no JAL)
 
 -- Store exit address
-private theorem byte_store_exit_eq (base : Addr) :
+private theorem byte_store_exit_eq (base : Word) :
     (base + 136 + 20) + signExtend21 (24 : BitVec 21) = base + 180 := by
   rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_omega
 
@@ -213,7 +213,7 @@ private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h →
   fun _ hp => ⟨v, hp⟩
 
 /-- Helper to derive ValidMemRange for the value portion (sp+32..sp+56). -/
-private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8) :
+private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
     ValidMemRange (sp + 32) 4 := by
   intro i hi; have := hvalid.get (i := i + 4) (by omega)
   have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
@@ -221,8 +221,8 @@ private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8)
   exact this
 
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)}
+private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
@@ -230,8 +230,8 @@ private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)} {F : Assertion}
+private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
   intro R hR s hcr hPFR hpc
@@ -245,7 +245,7 @@ private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
 
 /-- Strip a pure fact from a cpsTriple's precondition and use it to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Addr} {cr : CodeReq}
+    {entry exit_ : Word} {cr : CodeReq}
     {P Q Q' : Assertion} {fact : Prop}
     (hbody : cpsTriple entry exit_ cr P Q)
     (hpost : fact → ∀ h, Q h → Q' h) :
@@ -296,7 +296,7 @@ private theorem bv_srl_mask_eq (x : Word) (n : Nat) (hn : n < 64) :
 set_option maxHeartbeats 1600000 in
 /-- Zero path via BNE taken: high index limbs are nonzero → result is zero.
     Execution: LD idx[1] → LD/OR idx[2] → LD/OR idx[3] → BNE(taken) → zero_path. -/
-theorem evm_byte_zero_high_spec (sp base : Addr)
+theorem evm_byte_zero_high_spec (sp base : Word)
     (i0 i1 i2 i3 v0 v1 v2 v3 r5 r10 : Word)
     (hhigh : i1 ||| i2 ||| i3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -386,7 +386,7 @@ theorem evm_byte_zero_high_spec (sp base : Addr)
 set_option maxHeartbeats 3200000 in
 /-- Zero path via BEQ taken: i1=i2=i3=0 but i0 >= 32 → result is zero.
     Execution: OR-reduce → BNE(ntaken) → LD idx[0] → SLTIU → BEQ(taken) → zero_path. -/
-theorem evm_byte_zero_geq32_spec (sp base : Addr)
+theorem evm_byte_zero_geq32_spec (sp base : Word)
     (i0 i1 i2 i3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : i1 ||| i2 ||| i3 = 0)
     (hlarge : BitVec.ult i0 (signExtend12 (32 : BitVec 12)) = false)
@@ -527,7 +527,7 @@ set_option maxHeartbeats 6400000 in
 /-- Body path: idx < 32 → result is `EvmWord.byte idx value`.
     Composes Phase A ntaken → Phase B → Phase C → body_L + store → exit
     and uses byte_correct to connect per-limb results to EvmWord.byte. -/
-theorem evm_byte_body_evmWord_spec (sp base : Addr)
+theorem evm_byte_body_evmWord_spec (sp base : Word)
     (idx value : EvmWord) (r5 r6 r10 : Word)
     (hvalid : ValidMemRange sp 8)
     (hhigh_zero : idx.getLimb 1 ||| idx.getLimb 2 ||| idx.getLimb 3 = 0)
@@ -564,15 +564,15 @@ theorem evm_byte_body_evmWord_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega]
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat memIs form
@@ -587,12 +587,12 @@ theorem evm_byte_body_evmWord_spec (sp base : Addr)
     have := hvalid.get (i := 3) (by omega); simpa using this
   have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Phase A: OR-reduce (base → base+20)
   have hOR := cpsTriple_extend_code (byte_phase_a_sub base)
     (byte_phase_a_or_reduce_spec sp r5 r10 i1 i2 i3 base
@@ -709,7 +709,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Addr)
   -- Body 0 spec (load from sp+56, i.e. limb 3 = v3)
   have hbody0_raw := byte_body_0_spec sp limb_from_msb shift_amount v3 (base + 124) hv56_single
   simp only [signExtend12_56] at hbody0_raw
-  have hbody0_exit : (base + 124 : Addr) + 12 = base + 136 := by bv_omega
+  have hbody0_exit : (base + 124 : Word) + 12 = base + 136 := by bv_omega
   rw [hbody0_exit] at hbody0_raw
   have hbody0 := cpsTriple_extend_code (byte_body_0_sub base) hbody0_raw
   -- Body+store composition, bridge, Phase C merge, and final composition
@@ -859,7 +859,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Addr)
   -- and convert the postcondition using the bridge.
   -- Body+store for each body (produces concrete mem values, not yet bridged to getLimb result)
   -- Helper to build body+store (parametric in x10 value)
-  have mk_body_store : ∀ (bodyBase : Addr) (x10v vLimb : Word)
+  have mk_body_store : ∀ (bodyBase : Word) (x10v vLimb : Word)
       (hbodyRaw : cpsTriple bodyBase (base + 136) (evm_byte_code base)
         ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
          ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
@@ -980,7 +980,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Addr)
 
 set_option maxHeartbeats 4000000 in
 /-- Stack-level BYTE spec using evmWordIs and EvmWord.byte. -/
-theorem evm_byte_stack_spec (sp base : Addr)
+theorem evm_byte_stack_spec (sp base : Word)
     (idx val : EvmWord) (v5 v6 v10 : Word)
     (hvalid : ValidMemRange sp 8) :
     cpsTriple base (base + 180) (evm_byte_code base)
@@ -1031,15 +1031,15 @@ theorem evm_byte_stack_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                    show (0 : EvmWord).getLimb 0 = 0 from by simp [EvmWord.getLimb],
                    show (0 : EvmWord).getLimb 1 = 0 from by simp [EvmWord.getLimb],
                    show (0 : EvmWord).getLimb 2 = 0 from by simp [EvmWord.getLimb],
@@ -1076,15 +1076,15 @@ theorem evm_byte_stack_spec (sp base : Addr)
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by
           unfold evmWordIs at hp
-          simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                     show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                     show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+          simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                     show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                     show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
           xperm_hyp hp)
         (fun h hq => by
           unfold evmWordIs
-          simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                     show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                     show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+          simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                     show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                     show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                      show (0 : EvmWord).getLimb 0 = 0 from by simp [EvmWord.getLimb],
                      show (0 : EvmWord).getLimb 1 = 0 from by simp [EvmWord.getLimb],
                      show (0 : EvmWord).getLimb 2 = 0 from by simp [EvmWord.getLimb],

--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -52,9 +52,9 @@ def cc_epilogue : Program :=
   LD .x1 .x2 8 ;; ADDI .x2 .x2 16 ;; cc_ret
 
 -- CodeReq abbreviations
-abbrev cc_ret_code (base : Addr) : CodeReq := CodeReq.ofProg base cc_ret
-abbrev cc_prologue_code (base : Addr) : CodeReq := CodeReq.ofProg base cc_prologue
-abbrev cc_epilogue_code (base : Addr) : CodeReq := CodeReq.ofProg base cc_epilogue
+abbrev cc_ret_code (base : Word) : CodeReq := CodeReq.ofProg base cc_ret
+abbrev cc_prologue_code (base : Word) : CodeReq := CodeReq.ofProg base cc_prologue
+abbrev cc_epilogue_code (base : Word) : CodeReq := CodeReq.ofProg base cc_epilogue
 
 -- ============================================================================
 -- Call / return specs
@@ -62,7 +62,7 @@ abbrev cc_epilogue_code (base : Addr) : CodeReq := CodeReq.ofProg base cc_epilog
 
 /-- Near call: JAL x1, offset.
     Saves PC+4 in ra (x1), jumps to PC + sext(offset). -/
-theorem callNear_spec (offset : BitVec 21) (base : Addr) (old_ra : Word) :
+theorem callNear_spec (offset : BitVec 21) (base : Word) (old_ra : Word) :
     cpsTriple base (base + signExtend21 offset)
       (CodeReq.singleton base (.JAL .x1 offset))
       (.x1 ↦ᵣ old_ra)
@@ -72,7 +72,7 @@ theorem callNear_spec (offset : BitVec 21) (base : Addr) (old_ra : Word) :
 /-- Far call: JALR x1, target, 0.
     Saves PC+4 in ra (x1), jumps to target.
     target must differ from x1 (enforced by sep conj). -/
-theorem callFar_spec (target : Reg) (v_target old_ra : Word) (base : Addr) :
+theorem callFar_spec (target : Reg) (v_target old_ra : Word) (base : Word) :
     cpsTriple base ((v_target + signExtend12 0) &&& ~~~1)
       (CodeReq.singleton base (.JALR .x1 target 0))
       ((target ↦ᵣ v_target) ** (.x1 ↦ᵣ old_ra))
@@ -81,7 +81,7 @@ theorem callFar_spec (target : Reg) (v_target old_ra : Word) (base : Addr) :
 
 /-- Return: JALR x0, x1, 0.
     Jumps to (ra + 0) &&& ~1. Preserves ra in x1. -/
-theorem ret_spec (base : Addr) (ra_val : Word) :
+theorem ret_spec (base : Word) (ra_val : Word) :
     cpsTriple base ((ra_val + signExtend12 0) &&& ~~~1)
       (CodeReq.singleton base (.JALR .x0 .x1 0))
       (.x1 ↦ᵣ ra_val)
@@ -89,7 +89,7 @@ theorem ret_spec (base : Addr) (ra_val : Word) :
   jalr_x0_spec_gen .x1 ra_val 0 base
 
 /-- Return with simplified exit: ra &&& ~1 (signExtend12 0 = 0 eliminated). -/
-theorem ret_spec' (base : Addr) (ra_val : Word) :
+theorem ret_spec' (base : Word) (ra_val : Word) :
     cpsTriple base (ra_val &&& ~~~1)
       (CodeReq.singleton base (.JALR .x0 .x1 0))
       (.x1 ↦ᵣ ra_val)
@@ -168,7 +168,7 @@ theorem cc_epilogue_spec (base sp_val old_x1 saved_ra : Word)
     This theorem composes the JAL with the function's spec, yielding a
     round-trip: call_site → function → call_site + 4. -/
 theorem callNear_function_spec
-    (call_site func_entry : Addr) (offset : BitVec 21)
+    (call_site func_entry : Word) (offset : BitVec 21)
     (cr_func : CodeReq) (P Q : Assertion) (old_ra : Word)
     (hP : P.pcFree)
     (hoff : call_site + signExtend21 offset = func_entry)
@@ -203,7 +203,7 @@ theorem callNear_function_spec
     sp_val: ORIGINAL sp on entry.
     The overall function runs from prol_base to ra &&& ~1, preserving sp. -/
 theorem nonleaf_function_spec
-    (prol_base body_entry body_exit epi_base : Addr)
+    (prol_base body_entry body_exit epi_base : Word)
     (sp_val ra_val old_slot : Word)
     (cr_prol cr_body cr_epi : CodeReq) (P Q : Assertion)
     (hprol_exit : prol_base + 8 = body_entry)

--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -85,7 +85,7 @@ theorem extractByte_packBytes (bytes : List (BitVec 8)) (k : Nat)
 -- ============================================================================
 
 /-- Auxiliary: assert `nChunks` consecutive doubleword chunks of bytecode. -/
-def evmCodeIsAux (base : Addr) : Nat → List (BitVec 8) → Assertion
+def evmCodeIsAux (base : Word) : Nat → List (BitVec 8) → Assertion
   | 0, _ => empAssertion
   | n + 1, bytes =>
     (base ↦ₘ packBytes (bytes.take 8)) ** evmCodeIsAux (base + 8) n (bytes.drop 8)
@@ -99,14 +99,14 @@ private def numChunks (n : Nat) : Nat := (n + 7) / 8
 
     Each doubleword is packed little-endian: byte at `base+k` is stored
     at bit position `(k%8)*8` within the doubleword at `alignToDword(base+k)`. -/
-def evmCodeIs (base : Addr) (bytes : List (BitVec 8)) : Assertion :=
+def evmCodeIs (base : Word) (bytes : List (BitVec 8)) : Assertion :=
   evmCodeIsAux base (numChunks bytes.length) bytes
 
 -- ============================================================================
 -- Basic properties
 -- ============================================================================
 
-@[simp] theorem evmCodeIs_nil (base : Addr) :
+@[simp] theorem evmCodeIs_nil (base : Word) :
     evmCodeIs base [] = empAssertion := rfl
 
 private theorem numChunks_pos {n : Nat} (hn : 0 < n) : 0 < numChunks n := by
@@ -117,7 +117,7 @@ private theorem numChunks_step {n : Nat} (hn : 0 < n) :
   unfold numChunks; omega
 
 /-- evmCodeIs of a non-empty list decomposes into a chunk and the rest. -/
-theorem evmCodeIs_nonempty (base : Addr) (bytes : List (BitVec 8)) (h : bytes ≠ []) :
+theorem evmCodeIs_nonempty (base : Word) (bytes : List (BitVec 8)) (h : bytes ≠ []) :
     evmCodeIs base bytes =
     ((base ↦ₘ packBytes (bytes.take 8)) **
      evmCodeIs (base + 8) (bytes.drop 8)) := by
@@ -130,17 +130,17 @@ theorem evmCodeIs_nonempty (base : Addr) (bytes : List (BitVec 8)) (h : bytes �
     simp [numChunks]; omega
   rw [hstep]; rfl
 
-theorem pcFree_evmCodeIsAux (base : Addr) (n : Nat) (bytes : List (BitVec 8)) :
+theorem pcFree_evmCodeIsAux (base : Word) (n : Nat) (bytes : List (BitVec 8)) :
     (evmCodeIsAux base n bytes).pcFree := by
   induction n generalizing base bytes with
   | zero => exact pcFree_emp
   | succ n ih => exact pcFree_sepConj (pcFree_memIs _ _) (ih _ _)
 
-theorem pcFree_evmCodeIs (base : Addr) (bytes : List (BitVec 8)) :
+theorem pcFree_evmCodeIs (base : Word) (bytes : List (BitVec 8)) :
     (evmCodeIs base bytes).pcFree :=
   pcFree_evmCodeIsAux base _ bytes
 
-instance (base : Addr) (bytes : List (BitVec 8)) :
+instance (base : Word) (bytes : List (BitVec 8)) :
     Assertion.PCFree (evmCodeIs base bytes) :=
   ⟨pcFree_evmCodeIs base bytes⟩
 
@@ -148,7 +148,7 @@ instance (base : Addr) (bytes : List (BitVec 8)) :
 -- evmCodeIs_split_at: extract the doubleword containing byte k
 -- ============================================================================
 
-theorem evmCodeIs_split_at (base : Addr) (bytes : List (BitVec 8)) (dw : Nat)
+theorem evmCodeIs_split_at (base : Word) (bytes : List (BitVec 8)) (dw : Nat)
     (hdw : dw * 8 + 8 ≤ bytes.length) :
     evmCodeIs base bytes =
     (evmCodeIs base (bytes.take (dw * 8)) **
@@ -171,11 +171,11 @@ theorem evmCodeIs_split_at (base : Addr) (bytes : List (BitVec 8)) (dw : Nat)
       omega
     rw [ih (base + 8) (bytes.drop 8) hdw']; clear hdw'
     -- Normalize addresses
-    have ha1 : (base + 8 : Addr) + BitVec.ofNat 64 (n * 8) =
+    have ha1 : (base + 8 : Word) + BitVec.ofNat 64 (n * 8) =
                base + BitVec.ofNat 64 ((n + 1) * 8) := by
       apply BitVec.eq_of_toNat_eq
       simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-    have ha2 : (base + 8 : Addr) + BitVec.ofNat 64 ((n + 1) * 8) =
+    have ha2 : (base + 8 : Word) + BitVec.ofNat 64 ((n + 1) * 8) =
                base + BitVec.ofNat 64 ((n + 2) * 8) := by
       apply BitVec.eq_of_toNat_eq
       simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
@@ -211,10 +211,10 @@ theorem evmCodeIs_split_at (base : Addr) (bytes : List (BitVec 8)) (dw : Nat)
 -- ============================================================================
 
 /-- Aligned base: low 3 bits are zero. -/
-abbrev IsAligned8 (addr : Addr) : Prop := addr &&& 7#64 = 0#64
+abbrev IsAligned8 (addr : Word) : Prop := addr &&& 7#64 = 0#64
 
 /-- An aligned address is unchanged by alignToDword. -/
-theorem alignToDword_of_aligned (base : Addr) (h : IsAligned8 base) :
+theorem alignToDword_of_aligned (base : Word) (h : IsAligned8 base) :
     alignToDword base = base := by
   unfold alignToDword
   have : base &&& ~~~7#64 = base ^^^ (base &&& 7#64) := by bv_decide

--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -24,7 +24,7 @@ namespace EvmAsm.Rv64
 /-- LT limb 0 spec (3 instructions): LD, LD, SLTU.
     Computes initial borrow = (a < b ? 1 : 0). Does NOT modify memory. -/
 theorem lt_limb0_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -44,7 +44,7 @@ theorem lt_limb0_spec (off_a off_b : BitVec 12)
 /-- LT carry limb spec (6 instructions): LD, LD, SLTU, SUB, SLTU, OR.
     Propagates borrow without storing result. Memory is NOT modified. -/
 theorem lt_limb_carry_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -74,7 +74,7 @@ theorem lt_limb_carry_spec (off_a off_b : BitVec 12)
 /-- BEQ when values are equal: always taken (jump to PC + signExtend13 offset).
     BEQ only modifies PC; all pcFree assertions are preserved. -/
 theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
-    (v : Word) (base : Addr) :
+    (v : Word) (base : Word) :
     cpsTriple base (base + signExtend13 offset)
       (CodeReq.singleton base (.BEQ rs1 rs2 offset))
       ((rs1 ↦ᵣ v) ** (rs2 ↦ᵣ v))
@@ -99,7 +99,7 @@ theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
 /-- BEQ when values are not equal: never taken (fall through to PC + 4).
     BEQ only modifies PC; all pcFree assertions are preserved. -/
 theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
-    (v1 v2 : Word) (hne : v1 ≠ v2) (base : Addr) :
+    (v1 v2 : Word) (hne : v1 ≠ v2) (base : Word) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.BEQ rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
@@ -128,7 +128,7 @@ theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
 /-- SLT MSB load spec (2 instructions): LD x7, LD x6.
     Loads the MSB limbs (limb 3) of both operands into x7 and x6. -/
 theorem slt_msb_load_spec (off_a off_b : BitVec 12)
-    (sp a3 b3 v7 v6 : Word) (base : Addr)
+    (sp a3 b3 v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -50,7 +50,7 @@ macro "skipBlock" : tactic =>
 
 /-- The full evm_div code split into 14 per-phase CodeReq.ofProg blocks.
     This is the canonical CodeReq for all composed specs. -/
-abbrev divCode (base : Addr) : CodeReq :=
+abbrev divCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
     CodeReq.ofProg base (divK_phaseA 1016),             -- block 0
     CodeReq.ofProg (base + 32) divK_phaseB,              -- block 1
@@ -74,13 +74,13 @@ abbrev divCode (base : Addr) : CodeReq :=
 -- ============================================================================
 
 /-- Phase A code (8 instructions, block 0) is subsumed by divCode. -/
-private theorem divK_phaseA_code_sub_divCode (base : Addr) :
+private theorem divK_phaseA_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseA_code base) a = some i → (divCode base) a = some i := by
   unfold divCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _
 
 /-- Zero path code (5 instructions, block 11) is subsumed by divCode. -/
-private theorem divK_zeroPath_code_sub_divCode (base : Addr) :
+private theorem divK_zeroPath_code_sub_divCode (base : Word) :
     ∀ a i, (divK_zeroPath_code (base + 1044)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
   -- Skip blocks 0-10, then match block 11
@@ -89,7 +89,7 @@ private theorem divK_zeroPath_code_sub_divCode (base : Addr) :
   exact CodeReq.union_mono_left _ _
 
 /-- BEQ singleton at base+28 is subsumed by divCode (part of block 0: phaseA). -/
-private theorem beq_singleton_sub_divCode (base : Addr) :
+private theorem beq_singleton_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 28) (.BEQ .x5 .x0 1016)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
@@ -99,7 +99,7 @@ private theorem beq_singleton_sub_divCode (base : Addr) :
       (by native_decide) (by native_decide)) a i h)
 
 /-- Phase B init1 code (ofProg sub-range of block 1) is subsumed by divCode. -/
-private theorem divK_phaseB_init1_code_sub_divCode (base : Addr) :
+private theorem divK_phaseB_init1_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseB_init1_code (base + 32)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
@@ -114,7 +114,7 @@ private theorem divK_phaseB_init1_code_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 /-- Phase B init2 code (ofProg sub-range of block 1) is subsumed by divCode. -/
-private theorem divK_phaseB_init2_code_sub_divCode (base : Addr) :
+private theorem divK_phaseB_init2_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseB_init2_code (base + 60)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
@@ -127,15 +127,15 @@ private theorem divK_phaseB_init2_code_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 /-- ADDI x5 x0 4 singleton at base+68 (part of block 1: phaseB) is subsumed by divCode. -/
-private theorem addi_x5_singleton_sub_divCode (base : Addr) :
+private theorem addi_x5_singleton_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 68) (.ADDI .x5 .x0 4)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 9
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 36 = base + 68 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by native_decide,
+      show (base + 32 : Word) + 36 = base + 68 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -143,15 +143,15 @@ private theorem addi_x5_singleton_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 /-- BNE x10 x0 24 singleton at base+72 (part of block 1: phaseB) is subsumed by divCode. -/
-private theorem bne_x10_singleton_sub_divCode (base : Addr) :
+private theorem bne_x10_singleton_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 72) (.BNE .x10 .x0 24)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 10
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 40 = base + 72 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by native_decide,
+      show (base + 32 : Word) + 40 = base + 72 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -159,7 +159,7 @@ private theorem bne_x10_singleton_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 /-- Phase B tail code (ofProg sub-range of block 1) is subsumed by divCode. -/
-private theorem divK_phaseB_tail_code_sub_divCode (base : Addr) :
+private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseB_tail_code (base + 96)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
@@ -193,23 +193,23 @@ private theorem divK_phaseB_n4_nm1_x8 :
 private theorem divK_se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by native_decide
 
 -- Address normalization lemmas for phaseB composition (separate theorems for heartbeat budget)
-private theorem phB_off_4 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem phB_off_8 (base : Addr) : (base + 32 : Addr) + 8 = base + 40 := by bv_omega
-private theorem phB_off_12 (base : Addr) : (base + 32 : Addr) + 12 = base + 44 := by bv_omega
-private theorem phB_off_16 (base : Addr) : (base + 32 : Addr) + 16 = base + 48 := by bv_omega
-private theorem phB_off_20 (base : Addr) : (base + 32 : Addr) + 20 = base + 52 := by bv_omega
-private theorem phB_off_24 (base : Addr) : (base + 32 : Addr) + 24 = base + 56 := by bv_omega
-private theorem phB_off_28 (base : Addr) : (base + 32 : Addr) + 28 = base + 60 := by bv_omega
-private theorem phB_i2_4 (base : Addr) : (base + 60 : Addr) + 4 = base + 64 := by bv_omega
-private theorem phB_i2_8 (base : Addr) : (base + 60 : Addr) + 8 = base + 68 := by bv_omega
-private theorem phB_addi_4 (base : Addr) : (base + 68 : Addr) + 4 = base + 72 := by bv_omega
-private theorem phB_bne_4 (base : Addr) : (base + 72 : Addr) + 4 = base + 76 := by bv_omega
-private theorem phB_t_4 (base : Addr) : (base + 96 : Addr) + 4 = base + 100 := by bv_omega
-private theorem phB_t_8 (base : Addr) : (base + 96 : Addr) + 8 = base + 104 := by bv_omega
-private theorem phB_t_12 (base : Addr) : (base + 96 : Addr) + 12 = base + 108 := by bv_omega
-private theorem phB_t_16 (base : Addr) : (base + 96 : Addr) + 16 = base + 112 := by bv_omega
-private theorem phB_t_20 (base : Addr) : (base + 96 : Addr) + 20 = base + 116 := by bv_omega
-private theorem phB_sp24_32 (sp : Addr) : (sp + (24 : Addr) + (32 : Addr)) = sp + 56 := by bv_omega
+private theorem phB_off_4 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem phB_off_8 (base : Word) : (base + 32 : Word) + 8 = base + 40 := by bv_omega
+private theorem phB_off_12 (base : Word) : (base + 32 : Word) + 12 = base + 44 := by bv_omega
+private theorem phB_off_16 (base : Word) : (base + 32 : Word) + 16 = base + 48 := by bv_omega
+private theorem phB_off_20 (base : Word) : (base + 32 : Word) + 20 = base + 52 := by bv_omega
+private theorem phB_off_24 (base : Word) : (base + 32 : Word) + 24 = base + 56 := by bv_omega
+private theorem phB_off_28 (base : Word) : (base + 32 : Word) + 28 = base + 60 := by bv_omega
+private theorem phB_i2_4 (base : Word) : (base + 60 : Word) + 4 = base + 64 := by bv_omega
+private theorem phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_omega
+private theorem phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_omega
+private theorem phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_omega
+private theorem phB_t_4 (base : Word) : (base + 96 : Word) + 4 = base + 100 := by bv_omega
+private theorem phB_t_8 (base : Word) : (base + 96 : Word) + 8 = base + 104 := by bv_omega
+private theorem phB_t_12 (base : Word) : (base + 96 : Word) + 12 = base + 108 := by bv_omega
+private theorem phB_t_16 (base : Word) : (base + 96 : Word) + 16 = base + 112 := by bv_omega
+private theorem phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + 116 := by bv_omega
+private theorem phB_sp24_32 (sp : Word) : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_omega
 
 -- ============================================================================
 -- Section 6b: Opaque memory bundle for phaseB invariant cells
@@ -220,14 +220,14 @@ private theorem phB_sp24_32 (sp : Addr) : (sp + (24 : Addr) + (32 : Addr)) = sp 
 /-- The 7 memory cells zeroed by phaseB init1 (q[0..3] + u[5..7]).
     Marked @[irreducible] so xperm treats this as 1 opaque atom, not 7. -/
 @[irreducible]
-def phaseB_zeroed_mem (sp : Addr) : Assertion :=
+def phaseB_zeroed_mem (sp : Word) : Assertion :=
   ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4000) ↦ₘ (0 : Word))
 
 /-- Fold 7 individual memory-zero assertions into the opaque bundle. -/
-theorem phaseB_zeroed_mem_fold (sp : Addr) :
+theorem phaseB_zeroed_mem_fold (sp : Word) :
     (((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
@@ -235,7 +235,7 @@ theorem phaseB_zeroed_mem_fold (sp : Addr) :
   delta phaseB_zeroed_mem; rfl
 
 /-- Unfold the opaque bundle back to 7 individual assertions. -/
-theorem phaseB_zeroed_mem_unfold (sp : Addr) :
+theorem phaseB_zeroed_mem_unfold (sp : Word) :
     phaseB_zeroed_mem sp =
     (((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
@@ -251,7 +251,7 @@ theorem phaseB_zeroed_mem_unfold (sp : Addr) :
 set_option maxRecDepth 2048 in
 /-- When b = 0 (all limbs zero), evm_div writes zeros and advances sp.
     Execution path: phaseA body (7 instrs), BEQ taken, zeroPath (5 instrs). -/
-theorem evm_div_bzero_spec (sp base : Addr)
+theorem evm_div_bzero_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbz : b0 ||| b1 ||| b2 ||| b3 = 0)
     (hvalid : ValidMemRange sp 8) :
@@ -268,9 +268,9 @@ theorem evm_div_bzero_spec (sp base : Addr)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Addr) + signExtend13 1016 = base + 1044 from by
+  rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
         rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Addr) + 4 = base + 32 from by bv_omega] at hbeq_raw
+      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -290,7 +290,7 @@ theorem evm_div_bzero_spec (sp base : Addr)
   -- Extend to divCode CodeReq
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_divCode base)
     (divK_zeroPath_spec sp (base + 1044) b0 b1 b2 b3 hvalid)
-  rw [show (base + 1044 : Addr) + 20 = base + 1064 from by bv_omega] at hzp
+  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_omega] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -312,7 +312,7 @@ theorem evm_div_bzero_spec (sp base : Addr)
 set_option maxRecDepth 2048 in
 /-- When b ≠ 0, evm_div falls through Phase A to Phase B at base+32.
     Execution path: phaseA body (7 instrs), BEQ not taken. -/
-theorem evm_div_phaseA_ntaken_spec (sp base : Addr)
+theorem evm_div_phaseA_ntaken_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -328,9 +328,9 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Addr)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Addr) + signExtend13 1016 = base + 1044 from by
+  rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
         rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Addr) + 4 = base + 32 from by bv_omega] at hbeq_raw
+      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -362,7 +362,7 @@ set_option maxRecDepth 4096 in
 /-- Phase B when b[3] ≠ 0 (n=4): zero scratch, load b[1..2], cascade BNE taken, load leading limb.
     Execution path: init1 (7 instrs) + init2 (2) + ADDI (1) + BNE taken (1) + tail (5) = 16 instrs.
     Exit at base+116 (start of CLZ). x5 = b[3] (leading limb), x6 = b[1], x7 = b[2], n = 4. -/
-theorem evm_div_phaseB_n4_spec (sp base : Addr)
+theorem evm_div_phaseB_n4_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3nz : b3 ≠ 0)
@@ -414,7 +414,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Addr)
   seqFrame hinit1fhinit2 haddi
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Addr) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne_raw
     (fun hp hQf => by
@@ -448,7 +448,7 @@ set_option maxRecDepth 2048 in
 /-- When b ≠ 0 and b[3] ≠ 0, evm_div executes Phase A (ntaken) then Phase B (n=4).
     Execution: 8 + 16 = 24 instructions, base → base+116 (start of CLZ).
     Pre/postcondition shapes reflect frame structure from composition. -/
-theorem evm_div_phaseAB_n4_spec (sp base : Addr)
+theorem evm_div_phaseAB_n4_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
@@ -505,15 +505,15 @@ theorem evm_div_phaseAB_n4_spec (sp base : Addr)
 -- ============================================================================
 
 -- ADDI x5 x0 3 at base+76 (index 11 of phaseB)
-private theorem addi_x5_3_sub_divCode (base : Addr) :
+private theorem addi_x5_3_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 76) (.ADDI .x5 .x0 3)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 11
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 44 = base + 76 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by native_decide,
+      show (base + 32 : Word) + 44 = base + 76 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -521,15 +521,15 @@ private theorem addi_x5_3_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 -- BNE x7 x0 16 at base+80 (index 12 of phaseB)
-private theorem bne_x7_16_sub_divCode (base : Addr) :
+private theorem bne_x7_16_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 80) (.BNE .x7 .x0 16)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 12
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 48 = base + 80 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by native_decide,
+      show (base + 32 : Word) + 48 = base + 80 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -537,15 +537,15 @@ private theorem bne_x7_16_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 -- ADDI x5 x0 2 at base+84 (index 13 of phaseB)
-private theorem addi_x5_2_sub_divCode (base : Addr) :
+private theorem addi_x5_2_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 84) (.ADDI .x5 .x0 2)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 13
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 52 = base + 84 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by native_decide,
+      show (base + 32 : Word) + 52 = base + 84 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -553,15 +553,15 @@ private theorem addi_x5_2_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 -- BNE x6 x0 8 at base+88 (index 14 of phaseB)
-private theorem bne_x6_8_sub_divCode (base : Addr) :
+private theorem bne_x6_8_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 88) (.BNE .x6 .x0 8)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 14
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 56 = base + 88 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by native_decide,
+      show (base + 32 : Word) + 56 = base + 88 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -569,15 +569,15 @@ private theorem bne_x6_8_sub_divCode (base : Addr) :
     (CodeReq.union_mono_left _ _) a i h1
 
 -- ADDI x5 x0 1 at base+92 (index 15 of phaseB)
-private theorem addi_x5_1_sub_divCode (base : Addr) :
+private theorem addi_x5_1_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 92) (.ADDI .x5 .x0 1)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 15
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Addr) from by native_decide,
-      show (base + 32 : Addr) + 60 = base + 92 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by native_decide,
+      show (base + 32 : Word) + 60 = base + 92 from by bv_omega] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -607,16 +607,16 @@ private theorem divK_phaseB_n1_nm1_x8 :
   native_decide
 
 -- Cascade address normalization
-private theorem phB_step1_4 (base : Addr) : (base + 76 : Addr) + 4 = base + 80 := by bv_omega
-private theorem phB_step1_8 (base : Addr) : (base + 80 : Addr) + 4 = base + 84 := by bv_omega
-private theorem phB_step2_4 (base : Addr) : (base + 84 : Addr) + 4 = base + 88 := by bv_omega
-private theorem phB_step2_8 (base : Addr) : (base + 88 : Addr) + 4 = base + 92 := by bv_omega
-private theorem phB_fall_4 (base : Addr) : (base + 92 : Addr) + 4 = base + 96 := by bv_omega
+private theorem phB_step1_4 (base : Word) : (base + 76 : Word) + 4 = base + 80 := by bv_omega
+private theorem phB_step1_8 (base : Word) : (base + 80 : Word) + 4 = base + 84 := by bv_omega
+private theorem phB_step2_4 (base : Word) : (base + 84 : Word) + 4 = base + 88 := by bv_omega
+private theorem phB_step2_8 (base : Word) : (base + 88 : Word) + 4 = base + 92 := by bv_omega
+private theorem phB_fall_4 (base : Word) : (base + 92 : Word) + 4 = base + 96 := by bv_omega
 
 -- Tail memory address normalization
-private theorem phB_sp16_32 (sp : Addr) : (sp + (16 : Addr) + (32 : Addr)) = sp + 48 := by bv_omega
-private theorem phB_sp8_32 (sp : Addr) : (sp + (8 : Addr) + (32 : Addr)) = sp + 40 := by bv_omega
-private theorem phB_sp0_32 (sp : Addr) : (sp + (0 : Addr) + (32 : Addr)) = sp + 32 := by bv_omega
+private theorem phB_sp16_32 (sp : Word) : (sp + (16 : Word) + (32 : Word)) = sp + 48 := by bv_omega
+private theorem phB_sp8_32 (sp : Word) : (sp + (8 : Word) + (32 : Word)) = sp + 40 := by bv_omega
+private theorem phB_sp0_32 (sp : Word) : (sp + (0 : Word) + (32 : Word)) = sp + 32 := by bv_omega
 
 -- ============================================================================
 -- Section 10d: Phase B n=3 (b[3]=0, b[2]≠0)
@@ -628,7 +628,7 @@ set_option maxRecDepth 4096 in
 /-- Phase B when b[3]=0, b[2]≠0 (n=3): zero scratch, load b[1..2], cascade to n=3, load b[2].
     Execution: init1(7) + init2(2) + step0(2) + step1(2) + tail(5) = 18 instrs.
     Exit at base+116 (start of CLZ). x5 = b[2] (leading limb), n = 3. -/
-theorem evm_div_phaseB_n3_spec (sp base : Addr)
+theorem evm_div_phaseB_n3_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
@@ -700,7 +700,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Addr) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
@@ -735,7 +735,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Addr) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQf => by
@@ -788,7 +788,7 @@ set_option maxRecDepth 4096 in
 /-- Phase B when b[3]=b[2]=0, b[1]≠0 (n=2): zero scratch, cascade to n=2, load b[1].
     Execution: init1(7) + init2(2) + 3×step(6) + tail(5) = 20 instrs.
     Exit at base+116. x5 = b[1] (leading limb), n = 2. -/
-theorem evm_div_phaseB_n2_spec (sp base : Addr)
+theorem evm_div_phaseB_n2_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -860,7 +860,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Addr) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
@@ -895,7 +895,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Addr) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
@@ -930,7 +930,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Addr) + signExtend13 8 = base + 96 from by
+  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [signExtend13_8]; bv_omega, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQf => by
@@ -984,7 +984,7 @@ set_option maxRecDepth 4096 in
     Execution: all 21 instructions of divK_phaseB.
     Exit at base+116. x5 = b[0] (leading limb), n = 1.
     Note: b[0] must be in precondition since the tail loads from sp+32. -/
-theorem evm_div_phaseB_n1_spec (sp base : Addr)
+theorem evm_div_phaseB_n1_spec (sp base : Word)
     (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
@@ -1056,7 +1056,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Addr) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
@@ -1091,7 +1091,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Addr) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
@@ -1126,7 +1126,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Addr)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Addr) + signExtend13 8 = base + 96 from by
+  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [signExtend13_8]; bv_omega, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQt => by
@@ -1189,21 +1189,21 @@ theorem evm_div_phaseB_n1_spec (sp base : Addr)
 -- ============================================================================
 
 /-- Phase C2 code (block 3) is subsumed by divCode. -/
-private theorem divK_phaseC2_code_sub_divCode (base : Addr) :
+private theorem divK_phaseC2_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseC2_code 172 (base + 212)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- BEQ x6 x0 172 singleton at base+224 (index 3 of phaseC2) is subsumed by divCode. -/
-private theorem beq_shift_sub_divCode (base : Addr) :
+private theorem beq_shift_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 224) (.BEQ .x6 .x0 172)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 212) (divK_phaseC2 172) 3
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Addr) from by native_decide,
-      show (base + 212 : Addr) + 12 = base + 224 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
+      show (base + 212 : Word) + 12 = base + 224 from by bv_omega] at hlookup
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -1211,7 +1211,7 @@ private theorem signExtend13_172 : signExtend13 (172 : BitVec 13) = (172 : Word)
 
 /-- Phase C2 body (base+212 → base+224): store shift, compute anti_shift.
     Extends to divCode. Uses first 3 instructions of phaseC2. -/
-private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base : Addr)
+private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base : Word)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true) :
     cpsTriple (base + 212) (base + 224) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1219,13 +1219,13 @@ private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base :
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + 212) hv_shift
-  rw [show (base + 212 : Addr) + 12 = base + 224 from by bv_omega] at hbody
+  rw [show (base + 212 : Word) + 12 = base + 224 from by bv_omega] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_divCode base) hbody
 
 set_option maxRecDepth 2048 in
 /-- Phase C2 when shift ≠ 0: falls through to normB at base+228.
     Stores shift to scratch, computes anti_shift = -shift. -/
-theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Addr)
+theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
     (hshift_nz : shift ≠ 0) :
     cpsTriple (base + 212) (base + 228) (divCode base)
@@ -1235,9 +1235,9 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Addr)
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Addr) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
         rw [signExtend13_172]; bv_omega,
-      show (base + 224 : Addr) + 4 = base + 228 from by bv_omega] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + 228 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -1257,7 +1257,7 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Addr)
 set_option maxRecDepth 2048 in
 /-- Phase C2 when shift = 0: branches to copyAU at base+396.
     Stores shift (=0) to scratch, computes anti_shift = 0. -/
-theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Addr)
+theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
     (hshift_z : shift = 0) :
     cpsTriple (base + 212) (base + 396) (divCode base)
@@ -1267,9 +1267,9 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Addr)
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Addr) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
         rw [signExtend13_172]; bv_omega,
-      show (base + 224 : Addr) + 4 = base + 228 from by bv_omega] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + 228 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -1292,14 +1292,14 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Addr)
 -- ============================================================================
 
 /-- NormB code (block 4) is subsumed by divCode. -/
-private theorem divK_normB_code_sub_divCode (base : Addr) :
+private theorem divK_normB_code_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 228) divK_normB) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Helper: NormB sub-block subsumption via ofProg_mono_sub. -/
-private theorem normB_sub (base : Addr) (sub_prog : List Instr) (k : Nat)
+private theorem normB_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ divK_normB.length)
     (hslice : (divK_normB.drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * divK_normB.length < 2 ^ 64) :
@@ -1321,7 +1321,7 @@ set_option maxRecDepth 4096 in
     base+228 → base+312 (21 instructions).
     Pre: x12=sp, x6=shift, x2=anti_shift, b[0..3] at sp+32..56.
     Post: b[i] normalized, x5=b[0]<<<shift, x7=b[0]>>>anti_shift. -/
-theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Addr)
+theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word)
     (hvalid : ValidMemRange sp 8) :
     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
@@ -1342,7 +1342,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_56]; exact hvalid.get (show 7 < 8 from by omega))
     (by rw [se12_48]; exact hvalid.get (show 6 < 8 from by omega))
   simp only [se12_56, se12_48] at hm1
-  rw [show (base + 228 : Addr) + 24 = base + 252 from by bv_omega] at hm1
+  rw [show (base + 228 : Word) + 24 = base + 252 from by bv_omega] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 228) divK_normB
@@ -1358,7 +1358,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_48]; exact hvalid.get (show 6 < 8 from by omega))
     (by rw [se12_40]; exact hvalid.get (show 5 < 8 from by omega))
   simp only [se12_48, se12_40] at hm2
-  rw [show (base + 252 : Addr) + 24 = base + 276 from by bv_omega] at hm2
+  rw [show (base + 252 : Word) + 24 = base + 276 from by bv_omega] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 252) divK_normB
@@ -1375,7 +1375,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_40]; exact hvalid.get (show 5 < 8 from by omega))
     (by rw [se12_32]; exact hvalid.get (show 4 < 8 from by omega))
   simp only [se12_40, se12_32] at hm3
-  rw [show (base + 276 : Addr) + 24 = base + 300 from by bv_omega] at hm3
+  rw [show (base + 276 : Word) + 24 = base + 300 from by bv_omega] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 276) divK_normB
@@ -1390,7 +1390,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
   have hl := divK_normB_last_spec 32 sp b0 b1' shift (base + 300)
     (by rw [se12_32]; exact hvalid.get (show 4 < 8 from by omega))
   simp only [se12_32] at hl
-  rw [show (base + 300 : Addr) + 12 = base + 312 from by bv_omega] at hl
+  rw [show (base + 300 : Word) + 12 = base + 312 from by bv_omega] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 300) divK_normB
@@ -1413,14 +1413,14 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
 -- ============================================================================
 
 /-- NormA code (block 5) is subsumed by divCode. -/
-private theorem divK_normA_code_sub_divCode (base : Addr) :
+private theorem divK_normA_code_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 312) (divK_normA 40)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Helper: NormA sub-block subsumption via ofProg_mono_sub. -/
-private theorem normA_sub (base : Addr) (sub_prog : List Instr) (k : Nat)
+private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ (divK_normA 40).length)
     (hslice : ((divK_normA 40).drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * (divK_normA 40).length < 2 ^ 64) :
@@ -1448,7 +1448,7 @@ set_option maxRecDepth 4096 in
     base+312 → base+432 (21 instructions including JAL).
     u[4] = a[3]>>>anti_shift, u[3..0] = merged shifted limbs. -/
 theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
-    (u0_old u1_old u2_old u3_old u4_old : Word) (base : Addr)
+    (u0_old u1_old u2_old u3_old u4_old : Word) (base : Word)
     (hvalid : ValidMemRange sp 8)
     (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
@@ -1480,7 +1480,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + 312)
     (by rw [se12_24]; exact hvalid.get (show 3 < 8 from by omega)) hv_u4
   simp only [se12_24] at htop
-  rw [show (base + 312 : Addr) + 12 = base + 324 from by bv_omega] at htop
+  rw [show (base + 312 : Word) + 12 = base + 324 from by bv_omega] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 312) (divK_normA 40)
@@ -1498,7 +1498,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift anti_shift u3_old (base + 324)
     (by rw [se12_16]; exact hvalid.get (show 2 < 8 from by omega)) hv_u3
   simp only [se12_16] at hma1
-  rw [show (base + 324 : Addr) + 20 = base + 344 from by bv_omega] at hma1
+  rw [show (base + 324 : Word) + 20 = base + 344 from by bv_omega] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 324) (divK_normA 40)
@@ -1517,7 +1517,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     shift anti_shift u2_old (base + 344)
     (by rw [se12_8]; exact hvalid.get (show 1 < 8 from by omega)) hv_u2
   simp only [se12_8] at hmb
-  rw [show (base + 344 : Addr) + 20 = base + 364 from by bv_omega] at hmb
+  rw [show (base + 344 : Word) + 20 = base + 364 from by bv_omega] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 344) (divK_normA 40)
@@ -1535,7 +1535,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     shift anti_shift u1_old (base + 364)
     (by rw [se12_0]; exact hvalid.get (show 0 < 8 from by omega)) hv_u1
   simp only [se12_0] at hma2
-  rw [show (base + 364 : Addr) + 20 = base + 384 from by bv_omega] at hma2
+  rw [show (base + 364 : Word) + 20 = base + 384 from by bv_omega] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 364) (divK_normA 40)
@@ -1550,7 +1550,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     (fun h hp => by xperm_hyp hp) h123 hma2ef
   -- Last: u[0] = a[0]<<<shift (base+384 → base+392)
   have hlast := divK_normA_last_spec 4056 sp a0 shift u0_old (base + 384) hv_u0
-  rw [show (base + 384 : Addr) + 8 = base + 392 from by bv_omega] at hlast
+  rw [show (base + 384 : Word) + 8 = base + 392 from by bv_omega] at hlast
   have hlaste := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 384) (divK_normA 40)
@@ -1567,7 +1567,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     (fun h hp => by xperm_hyp hp) h1234 hlastef
   -- JAL x0 40 at base+392 → base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
-  rw [show (base + 392 : Addr) + signExtend21 40 = base + 432 from by
+  rw [show (base + 392 : Word) + signExtend21 40 = base + 432 from by
         rw [signExtend21_40]; bv_omega] at hjal
   have hjale := cpsTriple_extend_code (hmono := by
     intro a i h
@@ -1575,7 +1575,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + 312) (divK_normA 40) 20
           (by native_decide) (by native_decide)
-        rw [show (base + 312 : Addr) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_omega]
+        rw [show (base + 312 : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_omega]
           at hlookup
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
@@ -1608,7 +1608,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
 -- ============================================================================
 
 /-- CopyAU code (block 6) is subsumed by divCode. -/
-private theorem divK_copyAU_code_sub_divCode (base : Addr) :
+private theorem divK_copyAU_code_sub_divCode (base : Word) :
     ∀ a i, (divK_copyAU_code (base + 396)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -1616,8 +1616,8 @@ private theorem divK_copyAU_code_sub_divCode (base : Addr) :
 
 /-- Full CopyAU: copy a[0..3] to u[0..3], set u[4]=0.
     base+396 → base+432 (9 instructions). -/
-theorem divK_copyAU_full_spec (sp : Addr)
-    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Addr)
+theorem divK_copyAU_full_spec (sp : Word)
+    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word)
     (hvalid : ValidMemRange sp 8)
     (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
@@ -1639,7 +1639,7 @@ theorem divK_copyAU_full_spec (sp : Addr)
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
   have hcopy := divK_copyAU_spec sp (base + 396) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
     hvalid hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
-  rw [show (base + 396 : Addr) + 36 = base + 432 from by bv_omega] at hcopy
+  rw [show (base + 396 : Word) + 36 = base + 432 from by bv_omega] at hcopy
   exact cpsTriple_extend_code (divK_copyAU_code_sub_divCode base) hcopy
 
 -- ============================================================================
@@ -1648,21 +1648,21 @@ theorem divK_copyAU_full_spec (sp : Addr)
 -- ============================================================================
 
 /-- LoopSetup code (block 7) is subsumed by divCode. -/
-private theorem divK_loopSetup_code_sub_divCode (base : Addr) :
+private theorem divK_loopSetup_code_sub_divCode (base : Word) :
     ∀ a i, (divK_loopSetup_code 460 (base + 432)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- BLT singleton at base+444 (index 3 of loopSetup) is subsumed by divCode. -/
-private theorem blt_loopSetup_sub_divCode (base : Addr) :
+private theorem blt_loopSetup_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 444) (.BLT .x1 .x0 460)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + 432) (divK_loopSetup 460) 3
     (by native_decide) (by native_decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Addr) from by native_decide,
-      show (base + 432 : Addr) + 12 = base + 444 from by bv_omega] at hlookup
+  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
+      show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hlookup
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -1671,7 +1671,7 @@ private theorem signExtend13_460 : signExtend13 (460 : BitVec 13) = (460 : Word)
 set_option maxRecDepth 2048 in
 /-- LoopSetup when m ≥ 0 (n ≤ 4): falls through to loop body at base+448.
     Loads n from scratch, computes m = 4-n, BLT not taken. -/
-theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Addr)
+theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
@@ -1682,12 +1682,12 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Addr)
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec sp n v1 v5 460 (base + 432) hv_n
-  rw [show (base + 432 : Addr) + 12 = base + 444 from by bv_omega] at hbody
+  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 460 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Addr) + signExtend13 460 = base + 904 from by
+  rw [show (base + 444 : Word) + signExtend13 460 = base + 904 from by
         rw [signExtend13_460]; bv_omega,
-      show (base + 444 : Addr) + 4 = base + 448 from by bv_omega] at hblt_raw
+      show (base + 444 : Word) + 4 = base + 448 from by bv_omega] at hblt_raw
   have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -1705,7 +1705,7 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Addr)
 
 set_option maxRecDepth 2048 in
 /-- LoopSetup when m < 0 (n > 4, skip loop): branches to denorm at base+904. -/
-theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Addr)
+theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hm_lt : BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
@@ -1716,12 +1716,12 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Addr)
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec sp n v1 v5 460 (base + 432) hv_n
-  rw [show (base + 432 : Addr) + 12 = base + 444 from by bv_omega] at hbody
+  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 460 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Addr) + signExtend13 460 = base + 904 from by
+  rw [show (base + 444 : Word) + signExtend13 460 = base + 904 from by
         rw [signExtend13_460]; bv_omega,
-      show (base + 444 : Addr) + 4 = base + 448 from by bv_omega] at hblt_raw
+      show (base + 444 : Word) + 4 = base + 448 from by bv_omega] at hblt_raw
   have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -1743,7 +1743,7 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Addr)
 -- ============================================================================
 
 /-- Denorm code (block 9) is subsumed by divCode. -/
-private theorem divK_denorm_code_sub_divCode (base : Addr) :
+private theorem divK_denorm_code_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 904) divK_denorm) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -1751,7 +1751,7 @@ private theorem divK_denorm_code_sub_divCode (base : Addr) :
   exact CodeReq.union_mono_left _ _
 
 /-- Helper: Denorm sub-block subsumption via ofProg_mono_sub. -/
-private theorem denorm_sub (base : Addr) (sub_prog : List Instr) (k : Nat)
+private theorem denorm_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ divK_denorm.length)
     (hslice : (divK_denorm.drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * divK_denorm.length < 2 ^ 64) :
@@ -1772,7 +1772,7 @@ set_option maxRecDepth 4096 in
 /-- Full Denorm (shift body only): denormalize u[0..3] by right-shifting.
     base+904+16 → base+904+100 (21 instructions: ADDI+SUB + 3×merge + last).
     Used when shift≠0. The BEQ and LD are handled separately. -/
-theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Addr)
+theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word)
     (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
@@ -1794,7 +1794,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
   intro anti_shift u0' u1' u2' u3'
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+912 → base+920): compute anti_shift
   have haddi := addi_x0_spec_gen .x2 v2 0 (base + 912) (by nofun)
-  rw [show (base + 912 : Addr) + 4 = base + 916 from by bv_omega] at haddi
+  rw [show (base + 912 : Word) + 4 = base + 916 from by bv_omega] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 912) divK_denorm
@@ -1808,14 +1808,14 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
     (by pcFree) haddie
   have hsub := sub_spec_gen_rd_eq_rs1 .x2 .x6
     (signExtend12 (0 : BitVec 12)) shift (base + 916) (by nofun)
-  rw [show (base + 916 : Addr) + 4 = base + 920 from by bv_omega] at hsub
+  rw [show (base + 916 : Word) + 4 = base + 920 from by bv_omega] at hsub
   have hsube := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + 904) divK_denorm 3
           (by native_decide) (by native_decide)
-        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Addr) from by native_decide,
-            show (base + 904 : Addr) + 12 = base + 916 from by bv_omega] at hlookup
+        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
+            show (base + 904 : Word) + 12 = base + 916 from by bv_omega] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTriple_frame_left _ _ _ _ _
@@ -1828,7 +1828,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
   -- Merge u[0] with u[1] (base+920 → base+944)
   have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 920)
     hv_u0 hv_u1
-  rw [show (base + 920 : Addr) + 24 = base + 944 from by bv_omega] at hm0
+  rw [show (base + 920 : Word) + 24 = base + 944 from by bv_omega] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 920) divK_denorm
@@ -1844,7 +1844,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
     u0' (u1 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 944)
     hv_u1 hv_u2
-  rw [show (base + 944 : Addr) + 24 = base + 968 from by bv_omega] at hm1
+  rw [show (base + 944 : Word) + 24 = base + 968 from by bv_omega] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 944) divK_denorm
@@ -1860,7 +1860,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
     u1' (u2 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 968)
     hv_u2 hv_u3
-  rw [show (base + 968 : Addr) + 24 = base + 992 from by bv_omega] at hm2
+  rw [show (base + 968 : Word) + 24 = base + 992 from by bv_omega] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 968) divK_denorm
@@ -1874,7 +1874,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+992 → base+1004)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 992) hv_u3
-  rw [show (base + 992 : Addr) + 12 = base + 1004 from by bv_omega] at hl
+  rw [show (base + 992 : Word) + 12 = base + 1004 from by bv_omega] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 992) divK_denorm
@@ -1898,7 +1898,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Add
 -- ============================================================================
 
 /-- DIV epilogue code (block 10) is subsumed by divCode. -/
-private theorem divK_divEpilogue_code_sub_divCode (base : Addr) :
+private theorem divK_divEpilogue_code_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 1004) (divK_div_epilogue 24)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
@@ -1910,7 +1910,7 @@ set_option maxHeartbeats 12800000 in
 set_option maxRecDepth 4096 in
 /-- Full DIV epilogue: load q[0..3] from scratch, advance sp, store to output, JAL to NOP.
     base+1004 → base+1064 (10 instructions). -/
-theorem divK_div_epilogue_spec (sp : Addr) (base : Addr)
+theorem divK_div_epilogue_spec (sp : Word) (base : Word)
     (q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24 : Word)
     (hvalid : ValidMemRange sp 8)
     (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
@@ -1931,7 +1931,7 @@ theorem divK_div_epilogue_spec (sp : Addr) (base : Addr)
   -- Load phase (base+1004 → base+1020)
   have hload := divK_epilogue_load_spec 4088 4080 4072 4064 sp q0 q1 q2 q3 v5 v6 v7 v10
     (base + 1004) hv_q0 hv_q1 hv_q2 hv_q3
-  rw [show (base + 1004 : Addr) + 16 = base + 1020 from by bv_omega] at hload
+  rw [show (base + 1004 : Word) + 16 = base + 1020 from by bv_omega] at hload
   have hloade := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 1004) (base + 1004) (divK_div_epilogue 24)
@@ -1939,7 +1939,7 @@ theorem divK_div_epilogue_spec (sp : Addr) (base : Addr)
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hload
   -- Store phase (base+1020 → base+1064 via JAL)
   have hstore := divK_epilogue_store_spec sp (base + 1020) q0 q1 q2 q3 m0 m8 m16 m24 24 hvalid
-  rw [show (base + 1020 : Addr) + 20 + signExtend21 24 = base + 1064 from by
+  rw [show (base + 1020 : Word) + 20 + signExtend21 24 = base + 1064 from by
         rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_omega]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
@@ -1969,7 +1969,7 @@ theorem divK_div_epilogue_spec (sp : Addr) (base : Addr)
 
 /-- The full evm_mod code split into 14 per-phase CodeReq.ofProg blocks.
     Identical to divCode except block 10 uses divK_mod_epilogue. -/
-abbrev modCode (base : Addr) : CodeReq :=
+abbrev modCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
     CodeReq.ofProg base (divK_phaseA 1016),
     CodeReq.ofProg (base + 32) divK_phaseB,
@@ -1991,19 +1991,19 @@ abbrev modCode (base : Addr) : CodeReq :=
 -- Section 12: MOD CodeReq subsumption lemmas (via mono_unionAll)
 -- ============================================================================
 
-private theorem divK_phaseA_code_sub_modCode (base : Addr) :
+private theorem divK_phaseA_code_sub_modCode (base : Word) :
     ∀ a i, (divK_phaseA_code base) a = some i → (modCode base) a = some i := by
   unfold modCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _
 
-private theorem divK_zeroPath_code_sub_modCode (base : Addr) :
+private theorem divK_zeroPath_code_sub_modCode (base : Word) :
     ∀ a i, (divK_zeroPath_code (base + 1044)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-private theorem beq_singleton_sub_modCode (base : Addr) :
+private theorem beq_singleton_sub_modCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 28) (.BEQ .x5 .x0 1016)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
@@ -2020,7 +2020,7 @@ private theorem beq_singleton_sub_modCode (base : Addr) :
 set_option maxRecDepth 2048 in
 /-- When b = 0 (all limbs zero), evm_mod writes zeros and advances sp.
     Execution path: phaseA body (7 instrs), BEQ taken, zeroPath (5 instrs). -/
-theorem evm_mod_bzero_spec (sp base : Addr)
+theorem evm_mod_bzero_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbz : b0 ||| b1 ||| b2 ||| b3 = 0)
     (hvalid : ValidMemRange sp 8) :
@@ -2036,9 +2036,9 @@ theorem evm_mod_bzero_spec (sp base : Addr)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Addr) + signExtend13 1016 = base + 1044 from by
+  rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
         rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Addr) + 4 = base + 32 from by bv_omega] at hbeq_raw
+      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -2056,7 +2056,7 @@ theorem evm_mod_bzero_spec (sp base : Addr)
   -- Step 5: ZeroPath (base+1044 → base+1064)
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_modCode base)
     (divK_zeroPath_spec sp (base + 1044) b0 b1 b2 b3 hvalid)
-  rw [show (base + 1044 : Addr) + 20 = base + 1064 from by bv_omega] at hzp
+  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_omega] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -2077,7 +2077,7 @@ theorem evm_mod_bzero_spec (sp base : Addr)
 set_option maxRecDepth 2048 in
 /-- When b ≠ 0, evm_mod falls through Phase A to Phase B at base+32.
     Execution path: phaseA body (7 instrs), BEQ not taken. -/
-theorem evm_mod_phaseA_ntaken_spec (sp base : Addr)
+theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -2093,9 +2093,9 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Addr)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Addr) + signExtend13 1016 = base + 1044 from by
+  rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
         rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Addr) + 4 = base + 32 from by bv_omega] at hbeq_raw
+      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -2123,7 +2123,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Addr)
 
 -- Master subsumption: ofProg (base+1068) divK_div128 ⊆ divCode base
 -- Block 13 in divCode's unionAll; skip blocks 0-12.
-private theorem divK_div128_ofProg_sub_divCode (base : Addr) :
+private theorem divK_div128_ofProg_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 1068) divK_div128) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
@@ -2145,7 +2145,7 @@ private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
 
 -- Helper: singleton at index k of divK_div128 with explicit instr ⊆ divCode base.
 -- Used to prove each singleton in a block's cr is subsumed by divCode.
-private theorem d128_sub (base : Addr) (k : Nat) (addr : Addr) (instr : Instr)
+private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < divK_div128.length)
     (h_addr : addr = (base + 1068) + BitVec.ofNat 64 (4 * k))
     (h_instr : divK_div128.get ⟨k, hk⟩ = instr) :
@@ -2160,10 +2160,10 @@ private theorem d128_sub (base : Addr) (k : Nat) (addr : Addr) (instr : Instr)
 -- Each block's subsumption uses: CodeReq_union_sub (d128_sub ...) (CodeReq_union_sub ...)
 
 -- Address normalization: block entry offsets relative to (base + 1068)
-private theorem d128_off_40 (base : Addr) : (base + 1068 : Addr) + 40 = base + 1108 := by bv_omega
-private theorem d128_off_100 (base : Addr) : (base + 1068 : Addr) + 100 = base + 1168 := by bv_omega
-private theorem d128_off_120 (base : Addr) : (base + 1068 : Addr) + 120 = base + 1188 := by bv_omega
-private theorem d128_off_180 (base : Addr) : (base + 1068 : Addr) + 180 = base + 1248 := by bv_omega
+private theorem d128_off_40 (base : Word) : (base + 1068 : Word) + 40 = base + 1108 := by bv_omega
+private theorem d128_off_100 (base : Word) : (base + 1068 : Word) + 100 = base + 1168 := by bv_omega
+private theorem d128_off_120 (base : Word) : (base + 1068 : Word) + 120 = base + 1188 := by bv_omega
+private theorem d128_off_180 (base : Word) : (base + 1068 : Word) + 180 = base + 1248 := by bv_omega
 
 -- ============================================================================
 -- div128_spec: compose 5 block specs into single subroutine theorem.
@@ -2172,7 +2172,7 @@ private theorem d128_off_180 (base : Addr) : (base + 1068 : Addr) + 180 = base +
 
 set_option maxHeartbeats 25600000 in
 set_option maxRecDepth 4096 in
-theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
+theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (v1_old v6_old v11_old : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
@@ -2237,7 +2237,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
   -- ================================================================
   have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
     ret_mem d_mem dlo_mem un0_mem (base + 1068) hv_ret hv_d hv_dlo hv_un0
-  rw [show (base + 1068 : Addr) + 40 = base + 1108 from by bv_omega] at hph1
+  rw [show (base + 1068 : Word) + 40 = base + 1108 from by bv_omega] at hph1
   -- Extend phase1 cr to divCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1068)+{0,4,...,36}, indices 0-9
@@ -2262,7 +2262,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
   -- ================================================================
   have hst1 := divK_div128_step1_spec sp u_hi d_hi un1 d_lo un0 d d_lo
     (base + 1108) hv_dlo
-  rw [show (base + 1108 : Addr) + 60 = base + 1168 from by bv_omega] at hst1
+  rw [show (base + 1108 : Word) + 60 = base + 1168 from by bv_omega] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
     exact CodeReq_union_sub (d128_sub base 10 _ _ (by native_decide) (by bv_omega) (by native_decide))
      (CodeReq_union_sub (d128_sub base 11 _ _ (by native_decide) (by bv_omega) (by native_decide))
@@ -2294,7 +2294,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
   -- ================================================================
   have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo d_lo
     (base + 1168) hv_dlo
-  rw [show (base + 1168 : Addr) + 20 = base + 1188 from by bv_omega] at hcu
+  rw [show (base + 1168 : Word) + 20 = base + 1188 from by bv_omega] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
     exact CodeReq_union_sub (d128_sub base 25 _ _ (by native_decide) (by bv_omega) (by native_decide))
      (CodeReq_union_sub (d128_sub base 26 _ _ (by native_decide) (by bv_omega) (by native_decide))
@@ -2320,7 +2320,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 d_hi cu_q1_dlo cu_rhat_un1 un1 d_lo un0
     (base + 1188) hv_dlo hv_un0
-  rw [show (base + 1188 : Addr) + 60 = base + 1248 from by bv_omega] at hst2
+  rw [show (base + 1188 : Word) + 60 = base + 1248 from by bv_omega] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
     exact CodeReq_union_sub (d128_sub base 30 _ _ (by native_decide) (by bv_omega) (by native_decide))
      (CodeReq_union_sub (d128_sub base 31 _ _ (by native_decide) (by bv_omega) (by native_decide))
@@ -2383,7 +2383,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Addr)
 -- ============================================================================
 
 /-- CLZ code (block 2) is subsumed by divCode. -/
-private theorem divK_clz_code_sub_divCode (base : Addr) :
+private theorem divK_clz_code_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 116) divK_clz) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
@@ -2392,7 +2392,7 @@ private theorem divK_clz_code_sub_divCode (base : Addr) :
 
 /-- Helper: CLZ stage at instruction index k is subsumed by divCode.
     The stage has 4 instructions starting at index k of divK_clz. -/
-private theorem clz_stage_sub (base : Addr)
+private theorem clz_stage_sub (base : Word)
     (K M_s : BitVec 6) (M_a : BitVec 12) (k : Nat)
     (hk : k + (divK_clz_stage_prog K M_s M_a).length ≤ divK_clz.length)
     (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
@@ -2407,7 +2407,7 @@ private theorem clz_stage_sub (base : Addr)
 
 /-- Helper: CLZ last stage at instruction index k is subsumed by divCode.
     The last stage has 3 instructions. -/
-private theorem clz_last_sub (base : Addr) (k : Nat)
+private theorem clz_last_sub (base : Word) (k : Nat)
     (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
     (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
     (hbound : 4 * divK_clz.length < 2 ^ 64) :
@@ -2419,13 +2419,13 @@ private theorem clz_last_sub (base : Addr) (k : Nat)
       rfl hslice hk hbound a i h)
 
 /-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode. -/
-private theorem clz_init_sub (base : Addr) :
+private theorem clz_init_sub (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 116) (.ADDI .x6 .x0 0)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode base a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + 116) divK_clz 0
-      (by native_decide) (by native_decide)) a i (by rwa [show (base + 116 : Addr) =
+      (by native_decide) (by native_decide)) a i (by rwa [show (base + 116 : Word) =
         base + 116 + BitVec.ofNat 64 (4 * 0) from by bv_omega] at h))
 
 -- CLZ stage parameters: (SRLI_K, SLLI_M_s, ADDI_M_a, instruction_index)
@@ -2459,19 +2459,19 @@ noncomputable def clzResult (val : Word) : Word × Word :=
   (c5, v4)
 
 -- Address lemmas for CLZ stages
-private theorem clz_addr0 (base : Addr) : (base + 116 : Addr) + 4 = base + 120 := by bv_omega
-private theorem clz_addr1 (base : Addr) : (base + 120 : Addr) + 16 = base + 136 := by bv_omega
-private theorem clz_addr2 (base : Addr) : (base + 136 : Addr) + 16 = base + 152 := by bv_omega
-private theorem clz_addr3 (base : Addr) : (base + 152 : Addr) + 16 = base + 168 := by bv_omega
-private theorem clz_addr4 (base : Addr) : (base + 168 : Addr) + 16 = base + 184 := by bv_omega
-private theorem clz_addr5 (base : Addr) : (base + 184 : Addr) + 16 = base + 200 := by bv_omega
-private theorem clz_addr6 (base : Addr) : (base + 200 : Addr) + 12 = base + 212 := by bv_omega
+private theorem clz_addr0 (base : Word) : (base + 116 : Word) + 4 = base + 120 := by bv_omega
+private theorem clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_omega
+private theorem clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_omega
+private theorem clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_omega
+private theorem clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_omega
+private theorem clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_omega
+private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + 212 := by bv_omega
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     After stage: val' = if (val>>>K≠0) then val else val<<<M_s,
     count' = if (val>>>K≠0) then count else count+M_a. -/
 private theorem divK_clz_stage_combined
-    (K M_s : BitVec 6) (M_a : BitVec 12) (val count v7 : Word) (base : Addr) :
+    (K M_s : BitVec 6) (M_a : BitVec 12) (val count v7 : Word) (base : Word) :
     let cr := divK_clz_stage_code K M_s M_a base
     let val' := if val >>> K.toNat ≠ 0 then val else val <<< M_s.toNat
     let count' := if val >>> K.toNat ≠ 0 then count else count + signExtend12 M_a
@@ -2491,7 +2491,7 @@ private theorem divK_clz_stage_combined
       (fun _ hp => by rw [show (val >>> K.toNat : Word) = 0 from h]; exact hp) hs
 
 /-- Combined CLZ last stage: handles both taken and ntaken. -/
-private theorem divK_clz_last_combined (val count v7 : Word) (base : Addr) :
+private theorem divK_clz_last_combined (val count v7 : Word) (base : Word) :
     let cr := divK_clz_last_code base
     let count' := if val >>> (63 : Nat) ≠ 0 then count else count + signExtend12 (1 : BitVec 12)
     cpsTriple base (base + 12) cr
@@ -2515,7 +2515,7 @@ set_option maxHeartbeats 6400000 in
     Computes count of leading zeros in x6, shifts x5 left by that count.
     Entry: base+116 with x5=val, x6=v6_old, x7=v7_old, x0=0.
     Exit: base+212 with x5=(clzResult val).2, x6=(clzResult val).1, x0=0. -/
-theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
+theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
     cpsTriple (base + 116) (base + 212) (divCode base)
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
@@ -2534,7 +2534,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S0
   have S0e := cpsTriple_extend_code (hmono := clz_stage_sub base 32 32 32 1
     (by native_decide) (by native_decide) (by native_decide)) S0
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_omega] at S0e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_omega] at S0e
   rw [clz_addr1] at S0e
   seqFrame Ief S0e
   -- Abbreviations for stage 0 results
@@ -2547,7 +2547,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S1
   have S1e := cpsTriple_extend_code (hmono := clz_stage_sub base 48 16 16 5
     (by native_decide) (by native_decide) (by native_decide)) S1
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_omega] at S1e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_omega] at S1e
   rw [clz_addr2] at S1e
   seqFrame IefS0e S1e
   -- Stage 2: K=56, M_s=8, M_a=8 (base+152 → base+168)
@@ -2558,7 +2558,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S2
   have S2e := cpsTriple_extend_code (hmono := clz_stage_sub base 56 8 8 9
     (by native_decide) (by native_decide) (by native_decide)) S2
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_omega] at S2e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_omega] at S2e
   rw [clz_addr3] at S2e
   seqFrame IefS0eS1e S2e
   -- Stage 3: K=60, M_s=4, M_a=4 (base+168 → base+184)
@@ -2569,7 +2569,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S3
   have S3e := cpsTriple_extend_code (hmono := clz_stage_sub base 60 4 4 13
     (by native_decide) (by native_decide) (by native_decide)) S3
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_omega] at S3e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_omega] at S3e
   rw [clz_addr4] at S3e
   seqFrame IefS0eS1eS2e S3e
   -- Stage 4: K=62, M_s=2, M_a=2 (base+184 → base+200)
@@ -2580,7 +2580,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S4
   have S4e := cpsTriple_extend_code (hmono := clz_stage_sub base 62 2 2 17
     (by native_decide) (by native_decide) (by native_decide)) S4
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_omega] at S4e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_omega] at S4e
   rw [clz_addr5] at S4e
   seqFrame IefS0eS1eS2eS3e S4e
   -- Stage 5 (last): K=63 (base+200 → base+212)
@@ -2591,7 +2591,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Addr) :
   dsimp only [] at S5
   have S5e := cpsTriple_extend_code (hmono := clz_last_sub base 21
     (by native_decide) (by native_decide) (by native_decide)) S5
-  rw [show (base + 116 : Addr) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_omega] at S5e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_omega] at S5e
   rw [clz_addr6] at S5e
   seqFrame IefS0eS1eS2eS3eS4e S5e
   -- Final permutation

--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -19,12 +19,12 @@ namespace EvmAsm.Rv64
 -- Zero path: b = 0, push 0. 5 instructions.
 -- ============================================================================
 
-abbrev divK_zeroPath_code (base : Addr) : CodeReq :=
+abbrev divK_zeroPath_code (base : Word) : CodeReq :=
   CodeReq.ofProg base divK_zeroPath
 
 /-- Zero path: advance sp by 32, store four zeros at the output location.
     Used when b = 0 (both DIV and MOD return 0). -/
-theorem divK_zeroPath_spec (sp : Addr) (base : Addr)
+theorem divK_zeroPath_spec (sp : Word) (base : Word)
     (m32 m40 m48 m56 : Word)
     (hvalid : ValidMemRange sp 8) :
     let cr := divK_zeroPath_code base
@@ -47,13 +47,13 @@ theorem divK_zeroPath_spec (sp : Addr) (base : Addr)
 -- Pre/post include BEQ instruction and x0 for branch composition.
 -- ============================================================================
 
-abbrev divK_phaseA_code (base : Addr) : CodeReq :=
+abbrev divK_phaseA_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_phaseA 1016)
 
 /-- Phase A body: load and OR-reduce the 4 limbs of b.
     Produces x5 = b0 ||| b1 ||| b2 ||| b3.
     The BEQ instruction at base+28 and x0 are preserved for branch composition. -/
-theorem divK_phaseA_body_spec (sp : Addr) (base : Addr)
+theorem divK_phaseA_body_spec (sp : Word) (base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hvalid : ValidMemRange sp 8) :
     let cr := divK_phaseA_code base
@@ -80,7 +80,7 @@ theorem divK_phaseA_body_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Phase A: OR-reduce b then BEQ to zero path. -/
-theorem divK_phaseA_spec (sp : Addr) (base : Addr)
+theorem divK_phaseA_spec (sp : Word) (base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hvalid : ValidMemRange sp 8) :
     let bor := b0 ||| b1 ||| b2 ||| b3
@@ -103,7 +103,7 @@ theorem divK_phaseA_spec (sp : Addr) (base : Addr)
   have hbody := divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid
   -- 2. BEQ: branch at base + 28, drop pure facts
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 bor (0 : Word) (base + 28)
-  have ha1 : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
+  have ha1 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
   rw [ha1] at hbeq_raw
   have hbeq := cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun _ hp => hp)
@@ -143,11 +143,11 @@ theorem divK_phaseA_spec (sp : Addr) (base : Addr)
 -- 9 straight-line instructions.
 -- ============================================================================
 
-abbrev divK_phaseB_init1_code (base : Addr) : CodeReq :=
+abbrev divK_phaseB_init1_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_phaseB.take 7)
 
 /-- Phase B init part 1: zero scratch q[0..3] and u[5..7]. 7 instructions. -/
-theorem divK_phaseB_init1_spec (sp : Addr) (base : Addr)
+theorem divK_phaseB_init1_spec (sp : Word) (base : Word)
     (q0 q1 q2 q3 u5 u6 u7 : Word)
     (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
     (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
@@ -179,11 +179,11 @@ theorem divK_phaseB_init1_spec (sp : Addr) (base : Addr)
   have I6 := sd_x0_spec_gen .x12 sp u7 4000 (base + 24) hv_u7
   runBlock I0 I1 I2 I3 I4 I5 I6
 
-abbrev divK_phaseB_init2_code (base : Addr) : CodeReq :=
+abbrev divK_phaseB_init2_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_phaseB.drop 7 |>.take 2)
 
 /-- Phase B init part 2: load b[1] and b[2]. 2 instructions. -/
-theorem divK_phaseB_init2_spec (sp : Addr) (base : Addr)
+theorem divK_phaseB_init2_spec (sp : Word) (base : Word)
     (b1 b2 : Word) (v6 v7 : Word)
     (hvalid : ValidMemRange sp 8) :
     let cr := divK_phaseB_init2_code base
@@ -202,11 +202,11 @@ theorem divK_phaseB_init2_spec (sp : Addr) (base : Addr)
 -- Phase C4: Copy a → u[0..4] unshifted (shift = 0). 9 instructions.
 -- ============================================================================
 
-abbrev divK_copyAU_code (base : Addr) : CodeReq :=
+abbrev divK_copyAU_code (base : Word) : CodeReq :=
   CodeReq.ofProg base divK_copyAU
 
 /-- Copy a[0..3] to u[0..3] and set u[4] = 0 (no shift needed). -/
-theorem divK_copyAU_spec (sp : Addr) (base : Addr)
+theorem divK_copyAU_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 u0 u1 u2 u3 u4 : Word) (v5 : Word)
     (hvalid : ValidMemRange sp 8)
     (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
@@ -250,14 +250,14 @@ def divK_normB_merge_prog (high_off low_off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 high_off, .LD .x7 .x12 low_off, .SLL .x5 .x5 .x6,
    .SRL .x7 .x7 .x2, .OR .x5 .x5 .x7, .SD .x12 .x5 high_off]
 
-abbrev divK_normB_merge_code (high_off low_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normB_merge_code (high_off low_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normB_merge_prog high_off low_off)
 
 /-- NormB merge limb (6 instructions): LD high, LD low, SLL, SRL, OR, SD.
     Computes result = (high <<< shift) ||| (low >>> anti_shift) and stores to high_off.
     x6 = shift, x2 = anti_shift (= 64 - shift as unsigned). -/
 theorem divK_normB_merge_spec (high_off low_off : BitVec 12)
-    (sp high low v5 v7 shift anti_shift : Word) (base : Addr)
+    (sp high low v5 v7 shift anti_shift : Word) (base : Word)
     (hvalid_high : isValidDwordAccess (sp + signExtend12 high_off) = true)
     (hvalid_low : isValidDwordAccess (sp + signExtend12 low_off) = true) :
     let shifted_high := high <<< (shift.toNat % 64)
@@ -287,13 +287,13 @@ theorem divK_normB_merge_spec (high_off low_off : BitVec 12)
 def divK_normB_last_prog (off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 off, .SLL .x5 .x5 .x6, .SD .x12 .x5 off]
 
-abbrev divK_normB_last_code (off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normB_last_code (off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normB_last_prog off)
 
 /-- NormB last limb (3 instructions): LD, SLL, SD.
     Computes result = val <<< shift and stores to off. -/
 theorem divK_normB_last_spec (off : BitVec 12)
-    (sp val v5 shift : Word) (base : Addr)
+    (sp val v5 shift : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let result := val <<< (shift.toNat % 64)
     let cr := divK_normB_last_code off base
@@ -318,13 +318,13 @@ theorem divK_normB_last_spec (off : BitVec 12)
 def divK_normA_top_prog (src_off dst_off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 src_off, .SRL .x7 .x5 .x2, .SD .x12 .x7 dst_off]
 
-abbrev divK_normA_top_code (src_off dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normA_top_code (src_off dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normA_top_prog src_off dst_off)
 
 /-- NormA top: LD a[3], SRL to x7, SD u[4]. 3 instructions.
     Computes u[4] = a[3] >>> anti_shift (overflow bits from top limb). -/
 theorem divK_normA_top_spec (src_off dst_off : BitVec 12)
-    (sp val v5 v7 anti_shift dst_old : Word) (base : Addr)
+    (sp val v5 v7 anti_shift dst_old : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 src_off) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let result := val >>> (anti_shift.toNat % 64)
@@ -348,14 +348,14 @@ def divK_normA_mergeA_prog (next_off dst_off : BitVec 12) : List Instr :=
   [.LD .x7 .x12 next_off, .SLL .x5 .x5 .x6, .SRL .x10 .x7 .x2,
    .OR .x5 .x5 .x10, .SD .x12 .x5 dst_off]
 
-abbrev divK_normA_mergeA_code (next_off dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normA_mergeA_code (next_off dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normA_mergeA_prog next_off dst_off)
 
 /-- NormA merge type A (5 instructions): x5 holds current limb.
     LD next into x7, SLL x5 by shift, SRL x10 from x7 by anti_shift, OR into x5, SD.
     Used for u[3] and u[1] computation. -/
 theorem divK_normA_mergeA_spec (next_off dst_off : BitVec 12)
-    (sp current next v7 v10 shift anti_shift dst_old : Word) (base : Addr)
+    (sp current next v7 v10 shift anti_shift dst_old : Word) (base : Word)
     (hvalid_next : isValidDwordAccess (sp + signExtend12 next_off) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let shifted_curr := current <<< (shift.toNat % 64)
@@ -385,14 +385,14 @@ def divK_normA_mergeB_prog (next_off dst_off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 next_off, .SLL .x7 .x7 .x6, .SRL .x10 .x5 .x2,
    .OR .x7 .x7 .x10, .SD .x12 .x7 dst_off]
 
-abbrev divK_normA_mergeB_code (next_off dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normA_mergeB_code (next_off dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normA_mergeB_prog next_off dst_off)
 
 /-- NormA merge type B (5 instructions): x7 holds current limb.
     LD next into x5, SLL x7 by shift, SRL x10 from x5 by anti_shift, OR into x7, SD.
     Used for u[2] computation. -/
 theorem divK_normA_mergeB_spec (next_off dst_off : BitVec 12)
-    (sp current next v5 v10 shift anti_shift dst_old : Word) (base : Addr)
+    (sp current next v5 v10 shift anti_shift dst_old : Word) (base : Word)
     (hvalid_next : isValidDwordAccess (sp + signExtend12 next_off) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let shifted_curr := current <<< (shift.toNat % 64)
@@ -421,13 +421,13 @@ theorem divK_normA_mergeB_spec (next_off dst_off : BitVec 12)
 def divK_normA_last_prog (dst_off : BitVec 12) : List Instr :=
   [.SLL .x7 .x7 .x6, .SD .x12 .x7 dst_off]
 
-abbrev divK_normA_last_code (dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_normA_last_code (dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_normA_last_prog dst_off)
 
 /-- NormA last limb (2 instructions): SLL x7 by shift, SD to dst_off.
     Computes u[0] = a[0] <<< shift. -/
 theorem divK_normA_last_spec (dst_off : BitVec 12)
-    (sp val shift dst_old : Word) (base : Addr)
+    (sp val shift dst_old : Word) (base : Word)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let result := val <<< (shift.toNat % 64)
     let cr := divK_normA_last_code dst_off base
@@ -452,14 +452,14 @@ def divK_denorm_merge_prog (curr_off next_off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 curr_off, .LD .x7 .x12 next_off, .SRL .x5 .x5 .x6,
    .SLL .x7 .x7 .x2, .OR .x5 .x5 .x7, .SD .x12 .x5 curr_off]
 
-abbrev divK_denorm_merge_code (curr_off next_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_denorm_merge_code (curr_off next_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_denorm_merge_prog curr_off next_off)
 
 /-- Denorm merge limb (6 instructions): LD curr, LD next, SRL, SLL, OR, SD.
     Computes result = (curr >>> shift) ||| (next <<< anti_shift) and stores to curr_off.
     x6 = shift, x2 = anti_shift. -/
 theorem divK_denorm_merge_spec (curr_off next_off : BitVec 12)
-    (sp curr next v5 v7 shift anti_shift : Word) (base : Addr)
+    (sp curr next v5 v7 shift anti_shift : Word) (base : Word)
     (hvalid_curr : isValidDwordAccess (sp + signExtend12 curr_off) = true)
     (hvalid_next : isValidDwordAccess (sp + signExtend12 next_off) = true) :
     let shifted_curr := curr >>> (shift.toNat % 64)
@@ -489,13 +489,13 @@ theorem divK_denorm_merge_spec (curr_off next_off : BitVec 12)
 def divK_denorm_last_prog (off : BitVec 12) : List Instr :=
   [.LD .x5 .x12 off, .SRL .x5 .x5 .x6, .SD .x12 .x5 off]
 
-abbrev divK_denorm_last_code (off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_denorm_last_code (off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_denorm_last_prog off)
 
 /-- Denorm last limb (3 instructions): LD, SRL, SD.
     Computes result = val >>> shift and stores to off. -/
 theorem divK_denorm_last_spec (off : BitVec 12)
-    (sp val v5 shift : Word) (base : Addr)
+    (sp val v5 shift : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let result := val >>> (shift.toNat % 64)
     let cr := divK_denorm_last_code off base
@@ -520,13 +520,13 @@ theorem divK_denorm_last_spec (off : BitVec 12)
 def divK_epilogue_load_prog (off0 off1 off2 off3 : BitVec 12) : List Instr :=
   [.LD .x5 .x12 off0, .LD .x6 .x12 off1, .LD .x7 .x12 off2, .LD .x10 .x12 off3]
 
-abbrev divK_epilogue_load_code (off0 off1 off2 off3 : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_epilogue_load_code (off0 off1 off2 off3 : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_epilogue_load_prog off0 off1 off2 off3)
 
 /-- Epilogue load phase: load 4 values from scratch space. 4 instructions.
     Loads q[0..3] (for DIV) or u[0..3] (for MOD) into x5, x6, x7, x10. -/
 theorem divK_epilogue_load_spec (off0 off1 off2 off3 : BitVec 12)
-    (sp r0 r1 r2 r3 v5 v6 v7 v10 : Word) (base : Addr)
+    (sp r0 r1 r2 r3 v5 v6 v7 v10 : Word) (base : Word)
     (hv0 : isValidDwordAccess (sp + signExtend12 off0) = true)
     (hv1 : isValidDwordAccess (sp + signExtend12 off1) = true)
     (hv2 : isValidDwordAccess (sp + signExtend12 off2) = true)
@@ -551,11 +551,11 @@ def divK_epilogue_store_prog (jal_off : BitVec 21) : List Instr :=
   [.ADDI .x12 .x12 32, .SD .x12 .x5 0, .SD .x12 .x6 8,
    .SD .x12 .x7 16, .SD .x12 .x10 24, .JAL .x0 jal_off]
 
-abbrev divK_epilogue_store_code (jal_off : BitVec 21) (base : Addr) : CodeReq :=
+abbrev divK_epilogue_store_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_epilogue_store_prog jal_off)
 
 /-- Epilogue store phase: ADDI sp+32, store 4 values, JAL to exit. 6 instructions. -/
-theorem divK_epilogue_store_spec (sp : Addr) (base : Addr)
+theorem divK_epilogue_store_spec (sp : Word) (base : Word)
     (r0 r1 r2 r3 m0 m8 m16 m24 : Word) (jal_off : BitVec 21)
     (hvalid : ValidMemRange sp 8) :
     let cr := divK_epilogue_store_code jal_off base
@@ -581,12 +581,12 @@ theorem divK_epilogue_store_spec (sp : Addr) (base : Addr)
 -- 5 instructions: SD, ADDI, SLLI, ADD, LD.
 -- ============================================================================
 
-abbrev divK_phaseB_tail_code (base : Addr) : CodeReq :=
+abbrev divK_phaseB_tail_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_phaseB.drop 16)
 
 /-- Phase B tail: store n to scratch, compute sp + (n-1)*8, load b[n-1].
     x5 = n on entry. On exit, x5 = leading limb b[n-1]. -/
-theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Addr)
+theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_limb : isValidDwordAccess
       ((sp + ((n + signExtend12 4095) <<< (3 : BitVec 6).toNat)) + signExtend12 32) = true) :
@@ -615,7 +615,7 @@ theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Addr)
 -- Phase C2 body: store shift, compute anti_shift. 3 instructions.
 -- ============================================================================
 
-abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Addr) : CodeReq :=
+abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_phaseC2 shift0_off)
 
 /-- Phase C2 body: SD shift to scratch, ADDI x2 = 0, SUB x2 = -shift.
@@ -623,7 +623,7 @@ abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Addr) : CodeReq :=
     The postcondition uses `signExtend12 (0 : BitVec 12) - shift` (= 0 - shift)
     to match the syntactic form produced by addi_x0_spec_gen + sub_spec_gen. -/
 theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
-    (shift0_off : BitVec 13) (base : Addr)
+    (shift0_off : BitVec 13) (base : Word)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true) :
     let cr := divK_phaseC2_code shift0_off base
     cpsTriple base (base + 12) cr
@@ -650,7 +650,7 @@ set_option maxRecDepth 1024 in
     Not taken: shift ≠ 0, proceed to normalize.
     anti_shift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
 theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
-    (shift0_off : BitVec 13) (base : Addr)
+    (shift0_off : BitVec 13) (base : Word)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true) :
     let cr := divK_phaseC2_code shift0_off base
     let post :=
@@ -668,7 +668,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
   intro cr post
   have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem shift0_off base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 shift0_off shift (0 : Word) (base + 12)
-  have ha1 : (base + 12 : Addr) + 4 = base + 16 := by bv_omega
+  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_omega
   rw [ha1] at hbeq_raw
   have hbeq : cpsBranch (base + 12) _
       ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
@@ -713,7 +713,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
 -- ============================================================================
 
 abbrev divK_phaseB_cascade_step_code (n_val : BitVec 12) (rx : Reg) (bne_off : BitVec 13)
-    (base : Addr) : CodeReq :=
+    (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.ADDI .x5 .x0 n_val))
    (CodeReq.singleton (base + 4) (.BNE rx .x0 bne_off))
 
@@ -721,7 +721,7 @@ abbrev divK_phaseB_cascade_step_code (n_val : BitVec 12) (rx : Reg) (bne_off : B
     Taken: rx ≠ 0 (limb is nonzero), branch to target with x5 = n_val.
     Not taken: rx = 0, fall through with x5 = n_val. -/
 theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 : Word)
-    (bne_off : BitVec 13) (base : Addr) :
+    (bne_off : BitVec 13) (base : Word) :
     let n := (0 : Word) + signExtend12 n_val
     let cr := divK_phaseB_cascade_step_code n_val rx bne_off base
     let post :=
@@ -741,7 +741,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
     runBlock I0
   -- 2. BNE at base + 4, drop pure facts
   have hbne_raw := bne_spec_gen rx .x0 bne_off check (0 : Word) (base + 4)
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha1] at hbne_raw
   have hbne : cpsBranch (base + 4) _
       ((rx ↦ᵣ check) ** (.x0 ↦ᵣ (0 : Word)))
@@ -786,13 +786,13 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
 -- 4 instructions: LD, ADDI, SUB, BLT. cpsBranch.
 -- ============================================================================
 
-abbrev divK_loopSetup_code (blt_off : BitVec 13) (base : Addr) : CodeReq :=
+abbrev divK_loopSetup_code (blt_off : BitVec 13) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_loopSetup blt_off)
 
 /-- Loop setup body: load n, compute m = 4 - n. 3 straight-line instructions.
     Uses signExtend12 4 directly to match addi_x0_spec_gen + sub_spec_gen output. -/
 theorem divK_loopSetup_body_spec (sp n v1 v5 : Word)
-    (blt_off : BitVec 13) (base : Addr)
+    (blt_off : BitVec 13) (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true) :
     let cr := divK_loopSetup_code blt_off base
     cpsTriple base (base + 12) cr
@@ -814,7 +814,7 @@ theorem divK_loopSetup_body_spec (sp n v1 v5 : Word)
     Taken: m < 0 (n > 4, impossible in practice but handled).
     Not taken: m >= 0, proceed to loop. -/
 theorem divK_loopSetup_spec (sp n v1 v5 : Word)
-    (blt_off : BitVec 13) (base : Addr)
+    (blt_off : BitVec 13) (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true) :
     let m := signExtend12 (4 : BitVec 12) - n
     let cr := divK_loopSetup_code blt_off base
@@ -832,7 +832,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
   intro m cr post
   have hbody := divK_loopSetup_body_spec sp n v1 v5 blt_off base hv_n
   have hblt_raw := blt_spec_gen .x1 .x0 blt_off m (0 : Word) (base + 12)
-  have ha1 : (base + 12 : Addr) + 4 = base + 16 := by bv_omega
+  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_omega
   rw [ha1] at hblt_raw
   have hblt : cpsBranch (base + 12) _
       ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
@@ -876,7 +876,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
 -- ============================================================================
 
 /-- CLZ init: set x6 = 0 (count register). -/
-theorem divK_clz_init_spec (v6 : Word) (base : Addr) :
+theorem divK_clz_init_spec (v6 : Word) (base : Word) :
     let cr := CodeReq.singleton base (.ADDI .x6 .x0 0)
     cpsTriple base (base + 4) cr
       ((.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)))
@@ -895,13 +895,13 @@ theorem divK_clz_init_spec (v6 : Word) (base : Addr) :
 def divK_clz_stage_prog (K M_s : BitVec 6) (M_a : BitVec 12) : List Instr :=
   [.SRLI .x7 .x5 K, .BNE .x7 .x0 12, .SLLI .x5 .x5 M_s, .ADDI .x6 .x6 M_a]
 
-abbrev divK_clz_stage_code (K M_s : BitVec 6) (M_a : BitVec 12) (base : Addr) : CodeReq :=
+abbrev divK_clz_stage_code (K M_s : BitVec 6) (M_a : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (divK_clz_stage_prog K M_s M_a)
 
 /-- CLZ stage, taken branch: val >>> K ≠ 0, skip SLLI+ADDI.
     x5 = val (unchanged), x6 = count (unchanged), x7 = val >>> K. -/
 theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val count v7 : Word)
-    (base : Addr)
+    (base : Word)
     (hne : val >>> K.toNat ≠ 0) :
     let cr := divK_clz_stage_code K M_s M_a base
     cpsTriple base (base + 16) cr
@@ -915,7 +915,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbne_raw
   -- 3. Frame BNE with x5, x6
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -967,7 +967,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
 /-- CLZ stage, not-taken branch: val >>> K = 0, execute SLLI+ADDI.
     x5 = val <<< M, x6 = count + signExtend12 M, x7 = 0. -/
 theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val count v7 : Word)
-    (base : Addr)
+    (base : Word)
     (heq : val >>> K.toNat = 0) :
     let cr := divK_clz_stage_code K M_s M_a base
     cpsTriple base (base + 16) cr
@@ -981,7 +981,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbne_raw
   -- 3. Frame BNE with x5, x6
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -1046,12 +1046,12 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
 def divK_clz_last_prog : List Instr :=
   [.SRLI .x7 .x5 63, .BNE .x7 .x0 8, .ADDI .x6 .x6 1]
 
-abbrev divK_clz_last_code (base : Addr) : CodeReq :=
+abbrev divK_clz_last_code (base : Word) : CodeReq :=
   CodeReq.ofProg base divK_clz_last_prog
 
 /-- CLZ last stage, taken: val >>> 63 ≠ 0 (MSB is 1), skip ADDI.
     x5 unchanged, x6 unchanged, x7 = val >>> 63. -/
-theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Addr)
+theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
     (hne : val >>> 63 ≠ 0) :
     let cr := divK_clz_last_code base
     cpsTriple base (base + 12) cr
@@ -1065,7 +1065,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Addr)
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
@@ -1105,7 +1105,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Addr)
       xperm_hyp hp') hp hpq⟩⟩
 /-- CLZ last stage, ntaken: val >>> 63 = 0, execute ADDI.
     x5 unchanged, x6 = count + 1, x7 = 0. -/
-theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Addr)
+theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
     (heq : val >>> 63 = 0) :
     let cr := divK_clz_last_code base
     cpsTriple base (base + 12) cr
@@ -1119,7 +1119,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Addr)
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
@@ -1177,7 +1177,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Addr)
 /-- Mul-sub limb Part A: LD v[i], MUL, MULHU, ADD, SLTU, ADD.
     6 instructions. Produces full_sub (x7) and partial_carry (x10). -/
 theorem divK_mulsub_partA_spec (sp q_hat carry_in v5_old v7_old v_i : Word)
-    (v_off : BitVec 12) (base : Addr)
+    (v_off : BitVec 12) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 v_off) = true) :
     let prod_lo := q_hat * v_i
     let prod_hi := rv64_mulhu q_hat v_i
@@ -1210,7 +1210,7 @@ theorem divK_mulsub_partA_spec (sp q_hat carry_in v5_old v7_old v_i : Word)
 /-- Mul-sub limb Part B: LD u[j+i], SLTU, SUB, ADD, SD.
     5 instructions. Produces carry_out (x10) and stores u_new. -/
 theorem divK_mulsub_partB_spec (u_base partial_carry prod_hi full_sub v2_old u_i : Word)
-    (u_off : BitVec 12) (base : Addr)
+    (u_off : BitVec 12) (base : Word)
     (hv : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
     let u_new := u_i - full_sub
@@ -1244,7 +1244,7 @@ theorem divK_mulsub_partB_spec (u_base partial_carry prod_hi full_sub v2_old u_i
 /-- Add-back Part A: LD v[i], LD u[j+i], ADD carry, SLTU carry1, ADD v[i].
     5 instructions. Produces sum (x2) and carry1 (x7). -/
 theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word)
-    (v_off : BitVec 12) (u_off : BitVec 12) (base : Addr)
+    (v_off : BitVec 12) (u_off : BitVec 12) (base : Word)
     (hv_v : isValidDwordAccess (sp + signExtend12 v_off) = true)
     (hv_u : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let u_plus_carry := u_i + carry_in
@@ -1276,7 +1276,7 @@ theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word
 /-- Add-back Part B: SLTU carry2, OR carry_out, SD u_new.
     3 instructions. Produces carry_out (x7) and stores u_new. -/
 theorem divK_addback_partB_spec (u_base carry1 v_i u_new u_i : Word)
-    (u_off : BitVec 12) (base : Addr)
+    (u_off : BitVec 12) (base : Word)
     (hv_u : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let carry2 := if BitVec.ult u_new v_i then (1 : Word) else 0
     let carry_out := carry1 ||| carry2
@@ -1304,7 +1304,7 @@ theorem divK_addback_partB_spec (u_base carry1 v_i u_new u_i : Word)
 /-- Subtract carry from u[j+4].
     4 instructions: LD, SLTU, SUB, SD. Produces borrow (x7). -/
 theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
-    (u_off : BitVec 12) (base : Addr)
+    (u_off : BitVec 12) (base : Word)
     (hv : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let borrow := if BitVec.ult u_top carry_in then (1 : Word) else 0
     let u_new := u_top - carry_in
@@ -1334,7 +1334,7 @@ theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
 /-- Store q[j]: compute &q[j] = sp+4088 - j*8, store q_hat.
     First 3 instructions compute q_addr. Then SD stores. Split into 3+1. -/
 theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
-    (base : Addr) :
+    (base : Word) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let sp_m8 := sp + signExtend12 4088
     let q_addr := sp_m8 - j_x8
@@ -1354,7 +1354,7 @@ theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
   runBlock I0 I1 I2
 
 /-- Store q[j]: SD q_hat at q_addr. 1 instruction. -/
-theorem divK_store_qj_write_spec (q_addr q_hat q_old : Word) (base : Addr)
+theorem divK_store_qj_write_spec (q_addr q_hat q_old : Word) (base : Word)
     (hv : isValidDwordAccess q_addr = true) :
     let cr := CodeReq.singleton base (.SD .x7 .x11 0)
     cpsTriple base (base + 4) cr
@@ -1375,7 +1375,7 @@ theorem divK_store_qj_write_spec (q_addr q_hat q_old : Word) (base : Addr)
 
 /-- Add-back finalization after limb corrections. -/
 theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
-    (u_off : BitVec 12) (base : Addr)
+    (u_off : BitVec 12) (base : Word)
     (hv : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let u_new := u_top + carry
     let q_hat' := q_hat + signExtend12 4095
@@ -1404,7 +1404,7 @@ theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
 set_option maxRecDepth 1024 in
 /-- Loop control: decrement j and branch back if j >= 0. -/
 theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
-    (base : Addr) :
+    (base : Word) :
     let j' := j + signExtend12 4095
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADDI .x1 .x1 4095))
@@ -1424,7 +1424,7 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
     runBlock I0
   -- 2. BGE, drop pure facts
   have hbge_raw := bge_spec_gen .x1 .x0 loop_back_off j' 0 (base + 4)
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha1] at hbge_raw
   have hbge : cpsBranch (base + 4) _
       ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
@@ -1460,7 +1460,7 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
 
 /-- Mul-sub setup: restore j from scratch, compute u_base, zero carry. -/
 theorem divK_mulsub_setup_spec (sp q_hat j v1_old v5_old v6_old v10_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3976) = true) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let sp_m40 := sp + signExtend12 4056
@@ -1493,7 +1493,7 @@ theorem divK_mulsub_setup_spec (sp q_hat j v1_old v5_old v6_old v10_old : Word)
 -- ============================================================================
 
 /-- Save j to scratch memory. -/
-theorem divK_save_j_spec (sp j j_old : Word) (base : Addr)
+theorem divK_save_j_spec (sp j j_old : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3976) = true) :
     let cr := CodeReq.singleton base (.SD .x12 .x1 3976)
     cpsTriple base (base + 4) cr
@@ -1508,7 +1508,7 @@ theorem divK_save_j_spec (sp j j_old : Word) (base : Addr)
 -- ============================================================================
 
 /-- Initialize add-back carry to 0. -/
-theorem divK_addback_init_spec (v7_old : Word) (base : Addr) :
+theorem divK_addback_init_spec (v7_old : Word) (base : Word) :
     let cr := CodeReq.singleton base (.ADDI .x7 .x0 0)
     cpsTriple base (base + 4) cr
       ((.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ 0))
@@ -1522,7 +1522,7 @@ theorem divK_addback_init_spec (v7_old : Word) (base : Addr) :
 -- ============================================================================
 
 /-- Correction condition: branch if borrow (x7) is zero. -/
-theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base : Addr) :
+theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base : Word) :
     let cr := CodeReq.singleton base (.BEQ .x7 .x0 skip_off)
     cpsBranch base cr
       ((.x7 ↦ᵣ borrow) ** (.x0 ↦ᵣ 0))
@@ -1548,7 +1548,7 @@ theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base
     u_addr = sp + signExtend12 4056 - (j + n) <<< 3.
     u_hi = mem[u_addr], u_lo = mem[u_addr + 8]. -/
 theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
-    (base : Addr)
+    (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
     (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) + 8) = true) :
@@ -1596,7 +1596,7 @@ theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
     vtop_addr = sp + (n + signExtend12 4095) <<< 3.
     v_top = mem[vtop_addr + 32]. -/
 theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
-    (base : Addr)
+    (base : Word)
     (hv_n : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_vtop : isValidDwordAccess (sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true) :
     let nm1 := n + signExtend12 4095
@@ -1627,7 +1627,7 @@ theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
 -- ============================================================================
 
 /-- Trial quotient MAX path: set q_hat = MAX64, jump over div128 call. -/
-theorem divK_trial_max_spec (v11_old : Word) (base : Addr) :
+theorem divK_trial_max_spec (v11_old : Word) (base : Word) :
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADDI .x11 .x0 4095))
        (CodeReq.singleton (base + 4) (.JAL .x0 8))
@@ -1635,11 +1635,11 @@ theorem divK_trial_max_spec (v11_old : Word) (base : Addr) :
       ((.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ 0))
       ((.x11 ↦ᵣ signExtend12 4095) ** (.x0 ↦ᵣ 0)) := by
   intro cr
-  have hj : signExtend21 (8 : BitVec 21) = (8 : Addr) := by native_decide
+  have hj : signExtend21 (8 : BitVec 21) = (8 : Word) := by native_decide
   have I0 := addi_x0_spec_gen .x11 v11_old 4095 base (by nofun)
   have I1 := jal_x0_spec_gen 8 (base + 4)
   rw [hj] at I1
-  have ha : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
+  have ha : (base + 4 : Word) + 8 = base + 12 := by bv_omega
   rw [ha] at I1
   runBlock I0 I1
 
@@ -1650,7 +1650,7 @@ theorem divK_trial_max_spec (v11_old : Word) (base : Addr) :
 
 /-- div128 Phase 1a: save x2 (return addr) and x10 (d), compute d_hi and d_lo. -/
 theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
-    ret_mem d_mem dlo_mem : Word) (base : Addr)
+    ret_mem d_mem dlo_mem : Word) (base : Word)
     (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
     (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
     (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true) :
@@ -1689,7 +1689,7 @@ theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
 -- ============================================================================
 
 /-- div128 Phase 1b: split u_lo into un1 (x11) and un0 (x5), save un0. -/
-theorem divK_div128_split_ulo_spec (sp u_lo v11_old un0_mem : Word) (base : Addr)
+theorem divK_div128_split_ulo_spec (sp u_lo v11_old un0_mem : Word) (base : Word)
     (hv_un0 : isValidDwordAccess (sp + signExtend12 3944) = true) :
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1716,7 +1716,7 @@ theorem divK_div128_split_ulo_spec (sp u_lo v11_old un0_mem : Word) (base : Addr
 -- ============================================================================
 
 /-- div128 Step 1: q1 = DIVU(u_hi, d_hi), rhat = u_hi - q1 * d_hi. -/
-theorem divK_div128_step1_init_spec (u_hi d_hi v5_old v10_old : Word) (base : Addr) :
+theorem divK_div128_step1_init_spec (u_hi d_hi v5_old v10_old : Word) (base : Word) :
     let q1 := rv64_divu u_hi d_hi
     let rhat := u_hi - q1 * d_hi
     let cr :=
@@ -1741,7 +1741,7 @@ theorem divK_div128_step1_init_spec (u_hi d_hi v5_old v10_old : Word) (base : Ad
 
 /-- div128 un21 = rhat*2^32 + un1 - q1*d_lo.
     Loads d_lo from scratch memory. -/
-theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Word) (base : Addr)
+theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3952) = true) :
     let rhat_hi := rhat <<< (32 : BitVec 6).toNat
     let rhat_un1 := rhat_hi ||| un1
@@ -1775,7 +1775,7 @@ theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Wo
 -- ============================================================================
 
 /-- div128 product check body: compute q*d_lo and rhat*2^32+un1 for comparison. -/
-theorem divK_div128_prodcheck_body_spec (sp q rhat un1 v1_old v5_old dlo : Word) (base : Addr)
+theorem divK_div128_prodcheck_body_spec (sp q rhat un1 v1_old v5_old dlo : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3952) = true) :
     let q_dlo := q * dlo
     let rhat_hi := rhat <<< (32 : BitVec 6).toNat
@@ -1803,7 +1803,7 @@ theorem divK_div128_prodcheck_body_spec (sp q rhat un1 v1_old v5_old dlo : Word)
 -- ============================================================================
 
 /-- div128 correction: q-- and rhat += d_hi. Generic for q1 (x10) or q0 (x5). -/
-theorem divK_div128_correct_q1_spec (q rhat d_hi : Word) (base : Addr) :
+theorem divK_div128_correct_q1_spec (q rhat d_hi : Word) (base : Word) :
     let q' := q + signExtend12 4095
     let rhat' := rhat + d_hi
     let cr :=
@@ -1818,7 +1818,7 @@ theorem divK_div128_correct_q1_spec (q rhat d_hi : Word) (base : Addr) :
   runBlock I0 I1
 
 /-- div128 correction for q0: q0-- and rhat2 += d_hi. -/
-theorem divK_div128_correct_q0_spec (q0 rhat2 d_hi : Word) (base : Addr) :
+theorem divK_div128_correct_q0_spec (q0 rhat2 d_hi : Word) (base : Word) :
     let q0' := q0 + signExtend12 4095
     let rhat2' := rhat2 + d_hi
     let cr :=
@@ -1838,7 +1838,7 @@ theorem divK_div128_correct_q0_spec (q0 rhat2 d_hi : Word) (base : Addr) :
 -- ============================================================================
 
 /-- div128 q1 clamp test: x5 = q1 >>> 32 (nonzero iff q1 >= 2^32). -/
-theorem divK_div128_clamp_test_q1_spec (q1 v5_old : Word) (base : Addr) :
+theorem divK_div128_clamp_test_q1_spec (q1 v5_old : Word) (base : Word) :
     let hi := q1 >>> (32 : BitVec 6).toNat
     let cr := CodeReq.singleton base (.SRLI .x5 .x10 32)
     cpsTriple base (base + 4) cr
@@ -1849,7 +1849,7 @@ theorem divK_div128_clamp_test_q1_spec (q1 v5_old : Word) (base : Addr) :
   runBlock I0
 
 /-- div128 q0 clamp test: x1 = q0 >>> 32. -/
-theorem divK_div128_clamp_test_q0_spec (q0 v1_old : Word) (base : Addr) :
+theorem divK_div128_clamp_test_q0_spec (q0 v1_old : Word) (base : Word) :
     let hi := q0 >>> (32 : BitVec 6).toNat
     let cr := CodeReq.singleton base (.SRLI .x1 .x5 32)
     cpsTriple base (base + 4) cr
@@ -1865,7 +1865,7 @@ theorem divK_div128_clamp_test_q0_spec (q0 v1_old : Word) (base : Addr) :
 -- ============================================================================
 
 /-- div128 Step 2: q0 = DIVU(un21, d_hi), rhat2 = un21 - q0 * d_hi. -/
-theorem divK_div128_step2_init_spec (un21 d_hi v1_old v5_old v11_old : Word) (base : Addr) :
+theorem divK_div128_step2_init_spec (un21 d_hi v1_old v5_old v11_old : Word) (base : Word) :
     let q0 := rv64_divu un21 d_hi
     let rhat2 := un21 - q0 * d_hi
     let cr :=
@@ -1890,7 +1890,7 @@ theorem divK_div128_step2_init_spec (un21 d_hi v1_old v5_old v11_old : Word) (ba
 
 /-- div128 product check 2: compute q0*d_lo and rhat2*2^32+un0 for comparison. -/
 theorem divK_div128_prodcheck2_body_spec (sp q0 rhat2 v1_old v7_old dlo un0 : Word)
-    (base : Addr)
+    (base : Word)
     (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
     (hv_un0 : isValidDwordAccess (sp + signExtend12 3944) = true) :
     let q0_dlo := q0 * dlo
@@ -1923,7 +1923,7 @@ theorem divK_div128_prodcheck2_body_spec (sp q0 rhat2 v1_old v7_old dlo un0 : Wo
 -- ============================================================================
 
 /-- div128 product check 2 correction: q0--. -/
-theorem divK_div128_correct_q0_single_spec (q0 : Word) (base : Addr) :
+theorem divK_div128_correct_q0_single_spec (q0 : Word) (base : Word) :
     let q0' := q0 + signExtend12 4095
     let cr := CodeReq.singleton base (.ADDI .x5 .x5 4095)
     cpsTriple base (base + 4) cr
@@ -1939,7 +1939,7 @@ theorem divK_div128_correct_q0_single_spec (q0 : Word) (base : Addr) :
 -- ============================================================================
 
 /-- div128 combine: x11 = q1<<32 | q0. -/
-theorem divK_div128_combine_q_spec (q1 q0 v11_old : Word) (base : Addr) :
+theorem divK_div128_combine_q_spec (q1 q0 v11_old : Word) (base : Word) :
     let q1_hi := q1 <<< (32 : BitVec 6).toNat
     let q := q1_hi ||| q0
     let cr :=
@@ -1959,7 +1959,7 @@ theorem divK_div128_combine_q_spec (q1 q0 v11_old : Word) (base : Addr) :
 -- ============================================================================
 
 /-- div128 restore and return: load return addr, JALR x0 x2 0. -/
-theorem divK_div128_restore_return_spec (sp v2_old ret_addr : Word) (base : Addr)
+theorem divK_div128_restore_return_spec (sp v2_old ret_addr : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3968) = true)
     (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
     let cr :=
@@ -1983,7 +1983,7 @@ theorem divK_div128_restore_return_spec (sp v2_old ret_addr : Word) (base : Addr
 set_option maxRecDepth 1024 in
 /-- div128 clamp q1: test q1 >= 2^32, conditionally decrement and adjust rhat.
     Instrs [13]-[16]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Addr) :
+theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Word) :
     let hi := q1 >>> (32 : BitVec 6).toNat
     let q1' := if hi = 0 then q1 else q1 + signExtend12 4095
     let rhat' := if hi = 0 then rhat else rhat + d_hi
@@ -2010,7 +2010,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Ad
   have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbeq_raw
   -- 3. Frame BEQ with x10, x7, x6
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2088,7 +2088,7 @@ set_option maxRecDepth 8192 in
 /-- div128 product check 1: compute q1*d_lo vs rhat*2^32+un1, conditionally correct.
     Instrs [17]-[24]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck1_merged_spec
-    (sp q1 rhat d_hi un1 v1_old v5_old dlo : Word) (base : Addr)
+    (sp q1 rhat d_hi un1 v1_old v5_old dlo : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3952) = true) :
     let q_dlo := q1 * dlo
     let rhat_un1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
@@ -2128,7 +2128,7 @@ theorem divK_div128_prodcheck1_merged_spec
   have hbltu_raw := bltu_spec_gen .x1 .x5 (8 : BitVec 13) rhat_un1 q_dlo (base + 16)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
   have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [hsig]; bv_omega
-  have ha_f : (base + 16 : Addr) + 4 = base + 20 := by bv_omega
+  have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_omega
   rw [ha_t, ha_f] at hbltu_raw
   -- 3. Frame BLTU with remaining atoms
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2199,10 +2199,10 @@ theorem divK_div128_prodcheck1_merged_spec
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
     -- JAL skip: base+20 → base+32
-    have hj : signExtend21 (12 : BitVec 21) = (12 : Addr) := by native_decide
+    have hj : signExtend21 (12 : BitVec 21) = (12 : Word) := by native_decide
     have I_jal := jal_x0_spec_gen 12 (base + 20)
     rw [hj] at I_jal
-    have ha_jal : (base + 20 : Addr) + 12 = base + 32 := by bv_omega
+    have ha_jal : (base + 20 : Word) + 12 = base + 32 := by bv_omega
     rw [ha_jal] at I_jal
     -- Extend JAL CR from singleton to cr
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 20) (.JAL .x0 12) a = some i →
@@ -2252,7 +2252,7 @@ theorem divK_div128_prodcheck1_merged_spec
 set_option maxRecDepth 1024 in
 /-- div128 clamp q0: test q0 >= 2^32, conditionally decrement and adjust rhat2.
     Instrs [33]-[36]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : Addr) :
+theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : Word) :
     let hi := q0 >>> (32 : BitVec 6).toNat
     let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
     let rhat2' := if hi = 0 then rhat2 else rhat2 + d_hi
@@ -2279,7 +2279,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : A
   have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   rw [ha_t, ha_f] at hbeq_raw
   -- 3. Frame BEQ with x5, x11, x6
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2354,7 +2354,7 @@ set_option maxRecDepth 8192 in
 /-- div128 product check 2: compute q0*d_lo vs rhat2*2^32+un0, conditionally correct q0.
     Instrs [37]-[44]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck2_merged_spec
-    (sp q0 rhat2 v1_old v7_old dlo un0 : Word) (base : Addr)
+    (sp q0 rhat2 v1_old v7_old dlo un0 : Word) (base : Word)
     (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
     (hv_un0 : isValidDwordAccess (sp + signExtend12 3944) = true) :
     let q0_dlo := q0 * dlo
@@ -2395,7 +2395,7 @@ theorem divK_div128_prodcheck2_merged_spec
   have hbltu_raw := bltu_spec_gen .x1 .x7 (8 : BitVec 13) rhat2_un0 q0_dlo (base + 20)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
   have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [hsig]; bv_omega
-  have ha_f : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
+  have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_omega
   rw [ha_t, ha_f] at hbltu_raw
   -- 3. Frame BLTU
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2462,10 +2462,10 @@ theorem divK_div128_prodcheck2_merged_spec
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
     -- JAL skip: base+24 → base+32
-    have hj : signExtend21 (8 : BitVec 21) = (8 : Addr) := by native_decide
+    have hj : signExtend21 (8 : BitVec 21) = (8 : Word) := by native_decide
     have I_jal := jal_x0_spec_gen 8 (base + 24)
     rw [hj] at I_jal
-    have ha_jal : (base + 24 : Addr) + 8 = base + 32 := by bv_omega
+    have ha_jal : (base + 24 : Word) + 8 = base + 32 := by bv_omega
     rw [ha_jal] at I_jal
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 24) (.JAL .x0 8) a = some i →
         cr a = some i := by
@@ -2516,7 +2516,7 @@ set_option maxRecDepth 2048 in
     Input: u_hi in x7, d_hi in x6, un1 in x11, dlo in memory.
     Output: refined q1 in x10, refined rhat in x7. -/
 theorem divK_div128_step1_spec
-    (sp u_hi d_hi un1 v1_old v5_old v10_old dlo : Word) (base : Addr)
+    (sp u_hi d_hi un1 v1_old v5_old v10_old dlo : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3952) = true) :
     let q1 := rv64_divu u_hi d_hi
     let rhat := u_hi - q1 * d_hi
@@ -2578,10 +2578,10 @@ theorem divK_div128_step1_spec
     (by pcFree) h1
   -- Sub-spec 2: clamp q1 [13]-[16]
   have h2_raw := divK_div128_clamp_q1_merged_spec q1 rhat d_hi (q1 * d_hi) (base + 12)
-  have : (base + 12 : Addr) + 4 = base + 16 := by bv_omega
-  have : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-  have : (base + 12 : Addr) + 12 = base + 24 := by bv_omega
-  have : (base + 12 : Addr) + 16 = base + 28 := by bv_omega
+  have : (base + 12 : Word) + 4 = base + 16 := by bv_omega
+  have : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+  have : (base + 12 : Word) + 12 = base + 24 := by bv_omega
+  have : (base + 12 : Word) + 16 = base + 28 := by bv_omega
   simp only [*] at h2_raw
   have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
     cpsTriple_extend_code (h := h2_raw) (hmono := by
@@ -2606,14 +2606,14 @@ theorem divK_div128_step1_spec
   -- Sub-spec 3: prodcheck1 [17]-[24]
   have h3_raw := divK_div128_prodcheck1_merged_spec sp q1c rhatc d_hi un1
     v1_old hi dlo (base + 28) hv
-  have : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-  have : (base + 28 : Addr) + 8 = base + 36 := by bv_omega
-  have : (base + 28 : Addr) + 12 = base + 40 := by bv_omega
-  have : (base + 28 : Addr) + 16 = base + 44 := by bv_omega
-  have : (base + 28 : Addr) + 20 = base + 48 := by bv_omega
-  have : (base + 28 : Addr) + 24 = base + 52 := by bv_omega
-  have : (base + 28 : Addr) + 28 = base + 56 := by bv_omega
-  have : (base + 28 : Addr) + 32 = base + 60 := by bv_omega
+  have : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+  have : (base + 28 : Word) + 8 = base + 36 := by bv_omega
+  have : (base + 28 : Word) + 12 = base + 40 := by bv_omega
+  have : (base + 28 : Word) + 16 = base + 44 := by bv_omega
+  have : (base + 28 : Word) + 20 = base + 48 := by bv_omega
+  have : (base + 28 : Word) + 24 = base + 52 := by bv_omega
+  have : (base + 28 : Word) + 28 = base + 56 := by bv_omega
+  have : (base + 28 : Word) + 32 = base + 60 := by bv_omega
   simp only [*] at h3_raw
   have h3 : cpsTriple (base + 28) (base + 60) cr _ _ :=
     cpsTriple_extend_code (h := h3_raw) (hmono := by
@@ -2658,7 +2658,7 @@ set_option maxRecDepth 2048 in
     Input: un21 in x7, d_hi in x6, dlo/un0 in memory.
     Output: refined q0 in x5. -/
 theorem divK_div128_step2_spec
-    (sp un21 d_hi v1_old v5_old v11_old dlo un0 : Word) (base : Addr)
+    (sp un21 d_hi v1_old v5_old v11_old dlo un0 : Word) (base : Word)
     (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
     (hv_un0 : isValidDwordAccess (sp + signExtend12 3944) = true) :
     let q0 := rv64_divu un21 d_hi
@@ -2722,10 +2722,10 @@ theorem divK_div128_step2_spec
     (by pcFree) h1
   -- Sub-spec 2: clamp q0 [33]-[36]
   have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 d_hi (q0 * d_hi) (base + 12)
-  have : (base + 12 : Addr) + 4 = base + 16 := by bv_omega
-  have : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-  have : (base + 12 : Addr) + 12 = base + 24 := by bv_omega
-  have : (base + 12 : Addr) + 16 = base + 28 := by bv_omega
+  have : (base + 12 : Word) + 4 = base + 16 := by bv_omega
+  have : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+  have : (base + 12 : Word) + 12 = base + 24 := by bv_omega
+  have : (base + 12 : Word) + 16 = base + 28 := by bv_omega
   simp only [*] at h2_raw
   have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
     cpsTriple_extend_code (h := h2_raw) (hmono := by
@@ -2750,14 +2750,14 @@ theorem divK_div128_step2_spec
   -- Sub-spec 3: prodcheck2 [37]-[44]
   have h3_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c hi
     un21 dlo un0 (base + 28) hv_dlo hv_un0
-  have : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-  have : (base + 28 : Addr) + 8 = base + 36 := by bv_omega
-  have : (base + 28 : Addr) + 12 = base + 40 := by bv_omega
-  have : (base + 28 : Addr) + 16 = base + 44 := by bv_omega
-  have : (base + 28 : Addr) + 20 = base + 48 := by bv_omega
-  have : (base + 28 : Addr) + 24 = base + 52 := by bv_omega
-  have : (base + 28 : Addr) + 28 = base + 56 := by bv_omega
-  have : (base + 28 : Addr) + 32 = base + 60 := by bv_omega
+  have : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+  have : (base + 28 : Word) + 8 = base + 36 := by bv_omega
+  have : (base + 28 : Word) + 12 = base + 40 := by bv_omega
+  have : (base + 28 : Word) + 16 = base + 44 := by bv_omega
+  have : (base + 28 : Word) + 20 = base + 48 := by bv_omega
+  have : (base + 28 : Word) + 24 = base + 52 := by bv_omega
+  have : (base + 28 : Word) + 28 = base + 56 := by bv_omega
+  have : (base + 28 : Word) + 32 = base + 60 := by bv_omega
   simp only [*] at h3_raw
   have h3 : cpsTriple (base + 28) (base + 60) cr _ _ :=
     cpsTriple_extend_code (h := h3_raw) (hmono := by
@@ -2801,7 +2801,7 @@ set_option maxRecDepth 2048 in
     Output: x6=d_hi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
 theorem divK_div128_phase1_spec
     (sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-     ret_mem d_mem dlo_mem un0_mem : Word) (base : Addr)
+     ret_mem d_mem dlo_mem un0_mem : Word) (base : Word)
     (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
     (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
     (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
@@ -2859,7 +2859,7 @@ set_option maxRecDepth 2048 in
 /-- div128 end phase: combine q1,q0 into q, restore return addr, return.
     Instrs [45]-[48]. Exit to ret_addr. -/
 theorem divK_div128_end_spec
-    (sp q1 q0 v2_old v11_old ret_addr : Word) (base : Addr)
+    (sp q1 q0 v2_old v11_old ret_addr : Word) (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 3968) = true)
     (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
     let q1_hi := q1 <<< (32 : BitVec 6).toNat
@@ -2894,7 +2894,7 @@ set_option maxRecDepth 2048 in
     Output: carry_out (x10), u_new stored. -/
 theorem divK_mulsub_limb_spec
     (sp u_base q_hat carry_in v5_old v7_old v2_old v_i u_i : Word)
-    (v_off u_off : BitVec 12) (base : Addr)
+    (v_off u_off : BitVec 12) (base : Word)
     (hv_v : isValidDwordAccess (sp + signExtend12 v_off) = true)
     (hv_u : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let prod_lo := q_hat * v_i
@@ -2949,7 +2949,7 @@ set_option maxRecDepth 2048 in
     Output: carry_out (x7), u_new stored. -/
 theorem divK_addback_limb_spec
     (sp u_base carry_in v5_old v2_old v_i u_i : Word)
-    (v_off u_off : BitVec 12) (base : Addr)
+    (v_off u_off : BitVec 12) (base : Word)
     (hv_v : isValidDwordAccess (sp + signExtend12 v_off) = true)
     (hv_u : isValidDwordAccess (u_base + signExtend12 u_off) = true) :
     let u_plus_carry := u_i + carry_in
@@ -2998,7 +2998,7 @@ set_option maxRecDepth 2048 in
     Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtop_base. -/
 theorem divK_trial_load_spec
     (sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
-    (base : Addr)
+    (base : Word)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
     (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) + 8) = true)
@@ -3064,7 +3064,7 @@ set_option maxRecDepth 2048 in
 /-- Store q[j]: compute address and store q_hat. 4 instructions.
     q_addr = sp + 4088 - j*8. -/
 theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv : isValidDwordAccess (sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat) = true) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - j_x8

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -19,7 +19,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 /-- The loopBody ofProg (block 8) is subsumed by divCode. -/
-private theorem divK_loopBody_ofProg_sub_divCode (base : Addr) :
+private theorem divK_loopBody_ofProg_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 448) (divK_loopBody 556 7740)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
@@ -28,7 +28,7 @@ private theorem divK_loopBody_ofProg_sub_divCode (base : Addr) :
   exact CodeReq.union_mono_left _ _
 
 /-- Helper: singleton at index k of divK_loopBody ⊆ divCode base. -/
-private theorem lb_sub (base : Addr) (k : Nat) (addr : Addr) (instr : Instr)
+private theorem lb_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < (divK_loopBody 556 7740).length)
     (h_addr : addr = (base + 448) + BitVec.ofNat 64 (4 * k))
     (h_instr : (divK_loopBody 556 7740).get ⟨k, hk⟩ = instr) :
@@ -57,11 +57,11 @@ private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
 -- ============================================================================
 
 -- Mulsub limb base addresses (instrs [22]-[65])
-private theorem lb_ms0 (base : Addr) : (base + 448 : Addr) + 88 = base + 536 := by bv_omega
-private theorem lb_ms1 (base : Addr) : (base + 536 : Addr) + 44 = base + 580 := by bv_omega
-private theorem lb_ms2 (base : Addr) : (base + 580 : Addr) + 44 = base + 624 := by bv_omega
-private theorem lb_ms3 (base : Addr) : (base + 624 : Addr) + 44 = base + 668 := by bv_omega
-private theorem lb_ms_end (base : Addr) : (base + 668 : Addr) + 44 = base + 712 := by bv_omega
+private theorem lb_ms0 (base : Word) : (base + 448 : Word) + 88 = base + 536 := by bv_omega
+private theorem lb_ms1 (base : Word) : (base + 536 : Word) + 44 = base + 580 := by bv_omega
+private theorem lb_ms2 (base : Word) : (base + 580 : Word) + 44 = base + 624 := by bv_omega
+private theorem lb_ms3 (base : Word) : (base + 624 : Word) + 44 = base + 668 := by bv_omega
+private theorem lb_ms_end (base : Word) : (base + 668 : Word) + 44 = base + 712 := by bv_omega
 
 -- ============================================================================
 -- Section 3: Mulsub 4-limbs composition
@@ -76,7 +76,7 @@ set_option maxHeartbeats 800000 in
 theorem divK_mulsub_4limbs_spec
     (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     (v5_init v7_init v2_init : Word)
-    (base : Addr)
+    (base : Word)
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess (u_base + signExtend12 0) = true)
     (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
@@ -238,13 +238,13 @@ theorem divK_mulsub_4limbs_spec
 -- ============================================================================
 
 -- Addback base addresses (instrs [71]-[107])
-private theorem lb_ab_init (base : Addr) : (base + 448 : Addr) + 284 = base + 732 := by bv_omega
-private theorem lb_ab0 (base : Addr) : (base + 732 : Addr) + 4 = base + 736 := by bv_omega
-private theorem lb_ab0_end (base : Addr) : (base + 736 : Addr) + 32 = base + 768 := by bv_omega
-private theorem lb_ab1_end (base : Addr) : (base + 768 : Addr) + 32 = base + 800 := by bv_omega
-private theorem lb_ab2_end (base : Addr) : (base + 800 : Addr) + 32 = base + 832 := by bv_omega
-private theorem lb_ab3_end (base : Addr) : (base + 832 : Addr) + 32 = base + 864 := by bv_omega
-private theorem lb_abf_end (base : Addr) : (base + 864 : Addr) + 16 = base + 880 := by bv_omega
+private theorem lb_ab_init (base : Word) : (base + 448 : Word) + 284 = base + 732 := by bv_omega
+private theorem lb_ab0 (base : Word) : (base + 732 : Word) + 4 = base + 736 := by bv_omega
+private theorem lb_ab0_end (base : Word) : (base + 736 : Word) + 32 = base + 768 := by bv_omega
+private theorem lb_ab1_end (base : Word) : (base + 768 : Word) + 32 = base + 800 := by bv_omega
+private theorem lb_ab2_end (base : Word) : (base + 800 : Word) + 32 = base + 832 := by bv_omega
+private theorem lb_ab3_end (base : Word) : (base + 832 : Word) + 32 = base + 864 := by bv_omega
+private theorem lb_abf_end (base : Word) : (base + 864 : Word) + 16 = base + 880 := by bv_omega
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -254,7 +254,7 @@ set_option maxHeartbeats 800000 in
 theorem divK_addback_full_spec
     (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
-    (base : Addr)
+    (base : Word)
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess (u_base + signExtend12 0) = true)
     (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
@@ -409,10 +409,10 @@ theorem divK_addback_full_spec
 -- ============================================================================
 
 -- Address normalization for mulsub_setup
-private theorem lb_ms_setup (base : Addr) : (base + 516 : Addr) + 20 = base + 536 := by bv_omega
+private theorem lb_ms_setup (base : Word) : (base + 516 : Word) + 20 = base + 536 := by bv_omega
 
 -- Address normalization for sub_carry
-private theorem lb_sc (base : Addr) : (base + 712 : Addr) + 16 = base + 728 := by bv_omega
+private theorem lb_sc (base : Word) : (base + 712 : Word) + 16 = base + 728 := by bv_omega
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 1600000 in
@@ -422,7 +422,7 @@ set_option maxHeartbeats 1600000 in
 theorem divK_mulsub_full_spec
     (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
@@ -542,11 +542,11 @@ theorem divK_mulsub_full_spec
 -- BEQ at instr [70] (base+728): taken → base+880, not-taken → base+732.
 -- ============================================================================
 
-private theorem lb_beq_taken (base : Addr) : (base + 728 : Addr) + signExtend13 (152 : BitVec 13) = base + 880 := by
+private theorem lb_beq_taken (base : Word) : (base + 728 : Word) + signExtend13 (152 : BitVec 13) = base + 880 := by
   have : signExtend13 (152 : BitVec 13) = (152 : Word) := by native_decide
   rw [this]; bv_omega
 
-private theorem lb_beq_ntaken (base : Addr) : (base + 728 : Addr) + 4 = base + 732 := by bv_omega
+private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 732 := by bv_omega
 
 -- ============================================================================
 -- Section 6a: Correction skip spec (borrow = 0)
@@ -557,7 +557,7 @@ private theorem lb_beq_ntaken (base : Addr) : (base + 728 : Addr) + 4 = base + 7
     1 instruction. All registers and memory unchanged. -/
 theorem divK_correction_skip_spec
     (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
-    (v5_old v2_old : Word) (base : Addr) :
+    (v5_old v2_old : Word) (base : Word) :
     cpsTriple (base + 728) (base + 880) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -617,7 +617,7 @@ set_option maxHeartbeats 1600000 in
     38 instructions. Modifies u values and decrements q_hat. -/
 theorem divK_correction_addback_spec
     (sp u_base borrow q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
-    (v5_old v2_old : Word) (base : Addr)
+    (v5_old v2_old : Word) (base : Word)
     (hb : borrow ≠ (0 : Word))
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess (u_base + signExtend12 0) = true)
@@ -711,8 +711,8 @@ theorem divK_correction_addback_spec
 -- Instrs [0]-[12] at base+448 → base+500.
 -- ============================================================================
 
-private theorem lb_save_j (base : Addr) : (base + 448 : Addr) + 4 = base + 452 := by bv_omega
-private theorem lb_trial_load (base : Addr) : (base + 452 : Addr) + 48 = base + 500 := by bv_omega
+private theorem lb_save_j (base : Word) : (base + 448 : Word) + 4 = base + 452 := by bv_omega
+private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 500 := by bv_omega
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -721,7 +721,7 @@ set_option maxHeartbeats 800000 in
     Entry: base+448, Exit: base+500, CodeReq: divCode base. -/
 theorem divK_save_trial_load_spec
     (sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -793,15 +793,15 @@ theorem divK_save_trial_load_spec
 -- ============================================================================
 
 -- Address normalization for trial quotient
-private theorem lb_bltu_taken (base : Addr) : (base + 500 : Addr) + signExtend13 (12 : BitVec 13) = base + 512 := by
+private theorem lb_bltu_taken (base : Word) : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
   have : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
   rw [this]; bv_omega
-private theorem lb_bltu_ntaken (base : Addr) : (base + 500 : Addr) + 4 = base + 504 := by bv_omega
-private theorem lb_trial_max_end (base : Addr) : (base + 504 : Addr) + 12 = base + 516 := by bv_omega
-private theorem lb_jal_target (base : Addr) : (base + 512 : Addr) + signExtend21 (556 : BitVec 21) = base + 1068 := by
+private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_omega
+private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_omega
+private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (556 : BitVec 21) = base + 1068 := by
   have : signExtend21 (556 : BitVec 21) = (556 : Word) := by native_decide
   rw [this]; bv_omega
-private theorem lb_jal_ret (base : Addr) : (base + 512 : Addr) + 4 = base + 516 := by bv_omega
+private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_omega
 
 -- ============================================================================
 -- Section 8a: Trial quotient NOT-TAKEN path (u_hi >= v_top)
@@ -810,7 +810,7 @@ private theorem lb_jal_ret (base : Addr) : (base + 512 : Addr) + 4 = base + 516 
 
 /-- Trial quotient MAX path: q_hat = MAX64, skip div128 call.
     2 instructions at base+504. Entry: base+504, Exit: base+516. -/
-private theorem divK_trial_max_extended (v11_old : Word) (base : Addr) :
+private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
     cpsTriple (base + 504) (base + 516) (divCode base)
       ((.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ 0))
       ((.x11 ↦ᵣ signExtend12 4095) ** (.x0 ↦ᵣ 0)) := by
@@ -832,7 +832,7 @@ set_option maxHeartbeats 1600000 in
     Entry: base+512, Exit: base+516, CodeReq: divCode base.
     Computes q_hat = div128(u_hi, u_lo, v_top). -/
 theorem divK_trial_call_path_spec
-    (sp j u_lo u_hi v_top vtop_base : Word) (base : Addr)
+    (sp j u_lo u_hi v_top vtop_base : Word) (base : Word)
     (v2_old v11_old : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
@@ -922,12 +922,12 @@ theorem divK_trial_call_path_spec
 -- ============================================================================
 
 -- Address normalization for store_qj and loop control
-private theorem lb_sqj (base : Addr) : (base + 880 : Addr) + 16 = base + 896 := by bv_omega
-private theorem lb_lc_taken (base : Addr) :
-    (base + 896 : Addr) + 4 + signExtend13 (7740 : BitVec 13) = base + 448 := by
+private theorem lb_sqj (base : Word) : (base + 880 : Word) + 16 = base + 896 := by bv_omega
+private theorem lb_lc_taken (base : Word) :
+    (base + 896 : Word) + 4 + signExtend13 (7740 : BitVec 13) = base + 448 := by
   have : signExtend13 (7740 : BitVec 13) = (18446744073709551164 : Word) := by native_decide
   rw [this]; bv_omega
-private theorem lb_lc_exit (base : Addr) : (base + 896 : Addr) + 8 = base + 904 := by bv_omega
+private theorem lb_lc_exit (base : Word) : (base + 896 : Word) + 8 = base + 904 := by bv_omega
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -937,7 +937,7 @@ set_option maxHeartbeats 800000 in
     CodeReq: divCode base. -/
 theorem divK_store_loop_spec
     (sp j q_hat v5_old v7_old q_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_q : isValidDwordAccess (sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat) = true) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - j_x8
@@ -1017,7 +1017,7 @@ set_option maxHeartbeats 3200000 in
 theorem divK_mulsub_correction_skip_spec
     (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
@@ -1112,7 +1112,7 @@ set_option maxHeartbeats 3200000 in
 theorem divK_mulsub_correction_addback_spec
     (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
     (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
@@ -1236,7 +1236,7 @@ set_option maxHeartbeats 1600000 in
     Entry: base+448, Exit: base+516, CodeReq: divCode base. -/
 theorem divK_trial_max_full_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old u_hi u_lo v_top : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -1307,7 +1307,7 @@ set_option maxHeartbeats 3200000 in
 theorem divK_trial_call_full_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old u_hi u_lo v_top : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -1426,7 +1426,7 @@ set_option maxHeartbeats 6400000 in
 theorem divK_loop_body_max_skip_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old
      u_hi u_lo v_top v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -1590,7 +1590,7 @@ set_option maxHeartbeats 6400000 in
 theorem divK_loop_body_max_addback_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old
      u_hi u_lo v_top v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -1777,7 +1777,7 @@ theorem divK_loop_body_call_skip_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old
      u_hi u_lo v_top v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -1989,7 +1989,7 @@ theorem divK_loop_body_call_addback_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old
      u_hi u_lo v_top v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)
@@ -2258,7 +2258,7 @@ theorem divK_loop_body_combined_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old
      u_hi u_lo v_top v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Addr)
+    (base : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat) = true)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -36,23 +36,23 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
        evmWordIs (sp + 32) (EvmWord.div a b)) := by
   subst hbz
   -- Normalize (0 : EvmWord).getLimb k to (0 : Word)
-  have hg0 : (0 : EvmWord).getLimb 0 = (0 : Word) := by native_decide
-  have hg1 : (0 : EvmWord).getLimb 1 = (0 : Word) := by native_decide
-  have hg2 : (0 : EvmWord).getLimb 2 = (0 : Word) := by native_decide
-  have hg3 : (0 : EvmWord).getLimb 3 = (0 : Word) := by native_decide
+  have hg0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by native_decide
+  have hg1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by native_decide
+  have hg2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by native_decide
+  have hg3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by native_decide
   -- Get the limb-level zero-path spec
-  have hlimbs_or : (0 : EvmWord).getLimb 0 ||| (0 : EvmWord).getLimb 1 |||
-      (0 : EvmWord).getLimb 2 ||| (0 : EvmWord).getLimb 3 = (0 : Word) := by native_decide
+  have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
+      (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by native_decide
   have h_raw := evm_div_bzero_spec sp base
-    ((0 : EvmWord).getLimb 0) ((0 : EvmWord).getLimb 1)
-    ((0 : EvmWord).getLimb 2) ((0 : EvmWord).getLimb 3)
+    ((0 : EvmWord).getLimbN 0) ((0 : EvmWord).getLimbN 1)
+    ((0 : EvmWord).getLimbN 2) ((0 : EvmWord).getLimbN 3)
     v5 v10 hlimbs_or hvalid
   simp only [hg0, hg1, hg2, hg3] at h_raw
   -- Bridge: div a 0 = 0, getLimb (div a 0) k = 0
-  have hr0 : (EvmWord.div a 0).getLimb 0 = 0 := EvmWord.div_getLimb_zero_right a 0
-  have hr1 : (EvmWord.div a 0).getLimb 1 = 0 := EvmWord.div_getLimb_zero_right a 1
-  have hr2 : (EvmWord.div a 0).getLimb 2 = 0 := EvmWord.div_getLimb_zero_right a 2
-  have hr3 : (EvmWord.div a 0).getLimb 3 = 0 := EvmWord.div_getLimb_zero_right a 3
+  have hr0 : (EvmWord.div a 0).getLimbN 0 = 0 := EvmWord.div_getLimb_zero_right a 0
+  have hr1 : (EvmWord.div a 0).getLimbN 1 = 0 := EvmWord.div_getLimb_zero_right a 1
+  have hr2 : (EvmWord.div a 0).getLimbN 2 = 0 := EvmWord.div_getLimb_zero_right a 2
+  have hr3 : (EvmWord.div a 0).getLimbN 3 = 0 := EvmWord.div_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp
@@ -98,21 +98,21 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs (sp + 32) (EvmWord.mod a b)) := by
   subst hbz
-  have hg0 : (0 : EvmWord).getLimb 0 = (0 : Word) := by native_decide
-  have hg1 : (0 : EvmWord).getLimb 1 = (0 : Word) := by native_decide
-  have hg2 : (0 : EvmWord).getLimb 2 = (0 : Word) := by native_decide
-  have hg3 : (0 : EvmWord).getLimb 3 = (0 : Word) := by native_decide
-  have hlimbs_or : (0 : EvmWord).getLimb 0 ||| (0 : EvmWord).getLimb 1 |||
-      (0 : EvmWord).getLimb 2 ||| (0 : EvmWord).getLimb 3 = (0 : Word) := by native_decide
+  have hg0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by native_decide
+  have hg1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by native_decide
+  have hg2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by native_decide
+  have hg3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by native_decide
+  have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
+      (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by native_decide
   have h_raw := evm_mod_bzero_spec sp base
-    ((0 : EvmWord).getLimb 0) ((0 : EvmWord).getLimb 1)
-    ((0 : EvmWord).getLimb 2) ((0 : EvmWord).getLimb 3)
+    ((0 : EvmWord).getLimbN 0) ((0 : EvmWord).getLimbN 1)
+    ((0 : EvmWord).getLimbN 2) ((0 : EvmWord).getLimbN 3)
     v5 v10 hlimbs_or hvalid
   simp only [hg0, hg1, hg2, hg3] at h_raw
-  have hr0 : (EvmWord.mod a 0).getLimb 0 = 0 := EvmWord.mod_getLimb_zero_right a 0
-  have hr1 : (EvmWord.mod a 0).getLimb 1 = 0 := EvmWord.mod_getLimb_zero_right a 1
-  have hr2 : (EvmWord.mod a 0).getLimb 2 = 0 := EvmWord.mod_getLimb_zero_right a 2
-  have hr3 : (EvmWord.mod a 0).getLimb 3 = 0 := EvmWord.mod_getLimb_zero_right a 3
+  have hr0 : (EvmWord.mod a 0).getLimbN 0 = 0 := EvmWord.mod_getLimb_zero_right a 0
+  have hr1 : (EvmWord.mod a 0).getLimbN 1 = 0 := EvmWord.mod_getLimb_zero_right a 1
+  have hr2 : (EvmWord.mod a 0).getLimbN 2 = 0 := EvmWord.mod_getLimb_zero_right a 2
+  have hr3 : (EvmWord.mod a 0).getLimbN 3 = 0 := EvmWord.mod_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -25,7 +25,7 @@ private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h →
 
 /-- Stack-level DIV spec for the zero divisor path: when b = 0, result is 0.
     Uses evmWordIs for the b-operand at sp+32. The a-operand at sp is untouched. -/
-theorem evm_div_bzero_stack_spec (sp base : Addr)
+theorem evm_div_bzero_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v10 : Word)
     (hbz : b = 0)
     (hvalid : ValidMemRange sp 8) :
@@ -56,16 +56,16 @@ theorem evm_div_bzero_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp
-      simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                  hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                  hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
@@ -88,7 +88,7 @@ theorem evm_div_bzero_stack_spec (sp base : Addr)
 
 /-- Stack-level MOD spec for the zero divisor path: when b = 0, result is 0.
     Uses evmWordIs for the b-operand at sp+32. The a-operand at sp is untouched. -/
-theorem evm_mod_bzero_stack_spec (sp base : Addr)
+theorem evm_mod_bzero_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v10 : Word)
     (hbz : b = 0)
     (hvalid : ValidMemRange sp 8) :
@@ -116,16 +116,16 @@ theorem evm_mod_bzero_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp
-      simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                  hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
                  hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =

--- a/EvmAsm/Evm64/Dup/Program.lean
+++ b/EvmAsm/Evm64/Dup/Program.lean
@@ -24,7 +24,7 @@ def evm_dup (n : Nat) : Program :=
 
 /-- CodeReq for generic DUPn: 9 instructions = 36 bytes.
     Built as an explicit union chain because symbolic n prevents ofProg reduction. -/
-abbrev evm_dup_code (base : Addr) (n : Nat) : CodeReq :=
+abbrev evm_dup_code (base : Word) (n : Nat) : CodeReq :=
   CodeReq.singleton base (.ADDI .x12 .x12 (-32))
   |>.union (CodeReq.singleton (base + 4)  (.LD .x7 .x12 (BitVec.ofNat 12 (n*32))))
   |>.union (CodeReq.singleton (base + 8)  (.SD .x12 .x7 (BitVec.ofNat 12 0)))

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -127,7 +127,7 @@ theorem evm_dup_evmword_spec (nsp base : Word)
       ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
        evmWordIs nsp dst **
        evmWordIs (nsp + BitVec.ofNat 64 (n * 32)) src)
-      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ src.getLimb 3) **
+      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ src.getLimbN 3) **
        evmWordIs nsp src **
        evmWordIs (nsp + BitVec.ofNat 64 (n * 32)) src) := by
   -- Address normalizations for evmWordIs (nsp + BitVec.ofNat 64 (n*32))
@@ -138,15 +138,15 @@ theorem evm_dup_evmword_spec (nsp base : Word)
   have haddr24 : (nsp + BitVec.ofNat 64 (n*32) : Word) + 24 = nsp + BitVec.ofNat 64 (n*32+24) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   have h_main := evm_dup_spec nsp base n hn1 hn16
-    (src.getLimb 0) (src.getLimb 1) (src.getLimb 2) (src.getLimb 3)
-    (dst.getLimb 0) (dst.getLimb 1) (dst.getLimb 2) (dst.getLimb 3)
+    (src.getLimbN 0) (src.getLimbN 1) (src.getLimbN 2) (src.getLimbN 3)
+    (dst.getLimbN 0) (dst.getLimbN 1) (dst.getLimbN 2) (dst.getLimbN 3)
     v7 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun _ hp => by
-      simp only [evmWordIs, haddr8, haddr16, haddr24] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, haddr8, haddr16, haddr24] at hp
       xperm_hyp hp)
     (fun _ hq => by
-      simp only [evmWordIs, haddr8, haddr16, haddr24]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, haddr8, haddr16, haddr24]
       xperm_hyp hq)
     h_main
 
@@ -167,7 +167,7 @@ theorem evm_dup_stack_spec (nsp base : Word)
       ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
        evmWordIs nsp d **
        evmStackIs (nsp + 32) stack)
-      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ vn.getLimb 3) **
+      ((.x12 ↦ᵣ nsp) ** (.x7 ↦ᵣ vn.getLimbN 3) **
        evmWordIs nsp vn **
        evmStackIs (nsp + 32) stack) := by
   intro vn

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -143,10 +143,10 @@ theorem evm_dup_evmword_spec (nsp base : Word)
     v7 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun _ hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, haddr8, haddr16, haddr24] at hp
+      simp only [evmWordIs, haddr8, haddr16, haddr24] at hp
       xperm_hyp hp)
     (fun _ hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, haddr8, haddr16, haddr24]
+      simp only [evmWordIs, haddr8, haddr16, haddr24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -19,8 +19,8 @@ namespace EvmAsm.Rv64
 
 /-- Two-instruction spec for DUP: LD x7 from source, SD x7 to destination.
     Copies src_val from src address to dst address. -/
-theorem dup_pair_spec (sp : Addr)
-    (off_src off_dst : BitVec 12) (src_val dst_old v7 : Word) (base : Addr)
+theorem dup_pair_spec (sp : Word)
+    (off_src off_dst : BitVec 12) (src_val dst_old v7 : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 off_src) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 off_dst) = true) :
     cpsTriple base (base + 8)
@@ -39,7 +39,7 @@ theorem dup_pair_spec (sp : Addr)
 set_option maxHeartbeats 6400000 in
 /-- Generic DUPn spec (low level): copies 4 dword limbs from src (at nsp+n*32) to dst (at nsp).
     Requires 1 ≤ n ≤ 16 (valid EVM DUP range). -/
-theorem evm_dup_spec (nsp base : Addr)
+theorem evm_dup_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (s0 s1 s2 s3 : Word)
     (d0 d1 d2 d3 : Word)
@@ -119,7 +119,7 @@ theorem evm_dup_spec (nsp base : Addr)
 
 set_option maxHeartbeats 3200000 in
 /-- DUPn spec at evmWordIs level: copies the nth stack element to new top position. -/
-theorem evm_dup_evmword_spec (nsp base : Addr)
+theorem evm_dup_evmword_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (src dst : EvmWord) (v7 : Word)
     (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
@@ -131,11 +131,11 @@ theorem evm_dup_evmword_spec (nsp base : Addr)
        evmWordIs nsp src **
        evmWordIs (nsp + BitVec.ofNat 64 (n * 32)) src) := by
   -- Address normalizations for evmWordIs (nsp + BitVec.ofNat 64 (n*32))
-  have haddr8  : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 8  = nsp + BitVec.ofNat 64 (n*32+8)  := by
+  have haddr8  : (nsp + BitVec.ofNat 64 (n*32) : Word) + 8  = nsp + BitVec.ofNat 64 (n*32+8)  := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have haddr16 : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 16 = nsp + BitVec.ofNat 64 (n*32+16) := by
+  have haddr16 : (nsp + BitVec.ofNat 64 (n*32) : Word) + 16 = nsp + BitVec.ofNat 64 (n*32+16) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have haddr24 : (nsp + BitVec.ofNat 64 (n*32) : Addr) + 24 = nsp + BitVec.ofNat 64 (n*32+24) := by
+  have haddr24 : (nsp + BitVec.ofNat 64 (n*32) : Word) + 24 = nsp + BitVec.ofNat 64 (n*32+24) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   have h_main := evm_dup_spec nsp base n hn1 hn16
     (src.getLimb 0) (src.getLimb 1) (src.getLimb 2) (src.getLimb 3)
@@ -157,7 +157,7 @@ theorem evm_dup_evmword_spec (nsp base : Addr)
 set_option maxHeartbeats 3200000 in
 /-- DUPn stack spec: copies the (n-1)-th element (0-indexed) from the stack
     to a new top position, leaving the rest unchanged. -/
-theorem evm_dup_stack_spec (nsp base : Addr)
+theorem evm_dup_stack_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (stack : List EvmWord) (hlen : n ≤ stack.length)
     (d : EvmWord) (v7 : Word)
@@ -175,10 +175,10 @@ theorem evm_dup_stack_spec (nsp base : Addr)
   have hk : n - 1 < stack.length := by omega
   have hsplit := evmStackIs_split_at (nsp + 32) stack (n - 1) hk
   -- Address normalizations
-  have haddr_src : (nsp + 32 : Addr) + BitVec.ofNat 64 ((n - 1) * 32) =
+  have haddr_src : (nsp + 32 : Word) + BitVec.ofNat 64 ((n - 1) * 32) =
       nsp + BitVec.ofNat 64 (n * 32) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have haddr_rest : (nsp + 32 : Addr) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
+  have haddr_rest : (nsp + 32 : Word) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
       nsp + BitVec.ofNat 64 (n * 32 + 32) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   rw [haddr_src, haddr_rest, show n - 1 + 1 = n from by omega] at hsplit

--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -15,7 +15,7 @@ namespace EvmAsm.Rv64
 
 /-- EQ limb 0 spec (3 instructions): LD x7, LD x6, XOR x7 x7 x6. -/
 theorem eq_limb0_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -33,7 +33,7 @@ theorem eq_limb0_spec (off_a off_b : BitVec 12)
 
 /-- EQ OR-limb spec (4 instructions): LD x6, LD x5, XOR x6 x6 x5, OR x7 x7 x6. -/
 theorem eq_or_limb_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v6 v5 acc : Word) (base : Addr)
+    (sp a_limb b_limb v6 v5 acc : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -96,7 +96,7 @@ theorem evm_eq_stack_spec (sp base : Word)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
@@ -104,12 +104,14 @@ theorem evm_eq_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.eq_xor_or_reduce_correct]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -74,10 +74,10 @@ theorem evm_eq_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- XOR-OR accumulation chain
-    let acc0 := a.getLimb 0 ^^^ b.getLimb 0
-    let acc1 := acc0 ||| (a.getLimb 1 ^^^ b.getLimb 1)
-    let acc2 := acc1 ||| (a.getLimb 2 ^^^ b.getLimb 2)
-    let acc3 := acc2 ||| (a.getLimb 3 ^^^ b.getLimb 3)
+    let acc0 := a.getLimbN 0 ^^^ b.getLimbN 0
+    let acc1 := acc0 ||| (a.getLimbN 1 ^^^ b.getLimbN 1)
+    let acc2 := acc1 ||| (a.getLimbN 2 ^^^ b.getLimbN 2)
+    let acc3 := acc2 ||| (a.getLimbN 3 ^^^ b.getLimbN 3)
     let eq_result := if BitVec.ult acc3 (1 : Word) then (1 : Word) else 0
     let code := evm_eq_code base
     cpsTriple base (base + 84) code
@@ -86,17 +86,17 @@ theorem evm_eq_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) b)
       (-- Registers + memory (updated)
        (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ eq_result) ** (.x6 ↦ᵣ (a.getLimb 3 ^^^ b.getLimb 3)) **
-       (.x5 ↦ᵣ b.getLimb 3) ** (.x11 ↦ᵣ v11) **
+       (.x7 ↦ᵣ eq_result) ** (.x6 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) **
+       (.x5 ↦ᵣ b.getLimbN 3) ** (.x11 ↦ᵣ v11) **
        evmWordIs sp a ** evmWordIs (sp + 32) (if a = b then 1 else 0)) := by
   intro acc0 acc1 acc2 acc3 eq_result
   have h_main := evm_eq_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM EQ operation.
     21 instructions = 84 bytes. XOR-OR accumulation + SLTIU boolean + store. -/
-abbrev evm_eq_code (base : Addr) : CodeReq :=
+abbrev evm_eq_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_eq
 
 /-- Full 256-bit EVM EQ: EQ(a, b) = 1 iff a == b (unsigned).
@@ -22,7 +22,7 @@ abbrev evm_eq_code (base : Addr) : CodeReq :=
     Pops 2 stack words (A at sp, B at sp+32),
     writes result to sp+32..sp+56, advances sp by 32.
     21 instructions = 84 bytes total. -/
-theorem evm_eq_spec (sp : Addr) (base : Addr)
+theorem evm_eq_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -70,7 +70,7 @@ theorem evm_eq_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM EQ: operates on two EvmWords via evmWordIs. -/
-theorem evm_eq_stack_spec (sp base : Addr)
+theorem evm_eq_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- XOR-OR accumulation chain
@@ -97,9 +97,9 @@ theorem evm_eq_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
@@ -110,9 +110,9 @@ theorem evm_eq_stack_spec (sp base : Addr)
                  show ¬((3 : Fin 4) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.eq_xor_or_reduce_correct]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -107,7 +107,7 @@ theorem evm_gt_stack_spec (sp base : Word)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
@@ -115,12 +115,14 @@ theorem evm_gt_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.lt_borrow_chain_correct b a]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -78,17 +78,17 @@ theorem evm_gt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Borrow chain: b - a (GT direction)
-    let borrow0 := if BitVec.ult (b.getLimb 0) (a.getLimb 0) then (1 : Word) else 0
-    let borrow1a := if BitVec.ult (b.getLimb 1) (a.getLimb 1) then (1 : Word) else 0
-    let temp1 := b.getLimb 1 - a.getLimb 1
+    let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+    let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+    let temp1 := b.getLimbN 1 - a.getLimbN 1
     let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
     let borrow1 := borrow1a ||| borrow1b
-    let borrow2a := if BitVec.ult (b.getLimb 2) (a.getLimb 2) then (1 : Word) else 0
-    let temp2 := b.getLimb 2 - a.getLimb 2
+    let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+    let temp2 := b.getLimbN 2 - a.getLimbN 2
     let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
     let borrow2 := borrow2a ||| borrow2b
-    let borrow3a := if BitVec.ult (b.getLimb 3) (a.getLimb 3) then (1 : Word) else 0
-    let temp3 := b.getLimb 3 - a.getLimb 3
+    let borrow3a := if BitVec.ult (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+    let temp3 := b.getLimbN 3 - a.getLimbN 3
     let borrow3b := if BitVec.ult temp3 borrow2 then (1 : Word) else 0
     let borrow3 := borrow3a ||| borrow3b
     let code := evm_gt_code base
@@ -102,12 +102,12 @@ theorem evm_gt_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult b a then 1 else 0)) := by
   intro borrow0 borrow1a temp1 borrow1b borrow1 borrow2a temp2 borrow2b borrow2 borrow3a temp3 borrow3b borrow3
   have h_main := evm_gt_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM GT operation.
     26 instructions = 104 bytes. GT(a, b) = LT(b, a): load b-limbs first. -/
-abbrev evm_gt_code (base : Addr) : CodeReq :=
+abbrev evm_gt_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_gt
 
 /-- Full 256-bit EVM GT: GT(a, b) = 1 iff a > b (unsigned).
@@ -24,7 +24,7 @@ abbrev evm_gt_code (base : Addr) : CodeReq :=
     Pops 2 stack words (A at sp, B at sp+32),
     writes result to sp+32..sp+56, advances sp by 32.
     26 instructions = 104 bytes total. -/
-theorem evm_gt_spec (sp : Addr) (base : Addr)
+theorem evm_gt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -74,7 +74,7 @@ theorem evm_gt_spec (sp : Addr) (base : Addr)
 
 /-- Stack-level 256-bit EVM GT: operates on two EvmWords via evmWordIs.
     GT(a, b) = LT(b, a), using the borrow chain in b-a direction. -/
-theorem evm_gt_stack_spec (sp base : Addr)
+theorem evm_gt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Borrow chain: b - a (GT direction)
@@ -108,9 +108,9 @@ theorem evm_gt_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
@@ -121,9 +121,9 @@ theorem evm_gt_stack_spec (sp base : Addr)
                  show ¬((3 : Fin 4) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.lt_borrow_chain_correct b a]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/IsZero/LimbSpec.lean
+++ b/EvmAsm/Evm64/IsZero/LimbSpec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 /-- ISZERO OR-limb spec (2 instructions): LD x6, OR x7 x7 x6.
     Loads a limb and OR-accumulates into x7. -/
 theorem iszero_or_limb_spec (off : BitVec 12)
-    (sp a_limb v6 acc : Word) (base : Addr)
+    (sp a_limb v6 acc : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let mem := sp + signExtend12 off
     let cr :=

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -61,7 +61,7 @@ theorem evm_iszero_spec (sp : Word) (base : Word)
 theorem evm_iszero_stack_spec (sp base : Word)
     (a : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp 4) :
-    let or_all := a.getLimb 0 ||| a.getLimb 1 ||| a.getLimb 2 ||| a.getLimb 3
+    let or_all := a.getLimbN 0 ||| a.getLimbN 1 ||| a.getLimbN 2 ||| a.getLimbN 3
     let result := if BitVec.ult or_all 1 then (1 : Word) else 0
     let code := evm_iszero_code base
     cpsTriple base (base + 48) code
@@ -69,15 +69,15 @@ theorem evm_iszero_stack_spec (sp base : Word)
        (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp a)
       (-- Registers + memory (updated)
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a.getLimb 3) **
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ a.getLimbN 3) **
        evmWordIs sp (if a = 0 then 1 else 0)) := by
   intro or_all result
   have h_main := evm_iszero_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -77,16 +77,18 @@ theorem evm_iszero_stack_spec (sp base : Word)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.iszero_or_reduce_correct]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -14,13 +14,13 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM ISZERO operation.
     12 instructions = 48 bytes. OR-reduce 4 limbs + SLTIU boolean + store. -/
-abbrev evm_iszero_code (base : Addr) : CodeReq :=
+abbrev evm_iszero_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_iszero
 
 /-- Full 256-bit EVM ISZERO: result = 1 iff all 4 limbs are 0.
     Unary: reads 256-bit word at sp, overwrites with boolean result.
     12 instructions = 48 bytes. -/
-theorem evm_iszero_spec (sp : Addr) (base : Addr)
+theorem evm_iszero_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 : Word)
     (v7 v6 : Word)
     (hvalid : ValidMemRange sp 4) :
@@ -58,7 +58,7 @@ theorem evm_iszero_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM ISZERO: operates on an EvmWord via evmWordIs. -/
-theorem evm_iszero_stack_spec (sp base : Addr)
+theorem evm_iszero_stack_spec (sp base : Word)
     (a : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp 4) :
     let or_all := a.getLimb 0 ||| a.getLimb 1 ||| a.getLimb 2 ||| a.getLimb 3

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -74,10 +74,10 @@ theorem evm_lt_spec (sp : Word) (base : Word)
 theorem evm_lt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
-    let a0 := a.getLimb 0; let b0 := b.getLimb 0
-    let a1 := a.getLimb 1; let b1 := b.getLimb 1
-    let a2 := a.getLimb 2; let b2 := b.getLimb 2
-    let a3 := a.getLimb 3; let b3 := b.getLimb 3
+    let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+    let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+    let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+    let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
     let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
     let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
     let temp1 := a1 - b1
@@ -102,12 +102,12 @@ theorem evm_lt_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.ult a b then 1 else 0)) := by
   intro a0 b0 a1 b1 a2 b2 a3 b3 borrow0 borrow1a temp1 borrow1b borrow1 borrow2a temp2 borrow2b borrow2 borrow3a temp3 borrow3b borrow3
   have h_main := evm_lt_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -107,7 +107,7 @@ theorem evm_lt_stack_spec (sp base : Word)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
@@ -115,12 +115,14 @@ theorem evm_lt_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.lt_borrow_chain_correct a b]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -15,7 +15,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM LT operation.
     26 instructions = 104 bytes. Borrow chain across 4 limbs + store. -/
-abbrev evm_lt_code (base : Addr) : CodeReq :=
+abbrev evm_lt_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_lt
 
 /-- Full 256-bit EVM LT: LT(a, b) = 1 iff a < b (unsigned).
@@ -23,7 +23,7 @@ abbrev evm_lt_code (base : Addr) : CodeReq :=
     Pops 2 stack words (A at sp, B at sp+32),
     writes result to sp+32..sp+56, advances sp by 32.
     26 instructions = 104 bytes total. -/
-theorem evm_lt_spec (sp : Addr) (base : Addr)
+theorem evm_lt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -71,7 +71,7 @@ theorem evm_lt_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM LT: operates on two EvmWords via evmWordIs. -/
-theorem evm_lt_stack_spec (sp base : Addr)
+theorem evm_lt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
@@ -108,9 +108,9 @@ theorem evm_lt_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
@@ -121,9 +121,9 @@ theorem evm_lt_stack_spec (sp base : Addr)
                  show ¬((3 : Fin 4) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.lt_borrow_chain_correct a b]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Multiply/LimbSpec.lean
+++ b/EvmAsm/Evm64/Multiply/LimbSpec.lean
@@ -25,12 +25,12 @@ namespace EvmAsm.Rv64
 -- Column 3: b[3] × {a[0]} (5 instructions)
 -- ============================================================================
 
-abbrev mul_col3_code (base : Addr) : CodeReq :=
+abbrev mul_col3_code (base : Word) : CodeReq :=
   CodeReq.ofProg base mul_col3
 
 /-- Column 3: multiply b[3] × a[0], add to r3 accumulator, store result.
     5 instructions: LD b3; LD a0; MUL a0*b3; ADD acc; SD result. -/
-theorem mul_col3_spec (sp : Addr) (base : Addr)
+theorem mul_col3_spec (sp : Word) (base : Word)
     (a0 b3 r3_in v5 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := mul_col3_code base
@@ -50,13 +50,13 @@ theorem mul_col3_spec (sp : Addr) (base : Addr)
 -- Column 2: b[2] × {a[0], a[1]} (13 instructions)
 -- ============================================================================
 
-abbrev mul_col2_code (base : Addr) : CodeReq :=
+abbrev mul_col2_code (base : Word) : CodeReq :=
   CodeReq.ofProg base mul_col2
 
 /-- Column 2: multiply b[2] × {a[0],a[1]}, finalize r[2], update r[3] accumulator.
     13 instructions. Input: x11 = r2 acc, sp+16 = r3 partial.
     Output: x10 = r3 total, sp+48 = r2 stored. -/
-theorem mul_col2_spec (sp : Addr) (base : Addr)
+theorem mul_col2_spec (sp : Word) (base : Word)
     (a0 a1 b2 r2_in r3p v5 v6 v7 v10 : Word)
     (hvalid : ValidMemRange sp 8) :
     let lo_a0b2 := a0 * b2
@@ -95,12 +95,12 @@ theorem mul_col2_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 -- Part A: LD b1, LD a0, MUL, MULHU, ADD, SLTU, ADD, SD r1, ADD, SLTU (10 instrs)
-abbrev mul_col1_partA_code (base : Addr) : CodeReq :=
+abbrev mul_col1_partA_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (mul_col1.take 10)
 
 /-- Column 1 part A: load b1, multiply a0×b1, store r1, begin r2 accumulation.
     10 instructions at base..base+36. -/
-theorem mul_col1_partA_spec (sp : Addr) (base : Addr)
+theorem mul_col1_partA_spec (sp : Word) (base : Word)
     (a0 b1 r1_in r2_in v5 v6 v7 : Word)
     (hvalid : ValidMemRange sp 8) :
     let lo_a0b1 := a0 * b1
@@ -133,12 +133,12 @@ theorem mul_col1_partA_spec (sp : Addr) (base : Addr)
 
 -- Part B: LD a1, MUL, MULHU, ADD, SLTU, ADD, ADD, LD a2, MUL, ADD, LD r3p0, ADD, SD (13 instrs)
 -- Uses outer base (base = column base), so atoms are at base+40..base+88.
-abbrev mul_col1_partB_code (base : Addr) : CodeReq :=
+abbrev mul_col1_partB_code (base : Word) : CodeReq :=
   CodeReq.ofProg (base + 40) (mul_col1.drop 10)
 
 /-- Column 1 part B: multiply a1×b1, a2×b1, accumulate r2/r3, store r3 spill.
     13 instructions at base+40..base+88. -/
-theorem mul_col1_partB_spec (sp : Addr) (base : Addr)
+theorem mul_col1_partB_spec (sp : Word) (base : Word)
     (a1 a2 b1 r3p0 v6 v7 carry_r2_1 r2_acc1 : Word)
     (hvalid : ValidMemRange sp 8) :
     let lo_a1b1 := a1 * b1
@@ -172,13 +172,13 @@ theorem mul_col1_partB_spec (sp : Addr) (base : Addr)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11 I12
 
 -- Full column 1 code (used by evm_mul_code)
-abbrev mul_col1_code (base : Addr) : CodeReq :=
+abbrev mul_col1_code (base : Word) : CodeReq :=
   CodeReq.ofProg base mul_col1
 
 /-- Column 1: multiply b[1] × {a[0],a[1],a[2]}, finalize r[1], update r[2]/r[3].
     23 instructions. Input: x10 = r1 acc, x11 = r2 acc, sp+24 = r3 partial from col0.
     Output: x11 = r2 acc, sp+16 = r3 partial, sp+40 = r1 stored. -/
-theorem mul_col1_spec (sp : Addr) (base : Addr)
+theorem mul_col1_spec (sp : Word) (base : Word)
     (a0 a1 a2 b1 r1_in r2_in r3p0 v5 v6 v7 : Word)
     (hvalid : ValidMemRange sp 8) :
     let lo_a0b1 := a0 * b1
@@ -215,12 +215,12 @@ theorem mul_col1_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 -- Part A: LD b0, LD a0, MUL, MULHU, SD r0, LD a1, MUL, MULHU, ADD, SLTU, ADD (11 instrs)
-abbrev mul_col0_partA_code (base : Addr) : CodeReq :=
+abbrev mul_col0_partA_code (base : Word) : CodeReq :=
   CodeReq.ofProg base (mul_col0.take 11)
 
 /-- Column 0 part A: load b0, multiply a0×b0 and a1×b0, store r0, begin r1/r2 accumulation.
     11 instructions at base..base+40. -/
-theorem mul_col0_partA_spec (sp : Addr) (base : Addr)
+theorem mul_col0_partA_spec (sp : Word) (base : Word)
     (a0 a1 b0 v5 v6 v7 v10 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let r0 := a0 * b0
@@ -253,12 +253,12 @@ theorem mul_col0_partA_spec (sp : Addr) (base : Addr)
 
 -- Part B: LD a2, MUL, MULHU, ADD, SLTU, ADD, LD a3, MUL, ADD, SD r3p (10 instrs)
 -- Uses outer base (base = column base), so atoms are at base+44..base+80.
-abbrev mul_col0_partB_code (base : Addr) : CodeReq :=
+abbrev mul_col0_partB_code (base : Word) : CodeReq :=
   CodeReq.ofProg (base + 44) (mul_col0.drop 11)
 
 /-- Column 0 part B: multiply a2×b0 and a3×b0, accumulate r2, store r3 partial.
     10 instructions at base+44..base+80. -/
-theorem mul_col0_partB_spec (sp : Addr) (base : Addr)
+theorem mul_col0_partB_spec (sp : Word) (base : Word)
     (a2 a3 b0 v6 v7 r2_partial : Word)
     (hvalid : ValidMemRange sp 8) :
     let lo_a2b0 := a2 * b0
@@ -288,12 +288,12 @@ theorem mul_col0_partB_spec (sp : Addr) (base : Addr)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9
 
 -- Full column 0 code (used by evm_mul_code)
-abbrev mul_col0_code (base : Addr) : CodeReq :=
+abbrev mul_col0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base mul_col0
 
 /-- Column 0: multiply b[0] × {a[0],a[1],a[2],a[3]}, store r[0], spill r[3] partial.
     21 instructions. Output: x10 = r1 acc, x11 = r2 acc, sp+24 = r3p, sp+32 = r0. -/
-theorem mul_col0_spec (sp : Addr) (base : Addr)
+theorem mul_col0_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 v5 v6 v7 v10 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let r0 := a0 * b0
@@ -328,11 +328,11 @@ theorem mul_col0_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 -- Intermediate code: columns 0 + 1
-abbrev evm_mul_code01 (base : Addr) : CodeReq :=
+abbrev evm_mul_code01 (base : Word) : CodeReq :=
   CodeReq.union (mul_col0_code base) (mul_col1_code (base + 84))
 
 /-- Intermediate: compose col0 + col1. 44 instructions at base..base+176. -/
-theorem evm_mul_cols01_spec (sp : Addr) (base : Addr)
+theorem evm_mul_cols01_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 : Word)
     (v5 v6 v7 v10 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -378,13 +378,13 @@ theorem evm_mul_cols01_spec (sp : Addr) (base : Addr)
   runBlock C0 C1
 
 -- Intermediate code: columns 2 + 3 + epilogue
-abbrev evm_mul_cols23ep_code (base : Addr) : CodeReq :=
+abbrev evm_mul_cols23ep_code (base : Word) : CodeReq :=
   CodeReq.union (mul_col2_code (base + 176))
   (CodeReq.union (mul_col3_code (base + 228))
   (CodeReq.singleton (base + 248) (.ADDI .x12 .x12 32)))
 
 /-- Intermediate: compose col2 + col3 + epilogue. 19 instructions at base+176..base+252. -/
-theorem evm_mul_cols23ep_spec (sp : Addr) (base : Addr)
+theorem evm_mul_cols23ep_spec (sp : Word) (base : Word)
     (a0 a1 b2 b3 r2_in r3p_in v5 v6 v7 v10 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Col2 intermediates
@@ -413,7 +413,7 @@ theorem evm_mul_cols23ep_spec (sp : Addr) (base : Addr)
   runBlock C2 C3 EP
 
 -- Full code: union of sub-codes (used by evm_mul_spec for composition)
-abbrev evm_mul_code (base : Addr) : CodeReq :=
+abbrev evm_mul_code (base : Word) : CodeReq :=
   CodeReq.union (mul_col0_code base) (CodeReq.union (mul_col1_code (base + 84))
     (CodeReq.union (mul_col2_code (base + 176))
       (CodeReq.union (mul_col3_code (base + 228))
@@ -422,7 +422,7 @@ abbrev evm_mul_code (base : Addr) : CodeReq :=
 /-- Full 256-bit EVM MUL: composes cols01 + cols23ep intermediate triples.
     63 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes (A * B) mod 2^256 to sp+32..sp+56, advances sp by 32. -/
-theorem evm_mul_spec (sp : Addr) (base : Addr)
+theorem evm_mul_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v5 v6 v7 v10 v11 : Word)
     (hvalid : ValidMemRange sp 8) :

--- a/EvmAsm/Evm64/Not/LimbSpec.lean
+++ b/EvmAsm/Evm64/Not/LimbSpec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 /-- Per-limb NOT spec (3 instructions: LD x7, XORI x7 x7 (-1), SD x12 x7).
     Unary: loads limb, complements it, stores back to same location. -/
 theorem not_limb_spec (off : BitVec 12)
-    (sp limb v7 : Word) (base : Addr)
+    (sp limb v7 : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let mem := sp + signExtend12 off
     let cr :=

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -59,21 +59,22 @@ theorem evm_not_stack_spec (sp base : Word)
        (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** evmWordIs sp a)
       (-- Registers + memory (updated)
        (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a.getLimbN 3 ^^^ c)) ** evmWordIs sp (~~~a)) := by
-  -- Helper: (~~~a).getLimb i = a.getLimb i ^^^ signExtend12 (-1)
-  have not_limb_eq : ∀ i : Fin 4,
-      (~~~a).getLimb i = a.getLimb i ^^^ signExtend12 (-1 : BitVec 12) := by
-    intro i
-    rw [EvmWord.getLimbN_not, BitVec.not_def, BitVec.xor_comm, ← signExtend12_neg1_eq_allOnes]
+  -- Helper: (~~~a).getLimbN k = a.getLimbN k ^^^ signExtend12 (-1)
+  have not_limb_eq : ∀ (k : Nat), k < 4 →
+      (~~~a).getLimbN k = a.getLimbN k ^^^ signExtend12 (-1 : BitVec 12) := by
+    intro k hk
+    rw [EvmWord.getLimbN_not _ _ hk, BitVec.not_def, BitVec.xor_comm, ← signExtend12_neg1_eq_allOnes]
   -- Apply evm_not_spec with individual limbs
   have h_main := evm_not_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     v7 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, not_limb_eq]
+      simp only [evmWordIs, not_limb_eq 0 (by omega), not_limb_eq 1 (by omega),
+                 not_limb_eq 2 (by omega), not_limb_eq 3 (by omega)]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -58,22 +58,22 @@ theorem evm_not_stack_spec (sp base : Word)
       (-- Registers + memory
        (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** evmWordIs sp a)
       (-- Registers + memory (updated)
-       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a.getLimb 3 ^^^ c)) ** evmWordIs sp (~~~a)) := by
+       (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a.getLimbN 3 ^^^ c)) ** evmWordIs sp (~~~a)) := by
   -- Helper: (~~~a).getLimb i = a.getLimb i ^^^ signExtend12 (-1)
   have not_limb_eq : ∀ i : Fin 4,
       (~~~a).getLimb i = a.getLimb i ^^^ signExtend12 (-1 : BitVec 12) := by
     intro i
-    rw [EvmWord.getLimb_not, BitVec.not_def, BitVec.xor_comm, ← signExtend12_neg1_eq_allOnes]
+    rw [EvmWord.getLimbN_not, BitVec.not_def, BitVec.xor_comm, ← signExtend12_neg1_eq_allOnes]
   -- Apply evm_not_spec with individual limbs
   have h_main := evm_not_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     v7 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, not_limb_eq]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, not_limb_eq]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -16,12 +16,12 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM NOT operation.
     12 instructions = 48 bytes. 4 per-limb XORI(-1) blocks. -/
-abbrev evm_not_code (base : Addr) : CodeReq :=
+abbrev evm_not_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_not
 
 /-- Full 256-bit EVM NOT: composes 4 per-limb NOT specs.
     12 instructions total. Unary: complements each limb in-place, sp unchanged. -/
-theorem evm_not_spec (sp base : Addr)
+theorem evm_not_spec (sp base : Word)
     (a0 a1 a2 a3 : Word)
     (v7 : Word)
     (hvalid : ValidMemRange sp 4) :
@@ -49,7 +49,7 @@ theorem signExtend12_neg1_eq_allOnes : signExtend12 (-1 : BitVec 12) = BitVec.al
   native_decide
 
 /-- Stack-level 256-bit EVM NOT: complements an EvmWord in-place. -/
-theorem evm_not_stack_spec (sp base : Addr)
+theorem evm_not_stack_spec (sp base : Word)
     (a : EvmWord) (v7 : Word)
     (hvalid : ValidMemRange sp 4) :
     let c := signExtend12 (-1 : BitVec 12)

--- a/EvmAsm/Evm64/Or/LimbSpec.lean
+++ b/EvmAsm/Evm64/Or/LimbSpec.lean
@@ -15,7 +15,7 @@ namespace EvmAsm.Rv64
 
 /-- Per-limb OR spec (4 instructions: LD x7, LD x6, OR x7 x7 x6, SD x12 x7). -/
 theorem or_limb_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -40,22 +40,22 @@ theorem evm_or_stack_spec (sp base : Word)
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp a ** evmWordIs (sp + 32) b)
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimb 3 ||| b.getLimb 3)) ** (.x6 ↦ᵣ b.getLimb 3) **
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimbN 3 ||| b.getLimbN 3)) ** (.x6 ↦ᵣ b.getLimbN 3) **
        evmWordIs sp a ** evmWordIs (sp + 32) (a ||| b)) := by
   have h_main := evm_or_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_or]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_or]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -48,14 +48,14 @@ theorem evm_or_stack_spec (sp base : Word)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_or]
+      simp only [evmWordIs, EvmWord.getLimbN_or]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -10,11 +10,11 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM OR operation.
     17 instructions = 68 bytes. 4 per-limb OR blocks + ADDI sp adjustment. -/
-abbrev evm_or_code (base : Addr) : CodeReq :=
+abbrev evm_or_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_or
 
 /-- Full 256-bit EVM OR: composes 4 per-limb OR specs + sp adjustment. -/
-theorem evm_or_spec (sp base : Addr)
+theorem evm_or_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_or_code base
@@ -33,7 +33,7 @@ theorem evm_or_spec (sp base : Addr)
   runBlock L0 L1 L2 L3 LADDI
 
 /-- Stack-level 256-bit EVM OR. -/
-theorem evm_or_stack_spec (sp base : Addr)
+theorem evm_or_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_or_code base
@@ -49,16 +49,16 @@ theorem evm_or_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_or]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Pop/Program.lean
+++ b/EvmAsm/Evm64/Pop/Program.lean
@@ -12,7 +12,7 @@ namespace EvmAsm.Rv64
 
 def evm_pop : Program := ADDI .x12 .x12 32
 
-abbrev evm_pop_code (base : Addr) : CodeReq :=
+abbrev evm_pop_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_pop
 
 end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Pop/Spec.lean
+++ b/EvmAsm/Evm64/Pop/Spec.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Rv64
 
 /-- POP: advances stack pointer by 32 bytes (discards top 256-bit element).
     1 instruction = 4 bytes. -/
-theorem evm_pop_spec (sp base : Addr) :
+theorem evm_pop_spec (sp base : Word) :
     cpsTriple base (base + 4) (evm_pop_code base)
       (.x12 ↦ᵣ sp)
       (.x12 ↦ᵣ (sp + 32)) := by
@@ -23,7 +23,7 @@ theorem evm_pop_spec (sp base : Addr) :
   runBlock h
 
 /-- POP stack spec: discards top element, rest untouched. -/
-theorem evm_pop_stack_spec (sp base : Addr)
+theorem evm_pop_stack_spec (sp base : Word)
     (a : EvmWord) (rest : List EvmWord) :
     cpsTriple base (base + 4) (evm_pop_code base)
       ((.x12 ↦ᵣ sp) ** evmWordIs sp a ** evmStackIs (sp + 32) rest)

--- a/EvmAsm/Evm64/Push0/Program.lean
+++ b/EvmAsm/Evm64/Push0/Program.lean
@@ -14,7 +14,7 @@ def evm_push0 : Program :=
   ADDI .x12 .x12 (-32) ;;
   SD .x12 .x0 0 ;; SD .x12 .x0 8 ;; SD .x12 .x0 16 ;; SD .x12 .x0 24
 
-abbrev evm_push0_code (base : Addr) : CodeReq :=
+abbrev evm_push0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_push0
 
 end EvmAsm.Rv64

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -46,7 +46,7 @@ theorem evm_push0_stack_spec (nsp base : Word)
       ((.x12 ↦ᵣ nsp) ** evmWordIs nsp 0 ** evmStackIs (nsp + 32) rest) :=
   cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by simp only [evmWordIs, EvmWord.getLimb_zero]; xperm_hyp hq)
+    (fun h hq => by simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]; xperm_hyp hq)
     (cpsTriple_frame_left _ _ _ _ _
       (evmStackIs (nsp + 32) rest)
       (by exact pcFree_evmStackIs (nsp + 32) rest)

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -46,7 +46,7 @@ theorem evm_push0_stack_spec (nsp base : Word)
       ((.x12 ↦ᵣ nsp) ** evmWordIs nsp 0 ** evmStackIs (nsp + 32) rest) :=
   cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]; xperm_hyp hq)
+    (fun h hq => by simp only [evmWordIs, EvmWord.getLimbN_zero]; xperm_hyp hq)
     (cpsTriple_frame_left _ _ _ _ _
       (evmStackIs (nsp + 32) rest)
       (by exact pcFree_evmStackIs (nsp + 32) rest)

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 set_option maxHeartbeats 6400000 in
 /-- PUSH0: writes 4 zero limbs at nsp, moves SP backward by 32.
     5 instructions = 20 bytes. nsp is the NEW stack pointer (after decrement). -/
-theorem evm_push0_spec (nsp base : Addr)
+theorem evm_push0_spec (nsp base : Word)
     (d0 d1 d2 d3 : Word)
     (hvalid : ValidMemRange nsp 4) :
     let code := evm_push0_code base
@@ -35,7 +35,7 @@ theorem evm_push0_spec (nsp base : Addr)
   runBlock LADDI L0 L1 L2 L3
 
 /-- PUSH0 stack spec: pushes EvmWord 0 onto stack. -/
-theorem evm_push0_stack_spec (nsp base : Addr)
+theorem evm_push0_stack_spec (nsp base : Word)
     (d0 d1 d2 d3 : Word) (rest : List EvmWord)
     (hvalid : ValidMemRange nsp 4) :
     let code := evm_push0_code base

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -147,7 +147,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
@@ -155,12 +155,14 @@ theorem evm_sgt_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.slt_result_correct b a]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -116,18 +116,18 @@ theorem evm_sgt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Lower 3 limbs borrow chain: b - a direction (used when MSB limbs equal)
-    let borrow0 := if BitVec.ult (b.getLimb 0) (a.getLimb 0) then (1 : Word) else 0
-    let borrow1a := if BitVec.ult (b.getLimb 1) (a.getLimb 1) then (1 : Word) else 0
-    let temp1 := b.getLimb 1 - a.getLimb 1
+    let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
+    let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
+    let temp1 := b.getLimbN 1 - a.getLimbN 1
     let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
     let borrow1 := borrow1a ||| borrow1b
-    let borrow2a := if BitVec.ult (b.getLimb 2) (a.getLimb 2) then (1 : Word) else 0
-    let temp2 := b.getLimb 2 - a.getLimb 2
+    let borrow2a := if BitVec.ult (b.getLimbN 2) (a.getLimbN 2) then (1 : Word) else 0
+    let temp2 := b.getLimbN 2 - a.getLimbN 2
     let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
     let borrow2 := borrow2a ||| borrow2b
     -- Signed comparison of MSB limbs (swapped: b3 vs a3)
-    let sgt_msb := if BitVec.slt (b.getLimb 3) (a.getLimb 3) then (1 : Word) else 0
-    let result := if b.getLimb 3 = a.getLimb 3 then borrow2 else sgt_msb
+    let sgt_msb := if BitVec.slt (b.getLimbN 3) (a.getLimbN 3) then (1 : Word) else 0
+    let result := if b.getLimbN 3 = a.getLimbN 3 then borrow2 else sgt_msb
     let code := evm_sgt_code base
     cpsTriple base (base + 100) code
       (-- Registers + memory
@@ -135,19 +135,19 @@ theorem evm_sgt_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) b)
       (-- Registers + memory (updated)
        (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if b.getLimb 3 = a.getLimb 3 then temp2 else b.getLimb 3)) **
-       (.x6 ↦ᵣ (if b.getLimb 3 = a.getLimb 3 then borrow2b else a.getLimb 3)) **
+       (.x7 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then temp2 else b.getLimbN 3)) **
+       (.x6 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2b else a.getLimbN 3)) **
        (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if b.getLimb 3 = a.getLimb 3 then borrow2a else v11)) **
+       (.x11 ↦ᵣ (if b.getLimbN 3 = a.getLimbN 3 then borrow2a else v11)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt b a then 1 else 0)) := by
   intro borrow0 borrow1a temp1 borrow1b borrow1 borrow2a temp2 borrow2b borrow2 sgt_msb result
   have h_main := evm_sgt_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM SGT operation.
     25 instructions = 100 bytes. SGT(a, b) = SLT(b, a): swapped load order. -/
-abbrev evm_sgt_code (base : Addr) : CodeReq :=
+abbrev evm_sgt_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_sgt
 
 /-- Full 256-bit EVM SGT: SGT(a, b) = 1 iff a >s b (signed).
@@ -29,7 +29,7 @@ abbrev evm_sgt_code (base : Addr) : CodeReq :=
     Pops 2 stack words (A at sp, B at sp+32),
     writes result to sp+32..sp+56, advances sp by 32.
     25 instructions = 100 bytes total. -/
-theorem evm_sgt_spec (sp : Addr) (base : Addr)
+theorem evm_sgt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -71,7 +71,7 @@ theorem evm_sgt_spec (sp : Addr) (base : Addr)
     have M := slt_msb_load_spec 56 24 sp b3 b3 v7 v6 base (by validMem) (by validMem)
     -- BEQ taken (b3 = b3)
     have B := beq_eq_spec .x7 .x6 (12 : BitVec 13) b3 (base + 8)
-    have hsig13 : signExtend13 (12 : BitVec 13) = (12 : Addr) := by native_decide
+    have hsig13 : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
     simp only [hsig13] at B
     -- Lower limb borrow chain (swapped: b-limbs into x7, a-limbs into x6)
     have L0 := lt_limb0_spec 32 0 sp b0 a0 b3 b3 v5 (base + 20) (by validMem) (by validMem)
@@ -95,7 +95,7 @@ theorem evm_sgt_spec (sp : Addr) (base : Addr)
     have S := slt_spec_gen .x5 .x7 .x6 v5 b3 a3 (base + 12) (by nofun)
     -- JAL to store
     have J := jal_x0_spec_gen (64 : BitVec 21) (base + 16)
-    have hsig21 : signExtend21 (64 : BitVec 21) = (64 : Addr) := by native_decide
+    have hsig21 : signExtend21 (64 : BitVec 21) = (64 : Word) := by native_decide
     simp only [hsig21] at J
     -- Store phase
     have A := addi_spec_gen_same .x12 sp 32 (base + 80) (by nofun)
@@ -112,7 +112,7 @@ theorem evm_sgt_spec (sp : Addr) (base : Addr)
 
 /-- Stack-level 256-bit EVM SGT: operates on two EvmWords via evmWordIs.
     SGT(a, b) = SLT(b, a), using signed comparison with swapped operands. -/
-theorem evm_sgt_stack_spec (sp base : Addr)
+theorem evm_sgt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Lower 3 limbs borrow chain: b - a direction (used when MSB limbs equal)
@@ -148,9 +148,9 @@ theorem evm_sgt_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
@@ -161,9 +161,9 @@ theorem evm_sgt_stack_spec (sp base : Addr)
                  show ¬((3 : Fin 4) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.slt_result_correct b a]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -795,12 +795,16 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -38,7 +38,7 @@ local macro "skipBlock" : tactic =>
         bv_omega)))
 
 /-- The full evm_shr code split into 8 per-phase CodeReq.ofProg blocks. -/
-abbrev shrCode (base : Addr) : CodeReq :=
+abbrev shrCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
     CodeReq.ofProg base shr_phase_a,                      -- block 0: 9 instrs at +0
     CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1: 7 instrs at +36
@@ -67,7 +67,7 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
 
 /-- A singleton at instruction k of a small program is subsumed by its ofProg.
     Same pattern as the old singleton_sub_shrCode but parametric over any program. -/
-private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+private theorem singleton_sub_ofProg (base addr : Word) (prog : List Instr) (instr : Instr) (k : Nat)
     (hk : k < prog.length)
     (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
@@ -84,7 +84,7 @@ private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (ins
 -- ============================================================================
 
 -- Bridge: shr_phase_a_code (union chain) ⊆ ofProg shr_phase_a (9-element list)
-private theorem phase_a_code_sub_ofProg (base : Addr) :
+private theorem phase_a_code_sub_ofProg (base : Word) :
     ∀ a i, shr_phase_a_code base a = some i →
       (CodeReq.ofProg base shr_phase_a) a = some i := by
   unfold shr_phase_a_code shr_ld_or_acc_code
@@ -110,21 +110,21 @@ private theorem phase_a_code_sub_ofProg (base : Addr) :
                 (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
 
 /-- Phase A code (union chain, 9 instrs at +0) is subsumed by shrCode (block 0). -/
-private theorem phase_a_sub_shrCode (base : Addr) :
+private theorem phase_a_sub_shrCode (base : Word) :
     ∀ a i, shr_phase_a_code base a = some i → shrCode base a = some i := by
   intro a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i (phase_a_code_sub_ofProg base a i h)
 
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shrCode (block 1). -/
-private theorem phase_b_sub_shrCode (base : Addr) :
+private theorem phase_b_sub_shrCode (base : Word) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shrCode base a = some i := by
   unfold shr_phase_b_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock
   exact CodeReq.union_mono_left _ _
 
 -- Bridge: shr_phase_c_code (union chain) ⊆ ofProg shr_phase_c (5-element list)
-private theorem phase_c_code_sub_ofProg (base : Addr) :
+private theorem phase_c_code_sub_ofProg (base : Word) :
     ∀ a i, shr_phase_c_code base a = some i →
       (CodeReq.ofProg base shr_phase_c) a = some i := by
   unfold shr_phase_c_code shr_cascade_step_code
@@ -138,48 +138,48 @@ private theorem phase_c_code_sub_ofProg (base : Addr) :
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- ofProg shr_phase_c (block 2) is subsumed by shrCode. -/
-private theorem ofProg_phase_c_sub_shrCode (base : Addr) :
+private theorem ofProg_phase_c_sub_shrCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shrCode base a = some i := by
   unfold shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Phase C code (union chain, 5 instrs at +64) is subsumed by shrCode (block 2). -/
-private theorem phase_c_sub_shrCode (base : Addr) :
+private theorem phase_c_sub_shrCode (base : Word) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shrCode base a = some i := by
   intro a i h
   exact ofProg_phase_c_sub_shrCode base a i (phase_c_code_sub_ofProg (base + 64) a i h)
 
 /-- Body 3 code (ofProg, 7 instrs at +84) is subsumed by shrCode (block 3). -/
-private theorem body_3_sub_shrCode (base : Addr) :
+private theorem body_3_sub_shrCode (base : Word) :
     ∀ a i, shr_body_3_code 252 (base + 84) a = some i → shrCode base a = some i := by
   unfold shr_body_3_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Body 2 code (ofProg, 13 instrs at +112) is subsumed by shrCode (block 4). -/
-private theorem body_2_sub_shrCode (base : Addr) :
+private theorem body_2_sub_shrCode (base : Word) :
     ∀ a i, shr_body_2_code 200 (base + 112) a = some i → shrCode base a = some i := by
   unfold shr_body_2_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Body 1 code (ofProg, 19 instrs at +164) is subsumed by shrCode (block 5). -/
-private theorem body_1_sub_shrCode (base : Addr) :
+private theorem body_1_sub_shrCode (base : Word) :
     ∀ a i, shr_body_1_code 124 (base + 164) a = some i → shrCode base a = some i := by
   unfold shr_body_1_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Body 0 code (ofProg, 25 instrs at +240) is subsumed by shrCode (block 6). -/
-private theorem body_0_sub_shrCode (base : Addr) :
+private theorem body_0_sub_shrCode (base : Word) :
     ∀ a i, shr_body_0_code 24 (base + 240) a = some i → shrCode base a = some i := by
   unfold shr_body_0_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shrCode (block 7). -/
-private theorem zero_path_sub_shrCode (base : Addr) :
+private theorem zero_path_sub_shrCode (base : Word) :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shrCode base a = some i := by
   unfold shr_zero_path_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -189,7 +189,7 @@ private theorem zero_path_sub_shrCode (base : Addr) :
 -- Each bridges singleton → ofProg shr_phase_a (9-element) → shrCode block 0
 
 /-- LD x5 x12 8 singleton at base is subsumed by shrCode. -/
-private theorem ld_s1_sub_shrCode (base : Addr) :
+private theorem ld_s1_sub_shrCode (base : Word) :
     ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shrCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
@@ -198,7 +198,7 @@ private theorem ld_s1_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD/OR acc at base+4 (2 instrs) is subsumed by shrCode. -/
-private theorem ld_or_16_sub_shrCode (base : Addr) :
+private theorem ld_or_16_sub_shrCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shrCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
@@ -207,7 +207,7 @@ private theorem ld_or_16_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD/OR acc at base+12 (2 instrs) is subsumed by shrCode. -/
-private theorem ld_or_24_sub_shrCode (base : Addr) :
+private theorem ld_or_24_sub_shrCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shrCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
@@ -216,7 +216,7 @@ private theorem ld_or_24_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- BNE singleton at base+20 is subsumed by shrCode. -/
-private theorem bne_sub_shrCode (base : Addr) :
+private theorem bne_sub_shrCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shrCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
@@ -225,7 +225,7 @@ private theorem bne_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- LD x5 x12 0 singleton at base+24 is subsumed by shrCode. -/
-private theorem ld_s0_sub_shrCode (base : Addr) :
+private theorem ld_s0_sub_shrCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shrCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
@@ -234,7 +234,7 @@ private theorem ld_s0_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- SLTIU singleton at base+28 is subsumed by shrCode. -/
-private theorem sltiu_sub_shrCode (base : Addr) :
+private theorem sltiu_sub_shrCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shrCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
@@ -243,7 +243,7 @@ private theorem sltiu_sub_shrCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- BEQ singleton at base+32 is subsumed by shrCode. -/
-private theorem beq_sub_shrCode (base : Addr) :
+private theorem beq_sub_shrCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shrCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
@@ -255,34 +255,34 @@ private theorem beq_sub_shrCode (base : Addr) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem shr_off_4 (base : Addr) : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-private theorem shr_off_12 (base : Addr) : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-private theorem shr_off_20 (base : Addr) : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-private theorem shr_off_24 (base : Addr) : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-private theorem shr_off_28 (base : Addr) : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-private theorem shr_off_32 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem shr_off_36_28 (base : Addr) : (base + 36 : Addr) + 28 = base + 64 := by bv_omega
-private theorem shr_off_340_20 (base : Addr) : (base + 340 : Addr) + 20 = base + 360 := by bv_omega
-private theorem shr_bne_target (base : Addr) : (base + 20 : Addr) + signExtend13 320 = base + 340 := by
+private theorem shr_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem shr_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem shr_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem shr_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem shr_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem shr_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem shr_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem shr_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
+private theorem shr_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
   rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by native_decide]; bv_omega
-private theorem shr_beq_target (base : Addr) : (base + 32 : Addr) + signExtend13 308 = base + 340 := by
+private theorem shr_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
   rw [show signExtend13 (308 : BitVec 13) = (308 : Word) from by native_decide]; bv_omega
 -- Phase C exit addresses
-private theorem shr_c_e0 (base : Addr) : (base + 64 : Addr) + signExtend13 176 = base + 240 := by
+private theorem shr_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by
   rw [show signExtend13 (176 : BitVec 13) = (176 : Word) from by native_decide]; bv_omega
-private theorem shr_c_e1 (base : Addr) : ((base + 64 : Addr) + 8) + signExtend13 92 = base + 164 := by
+private theorem shr_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 92 = base + 164 := by
   rw [show signExtend13 (92 : BitVec 13) = (92 : Word) from by native_decide]; bv_omega
-private theorem shr_c_e2 (base : Addr) : ((base + 64 : Addr) + 16) + signExtend13 32 = base + 112 := by
+private theorem shr_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 32 = base + 112 := by
   rw [show signExtend13 (32 : BitVec 13) = (32 : Word) from by native_decide]; bv_omega
-private theorem shr_c_e3 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem shr_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets)
-private theorem shr_body3_exit (base : Addr) : ((base + 84 : Addr) + 24) + signExtend21 252 = base + 360 := by
+private theorem shr_body3_exit (base : Word) : ((base + 84 : Word) + 24) + signExtend21 252 = base + 360 := by
   rw [show signExtend21 (252 : BitVec 21) = (252 : Word) from by native_decide]; bv_omega
-private theorem shr_body2_exit (base : Addr) : ((base + 112 : Addr) + 48) + signExtend21 200 = base + 360 := by
+private theorem shr_body2_exit (base : Word) : ((base + 112 : Word) + 48) + signExtend21 200 = base + 360 := by
   rw [show signExtend21 (200 : BitVec 21) = (200 : Word) from by native_decide]; bv_omega
-private theorem shr_body1_exit (base : Addr) : ((base + 164 : Addr) + 72) + signExtend21 124 = base + 360 := by
+private theorem shr_body1_exit (base : Word) : ((base + 164 : Word) + 72) + signExtend21 124 = base + 360 := by
   rw [show signExtend21 (124 : BitVec 21) = (124 : Word) from by native_decide]; bv_omega
-private theorem shr_body0_exit (base : Addr) : ((base + 240 : Addr) + 96) + signExtend21 24 = base + 360 := by
+private theorem shr_body0_exit (base : Word) : ((base + 240 : Word) + 96) + signExtend21 24 = base + 360 := by
   rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_omega
 
 -- ============================================================================
@@ -292,7 +292,7 @@ private theorem shr_body0_exit (base : Addr) : ((base + 240 : Addr) + 96) + sign
 set_option maxHeartbeats 1600000 in
 /-- Zero path via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is zero.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → zero_path. -/
-theorem evm_shr_zero_high_spec (sp base : Addr)
+theorem evm_shr_zero_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -383,12 +383,12 @@ theorem evm_shr_zero_high_spec (sp base : Addr)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hzp
   -- Address normalization lemmas
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose AB → ZP: normalize addresses in perm callback
   have hABZ := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _
     _ _ _ _
@@ -418,7 +418,7 @@ theorem evm_shr_zero_high_spec (sp base : Addr)
 set_option maxHeartbeats 3200000 in
 /-- Zero path via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is zero.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(ntaken) → LD s0 → SLTIU → BEQ(taken) → zero_path. -/
-theorem evm_shr_zero_large_spec (sp base : Addr)
+theorem evm_shr_zero_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
@@ -548,12 +548,12 @@ theorem evm_shr_zero_large_spec (sp base : Addr)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hzp
   -- Address normalization lemmas
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose → ZP: normalize addresses in perm callback
   have hfull := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _ _ _ _ _
     (fun h hp => by
@@ -586,8 +586,8 @@ theorem evm_shr_zero_large_spec (sp base : Addr)
 -- Helpers for extending code requirements to cpsNBranch
 
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)}
+private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
@@ -595,8 +595,8 @@ private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)} {F : Assertion}
+private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
   intro R hR s hcr hPFR hpc
@@ -609,7 +609,7 @@ private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
 -- Address normalization lemmas for body path
-private theorem shr_off_64_20 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem shr_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 private theorem shr_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
   simp only [signExtend12_32]
 
@@ -627,7 +627,7 @@ private theorem shr_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = 
 -- ============================================================================
 
 -- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8) :
+private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
     ValidMemRange (sp + 32) 4 := by
   intro i hi; have := hvalid.get (i := i + 4) (by omega)
   have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
@@ -648,7 +648,7 @@ private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8)
 /-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Addr} {cr : CodeReq}
+    {entry exit_ : Word} {cr : CodeReq}
     {P Q Q' : Assertion} {fact : Prop}
     (hbody : cpsTriple entry exit_ cr P Q)
     (hpost : fact → ∀ h, Q h → Q' h) :
@@ -758,7 +758,7 @@ set_option maxHeartbeats 6400000 in
 /-- Body path: shift < 256 → result is `value >>> shift.toNat`.
     Composes Phase A ntaken → B → C → body_L → exit and uses
     getLimb_ushiftRight to connect per-limb results to the 256-bit shift. -/
-theorem evm_shr_body_evmWord_spec (sp base : Addr)
+theorem evm_shr_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
@@ -795,15 +795,15 @@ theorem evm_shr_body_evmWord_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega]
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
@@ -818,9 +818,9 @@ theorem evm_shr_body_evmWord_spec (sp base : Addr)
     have := hvalid.get (i := 3) (by omega); simpa using this
   have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
   -- Phase A: linear chain base -> base+36
   have h1 := cpsTriple_extend_code (ld_s1_sub_shrCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun) (by simp only [signExtend12_8]; exact hv8))
@@ -955,9 +955,9 @@ theorem evm_shr_body_evmWord_spec (sp base : Addr)
   have hbody0_f := cpsTriple_frame_left (base + 240) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody0
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
   -- For each body, we keep the concrete memory values and weaken regs to regOwn

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -31,11 +31,11 @@ namespace EvmAsm.Rv64
 
 -- SHR Merge Limb (7 instructions)
 
-abbrev shr_merge_limb_code (src_off next_off dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev shr_merge_limb_code (src_off next_off dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_merge_limb_prog src_off next_off dst_off)
 
 theorem shr_merge_limb_spec (src_off next_off dst_off : BitVec 12)
-    (sp src next dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Addr)
+    (sp src next dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 src_off) = true)
     (hvalid_next : isValidDwordAccess (sp + signExtend12 next_off) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
@@ -64,11 +64,11 @@ theorem shr_merge_limb_spec (src_off next_off dst_off : BitVec 12)
 
 -- SHR Last Limb (3 instructions)
 
-abbrev shr_last_limb_code (dst_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev shr_last_limb_code (dst_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_last_limb_prog dst_off)
 
 theorem shr_last_limb_spec (dst_off : BitVec 12)
-    (sp src dst_old v5 bit_shift : Word) (base : Addr)
+    (sp src dst_old v5 bit_shift : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 (24 : BitVec 12)) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let mem_src := sp + signExtend12 (24 : BitVec 12)
@@ -87,11 +87,11 @@ theorem shr_last_limb_spec (dst_off : BitVec 12)
 
 -- SHR Merge Limb In-place (7 instructions, src_off = dst_off)
 
-abbrev shr_merge_limb_inplace_code (off next_off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev shr_merge_limb_inplace_code (off next_off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_merge_limb_inplace_prog off next_off)
 
 theorem shr_merge_limb_inplace_spec (off next_off : BitVec 12)
-    (sp src next v5 v10 bit_shift anti_shift mask : Word) (base : Addr)
+    (sp src next v5 v10 bit_shift anti_shift mask : Word) (base : Word)
     (hvalid_loc : isValidDwordAccess (sp + signExtend12 off) = true)
     (hvalid_next : isValidDwordAccess (sp + signExtend12 next_off) = true) :
     let mem_loc := sp + signExtend12 off
@@ -118,11 +118,11 @@ theorem shr_merge_limb_inplace_spec (off next_off : BitVec 12)
 
 -- SHR Last Limb In-place (3 instructions, dst_off = 24)
 
-abbrev shr_last_limb_inplace_code (base : Addr) : CodeReq :=
+abbrev shr_last_limb_inplace_code (base : Word) : CodeReq :=
   CodeReq.ofProg base shr_last_limb_inplace_prog
 
 theorem shr_last_limb_inplace_spec
-    (sp src v5 bit_shift : Word) (base : Addr)
+    (sp src v5 bit_shift : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (24 : BitVec 12)) = true) :
     let mem := sp + signExtend12 (24 : BitVec 12)
     let result := src >>> (bit_shift.toNat % 64)
@@ -139,13 +139,13 @@ theorem shr_last_limb_inplace_spec
 -- Section 2: Zero Path (5 instructions)
 -- ============================================================================
 
-abbrev shr_zero_path_code (base : Addr) : CodeReq :=
+abbrev shr_zero_path_code (base : Word) : CodeReq :=
   CodeReq.ofProg base shr_zero_path
 
 set_option maxHeartbeats 3200000 in
 theorem shr_zero_path_spec (sp : Word)
     (d0 d1 d2 d3 : Word)
-    (base : Addr)
+    (base : Word)
     (hvalid : ValidMemRange (sp + 32) 4) :
     let nsp := sp + 32
     let code := shr_zero_path_code base
@@ -167,11 +167,11 @@ theorem shr_zero_path_spec (sp : Word)
 -- Section 3: Phase B (7 instructions)
 -- ============================================================================
 
-abbrev shr_phase_b_code (base : Addr) : CodeReq :=
+abbrev shr_phase_b_code (base : Word) : CodeReq :=
   CodeReq.ofProg base shr_phase_b
 
 set_option maxHeartbeats 1600000 in
-theorem shr_phase_b_spec (shift0 sp r6 r7 r11 : Word) (base : Addr) :
+theorem shr_phase_b_spec (shift0 sp r6 r7 r11 : Word) (base : Word) :
     let bit_shift := shift0 &&& signExtend12 63
     let limb_shift := shift0 >>> (6 : BitVec 6).toNat
     let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
@@ -196,11 +196,11 @@ theorem shr_phase_b_spec (shift0 sp r6 r7 r11 : Word) (base : Addr) :
 -- Section 4: LD/OR Accumulator Helper (2 instructions)
 -- ============================================================================
 
-abbrev shr_ld_or_acc_code (off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev shr_ld_or_acc_code (off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_ld_or_acc_prog off)
 
 theorem shr_ld_or_acc_spec (sp acc prev_x10 val : Word) (off : BitVec 12)
-    (base : Addr)
+    (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let code := shr_ld_or_acc_code off base
     cpsTriple base (base + 8) code
@@ -216,13 +216,13 @@ theorem shr_ld_or_acc_spec (sp acc prev_x10 val : Word) (off : BitVec 12)
 
 -- Body 3: limb_shift=3, 7 instructions
 
-abbrev shr_body_3_code (jal_off : BitVec 21) (base : Addr) : CodeReq :=
+abbrev shr_body_3_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_3_prog jal_off)
 
 theorem shr_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := v3 >>> (bit_shift.toNat % 64)
@@ -244,14 +244,14 @@ theorem shr_body_3_spec (sp : Word)
 
 -- Body 2: limb_shift=2, 13 instructions
 
-abbrev shr_body_2_code (jal_off : BitVec 21) (base : Addr) : CodeReq :=
+abbrev shr_body_2_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_2_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
 theorem shr_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 48) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -276,14 +276,14 @@ theorem shr_body_2_spec (sp : Word)
 
 -- Body 1: limb_shift=1, 19 instructions
 
-abbrev shr_body_1_code (jal_off : BitVec 21) (base : Addr) : CodeReq :=
+abbrev shr_body_1_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_1_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
 theorem shr_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 72) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -312,14 +312,14 @@ theorem shr_body_1_spec (sp : Word)
 
 -- Body 0: limb_shift=0, 25 instructions
 
-abbrev shr_body_0_code (jal_off : BitVec 21) (base : Addr) : CodeReq :=
+abbrev shr_body_0_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_0_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
 theorem shr_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -354,14 +354,14 @@ theorem shr_body_0_spec (sp : Word)
 -- Section 6: Cascade Step Helper (2 instructions)
 -- ============================================================================
 
-abbrev shr_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Addr) : CodeReq :=
+abbrev shr_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_cascade_step_prog k offset)
 
 /-- Cascade step: ADDI x10,x0,k followed by BEQ x5,x10,off.
     Produces a cpsBranch with clean postconditions (no pure facts).
     Uses disjoint composition of the two singleton CRs. -/
 theorem shr_cascade_step_spec (v5 v10 : Word)
-    (k : BitVec 12) (offset : BitVec 13) (base target : Addr)
+    (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
     let k_val := (0 : Word) + signExtend12 k
     let code := shr_cascade_step_code k offset base
@@ -369,7 +369,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val))
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)) := by
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   -- Disjointness of the two singletons
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
@@ -414,7 +414,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
 /-- Cascade step variant that preserves pure dispatch facts.
     Taken postcondition includes `⌜v5 = k_val⌝`, not-taken includes `⌜v5 ≠ k_val⌝`. -/
 theorem shr_cascade_step_spec_pure (v5 v10 : Word)
-    (k : BitVec 12) (offset : BitVec 13) (base target : Addr)
+    (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
     let k_val := (0 : Word) + signExtend12 k
     let code := shr_cascade_step_code k offset base
@@ -422,7 +422,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 = k_val⌝)
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 ≠ k_val⌝) := by
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
@@ -456,7 +456,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
 -- ============================================================================
 
 /-- Phase C code as explicit union of sub-CRs (matching disjoint composition structure). -/
-abbrev shr_phase_c_code (base : Addr) : CodeReq :=
+abbrev shr_phase_c_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.BEQ .x5 .x0 176))
   (CodeReq.union (shr_cascade_step_code 1 92 (base + 4))
   (shr_cascade_step_code 2 32 (base + 12)))
@@ -464,8 +464,8 @@ abbrev shr_phase_c_code (base : Addr) : CodeReq :=
 set_option maxHeartbeats 3200000 in
 /-- Phase C spec: cascade dispatch on limb_shift (0-3).
     Uses disjoint composition to chain BEQ + two cascade steps. -/
-theorem shr_phase_c_spec (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 176 = e0)
     (he1 : (base + 8) + signExtend13 92 = e1)
     (he2 : (base + 16) + signExtend13 32 = e2)
@@ -478,10 +478,10 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Addr)
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2))),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))] := by
   -- Address arithmetic
-  have hc1 : ((base + 4 : Addr) + 4) + signExtend13 92 = e1 := by
-    rw [show (base + 4 : Addr) + 4 = base + 8 from by bv_omega]; exact he1
-  have hc2 : ((base + 12 : Addr) + 4) + signExtend13 32 = e2 := by
-    rw [show (base + 12 : Addr) + 4 = base + 16 from by bv_omega]; exact he2
+  have hc1 : ((base + 4 : Word) + 4) + signExtend13 92 = e1 := by
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+  have hc2 : ((base + 12 : Word) + 4) + signExtend13 32 = e2 := by
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
   -- Sub-CRs
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 176)
   let cr_cs1 := shr_cascade_step_code 1 92 (base + 4)
@@ -525,10 +525,10 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Addr)
     (.x10 ↦ᵣ v10) (by pcFree) beq0
   -- Step 1: cascade step at base+4 (CR = cr_cs1)
   have cs1 := shr_cascade_step_spec v5 v10 1 92 (base + 4) e1 hc1
-  rw [show (base + 4 : Addr) + 8 = base + 12 from by bv_omega] at cs1
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1
   -- Step 2: cascade step at base+12 (CR = cr_cs2)
   have cs2 := shr_cascade_step_spec v5 ((0 : Word) + signExtend12 1) 2 32 (base + 12) e2 hc2
-  rw [show (base + 12 : Addr) + 8 = base + 20 from by bv_omega] at cs2
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2
   -- Fallthrough at base+20 (CR = empty)
   have ft := cpsNBranch_refl (base + 20)
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))
@@ -575,8 +575,8 @@ set_option maxHeartbeats 6400000 in
 /-- Phase C spec with pure dispatch facts: each exit postcondition includes
     the constraint that identifies which branch was taken.
     Built by composing sub-specs with pure-fact framing. -/
-theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 176 = e0)
     (he1 : (base + 8) + signExtend13 92 = e1)
     (he2 : (base + 16) + signExtend13 32 = e2)
@@ -588,10 +588,10 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
        (e1, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 = (0 : Word) + signExtend12 1⌝),
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 = (0 : Word) + signExtend12 2⌝),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝)] := by
-  have hc1 : ((base + 4 : Addr) + 4) + signExtend13 92 = e1 := by
-    rw [show (base + 4 : Addr) + 4 = base + 8 from by bv_omega]; exact he1
-  have hc2 : ((base + 12 : Addr) + 4) + signExtend13 32 = e2 := by
-    rw [show (base + 12 : Addr) + 4 = base + 16 from by bv_omega]; exact he2
+  have hc1 : ((base + 4 : Word) + 4) + signExtend13 92 = e1 := by
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+  have hc2 : ((base + 12 : Word) + 4) + signExtend13 32 = e2 := by
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 176)
   let cr_cs1 := shr_cascade_step_code 1 92 (base + 4)
   let cr_cs2 := shr_cascade_step_code 2 32 (base + 12)
@@ -625,7 +625,7 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4 with pure facts, framed with ⌜v5 ≠ 0⌝
   have cs1_raw := shr_cascade_step_spec_pure v5 v10 1 92 (base + 4) e1 hc1
-  rw [show (base + 4 : Addr) + 8 = base + 12 from by bv_omega] at cs1_raw
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1_raw
   have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   -- cs1f taken: (regs ** ⌜v5 = 1⌝) ** ⌜v5 ≠ 0⌝
   -- cs1f ntaken: (regs ** ⌜v5 ≠ 1⌝) ** ⌜v5 ≠ 0⌝
@@ -650,7 +650,7 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       cs1f
   -- Step 2: cascade step at base+12, framed with ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 32 (base + 12) e2 hc2
-  rw [show (base + 12 : Addr) + 8 = base + 20 from by bv_omega] at cs2_raw
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2_raw
   have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   -- cs2f taken: (regs ** ⌜v5 = 2⌝) ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
@@ -724,7 +724,7 @@ private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h →
 
 /-- Phase A code as explicit union of sub-CRs (matching disjoint composition structure).
     9 instructions: LD + LD/OR + LD/OR + BNE + LD + SLTIU + BEQ -/
-abbrev shr_phase_a_code (base : Addr) : CodeReq :=
+abbrev shr_phase_a_code (base : Word) : CodeReq :=
   -- LD x5 x12 8 at base
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 8))
   -- LD x10 x12 16 + OR x5 x5 x10 at base+4, base+8
@@ -748,7 +748,7 @@ set_option maxHeartbeats 6400000 in
     Uses disjoint composition throughout (no extend_code). -/
 theorem shr_phase_a_spec (sp r5 r10 : Word)
     (s0 s1 s2 s3 : Word)
-    (base zero_path : Addr)
+    (base zero_path : Word)
     (hzero : (base + 20) + signExtend13 320 = zero_path)
     (hzero2 : (base + 32) + signExtend13 308 = zero_path)
     (hvalid : ValidMemRange sp 8) :
@@ -772,12 +772,12 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   have hv24 : isValidDwordAccess (sp + 24) = true := by
     have := hvalid.get (i := 3) (by omega); simpa using this
   -- Address arithmetic
-  have ha48 : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-  have ha128 : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-  have ha20 : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-  have ha24 : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-  have ha28 : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-  have ha32 : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
+  have ha48 : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+  have ha128 : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+  have ha20 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+  have ha24 : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+  have ha28 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+  have ha32 : (base + 32 : Word) + 4 = base + 36 := by bv_omega
   -- Sub-CRs for each instruction group
   let cr_ld1 := CodeReq.singleton base (.LD .x5 .x12 8)
   let cr_lor2 := shr_ld_or_acc_code 16 (base + 4)
@@ -950,7 +950,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Disjoint: (cr_linear ∪ cr_bne) vs cr_tail
   -- All addresses in left (base..base+20) distinct from right (base+24..base+32)
   -- Helper: "singleton at addr is disjoint from cr_tail"
-  have sd_tail (a : Addr) (i : Instr)
+  have sd_tail (a : Word) (i : Instr)
       (h24 : a ≠ base + 24) (h28 : a ≠ base + 28) (h32 : a ≠ base + 32) :
       (CodeReq.singleton a i).Disjoint cr_tail :=
     CodeReq.Disjoint.union_right

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -914,12 +914,16 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -40,7 +40,7 @@ local macro "skipBlock" : tactic =>
         bv_omega)))
 
 /-- The full evm_sar code split into 8 per-phase CodeReq.ofProg blocks. -/
-abbrev sarCode (base : Addr) : CodeReq :=
+abbrev sarCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
     CodeReq.ofProg base sar_phase_a,                      -- block 0: 9 instrs at +0
     CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1: 7 instrs at +36
@@ -67,7 +67,7 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | none => simp [h1a] at h; exact h2 a i h
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
-private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+private theorem singleton_sub_ofProg (base addr : Word) (prog : List Instr) (instr : Instr) (k : Nat)
     (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
     (h_instr : prog.get ⟨k, hk⟩ = instr) :
@@ -80,7 +80,7 @@ private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (ins
 
 -- Phase A individual instruction subsumption (via ofProg sar_phase_a, 9-element list)
 
-private theorem ld_s1_sub_sarCode (base : Addr) :
+private theorem ld_s1_sub_sarCode (base : Word) :
     ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → sarCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base base sar_phase_a (.LD .x5 .x12 8) 0
@@ -88,7 +88,7 @@ private theorem ld_s1_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_16_sub_sarCode (base : Addr) :
+private theorem ld_or_16_sub_sarCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → sarCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) sar_phase_a (shr_ld_or_acc_prog 16) 1
@@ -96,7 +96,7 @@ private theorem ld_or_16_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_24_sub_sarCode (base : Addr) :
+private theorem ld_or_24_sub_sarCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → sarCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) sar_phase_a (shr_ld_or_acc_prog 24) 3
@@ -104,7 +104,7 @@ private theorem ld_or_24_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem bne_sub_sarCode (base : Addr) :
+private theorem bne_sub_sarCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 332) a = some i → sarCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 20) sar_phase_a (.BNE .x5 .x0 332) 5
@@ -112,7 +112,7 @@ private theorem bne_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_s0_sub_sarCode (base : Addr) :
+private theorem ld_s0_sub_sarCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → sarCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 24) sar_phase_a (.LD .x5 .x12 0) 6
@@ -120,7 +120,7 @@ private theorem ld_s0_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem sltiu_sub_sarCode (base : Addr) :
+private theorem sltiu_sub_sarCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → sarCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 28) sar_phase_a (.SLTIU .x10 .x5 256) 7
@@ -128,7 +128,7 @@ private theorem sltiu_sub_sarCode (base : Addr) :
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem beq_sub_sarCode (base : Addr) :
+private theorem beq_sub_sarCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 320) a = some i → sarCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 32) sar_phase_a (.BEQ .x10 .x0 320) 8
@@ -137,7 +137,7 @@ private theorem beq_sub_sarCode (base : Addr) :
   exact CodeReq.union_mono_left _ _ a i h1
 
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by sarCode (block 1). -/
-private theorem phase_b_sub_sarCode (base : Addr) :
+private theorem phase_b_sub_sarCode (base : Word) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → sarCode base a = some i := by
   unfold shr_phase_b_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock
@@ -146,13 +146,13 @@ private theorem phase_b_sub_sarCode (base : Addr) :
 -- Phase C subsumption (SAR-specific offsets)
 
 /-- SAR Phase C code (union chain, 5 instrs at +64). -/
-abbrev sar_phase_c_code (base : Addr) : CodeReq :=
+abbrev sar_phase_c_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.BEQ .x5 .x0 188))
   (CodeReq.union (shr_cascade_step_code 1 100 (base + 4))
   (shr_cascade_step_code 2 36 (base + 12)))
 
 -- Bridge: sar_phase_c_code (union chain) ⊆ ofProg sar_phase_c (5-element list)
-private theorem sar_phase_c_code_sub_ofProg (base : Addr) :
+private theorem sar_phase_c_code_sub_ofProg (base : Word) :
     ∀ a i, sar_phase_c_code base a = some i →
       (CodeReq.ofProg base sar_phase_c) a = some i := by
   unfold sar_phase_c_code shr_cascade_step_code
@@ -165,14 +165,14 @@ private theorem sar_phase_c_code_sub_ofProg (base : Addr) :
     · exact CodeReq.ofProg_mono_sub base (base + 12) sar_phase_c (shr_cascade_step_prog 2 36) 3
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-private theorem ofProg_phase_c_sub_sarCode (base : Addr) :
+private theorem ofProg_phase_c_sub_sarCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 64) sar_phase_c) a = some i → sarCode base a = some i := by
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SAR Phase C code is subsumed by sarCode (block 2). -/
-private theorem sar_phase_c_sub_sarCode (base : Addr) :
+private theorem sar_phase_c_sub_sarCode (base : Word) :
     ∀ a i, sar_phase_c_code (base + 64) a = some i → sarCode base a = some i := by
   intro a i h
   exact ofProg_phase_c_sub_sarCode base a i (sar_phase_c_code_sub_ofProg (base + 64) a i h)
@@ -180,35 +180,35 @@ private theorem sar_phase_c_sub_sarCode (base : Addr) :
 -- Body subsumption lemmas
 
 /-- SAR Body 3 code (8 instrs at +84) is subsumed by sarCode (block 3). -/
-private theorem sar_body_3_sub_sarCode (base : Addr) :
+private theorem sar_body_3_sub_sarCode (base : Word) :
     ∀ a i, sar_body_3_code (base + 84) 268 a = some i → sarCode base a = some i := by
   unfold sar_body_3_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SAR Body 2 code (14 instrs at +116) is subsumed by sarCode (block 4). -/
-private theorem sar_body_2_sub_sarCode (base : Addr) :
+private theorem sar_body_2_sub_sarCode (base : Word) :
     ∀ a i, sar_body_2_code (base + 116) 212 a = some i → sarCode base a = some i := by
   unfold sar_body_2_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SAR Body 1 code (20 instrs at +172) is subsumed by sarCode (block 5). -/
-private theorem sar_body_1_sub_sarCode (base : Addr) :
+private theorem sar_body_1_sub_sarCode (base : Word) :
     ∀ a i, sar_body_1_code (base + 172) 132 a = some i → sarCode base a = some i := by
   unfold sar_body_1_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SAR Body 0 code (25 instrs at +252) is subsumed by sarCode (block 6). -/
-private theorem sar_body_0_sub_sarCode (base : Addr) :
+private theorem sar_body_0_sub_sarCode (base : Word) :
     ∀ a i, sar_body_0_code (base + 252) 32 a = some i → sarCode base a = some i := by
   unfold sar_body_0_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 -- Bridge: sar_sign_fill_path_code (union chain) ⊆ ofProg sar_sign_fill_path (7-element list)
-private theorem sign_fill_code_sub_ofProg (base : Addr) :
+private theorem sign_fill_code_sub_ofProg (base : Word) :
     ∀ a i, sar_sign_fill_path_code base a = some i →
       (CodeReq.ofProg base sar_sign_fill_path) a = some i := by
   unfold sar_sign_fill_path_code
@@ -233,14 +233,14 @@ private theorem sign_fill_code_sub_ofProg (base : Addr) :
             · exact singleton_sub_ofProg base (base + 24) sar_sign_fill_path (.SD .x12 .x5 24) 6
                 (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem ofProg_sign_fill_sub_sarCode (base : Addr) :
+private theorem ofProg_sign_fill_sub_sarCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 352) sar_sign_fill_path) a = some i → sarCode base a = some i := by
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Sign-fill path code (7 instrs at +352) is subsumed by sarCode (block 7). -/
-private theorem sign_fill_sub_sarCode (base : Addr) :
+private theorem sign_fill_sub_sarCode (base : Word) :
     ∀ a i, sar_sign_fill_path_code (base + 352) a = some i → sarCode base a = some i := by
   intro a i h
   exact ofProg_sign_fill_sub_sarCode base a i (sign_fill_code_sub_ofProg (base + 352) a i h)
@@ -249,34 +249,34 @@ private theorem sign_fill_sub_sarCode (base : Addr) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem sar_off_4 (base : Addr) : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-private theorem sar_off_12 (base : Addr) : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-private theorem sar_off_20 (base : Addr) : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-private theorem sar_off_24 (base : Addr) : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-private theorem sar_off_28 (base : Addr) : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-private theorem sar_off_32 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem sar_off_36_28 (base : Addr) : (base + 36 : Addr) + 28 = base + 64 := by bv_omega
-private theorem sar_off_352_28 (base : Addr) : (base + 352 : Addr) + 28 = base + 380 := by bv_omega
-private theorem sar_bne_target (base : Addr) : (base + 20 : Addr) + signExtend13 332 = base + 352 := by
+private theorem sar_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem sar_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem sar_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem sar_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem sar_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem sar_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem sar_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem sar_off_352_28 (base : Word) : (base + 352 : Word) + 28 = base + 380 := by bv_omega
+private theorem sar_bne_target (base : Word) : (base + 20 : Word) + signExtend13 332 = base + 352 := by
   rw [show signExtend13 (332 : BitVec 13) = (332 : Word) from by native_decide]; bv_omega
-private theorem sar_beq_target (base : Addr) : (base + 32 : Addr) + signExtend13 320 = base + 352 := by
+private theorem sar_beq_target (base : Word) : (base + 32 : Word) + signExtend13 320 = base + 352 := by
   rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by native_decide]; bv_omega
 -- Phase C exit addresses
-private theorem sar_c_e0 (base : Addr) : (base + 64 : Addr) + signExtend13 188 = base + 252 := by
+private theorem sar_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 188 = base + 252 := by
   rw [show signExtend13 (188 : BitVec 13) = (188 : Word) from by native_decide]; bv_omega
-private theorem sar_c_e1 (base : Addr) : ((base + 64 : Addr) + 8) + signExtend13 100 = base + 172 := by
+private theorem sar_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 100 = base + 172 := by
   rw [show signExtend13 (100 : BitVec 13) = (100 : Word) from by native_decide]; bv_omega
-private theorem sar_c_e2 (base : Addr) : ((base + 64 : Addr) + 16) + signExtend13 36 = base + 116 := by
+private theorem sar_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 36 = base + 116 := by
   rw [show signExtend13 (36 : BitVec 13) = (36 : Word) from by native_decide]; bv_omega
-private theorem sar_c_e3 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem sar_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets → base+380)
-private theorem sar_body3_exit (base : Addr) : ((base + 84 : Addr) + 28) + signExtend21 268 = base + 380 := by
+private theorem sar_body3_exit (base : Word) : ((base + 84 : Word) + 28) + signExtend21 268 = base + 380 := by
   rw [show signExtend21 (268 : BitVec 21) = (268 : Word) from by native_decide]; bv_omega
-private theorem sar_body2_exit (base : Addr) : ((base + 116 : Addr) + 52) + signExtend21 212 = base + 380 := by
+private theorem sar_body2_exit (base : Word) : ((base + 116 : Word) + 52) + signExtend21 212 = base + 380 := by
   rw [show signExtend21 (212 : BitVec 21) = (212 : Word) from by native_decide]; bv_omega
-private theorem sar_body1_exit (base : Addr) : ((base + 172 : Addr) + 76) + signExtend21 132 = base + 380 := by
+private theorem sar_body1_exit (base : Word) : ((base + 172 : Word) + 76) + signExtend21 132 = base + 380 := by
   rw [show signExtend21 (132 : BitVec 21) = (132 : Word) from by native_decide]; bv_omega
-private theorem sar_body0_exit (base : Addr) : ((base + 252 : Addr) + 96) + signExtend21 32 = base + 380 := by
+private theorem sar_body0_exit (base : Word) : ((base + 252 : Word) + 96) + signExtend21 32 = base + 380 := by
   rw [show signExtend21 (32 : BitVec 21) = (32 : Word) from by native_decide]; bv_omega
 
 private theorem sar_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
@@ -289,7 +289,7 @@ private theorem sar_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = 
 set_option maxHeartbeats 1600000 in
 /-- Sign-fill via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is sign extension.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → sign_fill_path. -/
-theorem evm_sar_sign_fill_high_spec (sp base : Addr)
+theorem evm_sar_sign_fill_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -409,7 +409,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Addr)
 
 set_option maxHeartbeats 3200000 in
 /-- Sign-fill via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is sign extension. -/
-theorem evm_sar_sign_fill_large_spec (sp base : Addr)
+theorem evm_sar_sign_fill_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
@@ -573,8 +573,8 @@ theorem evm_sar_sign_fill_large_spec (sp base : Addr)
 
 set_option maxHeartbeats 6400000 in
 /-- SAR Phase C cascade dispatch. Same structure as SHR but with SAR exit addresses. -/
-theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 188 = e0)
     (he1 : (base + 8) + signExtend13 100 = e1)
     (he2 : (base + 16) + signExtend13 36 = e2)
@@ -587,10 +587,10 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 = (0 : Word) + signExtend12 2⌝),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) **
             ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝)] := by
-  have hc1 : ((base + 4 : Addr) + 4) + signExtend13 100 = e1 := by
-    rw [show (base + 4 : Addr) + 4 = base + 8 from by bv_omega]; exact he1
-  have hc2 : ((base + 12 : Addr) + 4) + signExtend13 36 = e2 := by
-    rw [show (base + 12 : Addr) + 4 = base + 16 from by bv_omega]; exact he2
+  have hc1 : ((base + 4 : Word) + 4) + signExtend13 100 = e1 := by
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+  have hc2 : ((base + 12 : Word) + 4) + signExtend13 36 = e2 := by
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 188)
   let cr_cs1 := shr_cascade_step_code 1 100 (base + 4)
   let cr_cs2 := shr_cascade_step_code 2 36 (base + 12)
@@ -624,7 +624,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := shr_cascade_step_spec_pure v5 v10 1 100 (base + 4) e1 hc1
-  rw [show (base + 4 : Addr) + 8 = base + 12 from by bv_omega] at cs1_raw
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1_raw
   have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
@@ -642,7 +642,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 36 (base + 12) e2 hc2
-  rw [show (base + 12 : Addr) + 8 = base + 20 from by bv_omega] at cs2_raw
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2_raw
   have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2
@@ -702,8 +702,8 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
 -- ============================================================================
 
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)}
+private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
@@ -711,8 +711,8 @@ private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)} {F : Assertion}
+private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
   intro R hR s hcr hPFR hpc
@@ -725,10 +725,10 @@ private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
 -- Address normalization for body path
-private theorem sar_off_64_20 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem sar_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 
 -- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8) :
+private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
     ValidMemRange (sp + 32) 4 := by
   intro i hi; have := hvalid.get (i := i + 4) (by omega)
   have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
@@ -738,7 +738,7 @@ private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8)
 /-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Addr} {cr : CodeReq}
+    {entry exit_ : Word} {cr : CodeReq}
     {P Q Q' : Assertion} {fact : Prop}
     (hbody : cpsTriple entry exit_ cr P Q)
     (hpost : fact → ∀ h, Q h → Q' h) :
@@ -877,7 +877,7 @@ set_option maxHeartbeats 6400000 in
 /-- Body path: shift < 256 → result is `sshiftRight value shift.toNat`.
     Composes Phase A ntaken → B → C → body_L → exit and uses
     bridge lemmas to connect per-limb results to the 256-bit arithmetic shift. -/
-theorem evm_sar_body_evmWord_spec (sp base : Addr)
+theorem evm_sar_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
@@ -914,15 +914,15 @@ theorem evm_sar_body_evmWord_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega]
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
@@ -937,9 +937,9 @@ theorem evm_sar_body_evmWord_spec (sp base : Addr)
     have := hvalid.get (i := 3) (by omega); simpa using this
   have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
   -- Phase A: linear chain base -> base+36
   have h1 := cpsTriple_extend_code (ld_s1_sub_sarCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun) (by simp only [signExtend12_8]; exact hv8))
@@ -1074,9 +1074,9 @@ theorem evm_sar_body_evmWord_spec (sp base : Addr)
   have hbody0_f := cpsTriple_frame_left (base + 252) (base + 380) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody0
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
   have body_post_weaken : ∀ (r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word),

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -106,14 +106,14 @@ private theorem sar_sign_fill_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_fromLimbs_const]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_fromLimbs_const]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -106,14 +106,20 @@ private theorem sar_sign_fill_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_fromLimbs_const]
+      simp only [evmWordIs, EvmWord.getLimbN_fromLimbs_const,
+                 show (0 : Nat) < 4 from by decide, show (1 : Nat) < 4 from by decide,
+                 show (2 : Nat) < 4 from by decide, show (3 : Nat) < 4 from by decide,
+                 ite_true]
+      simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -23,7 +23,7 @@ private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h �
   fun _ hp => ⟨v, hp⟩
 
 /-- Weaken: sign-fill result + frame regs → evmWordIs sign_fill + regOwn. -/
-private theorem sar_sign_fill_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 sign_ext : Word) :
+private theorem sar_sign_fill_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 sign_ext : Word) :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -56,7 +56,7 @@ private theorem sar_sign_fill_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 
 
 /-- Compose one sign-fill case into evmWordIs form.
     Shared proof structure for both high-limbs and s0≥256 cases. -/
-private theorem sar_sign_fill_lift (sp base : Addr)
+private theorem sar_sign_fill_lift (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (_hvalid : ValidMemRange sp 8)
     (hmain : cpsTriple base (base + 380) (sarCode base)
@@ -107,16 +107,16 @@ private theorem sar_sign_fill_lift (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_fromLimbs_const]
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
@@ -139,7 +139,7 @@ set_option maxHeartbeats 1600000 in
     Given shift and value as EvmWords on the stack, produces:
     - `fromLimbs (fun _ => sshiftRight (value.getLimb 3) 63)` when shift ≥ 256
     - `sshiftRight value shift.toNat` when shift < 256 -/
-theorem evm_sar_stack_spec (sp base : Addr)
+theorem evm_sar_stack_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let result := if shift.toNat ≥ 256

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Rv64
 -- Per-limb Specs: SAR Last Limb (3 instructions)
 -- ============================================================================
 
-abbrev sar_last_limb_code (base : Addr) (dst_off : BitVec 12) : CodeReq :=
+abbrev sar_last_limb_code (base : Word) (dst_off : BitVec 12) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 24))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SRA .x5 .x5 .x6))
    (CodeReq.singleton (base + 8) (.SD .x12 .x5 dst_off)))
@@ -31,7 +31,7 @@ abbrev sar_last_limb_code (base : Addr) (dst_off : BitVec 12) : CodeReq :=
     Computes: result = BitVec.sshiftRight value[3] bit_shift
     Mirror of shr_last_limb_spec with SRA (arithmetic shift right). -/
 theorem sar_last_limb_spec (dst_off : BitVec 12)
-    (sp src dst_old v5 bit_shift : Word) (base : Addr)
+    (sp src dst_old v5 bit_shift : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 (24 : BitVec 12)) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let mem_src := sp + signExtend12 (24 : BitVec 12)
@@ -52,7 +52,7 @@ theorem sar_last_limb_spec (dst_off : BitVec 12)
 -- Per-limb Specs: SAR Last Limb In-place (3 instructions, dst_off = 24)
 -- ============================================================================
 
-abbrev sar_last_limb_inplace_code (base : Addr) : CodeReq :=
+abbrev sar_last_limb_inplace_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 24))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SRA .x5 .x5 .x6))
    (CodeReq.singleton (base + 8) (.SD .x12 .x5 24)))
@@ -61,7 +61,7 @@ abbrev sar_last_limb_inplace_code (base : Addr) : CodeReq :=
     LD x5, 24(x12); SRA x5,x5,x6; SD x12,x5,24
     Reads and writes the same memory cell at sp+24. -/
 theorem sar_last_limb_inplace_spec
-    (sp src v5 bit_shift : Word) (base : Addr)
+    (sp src v5 bit_shift : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (24 : BitVec 12)) = true) :
     let mem := sp + signExtend12 (24 : BitVec 12)
     let result := BitVec.sshiftRight src (bit_shift.toNat % 64)
@@ -78,7 +78,7 @@ theorem sar_last_limb_inplace_spec
 -- Shift Body Specs
 -- ============================================================================
 
-abbrev sar_body_3_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev sar_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (sar_body_3_prog jal_off)
 
 /-- SAR body 3: limb_shift=3 (8 instructions).
@@ -87,7 +87,7 @@ abbrev sar_body_3_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
 theorem sar_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 28) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
@@ -111,7 +111,7 @@ theorem sar_body_3_spec (sp : Word)
   rw [hexit] at JL
   runBlock LL SR S0 S1 S2 JL
 
-abbrev sar_body_2_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev sar_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (sar_body_2_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -122,7 +122,7 @@ set_option maxHeartbeats 3200000 in
 theorem sar_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 52) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -153,7 +153,7 @@ theorem sar_body_2_spec (sp : Word)
   rw [hexit] at JL
   runBlock MM LL SR S0 S1 JL
 
-abbrev sar_body_1_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev sar_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (sar_body_1_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -164,7 +164,7 @@ set_option maxHeartbeats 3200000 in
 theorem sar_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 76) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -198,7 +198,7 @@ theorem sar_body_1_spec (sp : Word)
   rw [hexit] at JL
   runBlock MM1 MM2 LL SR S0 JL
 
-abbrev sar_body_0_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev sar_body_0_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (sar_body_0_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -210,7 +210,7 @@ set_option maxHeartbeats 3200000 in
 theorem sar_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
@@ -245,7 +245,7 @@ theorem sar_body_0_spec (sp : Word)
 -- Sign-fill path spec (7 instructions)
 -- ============================================================================
 
-abbrev sar_sign_fill_path_code (base : Addr) : CodeReq :=
+abbrev sar_sign_fill_path_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 56))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SRAI .x5 .x5 63))
   (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x12 .x12 32))
@@ -263,7 +263,7 @@ abbrev sar_sign_fill_path_code (base : Addr) : CodeReq :=
 theorem sar_sign_fill_path_spec (sp : Word)
     (v5 v10 : Word)
     (v0 v1 v2 v3 : Word)
-    (base : Addr) (hvalid_v3 : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true)
+    (base : Word) (hvalid_v3 : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true)
     (hvalid : ValidMemRange (sp + 32) 4) :
     let sign_ext := BitVec.sshiftRight v3 63
     let cr := sar_sign_fill_path_code base

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -100,14 +100,14 @@ private theorem shr_zero_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_zero]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -100,14 +100,17 @@ private theorem shr_zero_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]
+      simp only [evmWordIs, EvmWord.getLimbN_zero]
+      simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -22,7 +22,7 @@ private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h �
   fun _ hp => ⟨v, hp⟩
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
-private theorem shr_zero_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 : Word) :
+private theorem shr_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -55,7 +55,7 @@ private theorem shr_zero_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 : Wor
 
 /-- Compose one zero-path case into evmWordIs form.
     Shared proof structure for both high-limbs and s0≥256 cases. -/
-private theorem shr_zero_lift (sp base : Addr)
+private theorem shr_zero_lift (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (_hvalid : ValidMemRange sp 8)
     (hmain : cpsTriple base (base + 360) (shrCode base)
@@ -101,16 +101,16 @@ private theorem shr_zero_lift (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_zero]
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
@@ -130,7 +130,7 @@ set_option maxHeartbeats 1600000 in
 /-- **Main SHR theorem**: `evm_shr` computes the 256-bit logical right shift.
     Given shift and value as EvmWords on the stack, produces
     `if shift.toNat ≥ 256 then 0 else value >>> shift.toNat`. -/
-theorem evm_shr_stack_spec (sp base : Addr)
+theorem evm_shr_stack_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let result := if shift.toNat ≥ 256 then 0 else value >>> shift.toNat

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -764,12 +764,16 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
+        simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                   ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
         simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
                    show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
                    show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -40,7 +40,7 @@ local macro "skipBlock" : tactic =>
         bv_omega)))
 
 /-- The full evm_shl code split into 8 per-phase CodeReq.ofProg blocks. -/
-abbrev shlCode (base : Addr) : CodeReq :=
+abbrev shlCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
     CodeReq.ofProg base shr_phase_a,                      -- block 0 (shared with SHR)
     CodeReq.ofProg (base + 36) shr_phase_b,               -- block 1 (shared)
@@ -67,7 +67,7 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | none => simp [h1a] at h; exact h2 a i h
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
-private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (instr : Instr) (k : Nat)
+private theorem singleton_sub_ofProg (base addr : Word) (prog : List Instr) (instr : Instr) (k : Nat)
     (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
     (h_instr : prog.get ⟨k, hk⟩ = instr) :
@@ -79,7 +79,7 @@ private theorem singleton_sub_ofProg (base addr : Addr) (prog : List Instr) (ins
 -- ============================================================================
 
 -- Bridge: shr_phase_a_code (union chain) ⊆ ofProg shr_phase_a (9-element list)
-private theorem phase_a_code_sub_ofProg (base : Addr) :
+private theorem phase_a_code_sub_ofProg (base : Word) :
     ∀ a i, shr_phase_a_code base a = some i →
       (CodeReq.ofProg base shr_phase_a) a = some i := by
   unfold shr_phase_a_code shr_ld_or_acc_code
@@ -105,21 +105,21 @@ private theorem phase_a_code_sub_ofProg (base : Addr) :
                 (by native_decide) (by native_decide) (by bv_omega) (by native_decide)
 
 /-- Phase A code (union chain, 9 instrs at +0) is subsumed by shlCode (block 0). -/
-private theorem phase_a_sub_shlCode (base : Addr) :
+private theorem phase_a_sub_shlCode (base : Word) :
     ∀ a i, shr_phase_a_code base a = some i → shlCode base a = some i := by
   intro a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i (phase_a_code_sub_ofProg base a i h)
 
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shlCode (block 1). -/
-private theorem phase_b_sub_shlCode (base : Addr) :
+private theorem phase_b_sub_shlCode (base : Word) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shlCode base a = some i := by
   unfold shr_phase_b_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock
   exact CodeReq.union_mono_left _ _
 
 -- Bridge: shr_phase_c_code (union chain) ⊆ ofProg shr_phase_c (5-element list)
-private theorem phase_c_code_sub_ofProg (base : Addr) :
+private theorem phase_c_code_sub_ofProg (base : Word) :
     ∀ a i, shr_phase_c_code base a = some i →
       (CodeReq.ofProg base shr_phase_c) a = some i := by
   unfold shr_phase_c_code shr_cascade_step_code
@@ -132,48 +132,48 @@ private theorem phase_c_code_sub_ofProg (base : Addr) :
     · exact CodeReq.ofProg_mono_sub base (base + 12) shr_phase_c (shr_cascade_step_prog 2 32) 3
         (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-private theorem ofProg_phase_c_sub_shlCode (base : Addr) :
+private theorem ofProg_phase_c_sub_shlCode (base : Word) :
     ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shlCode base a = some i := by
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Phase C code (union chain, 5 instrs at +64) is subsumed by shlCode (block 2). -/
-private theorem phase_c_sub_shlCode (base : Addr) :
+private theorem phase_c_sub_shlCode (base : Word) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shlCode base a = some i := by
   intro a i h
   exact ofProg_phase_c_sub_shlCode base a i (phase_c_code_sub_ofProg (base + 64) a i h)
 
 /-- SHL Body 3 code (7 instrs at +84) is subsumed by shlCode (block 3). -/
-private theorem shl_body_3_sub_shlCode (base : Addr) :
+private theorem shl_body_3_sub_shlCode (base : Word) :
     ∀ a i, shl_body_3_code (base + 84) 252 a = some i → shlCode base a = some i := by
   unfold shl_body_3_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 2 code (13 instrs at +112) is subsumed by shlCode (block 4). -/
-private theorem shl_body_2_sub_shlCode (base : Addr) :
+private theorem shl_body_2_sub_shlCode (base : Word) :
     ∀ a i, shl_body_2_code (base + 112) 200 a = some i → shlCode base a = some i := by
   unfold shl_body_2_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 1 code (19 instrs at +164) is subsumed by shlCode (block 5). -/
-private theorem shl_body_1_sub_shlCode (base : Addr) :
+private theorem shl_body_1_sub_shlCode (base : Word) :
     ∀ a i, shl_body_1_code (base + 164) 124 a = some i → shlCode base a = some i := by
   unfold shl_body_1_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 0 code (25 instrs at +240) is subsumed by shlCode (block 6). -/
-private theorem shl_body_0_sub_shlCode (base : Addr) :
+private theorem shl_body_0_sub_shlCode (base : Word) :
     ∀ a i, shl_body_0_code (base + 240) 24 a = some i → shlCode base a = some i := by
   unfold shl_body_0_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shlCode (block 7). -/
-private theorem zero_path_sub_shlCode (base : Addr) :
+private theorem zero_path_sub_shlCode (base : Word) :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shlCode base a = some i := by
   unfold shr_zero_path_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -181,7 +181,7 @@ private theorem zero_path_sub_shlCode (base : Addr) :
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
 
-private theorem ld_s1_sub_shlCode (base : Addr) :
+private theorem ld_s1_sub_shlCode (base : Word) :
     ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
@@ -189,7 +189,7 @@ private theorem ld_s1_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_16_sub_shlCode (base : Addr) :
+private theorem ld_or_16_sub_shlCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shlCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
@@ -197,7 +197,7 @@ private theorem ld_or_16_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_24_sub_shlCode (base : Addr) :
+private theorem ld_or_24_sub_shlCode (base : Word) :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shlCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
@@ -205,7 +205,7 @@ private theorem ld_or_24_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem bne_sub_shlCode (base : Addr) :
+private theorem bne_sub_shlCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
@@ -213,7 +213,7 @@ private theorem bne_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_s0_sub_shlCode (base : Addr) :
+private theorem ld_s0_sub_shlCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
@@ -221,7 +221,7 @@ private theorem ld_s0_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem sltiu_sub_shlCode (base : Addr) :
+private theorem sltiu_sub_shlCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
@@ -229,7 +229,7 @@ private theorem sltiu_sub_shlCode (base : Addr) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem beq_sub_shlCode (base : Addr) :
+private theorem beq_sub_shlCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
@@ -241,34 +241,34 @@ private theorem beq_sub_shlCode (base : Addr) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem shl_off_4 (base : Addr) : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-private theorem shl_off_12 (base : Addr) : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-private theorem shl_off_20 (base : Addr) : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-private theorem shl_off_24 (base : Addr) : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-private theorem shl_off_28 (base : Addr) : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-private theorem shl_off_32 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem shl_off_36_28 (base : Addr) : (base + 36 : Addr) + 28 = base + 64 := by bv_omega
-private theorem shl_off_340_20 (base : Addr) : (base + 340 : Addr) + 20 = base + 360 := by bv_omega
-private theorem shl_bne_target (base : Addr) : (base + 20 : Addr) + signExtend13 320 = base + 340 := by
+private theorem shl_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem shl_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem shl_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem shl_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem shl_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem shl_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem shl_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem shl_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
+private theorem shl_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
   rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by native_decide]; bv_omega
-private theorem shl_beq_target (base : Addr) : (base + 32 : Addr) + signExtend13 308 = base + 340 := by
+private theorem shl_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
   rw [show signExtend13 (308 : BitVec 13) = (308 : Word) from by native_decide]; bv_omega
 -- Phase C exit addresses
-private theorem shl_c_e0 (base : Addr) : (base + 64 : Addr) + signExtend13 176 = base + 240 := by
+private theorem shl_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by
   rw [show signExtend13 (176 : BitVec 13) = (176 : Word) from by native_decide]; bv_omega
-private theorem shl_c_e1 (base : Addr) : ((base + 64 : Addr) + 8) + signExtend13 92 = base + 164 := by
+private theorem shl_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 92 = base + 164 := by
   rw [show signExtend13 (92 : BitVec 13) = (92 : Word) from by native_decide]; bv_omega
-private theorem shl_c_e2 (base : Addr) : ((base + 64 : Addr) + 16) + signExtend13 32 = base + 112 := by
+private theorem shl_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 32 = base + 112 := by
   rw [show signExtend13 (32 : BitVec 13) = (32 : Word) from by native_decide]; bv_omega
-private theorem shl_c_e3 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem shl_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets)
-private theorem shl_body3_exit (base : Addr) : ((base + 84 : Addr) + 24) + signExtend21 252 = base + 360 := by
+private theorem shl_body3_exit (base : Word) : ((base + 84 : Word) + 24) + signExtend21 252 = base + 360 := by
   rw [show signExtend21 (252 : BitVec 21) = (252 : Word) from by native_decide]; bv_omega
-private theorem shl_body2_exit (base : Addr) : ((base + 112 : Addr) + 48) + signExtend21 200 = base + 360 := by
+private theorem shl_body2_exit (base : Word) : ((base + 112 : Word) + 48) + signExtend21 200 = base + 360 := by
   rw [show signExtend21 (200 : BitVec 21) = (200 : Word) from by native_decide]; bv_omega
-private theorem shl_body1_exit (base : Addr) : ((base + 164 : Addr) + 72) + signExtend21 124 = base + 360 := by
+private theorem shl_body1_exit (base : Word) : ((base + 164 : Word) + 72) + signExtend21 124 = base + 360 := by
   rw [show signExtend21 (124 : BitVec 21) = (124 : Word) from by native_decide]; bv_omega
-private theorem shl_body0_exit (base : Addr) : ((base + 240 : Addr) + 96) + signExtend21 24 = base + 360 := by
+private theorem shl_body0_exit (base : Word) : ((base + 240 : Word) + 96) + signExtend21 24 = base + 360 := by
   rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_omega
 
 -- ============================================================================
@@ -277,7 +277,7 @@ private theorem shl_body0_exit (base : Addr) : ((base + 240 : Addr) + 96) + sign
 
 set_option maxHeartbeats 1600000 in
 /-- Zero path via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is zero. -/
-theorem evm_shl_zero_high_spec (sp base : Addr)
+theorem evm_shl_zero_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -368,12 +368,12 @@ theorem evm_shl_zero_high_spec (sp base : Addr)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hzp
   -- Address normalization lemmas
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose AB → ZP: normalize addresses in perm callback
   have hABZ := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _
     _ _ _ _
@@ -402,7 +402,7 @@ theorem evm_shl_zero_high_spec (sp base : Addr)
 
 set_option maxHeartbeats 3200000 in
 /-- Zero path via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is zero. -/
-theorem evm_shl_zero_large_spec (sp base : Addr)
+theorem evm_shl_zero_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
@@ -532,12 +532,12 @@ theorem evm_shl_zero_large_spec (sp base : Addr)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hzp
   -- Address normalization lemmas
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose → ZP: normalize addresses in perm callback
   have hfull := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _ _ _ _ _
     (fun h hp => by
@@ -570,8 +570,8 @@ theorem evm_shl_zero_large_spec (sp base : Addr)
 -- Helpers for extending code requirements to cpsNBranch
 
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)}
+private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
@@ -579,8 +579,8 @@ private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)} {F : Assertion}
+private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
   intro R hR s hcr hPFR hpc
@@ -593,12 +593,12 @@ private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
 -- Address normalization lemmas for body path
-private theorem shl_off_64_20 (base : Addr) : (base + 64 : Addr) + 20 = base + 84 := by bv_omega
+private theorem shl_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 private theorem shl_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
   simp only [signExtend12_32]
 
 -- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8) :
+private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
     ValidMemRange (sp + 32) 4 := by
   intro i hi; have := hvalid.get (i := i + 4) (by omega)
   have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
@@ -608,7 +608,7 @@ private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8)
 /-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Addr} {cr : CodeReq}
+    {entry exit_ : Word} {cr : CodeReq}
     {P Q Q' : Assertion} {fact : Prop}
     (hbody : cpsTriple entry exit_ cr P Q)
     (hpost : fact → ∀ h, Q h → Q' h) :
@@ -727,7 +727,7 @@ set_option maxHeartbeats 6400000 in
 /-- Body path: shift < 256 → result is `value <<< shift.toNat`.
     Composes Phase A ntaken → B → C → body_L → exit and uses
     bridge lemmas to connect per-limb results to the 256-bit shift. -/
-theorem evm_shl_body_evmWord_spec (sp base : Addr)
+theorem evm_shl_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
@@ -764,15 +764,15 @@ theorem evm_shl_body_evmWord_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         unfold evmWordIs at hp
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
-        simp only [show (sp + 32 : Addr) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Addr) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Addr) + 24 = sp + 56 from by bv_omega]
+        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
@@ -787,9 +787,9 @@ theorem evm_shl_body_evmWord_spec (sp base : Addr)
     have := hvalid.get (i := 3) (by omega); simpa using this
   have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
-  have ha40 : sp + 40 = (sp + 32 : Addr) + 8 := by bv_omega
-  have ha48 : sp + 48 = (sp + 32 : Addr) + 16 := by bv_omega
-  have ha56 : sp + 56 = (sp + 32 : Addr) + 24 := by bv_omega
+  have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
+  have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
+  have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
   -- Phase A: linear chain base -> base+36
   have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun) (by simp only [signExtend12_8]; exact hv8))
@@ -924,9 +924,9 @@ theorem evm_shl_body_evmWord_spec (sp base : Addr)
   have hbody0_f := cpsTriple_frame_left (base + 240) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody0
-  have ha40' : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-  have ha48' : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-  have ha56' : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+  have ha40' : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+  have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+  have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
   have body_post_weaken : ∀ (r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word),

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -100,14 +100,17 @@ private theorem shl_zero_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]
+      simp only [evmWordIs, EvmWord.getLimbN_zero]
+      simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+                 ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -100,14 +100,14 @@ private theorem shl_zero_lift (sp base : Word)
       hframed
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_zero]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimb_zero]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -22,7 +22,7 @@ private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h �
   fun _ hp => ⟨v, hp⟩
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
-private theorem shl_zero_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 : Word) :
+private theorem shl_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -55,7 +55,7 @@ private theorem shl_zero_evmWord_weaken (sp : Addr) (s0 s1 s2 s3 r6 r7 r11 : Wor
 
 /-- Compose one zero-path case into evmWordIs form.
     Shared proof structure for both high-limbs and s0≥256 cases. -/
-private theorem shl_zero_lift (sp base : Addr)
+private theorem shl_zero_lift (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (_hvalid : ValidMemRange sp 8)
     (hmain : cpsTriple base (base + 360) (shlCode base)
@@ -101,16 +101,16 @@ private theorem shl_zero_lift (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_zero]
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
@@ -130,7 +130,7 @@ set_option maxHeartbeats 1600000 in
 /-- **Main SHL theorem**: `evm_shl` computes the 256-bit logical left shift.
     Given shift and value as EvmWords on the stack, produces
     `if shift.toNat ≥ 256 then 0 else value <<< shift.toNat`. -/
-theorem evm_shl_stack_spec (sp base : Addr)
+theorem evm_shl_stack_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let result := if shift.toNat ≥ 256 then 0 else value <<< shift.toNat

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -19,7 +19,7 @@ namespace EvmAsm.Rv64
 -- Per-limb Specs: SHL Merge Limb (7 instructions)
 -- ============================================================================
 
-abbrev shl_merge_limb_code (base : Addr) (src_off prev_off dst_off : BitVec 12) : CodeReq :=
+abbrev shl_merge_limb_code (base : Word) (src_off prev_off dst_off : BitVec 12) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 src_off))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SLL .x5 .x5 .x6))
   (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x10 .x12 prev_off))
@@ -35,7 +35,7 @@ abbrev shl_merge_limb_code (base : Addr) (src_off prev_off dst_off : BitVec 12) 
     Computes: result = (src <<< bit_shift) ||| ((prev >>> anti_shift) &&& mask)
     Mirror of shr_merge_limb_spec with SLL/SRL swapped. -/
 theorem shl_merge_limb_spec (src_off prev_off dst_off : BitVec 12)
-    (sp src prev dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Addr)
+    (sp src prev dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 src_off) = true)
     (hvalid_prev : isValidDwordAccess (sp + signExtend12 prev_off) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
@@ -66,7 +66,7 @@ theorem shl_merge_limb_spec (src_off prev_off dst_off : BitVec 12)
 -- Per-limb Specs: SHL First Limb (3 instructions)
 -- ============================================================================
 
-abbrev shl_first_limb_code (base : Addr) (dst_off : BitVec 12) : CodeReq :=
+abbrev shl_first_limb_code (base : Word) (dst_off : BitVec 12) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 0))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SLL .x5 .x5 .x6))
    (CodeReq.singleton (base + 8) (.SD .x12 .x5 dst_off)))
@@ -77,7 +77,7 @@ abbrev shl_first_limb_code (base : Addr) (dst_off : BitVec 12) : CodeReq :=
     Computes: result = value[0] <<< bit_shift
     Mirror of shr_last_limb_spec: reads from offset 0 (lowest limb), uses SLL. -/
 theorem shl_first_limb_spec (dst_off : BitVec 12)
-    (sp src dst_old v5 bit_shift : Word) (base : Addr)
+    (sp src dst_old v5 bit_shift : Word) (base : Word)
     (hvalid_src : isValidDwordAccess (sp + signExtend12 (0 : BitVec 12)) = true)
     (hvalid_dst : isValidDwordAccess (sp + signExtend12 dst_off) = true) :
     let mem_src := sp + signExtend12 (0 : BitVec 12)
@@ -98,7 +98,7 @@ theorem shl_first_limb_spec (dst_off : BitVec 12)
 -- Per-limb Specs: SHL Merge Limb In-place (7 instructions, src_off = dst_off)
 -- ============================================================================
 
-abbrev shl_merge_limb_inplace_code (base : Addr) (off prev_off : BitVec 12) : CodeReq :=
+abbrev shl_merge_limb_inplace_code (base : Word) (off prev_off : BitVec 12) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 off))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SLL .x5 .x5 .x6))
   (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x10 .x12 prev_off))
@@ -110,7 +110,7 @@ abbrev shl_merge_limb_inplace_code (base : Addr) (off prev_off : BitVec 12) : Co
 /-- SHL merge limb in-place spec (7 instructions):
     Same as shl_merge_limb_spec but src_off = dst_off. -/
 theorem shl_merge_limb_inplace_spec (off prev_off : BitVec 12)
-    (sp src prev v5 v10 bit_shift anti_shift mask : Word) (base : Addr)
+    (sp src prev v5 v10 bit_shift anti_shift mask : Word) (base : Word)
     (hvalid_loc : isValidDwordAccess (sp + signExtend12 off) = true)
     (hvalid_prev : isValidDwordAccess (sp + signExtend12 prev_off) = true) :
     let mem_loc := sp + signExtend12 off
@@ -139,7 +139,7 @@ theorem shl_merge_limb_inplace_spec (off prev_off : BitVec 12)
 -- Per-limb Specs: SHL First Limb In-place (3 instructions, dst_off = 0)
 -- ============================================================================
 
-abbrev shl_first_limb_inplace_code (base : Addr) : CodeReq :=
+abbrev shl_first_limb_inplace_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 0))
   (CodeReq.union (CodeReq.singleton (base + 4) (.SLL .x5 .x5 .x6))
    (CodeReq.singleton (base + 8) (.SD .x12 .x5 0)))
@@ -148,7 +148,7 @@ abbrev shl_first_limb_inplace_code (base : Addr) : CodeReq :=
     LD x5, 0(x12); SLL x5,x5,x6; SD x12,x5,0
     Reads and writes the same memory cell at sp+0. -/
 theorem shl_first_limb_inplace_spec
-    (sp src v5 bit_shift : Word) (base : Addr)
+    (sp src v5 bit_shift : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 (0 : BitVec 12)) = true) :
     let mem := sp + signExtend12 (0 : BitVec 12)
     let result := src <<< (bit_shift.toNat % 64)
@@ -165,7 +165,7 @@ theorem shl_first_limb_inplace_spec
 -- Shift Body Specs
 -- ============================================================================
 
-abbrev shl_body_3_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev shl_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (shl_body_3_prog jal_off)
 
 /-- Shift body 3: limb_shift=3.
@@ -175,7 +175,7 @@ abbrev shl_body_3_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
 theorem shl_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result3 := v0 <<< (bit_shift.toNat % 64)
@@ -195,7 +195,7 @@ theorem shl_body_3_spec (sp : Word)
   rw [hexit] at JL
   runBlock FL S0 S1 S2 JL
 
-abbrev shl_body_2_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev shl_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (shl_body_2_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -207,7 +207,7 @@ set_option maxHeartbeats 3200000 in
 theorem shl_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 48) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result3 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
@@ -230,7 +230,7 @@ theorem shl_body_2_spec (sp : Word)
   rw [hexit] at JL
   runBlock MM FL S0 S1 JL
 
-abbrev shl_body_1_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev shl_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (shl_body_1_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -244,7 +244,7 @@ set_option maxHeartbeats 3200000 in
 theorem shl_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 72) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result3 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
@@ -271,7 +271,7 @@ theorem shl_body_1_spec (sp : Word)
   rw [hexit] at JL
   runBlock MM1 MM2 FL S0 JL
 
-abbrev shl_body_0_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev shl_body_0_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (shl_body_0_prog jal_off)
 
 set_option maxHeartbeats 3200000 in
@@ -283,7 +283,7 @@ set_option maxHeartbeats 3200000 in
 theorem shl_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 4) :
     let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (anti_shift.toNat % 64)) &&& mask)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -733,11 +733,10 @@ theorem signext_body_spec (sp base : Word)
             ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) ** ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56)) h := by
     intro r5v r6v r10v m32 m40 m48 m56 h hp
     rw [hse32] at hp
-    have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x5 _)) h
-      ((congrFun (show _ = _ from by xperm) h).mp hp)
+    have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x5 _)) h hp
     have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _))) h w1
     have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x10 _)))) h w2
-    exact (congrFun (show _ = _ from by xperm) h).mp w3
+    xperm_hyp w3
   -- Apply weakening to each body+done
   have hbd0_w := cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbd0

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 /-- The full evm_signextend code as a single CodeReq.ofProg block (48 instructions). -/
-abbrev signextCode (base : Addr) : CodeReq := CodeReq.ofProg base evm_signextend
+abbrev signextCode (base : Word) : CodeReq := CodeReq.ofProg base evm_signextend
 
 /-- Weaken concrete register to existential ownership. -/
 private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
@@ -38,7 +38,7 @@ private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
   | some v => simp [h1a] at h; subst h; exact h1 a v h1a
 
 /-- A singleton at instruction k of evm_signextend is subsumed by signextCode. -/
-private theorem singleton_sub_signextCode (base addr : Addr) (instr : Instr) (k : Nat)
+private theorem singleton_sub_signextCode (base addr : Word) (instr : Instr) (k : Nat)
     (hk : k < evm_signextend.length)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
     (h_instr : evm_signextend.get ⟨k, hk⟩ = instr) :
@@ -51,7 +51,7 @@ private theorem singleton_sub_signextCode (base addr : Addr) (instr : Instr) (k 
 -- ============================================================================
 
 /-- Phase A code (union chain, 9 instrs at +0) is subsumed by signextCode. -/
-private theorem phase_a_sub_signextCode (base : Addr) :
+private theorem phase_a_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_a_code base a = some i → signextCode base a = some i := by
   unfold signext_phase_a_code
   apply CodeReq_union_sub_both
@@ -78,26 +78,26 @@ private theorem phase_a_sub_signextCode (base : Addr) :
                 (by native_decide) (by bv_omega) (by native_decide)
 
 /-- Phase B code (ofProg, 5 instrs at +36) is subsumed by signextCode. -/
-private theorem phase_b_sub_signextCode (base : Addr) :
+private theorem phase_b_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_b_code (base + 36) a = some i → signextCode base a = some i := by
   unfold signext_phase_b_code
   exact CodeReq.ofProg_mono_sub base (base + 36) evm_signextend signext_phase_b 9
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 set_option maxHeartbeats 4000000 in
-private theorem cascade_15_sub_signextCode (base : Addr) :
+private theorem cascade_15_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.ofProg (base + 60) (signext_cascade_step_prog 1 60) a = some i → signextCode base a = some i :=
   CodeReq.ofProg_mono_sub base (base + 60) evm_signextend (signext_cascade_step_prog 1 60) 15
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 set_option maxHeartbeats 4000000 in
-private theorem cascade_17_sub_signextCode (base : Addr) :
+private theorem cascade_17_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.ofProg (base + 68) (signext_cascade_step_prog 2 24) a = some i → signextCode base a = some i :=
   CodeReq.ofProg_mono_sub base (base + 68) evm_signextend (signext_cascade_step_prog 2 24) 17
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Phase C code (union chain, 5 instrs at +56) is subsumed by signextCode. -/
-private theorem phase_c_sub_signextCode (base : Addr) :
+private theorem phase_c_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_c_code (base + 56) a = some i → signextCode base a = some i := by
   unfold signext_phase_c_code
   apply CodeReq_union_sub_both
@@ -105,83 +105,83 @@ private theorem phase_c_sub_signextCode (base : Addr) :
       (by native_decide) (by bv_omega) (by native_decide)
   · apply CodeReq_union_sub_both
     · unfold signext_cascade_step_code
-      have : (base + 56 : Addr) + 4 = base + 60 := by bv_omega
+      have : (base + 56 : Word) + 4 = base + 60 := by bv_omega
       rw [this]
       exact cascade_15_sub_signextCode base
     · unfold signext_cascade_step_code
-      have : (base + 56 : Addr) + 12 = base + 68 := by bv_omega
+      have : (base + 56 : Word) + 12 = base + 68 := by bv_omega
       rw [this]
       exact cascade_17_sub_signextCode base
 
 /-- Body 3 code (ofProg, 5 instrs at +76) is subsumed by signextCode. -/
-private theorem body_3_sub_signextCode (base : Addr) :
+private theorem body_3_sub_signextCode (base : Word) :
     ∀ a i, signext_body_3_code (base + 76) 96 a = some i → signextCode base a = some i := by
   unfold signext_body_3_code
   exact CodeReq.ofProg_mono_sub base (base + 76) evm_signextend (signext_body_3_prog 96) 19
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Body 2 code (ofProg, 7 instrs at +96) is subsumed by signextCode. -/
-private theorem body_2_sub_signextCode (base : Addr) :
+private theorem body_2_sub_signextCode (base : Word) :
     ∀ a i, signext_body_2_code (base + 96) 68 a = some i → signextCode base a = some i := by
   unfold signext_body_2_code
   exact CodeReq.ofProg_mono_sub base (base + 96) evm_signextend (signext_body_2_prog 68) 24
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Body 1 code (ofProg, 8 instrs at +124) is subsumed by signextCode. -/
-private theorem body_1_sub_signextCode (base : Addr) :
+private theorem body_1_sub_signextCode (base : Word) :
     ∀ a i, signext_body_1_code (base + 124) 36 a = some i → signextCode base a = some i := by
   unfold signext_body_1_code
   exact CodeReq.ofProg_mono_sub base (base + 124) evm_signextend (signext_body_1_prog 36) 31
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Body 0 code (ofProg, 8 instrs at +156) is subsumed by signextCode. -/
-private theorem body_0_sub_signextCode (base : Addr) :
+private theorem body_0_sub_signextCode (base : Word) :
     ∀ a i, signext_body_0_code (base + 156) a = some i → signextCode base a = some i := by
   unfold signext_body_0_code
   exact CodeReq.ofProg_mono_sub base (base + 156) evm_signextend signext_body_0 39
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
 /-- Done code (singleton, 1 instr at +188) is subsumed by signextCode. -/
-private theorem done_sub_signextCode (base : Addr) :
+private theorem done_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 188) (.ADDI .x12 .x12 32) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base (base + 188) (.ADDI .x12 .x12 32) 47
     (by native_decide) (by bv_omega) (by native_decide)
 
 -- Individual instruction subsumption helpers (for Phase A raw composition)
 
-private theorem ld_b1_sub_signextCode (base : Addr) :
+private theorem ld_b1_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base base (.LD .x5 .x12 8) 0
     (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem ld_or_16_sub_signextCode (base : Addr) :
+private theorem ld_or_16_sub_signextCode (base : Word) :
     ∀ a i, signext_ld_or_acc_code 16 (base + 4) a = some i → signextCode base a = some i := by
   unfold signext_ld_or_acc_code
   exact CodeReq.ofProg_mono_sub base (base + 4) evm_signextend (signext_ld_or_acc_prog 16) 1
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-private theorem ld_or_24_sub_signextCode (base : Addr) :
+private theorem ld_or_24_sub_signextCode (base : Word) :
     ∀ a i, signext_ld_or_acc_code 24 (base + 12) a = some i → signextCode base a = some i := by
   unfold signext_ld_or_acc_code
   exact CodeReq.ofProg_mono_sub base (base + 12) evm_signextend (signext_ld_or_acc_prog 24) 3
     (by bv_omega) (by native_decide) (by native_decide) (by native_decide)
 
-private theorem bne_sub_signextCode (base : Addr) :
+private theorem bne_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 168) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base (base + 20) (.BNE .x5 .x0 168) 5
     (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem ld_b0_sub_signextCode (base : Addr) :
+private theorem ld_b0_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base (base + 24) (.LD .x5 .x12 0) 6
     (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem sltiu_sub_signextCode (base : Addr) :
+private theorem sltiu_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 31) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base (base + 28) (.SLTIU .x10 .x5 31) 7
     (by native_decide) (by bv_omega) (by native_decide)
 
-private theorem beq_sub_signextCode (base : Addr) :
+private theorem beq_sub_signextCode (base : Word) :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 156) a = some i → signextCode base a = some i :=
   singleton_sub_signextCode base (base + 32) (.BEQ .x10 .x0 156) 8
     (by native_decide) (by bv_omega) (by native_decide)
@@ -190,32 +190,32 @@ private theorem beq_sub_signextCode (base : Addr) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem se_off_4 (base : Addr) : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-private theorem se_off_12 (base : Addr) : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-private theorem se_off_20 (base : Addr) : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-private theorem se_off_24 (base : Addr) : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-private theorem se_off_28 (base : Addr) : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-private theorem se_off_32 (base : Addr) : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
-private theorem se_bne_target (base : Addr) : (base + 20 : Addr) + signExtend13 168 = base + 188 := by
+private theorem se_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem se_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem se_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem se_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem se_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem se_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem se_bne_target (base : Word) : (base + 20 : Word) + signExtend13 168 = base + 188 := by
   rw [show signExtend13 (168 : BitVec 13) = (168 : Word) from by native_decide]; bv_omega
-private theorem se_beq_target (base : Addr) : (base + 32 : Addr) + signExtend13 156 = base + 188 := by
+private theorem se_beq_target (base : Word) : (base + 32 : Word) + signExtend13 156 = base + 188 := by
   rw [show signExtend13 (156 : BitVec 13) = (156 : Word) from by native_decide]; bv_omega
 -- Phase C exit addresses
-private theorem se_c_e0 (base : Addr) : (base + 56 : Addr) + signExtend13 100 = base + 156 := by
+private theorem se_c_e0 (base : Word) : (base + 56 : Word) + signExtend13 100 = base + 156 := by
   rw [show signExtend13 (100 : BitVec 13) = (100 : Word) from by native_decide]; bv_omega
-private theorem se_c_e1 (base : Addr) : ((base + 56 : Addr) + 8) + signExtend13 60 = base + 124 := by
+private theorem se_c_e1 (base : Word) : ((base + 56 : Word) + 8) + signExtend13 60 = base + 124 := by
   rw [show signExtend13 (60 : BitVec 13) = (60 : Word) from by native_decide]; bv_omega
-private theorem se_c_e2 (base : Addr) : ((base + 56 : Addr) + 16) + signExtend13 24 = base + 96 := by
+private theorem se_c_e2 (base : Word) : ((base + 56 : Word) + 16) + signExtend13 24 = base + 96 := by
   rw [show signExtend13 (24 : BitVec 13) = (24 : Word) from by native_decide]; bv_omega
-private theorem se_c_e3 (base : Addr) : (base + 56 : Addr) + 20 = base + 76 := by bv_omega
+private theorem se_c_e3 (base : Word) : (base + 56 : Word) + 20 = base + 76 := by bv_omega
 -- Body exit addresses (JAL targets)
-private theorem se_body3_exit (base : Addr) : ((base + 76 : Addr) + 16) + signExtend21 96 = base + 188 := by
+private theorem se_body3_exit (base : Word) : ((base + 76 : Word) + 16) + signExtend21 96 = base + 188 := by
   rw [show signExtend21 (96 : BitVec 21) = (96 : Word) from by native_decide]; bv_omega
-private theorem se_body2_exit (base : Addr) : ((base + 96 : Addr) + 24) + signExtend21 68 = base + 188 := by
+private theorem se_body2_exit (base : Word) : ((base + 96 : Word) + 24) + signExtend21 68 = base + 188 := by
   rw [show signExtend21 (68 : BitVec 21) = (68 : Word) from by native_decide]; bv_omega
-private theorem se_body1_exit (base : Addr) : ((base + 124 : Addr) + 28) + signExtend21 36 = base + 188 := by
+private theorem se_body1_exit (base : Word) : ((base + 124 : Word) + 28) + signExtend21 36 = base + 188 := by
   rw [show signExtend21 (36 : BitVec 21) = (36 : Word) from by native_decide]; bv_omega
-private theorem se_done_exit (base : Addr) : (base + 188 : Addr) + 4 = base + 192 := by bv_omega
+private theorem se_done_exit (base : Word) : (base + 188 : Word) + 4 = base + 192 := by bv_omega
 
 -- ============================================================================
 -- Section 4: No-change path 1 — high limbs nonzero
@@ -224,7 +224,7 @@ private theorem se_done_exit (base : Addr) : (base + 188 : Addr) + 4 = base + 19
 set_option maxHeartbeats 1600000 in
 /-- No-change path via BNE taken: high b limbs are nonzero → b >= 31 → x unchanged.
     Execution: LD b1 → LD/OR b2 → LD/OR b3 → BNE(taken) → done. -/
-theorem signext_nochange_high_spec (sp base : Addr)
+theorem signext_nochange_high_spec (sp base : Word)
     (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
     (hhigh : b1 ||| b2 ||| b3 ≠ 0)
     (hvalid : ValidMemRange sp 8) :
@@ -334,7 +334,7 @@ theorem signext_nochange_high_spec (sp base : Addr)
 set_option maxHeartbeats 3200000 in
 /-- No-change path via BEQ taken: b1=b2=b3=0 but b[0] >= 31 → x unchanged.
     Execution: LD b1 → LD/OR b2 → LD/OR b3 → BNE(ntaken) → LD b0 → SLTIU → BEQ(taken) → done. -/
-theorem signext_nochange_geq31_spec (sp base : Addr)
+theorem signext_nochange_geq31_spec (sp base : Word)
     (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : b1 ||| b2 ||| b3 = 0)
     (hlarge : BitVec.ult b0 (signExtend12 (31 : BitVec 12)) = false)
@@ -478,7 +478,7 @@ theorem signext_nochange_geq31_spec (sp base : Addr)
 /-- Strip a pure fact from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Addr} {cr : CodeReq}
+    {entry exit_ : Word} {cr : CodeReq}
     {P Q Q' : Assertion} {fact : Prop}
     (hbody : cpsTriple entry exit_ cr P Q)
     (hpost : fact → ∀ h, Q h → Q' h) :
@@ -498,16 +498,16 @@ private theorem cpsTriple_strip_pure_and_convert
     obtain ⟨hp', hcompat', hpq'⟩ := hQR
     exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
 
-private theorem cpsNBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)}
+private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
   intro R hR s hcr' hPR hpc
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
-private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
-    {P : Assertion} {exits : List (Addr × Assertion)} {F : Assertion}
+private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
   intro R hR s hcr hPFR hpc
@@ -519,7 +519,7 @@ private theorem cpsNBranch_frame_left {entry : Addr} {cr : CodeReq}
   refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
-private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8) :
+private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
     ValidMemRange (sp + 32) 4 := by
   intro i hi; have := hvalid.get (i := i + 4) (by omega)
   have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
@@ -533,7 +533,7 @@ private theorem validMem_value_portion {sp : Addr} (hvalid : ValidMemRange sp 8)
 set_option maxHeartbeats 12800000 in
 /-- Body path: b < 31 → raw-limb cpsTriple producing `signextend b x` limbs.
     Composes Phase A ntaken → B → C → body_L → done. -/
-theorem signext_body_spec (sp base : Addr)
+theorem signext_body_spec (sp base : Word)
     (b x : EvmWord) (r5 r6 r10 : Word)
     (hvalid : ValidMemRange sp 8)
     (hhigh : b.getLimb 1 ||| b.getLimb 2 ||| b.getLimb 3 = 0)
@@ -637,7 +637,7 @@ theorem signext_body_spec (sp base : Addr)
   let limb_idx := b0 >>> (3 : BitVec 6).toNat
   have hphaseB := cpsTriple_extend_code (phase_b_sub_signextCode base)
     (signext_phase_b_spec b0 r6 sltiu_val (base + 36))
-  rw [show (base + 36 : Addr) + 20 = base + 56 from by bv_omega] at hphaseB
+  rw [show (base + 36 : Word) + 20 = base + 56 from by bv_omega] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 56) _ _ _
     ((.x12 ↦ᵣ sp) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hphaseB
@@ -657,7 +657,7 @@ theorem signext_body_spec (sp base : Addr)
     (signext_body_1_spec sp limb_idx ((0 : Word) + signExtend12 1) shift_amount v1 v2 v3 (base + 124) (base + 188) 36 (se_body1_exit base) hvalid)
   have hbody0 := cpsTriple_extend_code (body_0_sub_signextCode base)
     (signext_body_0_spec sp limb_idx byte_shift shift_amount v0 v1 v2 v3 (base + 156) hvalid)
-  rw [show (base + 156 : Addr) + 32 = base + 188 from by bv_omega] at hbody0
+  rw [show (base + 156 : Word) + 32 = base + 188 from by bv_omega] at hbody0
   have hdone := cpsTriple_extend_code (done_sub_signextCode base) (signext_done_spec sp (base + 188))
   rw [se_done_exit] at hdone
   -- Frame bodies with b-mem + x0

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -26,7 +26,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for sign-extend in-place (4 instructions):
     LD x5, off(x12); SLL x5,x5,x6; SRA x5,x5,x6; SD x12,x5,off -/
-abbrev signext_inplace_code (off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev signext_inplace_code (off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (signext_inplace_prog off)
 
 /-- Sign-extend in-place spec (4 instructions):
@@ -35,7 +35,7 @@ abbrev signext_inplace_code (off : BitVec 12) (base : Addr) : CodeReq :=
     Loads a 64-bit limb, sign-extends using shift_amount, stores back.
     Result = BitVec.sshiftRight (limb <<< (sa % 64)) (sa % 64) -/
 theorem signext_inplace_spec (off : BitVec 12)
-    (sp limb v5 shift_amount : Word) (base : Addr)
+    (sp limb v5 shift_amount : Word) (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let result := BitVec.sshiftRight (limb <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let code := signext_inplace_code off base
@@ -56,14 +56,14 @@ theorem signext_inplace_spec (off : BitVec 12)
 
 /-- CodeReq for sign-extend body 3 (5 instructions):
     LD + SLL + SRA + SD at sp+56 + JAL. -/
-abbrev signext_body_3_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev signext_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_3_prog jal_off)
 
 /-- Body 3: limb_idx=3, sign-extend limb 3 at sp+56 (5 instrs).
     4 instructions: LD + SLL + SRA + SD + JAL. No higher limbs to fill. -/
 theorem signext_body_3_spec (sp : Word)
     (v5 shift_amount : Word) (v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 16) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 8) :
     let result := BitVec.sshiftRight (v3 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
@@ -80,14 +80,14 @@ theorem signext_body_3_spec (sp : Word)
 
 /-- CodeReq for sign-extend body 2 (7 instructions):
     LD + SLL + SRA + SD at sp+48 + SRAI + SD at sp+56 + JAL. -/
-abbrev signext_body_2_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev signext_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_2_prog jal_off)
 
 /-- Body 2: limb_idx=2, sign-extend limb 2 at sp+48, fill limb 3 (7 instrs).
     LD + SLL + SRA + SD + SRAI + SD + JAL. -/
 theorem signext_body_2_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 8) :
     let result := BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
@@ -113,14 +113,14 @@ theorem signext_body_2_spec (sp : Word)
 
 /-- CodeReq for sign-extend body 1 (8 instructions):
     LD + SLL + SRA + SD at sp+40 + SRAI + SD at sp+48 + SD at sp+56 + JAL. -/
-abbrev signext_body_1_code (base : Addr) (jal_off : BitVec 21) : CodeReq :=
+abbrev signext_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_1_prog jal_off)
 
 /-- Body 1: limb_idx=1, sign-extend limb 1 at sp+40, fill limbs 2-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + JAL. -/
 theorem signext_body_1_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v1 v2 v3 : Word)
-    (base exit : Addr) (jal_off : BitVec 21)
+    (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 28) + signExtend21 jal_off = exit)
     (hvalid : ValidMemRange sp 8) :
     let result := BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
@@ -150,14 +150,14 @@ theorem signext_body_1_spec (sp : Word)
 /-- CodeReq for sign-extend body 0 (8 instructions):
     LD + SLL + SRA + SD at sp+32 + SRAI + SD at sp+40 + SD at sp+48 + SD at sp+56.
     Falls through to done. -/
-abbrev signext_body_0_code (base : Addr) : CodeReq :=
+abbrev signext_body_0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base signext_body_0
 
 /-- Body 0: limb_idx=0, sign-extend limb 0 at sp+32, fill limbs 1-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + SD. Falls through to done. -/
 theorem signext_body_0_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v0 v1 v2 v3 : Word)
-    (base : Addr)
+    (base : Word)
     (hvalid : ValidMemRange sp 8) :
     let result := BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let sign_fill := BitVec.sshiftRight result 63
@@ -189,7 +189,7 @@ theorem signext_body_0_spec (sp : Word)
 -- ============================================================================
 
 /-- Done spec: ADDI x12, x12, 32 (pop b word). -/
-theorem signext_done_spec (sp : Word) (base : Addr) :
+theorem signext_done_spec (sp : Word) (base : Word) :
     let nsp := sp + signExtend12 (32 : BitVec 12)
     let code := CodeReq.singleton base (.ADDI .x12 .x12 32)
     cpsTriple base (base + 4) code
@@ -203,7 +203,7 @@ theorem signext_done_spec (sp : Word) (base : Addr) :
 
 /-- CodeReq for sign-extend phase B (5 instructions):
     ANDI x10,x5,7; SLLI x10,x10,3; ADDI x6,x0,56; SUB x6,x6,x10; SRLI x5,x5,3. -/
-abbrev signext_phase_b_code (base : Addr) : CodeReq :=
+abbrev signext_phase_b_code (base : Word) : CodeReq :=
   CodeReq.ofProg base signext_phase_b
 
 /-- Phase B spec: compute sign-extension parameters.
@@ -211,7 +211,7 @@ abbrev signext_phase_b_code (base : Addr) : CodeReq :=
     SUB x6,x6,x10; SRLI x5,x5,3.
     Outputs: x6 = 56 - (b%8)*8 (shift_amount), x5 = b/8 (limb_idx).
     Same computation as byte_phase_b_spec. -/
-theorem signext_phase_b_spec (b r6 r10 : Word) (base : Addr) :
+theorem signext_phase_b_spec (b r6 r10 : Word) (base : Word) :
     let byte_in_limb := b &&& signExtend12 (7 : BitVec 12)
     let byte_shift := byte_in_limb <<< (3 : BitVec 6).toNat
     let shift_amount := (56 : Word) - byte_shift
@@ -232,11 +232,11 @@ theorem signext_phase_b_spec (b r6 r10 : Word) (base : Addr) :
 -- LD/OR Accumulator Helper (2 instructions)
 -- ============================================================================
 
-abbrev signext_ld_or_acc_code (off : BitVec 12) (base : Addr) : CodeReq :=
+abbrev signext_ld_or_acc_code (off : BitVec 12) (base : Word) : CodeReq :=
   CodeReq.ofProg base (signext_ld_or_acc_prog off)
 
 theorem signext_ld_or_acc_spec (sp acc prev_x10 val : Word) (off : BitVec 12)
-    (base : Addr)
+    (base : Word)
     (hvalid : isValidDwordAccess (sp + signExtend12 off) = true) :
     let code := signext_ld_or_acc_code off base
     cpsTriple base (base + 8) code
@@ -250,13 +250,13 @@ theorem signext_ld_or_acc_spec (sp acc prev_x10 val : Word) (off : BitVec 12)
 -- Cascade Step Helper (2 instructions)
 -- ============================================================================
 
-abbrev signext_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Addr) : CodeReq :=
+abbrev signext_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Word) : CodeReq :=
   CodeReq.ofProg base (signext_cascade_step_prog k offset)
 
 /-- Cascade step: ADDI x10,x0,k followed by BEQ x5,x10,off.
     Produces a cpsBranch with clean postconditions (no pure facts). -/
 theorem signext_cascade_step_spec (v5 v10 : Word)
-    (k : BitVec 12) (offset : BitVec 13) (base target : Addr)
+    (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
     let k_val := (0 : Word) + signExtend12 k
     let code := signext_cascade_step_code k offset base
@@ -264,7 +264,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val))
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)) := by
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
@@ -309,7 +309,7 @@ private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h →
 
 /-- Phase A code as explicit union of sub-CRs (matching disjoint composition structure).
     9 instructions: LD + LD/OR + LD/OR + BNE + LD + SLTIU + BEQ -/
-abbrev signext_phase_a_code (base : Addr) : CodeReq :=
+abbrev signext_phase_a_code (base : Word) : CodeReq :=
   -- LD x5 x12 8 at base
   CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 8))
   -- LD x10 x12 16 + OR x5 x5 x10 at base+4, base+8
@@ -333,7 +333,7 @@ set_option maxHeartbeats 6400000 in
     Uses disjoint composition throughout (no extend_code). -/
 theorem signext_phase_a_spec (sp r5 r10 : Word)
     (b0 b1 b2 b3 : Word)
-    (base done_path : Addr)
+    (base done_path : Word)
     (hdone1 : (base + 20) + signExtend13 168 = done_path)
     (hdone2 : (base + 32) + signExtend13 156 = done_path)
     (hvalid : ValidMemRange sp 4) :
@@ -357,12 +357,12 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   have hv24 : isValidDwordAccess (sp + 24) = true := by
     have := hvalid.get (i := 3) (by omega); simpa using this
   -- Address arithmetic
-  have ha48 : (base + 4 : Addr) + 8 = base + 12 := by bv_omega
-  have ha128 : (base + 12 : Addr) + 8 = base + 20 := by bv_omega
-  have ha20 : (base + 20 : Addr) + 4 = base + 24 := by bv_omega
-  have ha24 : (base + 24 : Addr) + 4 = base + 28 := by bv_omega
-  have ha28 : (base + 28 : Addr) + 4 = base + 32 := by bv_omega
-  have ha32 : (base + 32 : Addr) + 4 = base + 36 := by bv_omega
+  have ha48 : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+  have ha128 : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+  have ha20 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+  have ha24 : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+  have ha28 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+  have ha32 : (base + 32 : Word) + 4 = base + 36 := by bv_omega
   -- Sub-CRs for each instruction group
   let cr_ld1 := CodeReq.singleton base (.LD .x5 .x12 8)
   let cr_lor2 := signext_ld_or_acc_code 16 (base + 4)
@@ -510,7 +510,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     (fun h hp => by xperm_hyp hp) c56 beq1f
   let cr_tail := (cr_ld5.union cr_sltiu).union cr_beq
   -- ── Part 4: Combine br1 and br2 ──
-  have sd_tail (a : Addr) (i : Instr)
+  have sd_tail (a : Word) (i : Instr)
       (h24 : a ≠ base + 24) (h28 : a ≠ base + 28) (h32 : a ≠ base + 32) :
       (CodeReq.singleton a i).Disjoint cr_tail :=
     CodeReq.Disjoint.union_right
@@ -615,7 +615,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
 -- ============================================================================
 
 /-- Phase C code as explicit union of sub-CRs (matching disjoint composition structure). -/
-abbrev signext_phase_c_code (base : Addr) : CodeReq :=
+abbrev signext_phase_c_code (base : Word) : CodeReq :=
   CodeReq.union (CodeReq.singleton base (.BEQ .x5 .x0 100))
   (CodeReq.union (signext_cascade_step_code 1 60 (base + 4))
   (signext_cascade_step_code 2 24 (base + 12)))
@@ -623,8 +623,8 @@ abbrev signext_phase_c_code (base : Addr) : CodeReq :=
 set_option maxHeartbeats 3200000 in
 /-- Phase C spec: cascade dispatch on limb_idx (0-3).
     Uses disjoint composition to chain BEQ + two cascade steps. -/
-theorem signext_phase_c_spec (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 100 = e0)
     (he1 : (base + 8) + signExtend13 60 = e1)
     (he2 : (base + 16) + signExtend13 24 = e2)
@@ -637,10 +637,10 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Addr)
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2))),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))] := by
   -- Address arithmetic
-  have hc1 : ((base + 4 : Addr) + 4) + signExtend13 60 = e1 := by
-    rw [show (base + 4 : Addr) + 4 = base + 8 from by bv_omega]; exact he1
-  have hc2 : ((base + 12 : Addr) + 4) + signExtend13 24 = e2 := by
-    rw [show (base + 12 : Addr) + 4 = base + 16 from by bv_omega]; exact he2
+  have hc1 : ((base + 4 : Word) + 4) + signExtend13 60 = e1 := by
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+  have hc2 : ((base + 12 : Word) + 4) + signExtend13 24 = e2 := by
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
   -- Sub-CRs
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 100)
   let cr_cs1 := signext_cascade_step_code 1 60 (base + 4)
@@ -682,10 +682,10 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Addr)
     (.x10 ↦ᵣ v10) (by pcFree) beq0
   -- Step 1: cascade step at base+4
   have cs1 := signext_cascade_step_spec v5 v10 1 60 (base + 4) e1 hc1
-  rw [show (base + 4 : Addr) + 8 = base + 12 from by bv_omega] at cs1
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1
   -- Step 2: cascade step at base+12
   have cs2 := signext_cascade_step_spec v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
-  rw [show (base + 12 : Addr) + 8 = base + 20 from by bv_omega] at cs2
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2
   -- Fallthrough at base+20
   have ft := cpsNBranch_refl (base + 20)
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))
@@ -730,7 +730,7 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Addr)
 
 /-- Cascade step with pure dispatch facts: each exit includes ⌜v5 = k_val⌝ / ⌜v5 ≠ k_val⌝. -/
 theorem signext_cascade_step_spec_pure (v5 v10 : Word)
-    (k : BitVec 12) (offset : BitVec 13) (base target : Addr)
+    (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
     let k_val := (0 : Word) + signExtend12 k
     let code := signext_cascade_step_code k offset base
@@ -738,7 +738,7 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 = k_val⌝)
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 ≠ k_val⌝) := by
-  have ha1 : (base + 4 : Addr) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
@@ -773,8 +773,8 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
 set_option maxHeartbeats 6400000 in
 /-- Phase C spec with pure dispatch facts: each exit postcondition includes
     the constraint that identifies which branch was taken. -/
-theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
-    (e0 e1 e2 e3 : Addr)
+theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
+    (e0 e1 e2 e3 : Word)
     (he0 : base + signExtend13 100 = e0)
     (he1 : (base + 8) + signExtend13 60 = e1)
     (he2 : (base + 16) + signExtend13 24 = e2)
@@ -786,10 +786,10 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
        (e1, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 = (0 : Word) + signExtend12 1⌝),
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 = (0 : Word) + signExtend12 2⌝),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝)] := by
-  have hc1 : ((base + 4 : Addr) + 4) + signExtend13 60 = e1 := by
-    rw [show (base + 4 : Addr) + 4 = base + 8 from by bv_omega]; exact he1
-  have hc2 : ((base + 12 : Addr) + 4) + signExtend13 24 = e2 := by
-    rw [show (base + 12 : Addr) + 4 = base + 16 from by bv_omega]; exact he2
+  have hc1 : ((base + 4 : Word) + 4) + signExtend13 60 = e1 := by
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+  have hc2 : ((base + 12 : Word) + 4) + signExtend13 24 = e2 := by
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 100)
   let cr_cs1 := signext_cascade_step_code 1 60 (base + 4)
   let cr_cs2 := signext_cascade_step_code 2 24 (base + 12)
@@ -823,7 +823,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := signext_cascade_step_spec_pure v5 v10 1 60 (base + 4) e1 hc1
-  rw [show (base + 4 : Addr) + 8 = base + 12 from by bv_omega] at cs1_raw
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1_raw
   have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
@@ -841,7 +841,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Addr)
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := signext_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
-  rw [show (base + 12 : Addr) + 8 = base + 20 from by bv_omega] at cs2_raw
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2_raw
   have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -46,14 +46,14 @@ private theorem signext_nochange_lift (sp base : Word)
   have hmain_f := cpsTriple_frame_left _ _ _ _ _ (.x6 ↦ᵣ r6) (by pcFree) hmain
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
+      simp only [evmWordIs]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
@@ -90,6 +90,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
         Classical.byContradiction (fun h => hhigh h)
       have hlarge : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = false := by
         have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh'
+        simp only [EvmWord.getLimb_as_getLimbN_0] at h_toNat
         rw [h_toNat] at hge
         have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by native_decide
         simp only [BitVec.ult, h31]
@@ -105,6 +106,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
       EvmWord.high_limbs_zero_of_toNat_lt b (by omega)
     have hsmall : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = true := by
       have hb_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh
+      simp only [EvmWord.getLimb_as_getLimbN_0] at hb_toNat
       have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by native_decide
       simp only [BitVec.ult, h31]
       cases h : decide ((b.getLimbN 0).toNat < 31)
@@ -114,18 +116,22 @@ theorem evm_signextend_stack_spec (sp base : Word)
     have h_raw := signext_body_spec sp base b x r5 r6 r10 hvalid hhigh hsmall
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
-        simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+        simp only [evmWordIs] at hp
         have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
         have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
         have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
         simp only [ha40, ha48, ha56] at hp
+        simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                   EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
         xperm_hyp hp)
       (fun h hq => by
-        simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
+        simp only [evmWordIs]
         have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
         have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
         have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
         simp only [ha40, ha48, ha56]
+        simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                   EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at hq
         xperm_hyp hq)
       h_raw
 

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -26,15 +26,15 @@ private theorem signext_nochange_lift (sp base : Word)
     (_hvalid : ValidMemRange sp 8)
     (hmain : cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
-       (sp ↦ₘ b.getLimb 0) ** ((sp + 8) ↦ₘ b.getLimb 1) **
-       ((sp + 16) ↦ₘ b.getLimb 2) ** ((sp + 24) ↦ₘ b.getLimb 3) **
-       ((sp + 32) ↦ₘ x.getLimb 0) ** ((sp + 40) ↦ₘ x.getLimb 1) **
-       ((sp + 48) ↦ₘ x.getLimb 2) ** ((sp + 56) ↦ₘ x.getLimb 3))
+       (sp ↦ₘ b.getLimbN 0) ** ((sp + 8) ↦ₘ b.getLimbN 1) **
+       ((sp + 16) ↦ₘ b.getLimbN 2) ** ((sp + 24) ↦ₘ b.getLimbN 3) **
+       ((sp + 32) ↦ₘ x.getLimbN 0) ** ((sp + 40) ↦ₘ x.getLimbN 1) **
+       ((sp + 48) ↦ₘ x.getLimbN 2) ** ((sp + 56) ↦ₘ x.getLimbN 3))
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
-       (sp ↦ₘ b.getLimb 0) ** ((sp + 8) ↦ₘ b.getLimb 1) **
-       ((sp + 16) ↦ₘ b.getLimb 2) ** ((sp + 24) ↦ₘ b.getLimb 3) **
-       ((sp + 32) ↦ₘ x.getLimb 0) ** ((sp + 40) ↦ₘ x.getLimb 1) **
-       ((sp + 48) ↦ₘ x.getLimb 2) ** ((sp + 56) ↦ₘ x.getLimb 3)))
+       (sp ↦ₘ b.getLimbN 0) ** ((sp + 8) ↦ₘ b.getLimbN 1) **
+       ((sp + 16) ↦ₘ b.getLimbN 2) ** ((sp + 24) ↦ₘ b.getLimbN 3) **
+       ((sp + 32) ↦ₘ x.getLimbN 0) ** ((sp + 40) ↦ₘ x.getLimbN 1) **
+       ((sp + 48) ↦ₘ x.getLimbN 2) ** ((sp + 56) ↦ₘ x.getLimbN 3)))
     (result : EvmWord) (hresult : result = x) :
     cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -46,14 +46,14 @@ private theorem signext_nochange_lift (sp base : Word)
   have hmain_f := cpsTriple_frame_left _ _ _ _ _ (.x6 ↦ᵣ r6) (by pcFree) hmain
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
@@ -82,18 +82,18 @@ theorem evm_signextend_stack_spec (sp base : Word)
   by_cases hge : b.toNat ≥ 31
   · -- b >= 31: result = x (no change)
     have hresult : result = x := by simp [result, EvmWord.signextend_ge31 b x hge]
-    by_cases hhigh : b.getLimb 1 ||| b.getLimb 2 ||| b.getLimb 3 ≠ 0
+    by_cases hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0
     · exact signext_nochange_lift sp base b x r5 r6 r10 hvalid
         (signext_nochange_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh hvalid)
         result hresult
-    · have hhigh' : b.getLimb 1 ||| b.getLimb 2 ||| b.getLimb 3 = 0 :=
+    · have hhigh' : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
-      have hlarge : BitVec.ult (b.getLimb 0) (signExtend12 (31 : BitVec 12)) = false := by
+      have hlarge : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = false := by
         have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh'
         rw [h_toNat] at hge
         have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by native_decide
         simp only [BitVec.ult, h31]
-        cases h : decide ((b.getLimb 0).toNat < 31)
+        cases h : decide ((b.getLimbN 0).toNat < 31)
         · rfl
         · simp at h; omega
       exact signext_nochange_lift sp base b x r5 r6 r10 hvalid
@@ -101,27 +101,27 @@ theorem evm_signextend_stack_spec (sp base : Word)
         result hresult
   · -- b < 31: body path
     push_neg at hge
-    have hhigh : b.getLimb 1 ||| b.getLimb 2 ||| b.getLimb 3 = 0 :=
+    have hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
       EvmWord.high_limbs_zero_of_toNat_lt b (by omega)
-    have hsmall : BitVec.ult (b.getLimb 0) (signExtend12 (31 : BitVec 12)) = true := by
+    have hsmall : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = true := by
       have hb_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh
       have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by native_decide
       simp only [BitVec.ult, h31]
-      cases h : decide ((b.getLimb 0).toNat < 31)
+      cases h : decide ((b.getLimbN 0).toNat < 31)
       · simp at h; omega
       · rfl
     -- Use the body path theorem from Compose, lifting to evmWordIs
     have h_raw := signext_body_spec sp base b x r5 r6 r10 hvalid hhigh hsmall
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
-        simp only [evmWordIs] at hp
+        simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
         have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
         have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
         have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
         simp only [ha40, ha48, ha56] at hp
         xperm_hyp hp)
       (fun h hq => by
-        simp only [evmWordIs]
+        simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
         have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
         have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
         have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -21,7 +21,7 @@ private theorem regIs_to_regOwn'' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h �
   fun _ hp => ⟨v, hp⟩
 
 /-- Helper: lift a no-change raw-limb spec to evmWordIs form (with x6 framing). -/
-private theorem signext_nochange_lift (sp base : Addr)
+private theorem signext_nochange_lift (sp base : Word)
     (b x : EvmWord) (r5 r6 r10 : Word)
     (_hvalid : ValidMemRange sp 8)
     (hmain : cpsTriple base (base + 192) (signextCode base)
@@ -47,16 +47,16 @@ private theorem signext_nochange_lift (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs]
-      have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56]
       have w := sepConj_mono_right (regIs_to_regOwn'' .x6 _) h hq
       xperm_hyp w)
@@ -69,7 +69,7 @@ private theorem signext_nochange_lift (sp base : Addr)
 set_option maxHeartbeats 1600000 in
 /-- **Main SIGNEXTEND theorem**: `evm_signextend` computes
     `EvmWord.signextend b x`. -/
-theorem evm_signextend_stack_spec (sp base : Addr)
+theorem evm_signextend_stack_spec (sp base : Word)
     (b x : EvmWord) (r5 r6 r10 : Word)
     (hvalid : ValidMemRange sp 8) :
     let result := EvmWord.signextend b x
@@ -115,16 +115,16 @@ theorem evm_signextend_stack_spec (sp base : Addr)
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         simp only [evmWordIs] at hp
-        have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-        have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-        have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+        have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+        have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+        have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
         simp only [ha40, ha48, ha56] at hp
         xperm_hyp hp)
       (fun h hq => by
         simp only [evmWordIs]
-        have ha40 : (sp + 32 : Addr) + 8 = sp + 40 := by bv_omega
-        have ha48 : (sp + 32 : Addr) + 16 = sp + 48 := by bv_omega
-        have ha56 : (sp + 32 : Addr) + 24 = sp + 56 := by bv_omega
+        have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
+        have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
+        have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
         simp only [ha40, ha48, ha56]
         xperm_hyp hq)
       h_raw

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -145,7 +145,7 @@ theorem evm_slt_stack_spec (sp base : Word)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
@@ -153,12 +153,14 @@ theorem evm_slt_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [EvmWord.getLimb_ite, EvmWord.getLimb_one, EvmWord.getLimb_zero,
-                 show ¬((1 : Fin 4) = 0) from by decide,
-                 show ¬((2 : Fin 4) = 0) from by decide,
-                 show ¬((3 : Fin 4) = 0) from by decide,
+      simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_one, EvmWord.getLimbN_zero,
+                 show ¬((1 : Nat) = 0) from by decide,
+                 show ¬((2 : Nat) = 0) from by decide,
+                 show ¬((3 : Nat) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.slt_result_correct a b]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -114,18 +114,18 @@ theorem evm_slt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Lower 3 limbs borrow chain (used when MSB limbs equal)
-    let borrow0 := if BitVec.ult (a.getLimb 0) (b.getLimb 0) then (1 : Word) else 0
-    let borrow1a := if BitVec.ult (a.getLimb 1) (b.getLimb 1) then (1 : Word) else 0
-    let temp1 := a.getLimb 1 - b.getLimb 1
+    let borrow0 := if BitVec.ult (a.getLimbN 0) (b.getLimbN 0) then (1 : Word) else 0
+    let borrow1a := if BitVec.ult (a.getLimbN 1) (b.getLimbN 1) then (1 : Word) else 0
+    let temp1 := a.getLimbN 1 - b.getLimbN 1
     let borrow1b := if BitVec.ult temp1 borrow0 then (1 : Word) else 0
     let borrow1 := borrow1a ||| borrow1b
-    let borrow2a := if BitVec.ult (a.getLimb 2) (b.getLimb 2) then (1 : Word) else 0
-    let temp2 := a.getLimb 2 - b.getLimb 2
+    let borrow2a := if BitVec.ult (a.getLimbN 2) (b.getLimbN 2) then (1 : Word) else 0
+    let temp2 := a.getLimbN 2 - b.getLimbN 2
     let borrow2b := if BitVec.ult temp2 borrow1 then (1 : Word) else 0
     let borrow2 := borrow2a ||| borrow2b
     -- Signed comparison of MSB limbs
-    let slt_msb := if BitVec.slt (a.getLimb 3) (b.getLimb 3) then (1 : Word) else 0
-    let result := if a.getLimb 3 = b.getLimb 3 then borrow2 else slt_msb
+    let slt_msb := if BitVec.slt (a.getLimbN 3) (b.getLimbN 3) then (1 : Word) else 0
+    let result := if a.getLimbN 3 = b.getLimbN 3 then borrow2 else slt_msb
     let code := evm_slt_code base
     cpsTriple base (base + 100) code
       (-- Registers + memory
@@ -133,19 +133,19 @@ theorem evm_slt_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) b)
       (-- Registers + memory (updated)
        (.x12 ↦ᵣ (sp + 32)) **
-       (.x7 ↦ᵣ (if a.getLimb 3 = b.getLimb 3 then temp2 else a.getLimb 3)) **
-       (.x6 ↦ᵣ (if a.getLimb 3 = b.getLimb 3 then borrow2b else b.getLimb 3)) **
+       (.x7 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then temp2 else a.getLimbN 3)) **
+       (.x6 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2b else b.getLimbN 3)) **
        (.x5 ↦ᵣ result) **
-       (.x11 ↦ᵣ (if a.getLimb 3 = b.getLimb 3 then borrow2a else v11)) **
+       (.x11 ↦ᵣ (if a.getLimbN 3 = b.getLimbN 3 then borrow2a else v11)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (if BitVec.slt a b then 1 else 0)) := by
   intro borrow0 borrow1a temp1 borrow1b borrow1 borrow2a temp2 borrow2b borrow2 slt_msb result
   have h_main := evm_slt_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -19,7 +19,7 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM SLT operation.
     25 instructions = 100 bytes. MSB signed compare + lower borrow chain + store. -/
-abbrev evm_slt_code (base : Addr) : CodeReq :=
+abbrev evm_slt_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_slt
 
 /-- Full 256-bit EVM SLT: SLT(a, b) = 1 iff a <s b (signed).
@@ -28,7 +28,7 @@ abbrev evm_slt_code (base : Addr) : CodeReq :=
     Pops 2 stack words (A at sp, B at sp+32),
     writes result to sp+32..sp+56, advances sp by 32.
     25 instructions = 100 bytes total. -/
-theorem evm_slt_spec (sp : Addr) (base : Addr)
+theorem evm_slt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -70,7 +70,7 @@ theorem evm_slt_spec (sp : Addr) (base : Addr)
     have M := slt_msb_load_spec 24 56 sp a3 a3 v7 v6 base (by validMem) (by validMem)
     -- BEQ taken (a3 = a3)
     have B := beq_eq_spec .x7 .x6 (12 : BitVec 13) a3 (base + 8)
-    have hsig13 : signExtend13 (12 : BitVec 13) = (12 : Addr) := by native_decide
+    have hsig13 : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
     simp only [hsig13] at B
     -- Lower limb borrow chain
     have L0 := lt_limb0_spec 0 32 sp a0 b0 a3 a3 v5 (base + 20) (by validMem) (by validMem)
@@ -94,7 +94,7 @@ theorem evm_slt_spec (sp : Addr) (base : Addr)
     have S := slt_spec_gen .x5 .x7 .x6 v5 a3 b3 (base + 12) (by nofun)
     -- JAL to store
     have J := jal_x0_spec_gen (64 : BitVec 21) (base + 16)
-    have hsig21 : signExtend21 (64 : BitVec 21) = (64 : Addr) := by native_decide
+    have hsig21 : signExtend21 (64 : BitVec 21) = (64 : Word) := by native_decide
     simp only [hsig21] at J
     -- Store phase
     have A := addi_spec_gen_same .x12 sp 32 (base + 80) (by nofun)
@@ -110,7 +110,7 @@ theorem evm_slt_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM SLT: operates on two EvmWords via evmWordIs. -/
-theorem evm_slt_stack_spec (sp base : Addr)
+theorem evm_slt_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     -- Lower 3 limbs borrow chain (used when MSB limbs equal)
@@ -146,9 +146,9 @@ theorem evm_slt_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
@@ -159,9 +159,9 @@ theorem evm_slt_stack_spec (sp base : Addr)
                  show ¬((3 : Fin 4) = 0) from by decide,
                  ite_true, ite_false, ite_self,
                  ← EvmWord.slt_result_correct a b]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -15,10 +15,10 @@ open EvmWord
 /-- Assert that 4 consecutive memory doublewords hold the limbs of an EvmWord.
     The limbs are stored little-endian: addr+0 is the LSB limb, addr+24 is the MSB limb. -/
 def evmWordIs (addr : Word) (v : EvmWord) : Assertion :=
-  (addr ↦ₘ v.getLimb 0) **
-  ((addr + 8) ↦ₘ v.getLimb 1) **
-  ((addr + 16) ↦ₘ v.getLimb 2) **
-  ((addr + 24) ↦ₘ v.getLimb 3)
+  (addr ↦ₘ v.getLimbN 0) **
+  ((addr + 8) ↦ₘ v.getLimbN 1) **
+  ((addr + 16) ↦ₘ v.getLimbN 2) **
+  ((addr + 24) ↦ₘ v.getLimbN 3)
 
 /-- Assert an EVM stack starting at sp. Each element is 32 bytes (4 × 8-byte limbs). -/
 def evmStackIs (sp : Word) (values : List EvmWord) : Assertion :=

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -14,38 +14,38 @@ open EvmWord
 
 /-- Assert that 4 consecutive memory doublewords hold the limbs of an EvmWord.
     The limbs are stored little-endian: addr+0 is the LSB limb, addr+24 is the MSB limb. -/
-def evmWordIs (addr : Addr) (v : EvmWord) : Assertion :=
+def evmWordIs (addr : Word) (v : EvmWord) : Assertion :=
   (addr ↦ₘ v.getLimb 0) **
   ((addr + 8) ↦ₘ v.getLimb 1) **
   ((addr + 16) ↦ₘ v.getLimb 2) **
   ((addr + 24) ↦ₘ v.getLimb 3)
 
 /-- Assert an EVM stack starting at sp. Each element is 32 bytes (4 × 8-byte limbs). -/
-def evmStackIs (sp : Addr) (values : List EvmWord) : Assertion :=
+def evmStackIs (sp : Word) (values : List EvmWord) : Assertion :=
   match values with
   | [] => empAssertion
   | v :: vs => evmWordIs sp v ** evmStackIs (sp + 32) vs
 
-theorem pcFree_evmWordIs (addr : Addr) (v : EvmWord) :
+theorem pcFree_evmWordIs (addr : Word) (v : EvmWord) :
     (evmWordIs addr v).pcFree := by
   unfold evmWordIs; pcFree
 
-theorem pcFree_evmStackIs (sp : Addr) (values : List EvmWord) :
+theorem pcFree_evmStackIs (sp : Word) (values : List EvmWord) :
     (evmStackIs sp values).pcFree := by
   induction values generalizing sp with
   | nil => exact pcFree_emp
   | cons v vs ih => exact pcFree_sepConj (pcFree_evmWordIs sp v) (ih (sp + 32))
 
-instance (addr : Addr) (v : EvmWord) : Assertion.PCFree (evmWordIs addr v) :=
+instance (addr : Word) (v : EvmWord) : Assertion.PCFree (evmWordIs addr v) :=
   ⟨pcFree_evmWordIs addr v⟩
 
-instance (sp : Addr) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp values) :=
+instance (sp : Word) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp values) :=
   ⟨pcFree_evmStackIs sp values⟩
 
-theorem evmStackIs_cons (sp : Addr) (v : EvmWord) (vs : List EvmWord) :
+theorem evmStackIs_cons (sp : Word) (v : EvmWord) (vs : List EvmWord) :
     evmStackIs sp (v :: vs) = (evmWordIs sp v ** evmStackIs (sp + 32) vs) := rfl
 
-theorem evmStackIs_nil (sp : Addr) :
+theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 
 -- ============================================================================
@@ -69,7 +69,7 @@ theorem signExtend12_ofNat_small (m : Nat) (hm : m < 2048) :
   · rw [BitVec.msb_eq_false_iff_two_mul_lt]; simp [BitVec.toNat_ofNat]; omega
 
 /-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
-theorem evmStackIs_split_at (sp : Addr) (stack : List EvmWord) (k : Nat)
+theorem evmStackIs_split_at (sp : Word) (stack : List EvmWord) (k : Nat)
     (hk : k < stack.length) :
     evmStackIs sp stack =
       (evmStackIs sp (stack.take k) **
@@ -89,10 +89,10 @@ theorem evmStackIs_split_at (sp : Addr) (stack : List EvmWord) (k : Nat)
     | nil => simp at hk
     | cons v vs =>
       have hk' : k < vs.length := by simp at hk; omega
-      have a1 : sp + (32 : Addr) + BitVec.ofNat 64 (k * 32) =
+      have a1 : sp + (32 : Word) + BitVec.ofNat 64 (k * 32) =
                 sp + BitVec.ofNat 64 ((k + 1) * 32) := by
         apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-      have a2 : sp + (32 : Addr) + BitVec.ofNat 64 ((k + 1) * 32) =
+      have a2 : sp + (32 : Word) + BitVec.ofNat 64 ((k + 1) * 32) =
                 sp + BitVec.ofNat 64 ((k + 2) * 32) := by
         apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
       rw [evmStackIs_cons, ih (sp + 32) vs hk', a1, a2]

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -16,7 +16,7 @@ namespace EvmAsm.Rv64
 /-- SUB limb 0 spec (5 instructions): LD, LD, SLTU, SUB, SD.
     Computes diff = a - b (mod 2^64) and borrow = (a < b ? 1 : 0). -/
 theorem sub_limb0_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -39,7 +39,7 @@ theorem sub_limb0_spec (off_a off_b : BitVec 12)
 /-- SUB carry limb phase 1 (4 instructions): LD, LD, SLTU, SUB.
     Loads a_limb and b_limb, computes borrow1 = (a < b ? 1 : 0), temp = a - b. -/
 theorem sub_limb_carry_spec_phase1 (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a
@@ -62,7 +62,7 @@ theorem sub_limb_carry_spec_phase1 (off_a off_b : BitVec 12)
     Takes temp, borrow1, borrow_in, computes borrow2 = (temp < borrow_in ? 1 : 0),
     result = temp - borrow_in, borrow_out = borrow1 ||| borrow2. -/
 theorem sub_limb_carry_spec_phase2 (off_b : BitVec 12)
-    (sp temp b_limb borrow_in borrow1 a_limb : Word) (mem_a : Addr) (base : Addr)
+    (sp temp b_limb borrow_in borrow1 a_limb : Word) (mem_a : Word) (base : Word)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_b := sp + signExtend12 off_b
     let borrow2 := if BitVec.ult temp borrow_in then (1 : Word) else 0
@@ -83,7 +83,7 @@ theorem sub_limb_carry_spec_phase2 (off_b : BitVec 12)
 /-- SUB carry limb spec (8 instructions): LD, LD, SLTU, SUB, SLTU, SUB, OR, SD.
     Composed from phase1 and phase2. -/
 theorem sub_limb_carry_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -107,18 +107,20 @@ theorem evm_sub_stack_spec (sp base : Word)
   have ⟨h0, h1, h2, h3⟩ := EvmWord.sub_borrow_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
+      simp only [evmWordIs]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
+                 EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at h0 h1 h2 h3
       rw [h0, h1, h2, h3]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -68,10 +68,10 @@ theorem evm_sub_spec (sp : Word) (base : Word)
 theorem evm_sub_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
-    let a0 := a.getLimb 0; let b0 := b.getLimb 0
-    let a1 := a.getLimb 1; let b1 := b.getLimb 1
-    let a2 := a.getLimb 2; let b2 := b.getLimb 2
-    let a3 := a.getLimb 3; let b3 := b.getLimb 3
+    let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
+    let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
+    let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
+    let a3 := a.getLimbN 3; let b3 := b.getLimbN 3
     let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
     let _diff0 := a0 - b0
     let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
@@ -100,21 +100,21 @@ theorem evm_sub_stack_spec (sp base : Word)
        evmWordIs sp a ** evmWordIs (sp + 32) (a - b)) := by
   intro a0 b0 a1 b1 a2 b2 a3 b3 borrow0 diff0 borrow1a temp1 borrow1b result1 borrow1 borrow2a temp2 borrow2b result2 borrow2 borrow3a temp3 borrow3b result3 borrow3
   have h_main := evm_sub_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 v5 v11 hvalid
   -- Get the borrow chain correctness
   have ⟨h0, h1, h2, h3⟩ := EvmWord.sub_borrow_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -14,14 +14,14 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM SUB operation.
     30 instructions = 120 bytes. 4 per-limb SUB blocks + ADDI sp adjustment. -/
-abbrev evm_sub_code (base : Addr) : CodeReq :=
+abbrev evm_sub_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_sub
 
 /-- Full 256-bit EVM SUB: composes 4 per-limb SUB specs + ADDI sp adjustment.
     30 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A - B to sp+32..sp+56, advances sp by 32.
     Borrow propagates through limbs via x5. -/
-theorem evm_sub_spec (sp : Addr) (base : Addr)
+theorem evm_sub_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
@@ -65,7 +65,7 @@ theorem evm_sub_spec (sp : Addr) (base : Addr)
 -- ============================================================================
 
 /-- Stack-level 256-bit EVM SUB: operates on two EvmWords via evmWordIs. -/
-theorem evm_sub_stack_spec (sp base : Addr)
+theorem evm_sub_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 v5 v11 : Word)
     (hvalid : ValidMemRange sp 8) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
@@ -108,16 +108,16 @@ theorem evm_sub_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       rw [h0, h1, h2, h3]
       xperm_hyp hq)

--- a/EvmAsm/Evm64/Swap/Program.lean
+++ b/EvmAsm/Evm64/Swap/Program.lean
@@ -25,7 +25,7 @@ def evm_swap (n : Nat) : Program :=
 
 /-- CodeReq for generic SWAPn: 16 instructions = 64 bytes.
     Built as an explicit union chain because symbolic n prevents ofProg reduction. -/
-abbrev evm_swap_code (base : Addr) (n : Nat) : CodeReq :=
+abbrev evm_swap_code (base : Word) (n : Nat) : CodeReq :=
   -- Limb 0
   CodeReq.singleton base (.LD .x7 .x12 (BitVec.ofNat 12 0))
   |>.union (CodeReq.singleton (base + 4)  (.LD .x6 .x12 (BitVec.ofNat 12 (n*32))))

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -139,10 +139,10 @@ theorem evm_swap_evmword_spec (sp base : Word)
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, ha8, ha16, ha24] at hp
+      simp only [evmWordIs, ha8, ha16, ha24] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, ha8, ha16, ha24]
+      simp only [evmWordIs, ha8, ha16, ha24]
       xperm_hyp hq)
     (evm_swap_spec sp base n hn1 hn16
       (top.getLimbN 0) (top.getLimbN 1) (top.getLimbN 2) (top.getLimbN 3)

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -127,7 +127,7 @@ theorem evm_swap_evmword_spec (sp base : Word)
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp top **
        evmWordIs (sp + BitVec.ofNat 64 (n * 32)) nth)
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimb 3) ** (.x6 ↦ᵣ nth.getLimb 3) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimbN 3) ** (.x6 ↦ᵣ nth.getLimbN 3) **
        evmWordIs sp nth **
        evmWordIs (sp + BitVec.ofNat 64 (n * 32)) top) := by
   -- Address normalizations
@@ -139,14 +139,14 @@ theorem evm_swap_evmword_spec (sp base : Word)
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, ha8, ha16, ha24] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, ha8, ha16, ha24] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, ha8, ha16, ha24]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, ha8, ha16, ha24]
       xperm_hyp hq)
     (evm_swap_spec sp base n hn1 hn16
-      (top.getLimb 0) (top.getLimb 1) (top.getLimb 2) (top.getLimb 3)
-      (nth.getLimb 0) (nth.getLimb 1) (nth.getLimb 2) (nth.getLimb 3)
+      (top.getLimbN 0) (top.getLimbN 1) (top.getLimbN 2) (top.getLimbN 3)
+      (nth.getLimbN 0) (nth.getLimbN 1) (nth.getLimbN 2) (nth.getLimbN 3)
       v7 v6 hvalid)
 
 -- ============================================================================
@@ -164,7 +164,7 @@ theorem evm_swap_stack_spec (sp base : Word)
     cpsTriple base (base + 64) (evm_swap_code base n)
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmStackIs sp stack)
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimb 3) ** (.x6 ↦ᵣ nth.getLimb 3) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ top.getLimbN 3) ** (.x6 ↦ᵣ nth.getLimbN 3) **
        evmWordIs sp nth **
        evmStackIs (sp + 32) ((stack.drop 1).take (n - 1)) **
        evmWordIs (sp + BitVec.ofNat 64 (n * 32)) top **

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -19,8 +19,8 @@ namespace EvmAsm.Rv64
 
 /-- Four-instruction spec for SWAP per-limb: LD x7 from A, LD x6 from B,
     SD x6 to A, SD x7 to B. Swaps values at offsets off_a and off_b. -/
-theorem swap_limb_spec (sp : Addr)
-    (off_a off_b : BitVec 12) (a_val b_val v7 v6 : Word) (base : Addr)
+theorem swap_limb_spec (sp : Word)
+    (off_a off_b : BitVec 12) (a_val b_val v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     cpsTriple base (base + 16)
@@ -41,7 +41,7 @@ theorem swap_limb_spec (sp : Addr)
 set_option maxHeartbeats 6400000 in
 /-- Generic SWAPn spec (low level): swaps 4 dword limbs at sp (top) with 4 at sp+n*32 (nth).
     Requires 1 ≤ n ≤ 16 (valid EVM SWAP range). -/
-theorem evm_swap_spec (sp base : Addr)
+theorem evm_swap_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (a0 a1 a2 a3 : Word)
     (b0 b1 b2 b3 : Word)
@@ -119,7 +119,7 @@ theorem evm_swap_spec (sp base : Addr)
 -- ============================================================================
 
 /-- SWAPn spec at evmWordIs level: swaps the top and nth stack elements. -/
-theorem evm_swap_evmword_spec (sp base : Addr)
+theorem evm_swap_evmword_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (top nth : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp ((n + 1) * 4)) :
@@ -131,11 +131,11 @@ theorem evm_swap_evmword_spec (sp base : Addr)
        evmWordIs sp nth **
        evmWordIs (sp + BitVec.ofNat 64 (n * 32)) top) := by
   -- Address normalizations
-  have ha8  : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 8  = sp + BitVec.ofNat 64 (n*32+8)  := by
+  have ha8  : (sp + BitVec.ofNat 64 (n * 32) : Word) + 8  = sp + BitVec.ofNat 64 (n*32+8)  := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have ha16 : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 16 = sp + BitVec.ofNat 64 (n*32+16) := by
+  have ha16 : (sp + BitVec.ofNat 64 (n * 32) : Word) + 16 = sp + BitVec.ofNat 64 (n*32+16) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have ha24 : (sp + BitVec.ofNat 64 (n * 32) : Addr) + 24 = sp + BitVec.ofNat 64 (n*32+24) := by
+  have ha24 : (sp + BitVec.ofNat 64 (n * 32) : Word) + 24 = sp + BitVec.ofNat 64 (n*32+24) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
@@ -154,7 +154,7 @@ theorem evm_swap_evmword_spec (sp base : Addr)
 -- ============================================================================
 
 /-- SWAPn stack spec: swaps top with the nth element (1-indexed) of the stack. -/
-theorem evm_swap_stack_spec (sp base : Addr)
+theorem evm_swap_stack_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (stack : List EvmWord) (hlen : n + 1 ≤ stack.length)
     (v7 v6 : Word)
@@ -177,10 +177,10 @@ theorem evm_swap_stack_spec (sp base : Addr)
   have htail_len : n - 1 < (stack.drop 1).length := by simp; omega
   have hsplit1 := evmStackIs_split_at (sp + 32) (stack.drop 1) (n - 1) htail_len
   -- Address normalizations
-  have haddr_src : (sp + 32 : Addr) + BitVec.ofNat 64 ((n - 1) * 32) =
+  have haddr_src : (sp + 32 : Word) + BitVec.ofNat 64 ((n - 1) * 32) =
       sp + BitVec.ofNat 64 (n * 32) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
-  have haddr_rest : (sp + 32 : Addr) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
+  have haddr_rest : (sp + 32 : Word) + BitVec.ofNat 64 (((n - 1) + 1) * 32) =
       sp + BitVec.ofNat 64 ((n + 1) * 32) := by
     apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
   -- Simplify element access
@@ -193,7 +193,7 @@ theorem evm_swap_stack_spec (sp base : Addr)
      evmStackIs (sp + BitVec.ofNat 64 ((n + 1) * 32)) ((stack.drop 1).drop n))
     (by pcFree)
     (evm_swap_evmword_spec sp base n hn1 hn16 top nth v7 v6 hvalid)
-  have haddr32 : (sp + BitVec.ofNat 64 (1 * 32) : Addr) = sp + 32 := by bv_omega
+  have haddr32 : (sp + BitVec.ofNat 64 (1 * 32) : Word) = sp + 32 := by bv_omega
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       rw [hsplit0] at hp

--- a/EvmAsm/Evm64/Xor/LimbSpec.lean
+++ b/EvmAsm/Evm64/Xor/LimbSpec.lean
@@ -15,7 +15,7 @@ namespace EvmAsm.Rv64
 
 /-- Per-limb XOR spec (4 instructions: LD x7, LD x6, XOR x7 x7 x6, SD x12 x7). -/
 theorem xor_limb_spec (off_a off_b : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Addr)
+    (sp a_limb b_limb v7 v6 : Word) (base : Word)
     (hvalid_a : isValidDwordAccess (sp + signExtend12 off_a) = true)
     (hvalid_b : isValidDwordAccess (sp + signExtend12 off_b) = true) :
     let mem_a := sp + signExtend12 off_a

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -48,14 +48,14 @@ theorem evm_xor_stack_spec (sp base : Word)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
+      simp only [evmWordIs] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_xor]
+      simp only [evmWordIs, EvmWord.getLimbN_xor]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -40,22 +40,22 @@ theorem evm_xor_stack_spec (sp base : Word)
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp a ** evmWordIs (sp + 32) b)
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimb 3 ^^^ b.getLimb 3)) ** (.x6 ↦ᵣ b.getLimb 3) **
+      ((.x12 ↦ᵣ (sp + 32)) ** (.x7 ↦ᵣ (a.getLimbN 3 ^^^ b.getLimbN 3)) ** (.x6 ↦ᵣ b.getLimbN 3) **
        evmWordIs sp a ** evmWordIs (sp + 32) (a ^^^ b)) := by
   have h_main := evm_xor_spec sp base
-    (a.getLimb 0) (a.getLimb 1) (a.getLimb 2) (a.getLimb 3)
-    (b.getLimb 0) (b.getLimb 1) (b.getLimb 2) (b.getLimb 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v7 v6 hvalid
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      simp only [evmWordIs] at hp
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN] at hp
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimb_xor]
+      simp only [evmWordIs, EvmWord.getLimb_eq_getLimbN, EvmWord.getLimbN_xor]
       have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
       have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
       have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -10,11 +10,11 @@ namespace EvmAsm.Rv64
 
 /-- CodeReq for the 256-bit EVM XOR operation.
     17 instructions = 68 bytes. 4 per-limb XOR blocks + ADDI sp adjustment. -/
-abbrev evm_xor_code (base : Addr) : CodeReq :=
+abbrev evm_xor_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_xor
 
 /-- Full 256-bit EVM XOR: composes 4 per-limb XOR specs + sp adjustment. -/
-theorem evm_xor_spec (sp base : Addr)
+theorem evm_xor_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_xor_code base
@@ -33,7 +33,7 @@ theorem evm_xor_spec (sp base : Addr)
   runBlock L0 L1 L2 L3 LADDI
 
 /-- Stack-level 256-bit EVM XOR. -/
-theorem evm_xor_stack_spec (sp base : Addr)
+theorem evm_xor_stack_spec (sp base : Word)
     (a b : EvmWord) (v7 v6 : Word)
     (hvalid : ValidMemRange sp 8) :
     let code := evm_xor_code base
@@ -49,16 +49,16 @@ theorem evm_xor_stack_spec (sp base : Addr)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimb_xor]
-      have : (sp : Addr) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Addr) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Addr) + 32 + 24 = sp + 56 := by bv_omega
+      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
+      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
+      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
       rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
       xperm_hyp hq)
     h_main

--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -53,8 +53,8 @@ end Reg
 /-- We use 64-bit words as our machine word size. -/
 abbrev Word := BitVec 64
 
-/-- Memory addresses are words. -/
-abbrev Addr := Word
+-- Note: Addr was previously a separate abbrev but has been unified with Word
+-- to avoid Expr.hash mismatches in the xperm tactic (Addr vs Word vs BitVec 64).
 
 -- ============================================================================
 -- Instructions (RV64IM)
@@ -198,71 +198,71 @@ def MEM_START : Nat := 0x20
 def MEM_END : Nat := 0x78000000
 
 /-- Address is 8-byte aligned (doubleword). -/
-def isAligned8 (addr : Addr) : Bool := addr.toNat % 8 == 0
+def isAligned8 (addr : Word) : Bool := addr.toNat % 8 == 0
 
 /-- Address is 4-byte aligned. -/
-def isAligned4 (addr : Addr) : Bool := addr.toNat % 4 == 0
+def isAligned4 (addr : Word) : Bool := addr.toNat % 4 == 0
 
 /-- Address is in valid memory range. -/
-def isValidMemAddr (addr : Addr) : Bool :=
+def isValidMemAddr (addr : Word) : Bool :=
   decide (MEM_START ≤ addr.toNat) && decide (addr.toNat ≤ MEM_END)
 
 /-- Valid doubleword memory access: in range AND 8-byte aligned. -/
-def isValidDwordAccess (addr : Addr) : Bool :=
+def isValidDwordAccess (addr : Word) : Bool :=
   isValidMemAddr addr && isAligned8 addr
 
 /-- Valid word-size memory access: in range AND 4-byte aligned. -/
-def isValidMemAccess (addr : Addr) : Bool :=
+def isValidMemAccess (addr : Word) : Bool :=
   isValidMemAddr addr && isAligned4 addr
 
-@[simp] theorem isValidDwordAccess_eq (addr : Addr) :
+@[simp] theorem isValidDwordAccess_eq (addr : Word) :
     isValidDwordAccess addr = (isValidMemAddr addr && isAligned8 addr) := rfl
 
-@[simp] theorem isValidMemAccess_eq (addr : Addr) :
+@[simp] theorem isValidMemAccess_eq (addr : Word) :
     isValidMemAccess addr = (isValidMemAddr addr && isAligned4 addr) := rfl
 
-@[simp] theorem isValidMemAddr_eq (addr : Addr) :
+@[simp] theorem isValidMemAddr_eq (addr : Word) :
     isValidMemAddr addr = (decide (MEM_START ≤ addr.toNat) && decide (addr.toNat ≤ MEM_END)) := rfl
 
-@[simp] theorem isAligned8_eq (addr : Addr) :
+@[simp] theorem isAligned8_eq (addr : Word) :
     isAligned8 addr = (addr.toNat % 8 == 0) := rfl
 
-@[simp] theorem isAligned4_eq (addr : Addr) :
+@[simp] theorem isAligned4_eq (addr : Word) :
     isAligned4 addr = (addr.toNat % 4 == 0) := rfl
 
 /-- Address is 2-byte aligned. -/
-def isAligned2 (addr : Addr) : Bool := addr.toNat % 2 == 0
+def isAligned2 (addr : Word) : Bool := addr.toNat % 2 == 0
 
 /-- Valid halfword memory access: in range AND 2-byte aligned. -/
-def isValidHalfwordAccess (addr : Addr) : Bool :=
+def isValidHalfwordAccess (addr : Word) : Bool :=
   isValidMemAddr addr && isAligned2 addr
 
 /-- Valid byte memory access: in range (bytes need no alignment). -/
-def isValidByteAccess (addr : Addr) : Bool :=
+def isValidByteAccess (addr : Word) : Bool :=
   isValidMemAddr addr
 
-@[simp] theorem isAligned2_eq (addr : Addr) :
+@[simp] theorem isAligned2_eq (addr : Word) :
     isAligned2 addr = (addr.toNat % 2 == 0) := rfl
 
-@[simp] theorem isValidHalfwordAccess_eq (addr : Addr) :
+@[simp] theorem isValidHalfwordAccess_eq (addr : Word) :
     isValidHalfwordAccess addr = (isValidMemAddr addr && isAligned2 addr) := rfl
 
-@[simp] theorem isValidByteAccess_eq (addr : Addr) :
+@[simp] theorem isValidByteAccess_eq (addr : Word) :
     isValidByteAccess addr = isValidMemAddr addr := rfl
 
 /-- ValidMemRange addr n holds when n consecutive doubleword-aligned memory accesses
     starting at addr are all valid. -/
-def ValidMemRange (addr : Addr) (n : Nat) : Prop :=
+def ValidMemRange (addr : Word) (n : Nat) : Prop :=
   ∀ (i : Nat), i < n → isValidDwordAccess (addr + BitVec.ofNat 64 (8 * i)) = true
 
 /-- Extract a single validity fact from ValidMemRange. -/
-theorem ValidMemRange.get {addr : Addr} {n : Nat}
+theorem ValidMemRange.get {addr : Word} {n : Nat}
     (h : ValidMemRange addr n) {i : Nat} (hi : i < n) :
     isValidDwordAccess (addr + BitVec.ofNat 64 (8 * i)) = true := h i hi
 
 /-- Extract a single validity fact from ValidMemRange with address normalization. -/
-theorem ValidMemRange.fetch {addr : Addr} {n : Nat}
-    (h : ValidMemRange addr n) (i : Nat) (target : Addr)
+theorem ValidMemRange.fetch {addr : Word} {n : Nat}
+    (h : ValidMemRange addr n) (i : Nat) (target : Word)
     (hi : i < n)
     (haddr : addr + BitVec.ofNat 64 (8 * i) = target) :
     isValidDwordAccess target = true := by
@@ -296,10 +296,10 @@ def replaceWord32 (w : Word) (pos : Nat) (v : BitVec 32) : Word :=
   (w &&& mask) ||| ((v.zeroExtend 64) <<< (pos * 32))
 
 /-- Align an address down to the nearest 8-byte boundary. -/
-def alignToDword (addr : Addr) : Addr := addr &&& ~~~7#64
+def alignToDword (addr : Word) : Word := addr &&& ~~~7#64
 
 /-- Get the byte offset within a doubleword (0-7). -/
-def byteOffset (addr : Addr) : Nat := (addr &&& 7#64).toNat
+def byteOffset (addr : Word) : Nat := (addr &&& 7#64).toNat
 
 -- ============================================================================
 -- Machine State
@@ -311,9 +311,9 @@ structure MachineState where
   /-- Register file: maps register to its value -/
   regs : Reg → Word
   /-- Doubleword-addressable memory -/
-  mem  : Addr → Word
+  mem  : Word → Word
   /-- Code memory: maps addresses to instructions -/
-  code : Addr → Option Instr := fun _ => none
+  code : Word → Option Instr := fun _ => none
   /-- Program counter -/
   pc   : Word
   /-- Committed public outputs (a0, a1) from COMMIT syscalls -/
@@ -338,11 +338,11 @@ def setReg (s : MachineState) (r : Reg) (v : Word) : MachineState :=
   | _   => { s with regs := fun r' => if r' == r then v else s.regs r' }
 
 /-- Read memory at an address. -/
-def getMem (s : MachineState) (a : Addr) : Word :=
+def getMem (s : MachineState) (a : Word) : Word :=
   s.mem a
 
 /-- Write memory at an address. -/
-def setMem (s : MachineState) (a : Addr) (v : Word) : MachineState :=
+def setMem (s : MachineState) (a : Word) (v : Word) : MachineState :=
   { s with mem := fun a' => if a' == a then v else s.mem a' }
 
 /-- Set the program counter. -/
@@ -354,12 +354,12 @@ def appendCommit (s : MachineState) (a0 a1 : Word) : MachineState :=
   { s with committed := s.committed ++ [(a0, a1)] }
 
 /-- Read n consecutive doublewords from memory starting at base address. -/
-def readWords (s : MachineState) (base : Addr) : Nat → List Word
+def readWords (s : MachineState) (base : Word) : Nat → List Word
   | 0 => []
   | n + 1 => s.getMem base :: readWords s (base + 8) n
 
 /-- Write n consecutive doublewords to memory starting at base address. -/
-def writeWords (s : MachineState) (base : Addr) : List Word → MachineState
+def writeWords (s : MachineState) (base : Word) : List Word → MachineState
   | [] => s
   | w :: ws => (s.setMem base w).writeWords (base + 8) ws
 
@@ -369,37 +369,37 @@ def appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) : MachineSta
 
 /-- Read a byte from memory at an arbitrary byte address.
     Reads the containing doubleword and extracts the appropriate byte. -/
-def getByte (s : MachineState) (addr : Addr) : BitVec 8 :=
+def getByte (s : MachineState) (addr : Word) : BitVec 8 :=
   extractByte (s.getMem (alignToDword addr)) (byteOffset addr)
 
 /-- Read a halfword from memory at a 2-byte aligned address. -/
-def getHalfword (s : MachineState) (addr : Addr) : BitVec 16 :=
+def getHalfword (s : MachineState) (addr : Word) : BitVec 16 :=
   extractHalfword (s.getMem (alignToDword addr)) ((byteOffset addr) / 2)
 
 /-- Read a 32-bit word from memory at a 4-byte aligned address. -/
-def getWord32 (s : MachineState) (addr : Addr) : BitVec 32 :=
+def getWord32 (s : MachineState) (addr : Word) : BitVec 32 :=
   extractWord32 (s.getMem (alignToDword addr)) ((byteOffset addr) / 4)
 
 /-- Write a byte to memory at an arbitrary byte address. -/
-def setByte (s : MachineState) (addr : Addr) (b : BitVec 8) : MachineState :=
+def setByte (s : MachineState) (addr : Word) (b : BitVec 8) : MachineState :=
   let wa := alignToDword addr
   let pos := byteOffset addr
   s.setMem wa (replaceByte (s.getMem wa) pos b)
 
 /-- Write a halfword to memory at a 2-byte aligned address. -/
-def setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) : MachineState :=
+def setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) : MachineState :=
   let wa := alignToDword addr
   let pos := (byteOffset addr) / 2
   s.setMem wa (replaceHalfword (s.getMem wa) pos h)
 
 /-- Write a 32-bit word to memory at a 4-byte aligned address. -/
-def setWord32 (s : MachineState) (addr : Addr) (v : BitVec 32) : MachineState :=
+def setWord32 (s : MachineState) (addr : Word) (v : BitVec 32) : MachineState :=
   let wa := alignToDword addr
   let pos := (byteOffset addr) / 4
   s.setMem wa (replaceWord32 (s.getMem wa) pos v)
 
 /-- Read n consecutive bytes from memory starting at base byte address. -/
-def readBytes (s : MachineState) (base : Addr) : Nat → List (BitVec 8)
+def readBytes (s : MachineState) (base : Word) : Nat → List (BitVec 8)
   | 0 => []
   | n + 1 => s.getByte base :: readBytes s (base + 1) n
 
@@ -421,7 +421,7 @@ def bytesToWordLE (bs : List (BitVec 8)) : Word :=
 namespace MachineState
 
 /-- Write a byte stream as consecutive LE doublewords to memory. -/
-def writeBytesAsWords (s : MachineState) (base : Addr) : List (BitVec 8) → MachineState
+def writeBytesAsWords (s : MachineState) (base : Word) : List (BitVec 8) → MachineState
   | [] => s
   | b :: bs =>
     let chunk := (b :: bs).take 8
@@ -436,34 +436,34 @@ termination_by l => l.length
 @[simp] theorem pc_setReg (s : MachineState) (r : Reg) (v : Word) :
     (s.setReg r v).pc = s.pc := by cases r <;> rfl
 
-@[simp] theorem pc_setMem (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem pc_setMem (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).pc = s.pc := by simp [setMem]
 
-@[simp] theorem pc_setByte (s : MachineState) (addr : Addr) (b : BitVec 8) :
+@[simp] theorem pc_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
     (s.setByte addr b).pc = s.pc := by simp [setByte]
 
-@[simp] theorem pc_setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) :
+@[simp] theorem pc_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
     (s.setHalfword addr h).pc = s.pc := by simp [setHalfword]
 
-@[simp] theorem pc_setWord32 (s : MachineState) (addr : Addr) (v : BitVec 32) :
+@[simp] theorem pc_setWord32 (s : MachineState) (addr : Word) (v : BitVec 32) :
     (s.setWord32 addr v).pc = s.pc := by simp [setWord32]
 
 @[simp] theorem code_setReg (s : MachineState) (r : Reg) (v : Word) :
     (s.setReg r v).code = s.code := by cases r <;> rfl
 
-@[simp] theorem code_setMem (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem code_setMem (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).code = s.code := by simp [setMem]
 
 @[simp] theorem code_setPC (s : MachineState) (v : Word) :
     (s.setPC v).code = s.code := by simp [setPC]
 
-@[simp] theorem code_setByte (s : MachineState) (addr : Addr) (b : BitVec 8) :
+@[simp] theorem code_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
     (s.setByte addr b).code = s.code := by simp [setByte]
 
-@[simp] theorem code_setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) :
+@[simp] theorem code_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
     (s.setHalfword addr h).code = s.code := by simp [setHalfword]
 
-@[simp] theorem code_setWord32 (s : MachineState) (addr : Addr) (v : BitVec 32) :
+@[simp] theorem code_setWord32 (s : MachineState) (addr : Word) (v : BitVec 32) :
     (s.setWord32 addr v).code = s.code := by simp [setWord32]
 
 @[simp] theorem code_appendCommit (s : MachineState) (a0 a1 : Word) :
@@ -472,7 +472,7 @@ termination_by l => l.length
 @[simp] theorem code_appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) :
     (s.appendPublicValues bytes).code = s.code := by simp [appendPublicValues]
 
-@[simp] theorem code_writeWords (s : MachineState) (base : Addr) (words : List Word) :
+@[simp] theorem code_writeWords (s : MachineState) (base : Word) (words : List Word) :
     (s.writeWords base words).code = s.code := by
   induction words generalizing s base with
   | nil => rfl
@@ -489,30 +489,30 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
     (h : r ≠ .x0) : (s.setReg r v).getReg r = v := by
   cases r <;> first | exact absurd rfl h | rfl
 
-@[simp] theorem getMem_setMem_eq (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem getMem_setMem_eq (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).getMem a = v := by simp [getMem, setMem]
 
-@[simp] theorem getMem_setMem_ne (s : MachineState) (a a' : Addr) (v : Word)
+@[simp] theorem getMem_setMem_ne (s : MachineState) (a a' : Word) (v : Word)
     (h : a' ≠ a) : (s.setMem a v).getMem a' = s.getMem a' := by
   simp [getMem, setMem, h]
 
-@[simp] theorem getMem_setReg (s : MachineState) (r : Reg) (v : Word) (a : Addr) :
+@[simp] theorem getMem_setReg (s : MachineState) (r : Reg) (v : Word) (a : Word) :
     (s.setReg r v).getMem a = s.getMem a := by
   cases r <;> simp [getMem, setReg]
 
-@[simp] theorem getMem_setPC (s : MachineState) (v : Word) (a : Addr) :
+@[simp] theorem getMem_setPC (s : MachineState) (v : Word) (a : Word) :
     (s.setPC v).getMem a = s.getMem a := by simp [getMem, setPC]
 
 @[simp] theorem committed_setReg (s : MachineState) (r : Reg) (v : Word) :
     (s.setReg r v).committed = s.committed := by cases r <;> rfl
 
-@[simp] theorem committed_setMem (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem committed_setMem (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).committed = s.committed := by simp [setMem]
 
-@[simp] theorem committed_setByte (s : MachineState) (addr : Addr) (b : BitVec 8) :
+@[simp] theorem committed_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
     (s.setByte addr b).committed = s.committed := by simp [setByte]
 
-@[simp] theorem committed_setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) :
+@[simp] theorem committed_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
     (s.setHalfword addr h).committed = s.committed := by simp [setHalfword]
 
 @[simp] theorem committed_setPC (s : MachineState) (v : Word) :
@@ -521,13 +521,13 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 @[simp] theorem publicValues_setReg (s : MachineState) (r : Reg) (v : Word) :
     (s.setReg r v).publicValues = s.publicValues := by cases r <;> rfl
 
-@[simp] theorem publicValues_setMem (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem publicValues_setMem (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).publicValues = s.publicValues := by simp [setMem]
 
-@[simp] theorem publicValues_setByte (s : MachineState) (addr : Addr) (b : BitVec 8) :
+@[simp] theorem publicValues_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
     (s.setByte addr b).publicValues = s.publicValues := by simp [setByte]
 
-@[simp] theorem publicValues_setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) :
+@[simp] theorem publicValues_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
     (s.setHalfword addr h).publicValues = s.publicValues := by simp [setHalfword]
 
 @[simp] theorem publicValues_setPC (s : MachineState) (v : Word) :
@@ -539,13 +539,13 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 @[simp] theorem privateInput_setReg (s : MachineState) (r : Reg) (v : Word) :
     (s.setReg r v).privateInput = s.privateInput := by cases r <;> rfl
 
-@[simp] theorem privateInput_setMem (s : MachineState) (a : Addr) (v : Word) :
+@[simp] theorem privateInput_setMem (s : MachineState) (a : Word) (v : Word) :
     (s.setMem a v).privateInput = s.privateInput := by simp [setMem]
 
-@[simp] theorem privateInput_setByte (s : MachineState) (addr : Addr) (b : BitVec 8) :
+@[simp] theorem privateInput_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
     (s.setByte addr b).privateInput = s.privateInput := by simp [setByte]
 
-@[simp] theorem privateInput_setHalfword (s : MachineState) (addr : Addr) (h : BitVec 16) :
+@[simp] theorem privateInput_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
     (s.setHalfword addr h).privateInput = s.privateInput := by simp [setHalfword]
 
 @[simp] theorem privateInput_setPC (s : MachineState) (v : Word) :
@@ -562,7 +562,7 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 @[simp] theorem getReg_appendCommit (s : MachineState) (a0 a1 : Word) (r : Reg) :
     (s.appendCommit a0 a1).getReg r = s.getReg r := by cases r <;> rfl
 
-@[simp] theorem getMem_appendCommit (s : MachineState) (a0 a1 : Word) (a : Addr) :
+@[simp] theorem getMem_appendCommit (s : MachineState) (a0 a1 : Word) (a : Word) :
     (s.appendCommit a0 a1).getMem a = s.getMem a := by simp [appendCommit, getMem]
 
 @[simp] theorem pc_appendCommit (s : MachineState) (a0 a1 : Word) :
@@ -576,7 +576,7 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 @[simp] theorem getReg_appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) (r : Reg) :
     (s.appendPublicValues bytes).getReg r = s.getReg r := by cases r <;> rfl
 
-@[simp] theorem getMem_appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) (a : Addr) :
+@[simp] theorem getMem_appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) (a : Word) :
     (s.appendPublicValues bytes).getMem a = s.getMem a := by simp [appendPublicValues, getMem]
 
 @[simp] theorem pc_appendPublicValues (s : MachineState) (bytes : List (BitVec 8)) :
@@ -591,43 +591,43 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 
 -- readWords / writeWords simp lemmas
 
-@[simp] theorem readWords_zero (s : MachineState) (base : Addr) :
+@[simp] theorem readWords_zero (s : MachineState) (base : Word) :
     s.readWords base 0 = [] := rfl
 
-@[simp] theorem readWords_succ (s : MachineState) (base : Addr) (n : Nat) :
+@[simp] theorem readWords_succ (s : MachineState) (base : Word) (n : Nat) :
     s.readWords base (n + 1) = s.getMem base :: s.readWords (base + 8) n := rfl
 
-@[simp] theorem writeWords_nil (s : MachineState) (base : Addr) :
+@[simp] theorem writeWords_nil (s : MachineState) (base : Word) :
     s.writeWords base [] = s := rfl
 
-@[simp] theorem writeWords_cons (s : MachineState) (base : Addr) (w : Word) (ws : List Word) :
+@[simp] theorem writeWords_cons (s : MachineState) (base : Word) (w : Word) (ws : List Word) :
     s.writeWords base (w :: ws) = (s.setMem base w).writeWords (base + 8) ws := rfl
 
-@[simp] theorem pc_writeWords (s : MachineState) (base : Addr) (words : List Word) :
+@[simp] theorem pc_writeWords (s : MachineState) (base : Word) (words : List Word) :
     (s.writeWords base words).pc = s.pc := by
   induction words generalizing s base with
   | nil => rfl
   | cons w ws ih => simp [writeWords, ih]
 
-@[simp] theorem committed_writeWords (s : MachineState) (base : Addr) (words : List Word) :
+@[simp] theorem committed_writeWords (s : MachineState) (base : Word) (words : List Word) :
     (s.writeWords base words).committed = s.committed := by
   induction words generalizing s base with
   | nil => rfl
   | cons w ws ih => simp [writeWords, ih]
 
-@[simp] theorem publicValues_writeWords (s : MachineState) (base : Addr) (words : List Word) :
+@[simp] theorem publicValues_writeWords (s : MachineState) (base : Word) (words : List Word) :
     (s.writeWords base words).publicValues = s.publicValues := by
   induction words generalizing s base with
   | nil => rfl
   | cons w ws ih => simp [writeWords, ih]
 
-@[simp] theorem privateInput_writeWords (s : MachineState) (base : Addr) (words : List Word) :
+@[simp] theorem privateInput_writeWords (s : MachineState) (base : Word) (words : List Word) :
     (s.writeWords base words).privateInput = s.privateInput := by
   induction words generalizing s base with
   | nil => rfl
   | cons w ws ih => simp [writeWords, ih]
 
-@[simp] theorem getReg_writeWords (s : MachineState) (base : Addr) (words : List Word) (r : Reg) :
+@[simp] theorem getReg_writeWords (s : MachineState) (base : Word) (words : List Word) (r : Reg) :
     (s.writeWords base words).getReg r = s.getReg r := by
   induction words generalizing s base with
   | nil => rfl
@@ -637,18 +637,18 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 
 -- readBytes simp lemmas
 
-@[simp] theorem readBytes_zero (s : MachineState) (base : Addr) :
+@[simp] theorem readBytes_zero (s : MachineState) (base : Word) :
     s.readBytes base 0 = [] := rfl
 
-@[simp] theorem readBytes_succ (s : MachineState) (base : Addr) (n : Nat) :
+@[simp] theorem readBytes_succ (s : MachineState) (base : Word) (n : Nat) :
     s.readBytes base (n + 1) = s.getByte base :: s.readBytes (base + 1) n := rfl
 
 -- writeBytesAsWords simp lemmas
 
-@[simp] theorem writeBytesAsWords_nil (s : MachineState) (base : Addr) :
+@[simp] theorem writeBytesAsWords_nil (s : MachineState) (base : Word) :
     s.writeBytesAsWords base [] = s := by unfold writeBytesAsWords; rfl
 
-@[simp] theorem pc_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) :
+@[simp] theorem pc_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) :
     (s.writeBytesAsWords base bytes).pc = s.pc := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl
@@ -659,7 +659,7 @@ theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
 termination_by bytes.length
 decreasing_by simp [List.length_drop]; omega
 
-@[simp] theorem code_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) :
+@[simp] theorem code_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) :
     (s.writeBytesAsWords base bytes).code = s.code := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl
@@ -670,7 +670,7 @@ decreasing_by simp [List.length_drop]; omega
 termination_by bytes.length
 decreasing_by simp [List.length_drop]; omega
 
-@[simp] theorem committed_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) :
+@[simp] theorem committed_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) :
     (s.writeBytesAsWords base bytes).committed = s.committed := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl
@@ -681,7 +681,7 @@ decreasing_by simp [List.length_drop]; omega
 termination_by bytes.length
 decreasing_by simp [List.length_drop]; omega
 
-@[simp] theorem publicValues_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) :
+@[simp] theorem publicValues_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) :
     (s.writeBytesAsWords base bytes).publicValues = s.publicValues := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl
@@ -692,7 +692,7 @@ decreasing_by simp [List.length_drop]; omega
 termination_by bytes.length
 decreasing_by simp [List.length_drop]; omega
 
-@[simp] theorem privateInput_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) :
+@[simp] theorem privateInput_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) :
     (s.writeBytesAsWords base bytes).privateInput = s.privateInput := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl
@@ -703,7 +703,7 @@ decreasing_by simp [List.length_drop]; omega
 termination_by bytes.length
 decreasing_by simp [List.length_drop]; omega
 
-@[simp] theorem getReg_writeBytesAsWords (s : MachineState) (base : Addr) (bytes : List (BitVec 8)) (r : Reg) :
+@[simp] theorem getReg_writeBytesAsWords (s : MachineState) (base : Word) (bytes : List (BitVec 8)) (r : Reg) :
     (s.writeBytesAsWords base bytes).getReg r = s.getReg r := by
   match bytes with
   | [] => unfold writeBytesAsWords; rfl

--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -50,8 +50,11 @@ end Reg
 -- Word type (64-bit bitvectors)
 -- ============================================================================
 
-/-- We use 64-bit words as our machine word size. -/
-abbrev Word := BitVec 64
+/-- We use 64-bit words as our machine word size.
+    Defined as `notation` (not `abbrev`) so the elaborator always produces `BitVec 64`
+    in Expr output, giving identical Expr.hash regardless of whether `Word` or `BitVec 64`
+    was written in source. This is required for the xperm AC reflection fast path. -/
+notation "Word" => BitVec 64
 
 -- Note: Addr was previously a separate abbrev but has been unified with Word
 -- to avoid Expr.hash mismatches in the xperm tactic (Addr vs Word vs BitVec 64).

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Rv64
 
 /-! ## byteOffset bound -/
 
-theorem byteOffset_lt_8 (addr : Addr) : byteOffset addr < 8 := by
+theorem byteOffset_lt_8 (addr : Word) : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by native_decide)
 
@@ -60,10 +60,10 @@ theorem extractByte_replaceByte_same (w : Word) (pos : Fin 8) (b : BitVec 8) :
 
 /-! ## getByte / setByte in terms of extractByte / replaceByte -/
 
-theorem getByte_eq (s : MachineState) (addr : Addr) :
+theorem getByte_eq (s : MachineState) (addr : Word) :
     s.getByte addr = extractByte (s.getMem (alignToDword addr)) (byteOffset addr) := rfl
 
-theorem setByte_eq (s : MachineState) (addr : Addr) (b : BitVec 8) :
+theorem setByte_eq (s : MachineState) (addr : Word) (b : BitVec 8) :
     s.setByte addr b = s.setMem (alignToDword addr)
       (replaceByte (s.getMem (alignToDword addr)) (byteOffset addr) b) := rfl
 
@@ -73,8 +73,8 @@ LBU reads a byte from memory at an arbitrary byte address. The precondition
 owns the containing doubleword; the postcondition preserves it unchanged. -/
 
 theorem generic_lbu_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -119,8 +119,8 @@ LB reads a byte from memory at an arbitrary byte address and sign-extends it.
 The precondition owns the containing doubleword; the postcondition preserves it unchanged. -/
 
 theorem generic_lb_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -164,8 +164,8 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr v_old : Word)
 SB writes a byte to memory at an arbitrary byte address. -/
 
 theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_old : Word)
     (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -43,7 +43,7 @@ namespace EvmAsm.Rv64
     The universal quantification over R means P and Q only describe the
     resources the code actually reads/writes.
     The CodeReq cr is a persistent side-condition: it is not consumed. -/
-def cpsTriple (entry exit_ : Addr) (cr : CodeReq)
+def cpsTriple (entry exit_ : Word) (cr : CodeReq)
     (P Q : Assertion) : Prop :=
   ∀ (R : Assertion), R.pcFree → ∀ s, cr.SatisfiedBy s → (P ** R).holdsFor s → s.pc = entry →
     ∃ k s', stepN k s = some s' ∧ s'.pc = exit_ ∧ (Q ** R).holdsFor s'
@@ -51,9 +51,9 @@ def cpsTriple (entry exit_ : Addr) (cr : CodeReq)
 /-- CPS spec for code with two exits (the branch pattern) with built-in frame:
     "For any pcFree frame R, if cr is satisfied and (P ** R) holds at entry,
      execution reaches EITHER exit_t with (Q_t ** R) OR exit_f with (Q_f ** R)." -/
-def cpsBranch (entry : Addr) (cr : CodeReq) (P : Assertion)
-    (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion) : Prop :=
+def cpsBranch (entry : Word) (cr : CodeReq) (P : Assertion)
+    (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion) : Prop :=
   ∀ (R : Assertion), R.pcFree → ∀ s, cr.SatisfiedBy s → (P ** R).holdsFor s → s.pc = entry →
     ∃ k s', stepN k s = some s' ∧
       ((s'.pc = exit_t ∧ (Q_t ** R).holdsFor s') ∨ (s'.pc = exit_f ∧ (Q_f ** R).holdsFor s'))
@@ -63,7 +63,7 @@ def cpsBranch (entry : Addr) (cr : CodeReq) (P : Assertion)
 -- ============================================================================
 
 /-- Sequence: compose two CPS triples sharing a midpoint. -/
-theorem cpsTriple_seq (l1 l2 l3 : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq (l1 l2 l3 : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
     (P Q R : Assertion)
     (h1 : cpsTriple l1 l2 cr1 P Q)
@@ -80,7 +80,7 @@ theorem cpsTriple_seq (l1 l2 l3 : Addr) (cr1 cr2 : CodeReq)
 /-- Consequence: strengthen precondition and weaken postcondition.
     Note: implications are at the assertion (PartialState) level, not holdsFor level,
     because (P' ** R).holdsFor s → (P ** R).holdsFor s requires P' h → P h pointwise. -/
-theorem cpsTriple_consequence (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsTriple_consequence (entry exit_ : Word) (cr : CodeReq)
     (P P' Q Q' : Assertion)
     (hpre  : ∀ h, P' h → P h)
     (hpost : ∀ h, Q h → Q' h)
@@ -96,9 +96,9 @@ theorem cpsTriple_consequence (entry exit_ : Addr) (cr : CodeReq)
     exact ⟨hp, hcompat, sepConj_mono_left hpost hp hpq⟩⟩
 
 /-- Rule of consequence for cpsBranch: strengthen pre, weaken both posts. -/
-theorem cpsBranch_consequence (entry : Addr) (cr : CodeReq)
-    (P P' : Assertion) (exit_t : Addr) (Q_t Q_t' : Assertion)
-    (exit_f : Addr) (Q_f Q_f' : Assertion)
+theorem cpsBranch_consequence (entry : Word) (cr : CodeReq)
+    (P P' : Assertion) (exit_t : Word) (Q_t Q_t' : Assertion)
+    (exit_f : Word) (Q_f Q_f' : Assertion)
     (hpre : ∀ h, P' h → P h)
     (hpost_t : ∀ h, Q_t h → Q_t' h)
     (hpost_f : ∀ h, Q_f h → Q_f' h)
@@ -157,7 +157,7 @@ theorem cpsTriple_of_forall_memIs_to_memOwn
 
 /-- Branch elimination: if both branch exits lead to the same
     continuation exit with R, merge back into a single cpsTriple. -/
-theorem cpsBranch_merge (entry l_t l_f exit_ : Addr) (cr1 cr_t cr_f : CodeReq)
+theorem cpsBranch_merge (entry l_t l_f exit_ : Word) (cr1 cr_t cr_f : CodeReq)
     (hd1 : cr1.Disjoint (cr_t.union cr_f)) (hd2 : cr_t.Disjoint cr_f)
     (P Q_t Q_f R : Assertion)
     (hbr   : cpsBranch entry cr1 P l_t Q_t l_f Q_f)
@@ -180,7 +180,7 @@ theorem cpsBranch_merge (entry l_t l_f exit_ : Addr) (cr1 cr_t cr_f : CodeReq)
 
 /-- Extract the taken path from a cpsBranch when the not-taken postcondition
     is unsatisfiable (e.g., contains a contradictory pure fact). -/
-theorem cpsBranch_elim_taken (entry l_t l_f : Addr) (cr : CodeReq)
+theorem cpsBranch_elim_taken (entry l_t l_f : Word) (cr : CodeReq)
     (P Q_t Q_f : Assertion)
     (hbr : cpsBranch entry cr P l_t Q_t l_f Q_f)
     (h_absurd : ∀ hp, Q_f hp → False) :
@@ -194,7 +194,7 @@ theorem cpsBranch_elim_taken (entry l_t l_f : Addr) (cr : CodeReq)
 
 /-- Extract the not-taken path from a cpsBranch when the taken postcondition
     is unsatisfiable (e.g., contains a contradictory pure fact). -/
-theorem cpsBranch_elim_ntaken (entry l_t l_f : Addr) (cr : CodeReq)
+theorem cpsBranch_elim_ntaken (entry l_t l_f : Word) (cr : CodeReq)
     (P Q_t Q_f : Assertion)
     (hbr : cpsBranch entry cr P l_t Q_t l_f Q_f)
     (h_absurd : ∀ hp, Q_t hp → False) :
@@ -211,7 +211,7 @@ theorem cpsBranch_elim_ntaken (entry l_t l_f : Addr) (cr : CodeReq)
     The return type is explicitly `cpsTriple entry l_t P (A ** B ** C)`, avoiding
     lambda-wrapped postconditions. -/
 theorem cpsBranch_elim_taken_strip_pure2
-    (entry l_t l_f : Addr) (cr : CodeReq) (P A B : Assertion) (Prop_t : Prop) (Q_f : Assertion)
+    (entry l_t l_f : Word) (cr : CodeReq) (P A B : Assertion) (Prop_t : Prop) (Q_f : Assertion)
     (hbr : cpsBranch entry cr P l_t (A ** B ** ⌜Prop_t⌝) l_f Q_f)
     (h_absurd : ∀ hp, Q_f hp → False) :
     cpsTriple entry l_t cr P (A ** B) :=
@@ -221,7 +221,7 @@ theorem cpsBranch_elim_taken_strip_pure2
     (cpsBranch_elim_taken _ _ _ _ _ _ _ hbr h_absurd)
 
 theorem cpsBranch_elim_taken_strip_pure3
-    (entry l_t l_f : Addr) (cr : CodeReq) (P A B C : Assertion) (Prop_t : Prop) (Q_f : Assertion)
+    (entry l_t l_f : Word) (cr : CodeReq) (P A B C : Assertion) (Prop_t : Prop) (Q_f : Assertion)
     (hbr : cpsBranch entry cr P l_t (A ** B ** C ** ⌜Prop_t⌝) l_f Q_f)
     (h_absurd : ∀ hp, Q_f hp → False) :
     cpsTriple entry l_t cr P (A ** B ** C) :=
@@ -233,7 +233,7 @@ theorem cpsBranch_elim_taken_strip_pure3
 /-- Eliminate the taken path from a cpsBranch AND strip the trailing pure fact
     from the not-taken postcondition (depth 2: A ** B ** ⌜P⌝ → A ** B). -/
 theorem cpsBranch_elim_ntaken_strip_pure2
-    (entry l_t l_f : Addr) (cr : CodeReq) (P A B : Assertion) (Prop_f : Prop) (Q_t : Assertion)
+    (entry l_t l_f : Word) (cr : CodeReq) (P A B : Assertion) (Prop_f : Prop) (Q_t : Assertion)
     (hbr : cpsBranch entry cr P l_t Q_t l_f (A ** B ** ⌜Prop_f⌝))
     (h_absurd : ∀ hp, Q_t hp → False) :
     cpsTriple entry l_f cr P (A ** B) :=
@@ -247,7 +247,7 @@ theorem cpsBranch_elim_ntaken_strip_pure2
     The return type is explicitly `cpsTriple entry l_f P (A ** B ** C)`, avoiding
     lambda-wrapped postconditions. -/
 theorem cpsBranch_elim_ntaken_strip_pure3
-    (entry l_t l_f : Addr) (cr : CodeReq) (P A B C : Assertion) (Prop_f : Prop) (Q_t : Assertion)
+    (entry l_t l_f : Word) (cr : CodeReq) (P A B C : Assertion) (Prop_f : Prop) (Q_t : Assertion)
     (hbr : cpsBranch entry cr P l_t Q_t l_f (A ** B ** C ** ⌜Prop_f⌝))
     (h_absurd : ∀ hp, Q_t hp → False) :
     cpsTriple entry l_f cr P (A ** B ** C) :=
@@ -257,7 +257,7 @@ theorem cpsBranch_elim_ntaken_strip_pure3
     (cpsBranch_elim_ntaken _ _ _ _ _ _ _ hbr h_absurd)
 
 /-- A cpsTriple with zero steps: if entry = exit and P implies Q, trivially holds. -/
-theorem cpsTriple_refl (addr : Addr) (P Q : Assertion)
+theorem cpsTriple_refl (addr : Word) (P Q : Assertion)
     (h : ∀ hp, P hp → Q hp) :
     cpsTriple addr addr CodeReq.empty P Q := by
   intro R hR s _hcr hPR hpc
@@ -266,7 +266,7 @@ theorem cpsTriple_refl (addr : Addr) (P Q : Assertion)
     exact ⟨hp, hcompat, sepConj_mono_left h hp hpq⟩⟩
 
 /-- Monotonicity: if cr' subsumes cr (cr' ⊇ cr), extend a cpsTriple to require more code. -/
-theorem cpsTriple_extend_code {entry exit_ : Addr} {cr cr' : CodeReq} {P Q : Assertion}
+theorem cpsTriple_extend_code {entry exit_ : Word} {cr cr' : CodeReq} {P Q : Assertion}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsTriple entry exit_ cr P Q) :
     cpsTriple entry exit_ cr' P Q := by
@@ -274,8 +274,8 @@ theorem cpsTriple_extend_code {entry exit_ : Addr} {cr cr' : CodeReq} {P Q : Ass
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Monotonicity for cpsBranch: extend to a larger CodeReq. -/
-theorem cpsBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
-    {P : Assertion} {exit_t : Addr} {Q_t : Assertion} {exit_f : Addr} {Q_f : Assertion}
+theorem cpsBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (hmono : ∀ a i, cr a = some i → cr' a = some i)
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr' P exit_t Q_t exit_f Q_f := by
@@ -284,8 +284,8 @@ theorem cpsBranch_extend_code {entry : Addr} {cr cr' : CodeReq}
 
 /-- Sequential composition: cpsTriple followed by cpsBranch, same CodeReq.
     Unlike `cpsTriple_seq_cpsBranch`, does not require disjointness. -/
-theorem cpsTriple_seq_cpsBranch_same_cr (entry mid : Addr) (cr : CodeReq)
-    (P Q : Assertion) (exit_t : Addr) (Q_t : Assertion) (exit_f : Addr) (Q_f : Assertion)
+theorem cpsTriple_seq_cpsBranch_same_cr (entry mid : Word) (cr : CodeReq)
+    (P Q : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
     (h1 : cpsTriple entry mid cr P Q)
     (h2 : cpsBranch mid cr Q exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr P exit_t Q_t exit_f Q_f := by
@@ -296,8 +296,8 @@ theorem cpsTriple_seq_cpsBranch_same_cr (entry mid : Addr) (cr : CodeReq)
   exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hbranch⟩
 
 /-- Sequential composition with permutation: cpsTriple followed by cpsBranch, same CodeReq. -/
-theorem cpsTriple_seq_cpsBranch_with_perm_same_cr (entry mid : Addr) (cr : CodeReq)
-    (P Q1 Q2 : Assertion) (exit_t : Addr) (Q_t : Assertion) (exit_f : Addr) (Q_f : Assertion)
+theorem cpsTriple_seq_cpsBranch_with_perm_same_cr (entry mid : Word) (cr : CodeReq)
+    (P Q1 Q2 : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
     (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple entry mid cr P Q1)
     (h2 : cpsBranch mid cr Q2 exit_t Q_t exit_f Q_f) :
@@ -314,8 +314,8 @@ theorem cpsTriple_seq_cpsBranch_with_perm_same_cr (entry mid : Addr) (cr : CodeR
     some exit in the list, with (exit.2 ** R) holding."
 
     Generalizes `cpsBranch` from 2 exits to an arbitrary list. -/
-def cpsNBranch (entry : Addr) (cr : CodeReq) (P : Assertion)
-    (exits : List (Addr × Assertion)) : Prop :=
+def cpsNBranch (entry : Word) (cr : CodeReq) (P : Assertion)
+    (exits : List (Word × Assertion)) : Prop :=
   ∀ (R : Assertion), R.pcFree → ∀ s, cr.SatisfiedBy s → (P ** R).holdsFor s → s.pc = entry →
     ∃ k s', stepN k s = some s' ∧
       ∃ exit ∈ exits, s'.pc = exit.1 ∧ (exit.2 ** R).holdsFor s'
@@ -325,7 +325,7 @@ def cpsNBranch (entry : Addr) (cr : CodeReq) (P : Assertion)
 -- ============================================================================
 
 /-- An N-branch with no exits is vacuously false (no reachable exit). -/
-theorem cpsNBranch_nil_false (entry : Addr) (cr : CodeReq) (P : Assertion)
+theorem cpsNBranch_nil_false (entry : Word) (cr : CodeReq) (P : Assertion)
     (h : cpsNBranch entry cr P [])
     (s : MachineState) (hcr : cr.SatisfiedBy s) (hP : P.holdsFor s) (hpc : s.pc = entry) : False := by
   -- Use empAssertion as the frame
@@ -337,13 +337,13 @@ theorem cpsNBranch_nil_false (entry : Addr) (cr : CodeReq) (P : Assertion)
   exact List.not_mem_nil hmem
 
 /-- An N-branch with impossible precondition vacuously holds for any exits. -/
-theorem cpsNBranch_nil_of_false (entry : Addr) (cr : CodeReq) :
+theorem cpsNBranch_nil_of_false (entry : Word) (cr : CodeReq) :
     cpsNBranch entry cr (fun _ => False) [] := by
   intro R _ s _ ⟨_, _, h1, h2, _, _, hf, _⟩ _
   exact absurd hf id
 
 /-- Reflexivity: zero steps, one exit at the same address. -/
-theorem cpsNBranch_refl (addr : Addr)
+theorem cpsNBranch_refl (addr : Word)
     (P Q : Assertion)
     (h : ∀ hp, P hp → Q hp) :
     cpsNBranch addr CodeReq.empty P [(addr, Q)] := by
@@ -357,7 +357,7 @@ theorem cpsNBranch_refl (addr : Addr)
 -- ============================================================================
 
 /-- A single-exit cpsTriple can be viewed as a cpsNBranch with one exit. -/
-theorem cpsTriple_to_cpsNBranch (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsTriple_to_cpsNBranch (entry exit_ : Word) (cr : CodeReq)
     (P Q : Assertion) (h : cpsTriple entry exit_ cr P Q) :
     cpsNBranch entry cr P [(exit_, Q)] := by
   intro R hR s hcr hPR hpc
@@ -365,7 +365,7 @@ theorem cpsTriple_to_cpsNBranch (entry exit_ : Addr) (cr : CodeReq)
   exact ⟨k, s', hstep, (exit_, Q), List.Mem.head _, hpc', hQR⟩
 
 /-- A singleton cpsNBranch gives back a cpsTriple. -/
-theorem cpsNBranch_to_cpsTriple (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsNBranch_to_cpsTriple (entry exit_ : Word) (cr : CodeReq)
     (P Q : Assertion) (h : cpsNBranch entry cr P [(exit_, Q)]) :
     cpsTriple entry exit_ cr P Q := by
   intro R hR s hcr hPR hpc
@@ -375,10 +375,10 @@ theorem cpsNBranch_to_cpsTriple (entry exit_ : Addr) (cr : CodeReq)
   | tail _ h => exact absurd h List.not_mem_nil
 
 /-- A 2-exit cpsBranch can be viewed as a cpsNBranch with two exits. -/
-theorem cpsBranch_to_cpsNBranch (entry : Addr) (cr : CodeReq)
+theorem cpsBranch_to_cpsNBranch (entry : Word) (cr : CodeReq)
     (P : Assertion)
-    (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion)
+    (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion)
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsNBranch entry cr P [(exit_t, Q_t), (exit_f, Q_f)] := by
   intro R hR s hcr hPR hpc
@@ -388,10 +388,10 @@ theorem cpsBranch_to_cpsNBranch (entry : Addr) (cr : CodeReq)
   · exact ⟨k, s', hstep, (exit_f, Q_f), List.Mem.tail _ (List.Mem.head _), hpc_f, hQ_f⟩
 
 /-- A 2-element cpsNBranch gives back a cpsBranch. -/
-theorem cpsNBranch_to_cpsBranch (entry : Addr) (cr : CodeReq)
+theorem cpsNBranch_to_cpsBranch (entry : Word) (cr : CodeReq)
     (P : Assertion)
-    (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion)
+    (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion)
     (h : cpsNBranch entry cr P [(exit_t, Q_t), (exit_f, Q_f)]) :
     cpsBranch entry cr P exit_t Q_t exit_f Q_f := by
   intro R hR s hcr hPR hpc
@@ -411,9 +411,9 @@ theorem cpsNBranch_to_cpsBranch (entry : Addr) (cr : CodeReq)
 /-- N-branch merge: if every exit leads to the same continuation,
     compose into a single cpsTriple. This is the main structural rule.
     Uses the same cr for all parts (simpler; use cpsTriple_extend_code to adapt). -/
-theorem cpsNBranch_merge (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsNBranch_merge (entry exit_ : Word) (cr : CodeReq)
     (P R : Assertion)
-    (exits : List (Addr × Assertion))
+    (exits : List (Word × Assertion))
     (hbr : cpsNBranch entry cr P exits)
     (hall : ∀ exit ∈ exits, cpsTriple exit.1 exit_ cr exit.2 R) :
     cpsTriple entry exit_ cr P R := by
@@ -424,9 +424,9 @@ theorem cpsNBranch_merge (entry exit_ : Addr) (cr : CodeReq)
   exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hRF⟩
 
 /-- Consequence: strengthen the precondition of an N-branch. -/
-theorem cpsNBranch_weaken_pre (entry : Addr) (cr : CodeReq)
+theorem cpsNBranch_weaken_pre (entry : Word) (cr : CodeReq)
     (P P' : Assertion)
-    (exits : List (Addr × Assertion))
+    (exits : List (Word × Assertion))
     (hpre : ∀ h, P' h → P h) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr P' exits := by
   intro R hR s hcr hP'R hpc
@@ -436,9 +436,9 @@ theorem cpsNBranch_weaken_pre (entry : Addr) (cr : CodeReq)
   exact h R hR s hcr hPR hpc
 
 /-- Monotonicity: expand the exit list (weaken the exit constraint). -/
-theorem cpsNBranch_weaken_exits (entry : Addr) (cr : CodeReq)
+theorem cpsNBranch_weaken_exits (entry : Word) (cr : CodeReq)
     (P : Assertion)
-    (exits exits' : List (Addr × Assertion))
+    (exits exits' : List (Word × Assertion))
     (hsub : ∀ ex, ex ∈ exits → ex ∈ exits') (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr P exits' := by
   intro R hR s hcr hPR hpc
@@ -446,9 +446,9 @@ theorem cpsNBranch_weaken_exits (entry : Addr) (cr : CodeReq)
   exact ⟨k, s', hstep, ex, hsub ex hmem, hpc', hQR⟩
 
 /-- Extend the head exit by composing a cpsTriple after it. -/
-theorem cpsNBranch_extend_head (entry l l' : Addr) (cr : CodeReq)
+theorem cpsNBranch_extend_head (entry l l' : Word) (cr : CodeReq)
     (P Q R : Assertion)
-    (others : List (Addr × Assertion))
+    (others : List (Word × Assertion))
     (hbr : cpsNBranch entry cr P ((l, Q) :: others))
     (hseq : cpsTriple l l' cr Q R) :
     cpsNBranch entry cr P ((l', R) :: others) := by
@@ -477,7 +477,7 @@ def isHalted (s : MachineState) : Bool :=
     For any pcFree frame R, starting from any state where cr is satisfied,
     (P ** R) holds and PC = entry, execution reaches a halted state where (Q ** R) holds.
     Unlike `cpsTriple`, there is no exit address — execution simply terminates. -/
-def cpsHaltTriple (entry : Addr) (cr : CodeReq)
+def cpsHaltTriple (entry : Word) (cr : CodeReq)
     (P Q : Assertion) : Prop :=
   ∀ (R : Assertion), R.pcFree → ∀ s, cr.SatisfiedBy s → (P ** R).holdsFor s → s.pc = entry →
     ∃ k s', stepN k s = some s' ∧ isHalted s' = true ∧ (Q ** R).holdsFor s'
@@ -485,7 +485,7 @@ def cpsHaltTriple (entry : Addr) (cr : CodeReq)
 /-- Promote a `cpsTriple` to a `cpsHaltTriple` when the exit address is halted.
     If execution reaches exit_ with Q, and every state satisfying (Q ** R) at exit_ is halted,
     then the program halts with Q. -/
-theorem cpsTriple_to_cpsHaltTriple (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsTriple_to_cpsHaltTriple (entry exit_ : Word) (cr : CodeReq)
     (P Q : Assertion)
     (h : cpsTriple entry exit_ cr P Q)
     (hhalt : ∀ (R : Assertion), R.pcFree → ∀ s, (Q ** R).holdsFor s → s.pc = exit_ →
@@ -496,7 +496,7 @@ theorem cpsTriple_to_cpsHaltTriple (entry exit_ : Addr) (cr : CodeReq)
   exact ⟨k, s', hstep, hhalt R hR s' hQR hpc', hQR⟩
 
 /-- Consequence: strengthen precondition and weaken postcondition of a halt triple. -/
-theorem cpsHaltTriple_consequence (entry : Addr) (cr : CodeReq)
+theorem cpsHaltTriple_consequence (entry : Word) (cr : CodeReq)
     (P P' Q Q' : Assertion)
     (hpre  : ∀ h, P' h → P h)
     (hpost : ∀ h, Q h → Q' h)
@@ -514,7 +514,7 @@ theorem cpsHaltTriple_consequence (entry : Addr) (cr : CodeReq)
 /-- Sequence a `cpsTriple` followed by a `cpsHaltTriple`:
     if code reaches midpoint with Q, and from midpoint it halts with R, then
     the composition halts with R. -/
-theorem cpsTriple_seq_halt (entry mid : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_halt (entry mid : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
     (P Q R : Assertion)
     (h1 : cpsTriple entry mid cr1 P Q)
@@ -533,7 +533,7 @@ theorem cpsTriple_seq_halt (entry mid : Addr) (cr1 cr2 : CodeReq)
     when Q1 and Q2 are AC-permutations (proved by hperm).
     Both Q1 and Q2 are fully determined by h1/h2, so the permutation
     obligation has no metavar ambiguity. -/
-theorem cpsTriple_seq_with_perm (s m e : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_with_perm (s m e : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
     (P Q1 Q2 R : Assertion)
     (hperm : ∀ h, Q1 h → Q2 h)
@@ -545,7 +545,7 @@ theorem cpsTriple_seq_with_perm (s m e : Addr) (cr1 cr2 : CodeReq)
 
 /-- Sequence with same CodeReq: compose two CPS triples sharing the same CodeReq.
     Unlike `cpsTriple_seq`, does not require disjointness (same cr on both sides). -/
-theorem cpsTriple_seq_same_cr (l1 l2 l3 : Addr) (cr : CodeReq)
+theorem cpsTriple_seq_same_cr (l1 l2 l3 : Word) (cr : CodeReq)
     (P Q R : Assertion)
     (h1 : cpsTriple l1 l2 cr P Q) (h2 : cpsTriple l2 l3 cr Q R) :
     cpsTriple l1 l3 cr P R := by
@@ -557,7 +557,7 @@ theorem cpsTriple_seq_same_cr (l1 l2 l3 : Addr) (cr : CodeReq)
 
 /-- Sequential composition with midpoint permutation (same CodeReq).
     Like `cpsTriple_seq_with_perm` but for same-CR (no disjointness required). -/
-theorem cpsTriple_seq_with_perm_same_cr (s m e : Addr) (cr : CodeReq)
+theorem cpsTriple_seq_with_perm_same_cr (s m e : Word) (cr : CodeReq)
     (P Q1 Q2 R : Assertion) (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple s m cr P Q1) (h2 : cpsTriple m e cr Q2 R) :
     cpsTriple s e cr P R :=
@@ -571,9 +571,9 @@ theorem cpsTriple_seq_with_perm_same_cr (s m e : Addr) (cr : CodeReq)
 /-- Sequential composition: cpsTriple followed by cpsNBranch.
     If code reaches mid with Q, and from mid it branches to one of exits,
     then code branches from entry to one of exits. -/
-theorem cpsTriple_seq_cpsNBranch (entry mid : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_cpsNBranch (entry mid : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P Q : Assertion) (exits : List (Addr × Assertion))
+    (P Q : Assertion) (exits : List (Word × Assertion))
     (h1 : cpsTriple entry mid cr1 P Q)
     (h2 : cpsNBranch mid cr2 Q exits) :
     cpsNBranch entry (cr1.union cr2) P exits := by
@@ -587,9 +587,9 @@ theorem cpsTriple_seq_cpsNBranch (entry mid : Addr) (cr1 cr2 : CodeReq)
 
 /-- Sequential composition with permutation: cpsTriple followed by cpsNBranch
     when the intermediate assertions are permutations. -/
-theorem cpsTriple_seq_cpsNBranch_with_perm (entry mid : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_cpsNBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P Q1 Q2 : Assertion) (exits : List (Addr × Assertion))
+    (P Q1 Q2 : Assertion) (exits : List (Word × Assertion))
     (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple entry mid cr1 P Q1)
     (h2 : cpsNBranch mid cr2 Q2 exits) :
@@ -600,9 +600,9 @@ theorem cpsTriple_seq_cpsNBranch_with_perm (entry mid : Addr) (cr1 cr2 : CodeReq
 /-- Sequential composition: cpsTriple followed by cpsBranch.
     If code reaches mid with Q, and from mid it branches, then the
     composition branches from entry. -/
-theorem cpsTriple_seq_cpsBranch (entry mid : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_cpsBranch (entry mid : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P Q : Assertion) (exit_t : Addr) (Q_t : Assertion) (exit_f : Addr) (Q_f : Assertion)
+    (P Q : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
     (h1 : cpsTriple entry mid cr1 P Q)
     (h2 : cpsBranch mid cr2 Q exit_t Q_t exit_f Q_f) :
     cpsBranch entry (cr1.union cr2) P exit_t Q_t exit_f Q_f := by
@@ -615,9 +615,9 @@ theorem cpsTriple_seq_cpsBranch (entry mid : Addr) (cr1 cr2 : CodeReq)
   exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hbranch⟩
 
 /-- Sequential composition with permutation: cpsTriple followed by cpsBranch. -/
-theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Addr) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P Q1 Q2 : Assertion) (exit_t : Addr) (Q_t : Assertion) (exit_f : Addr) (Q_f : Assertion)
+    (P Q1 Q2 : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
     (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple entry mid cr1 P Q1)
     (h2 : cpsBranch mid cr2 Q2 exit_t Q_t exit_f Q_f) :
@@ -627,11 +627,11 @@ theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Addr) (cr1 cr2 : CodeReq)
 
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken (false) path.
     The taken path becomes a new exit prepended to the cpsNBranch exits. -/
-theorem cpsBranch_cons_cpsNBranch (entry : Addr) (cr1 cr2 : CodeReq)
+theorem cpsBranch_cons_cpsNBranch (entry : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P : Assertion) (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion)
-    (exits : List (Addr × Assertion))
+    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion)
+    (exits : List (Word × Assertion))
     (hbr : cpsBranch entry cr1 P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr2 Q_f exits) :
     cpsNBranch entry (cr1.union cr2) P ((exit_t, Q_t) :: exits) := by
@@ -647,11 +647,11 @@ theorem cpsBranch_cons_cpsNBranch (entry : Addr) (cr1 cr2 : CodeReq)
            ex, List.Mem.tail _ hmem, hpc2, hER⟩
 
 /-- Compose a cpsBranch with a cpsNBranch, with permutation on the not-taken path. -/
-theorem cpsBranch_cons_cpsNBranch_with_perm (entry : Addr) (cr1 cr2 : CodeReq)
+theorem cpsBranch_cons_cpsNBranch_with_perm (entry : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
-    (P : Assertion) (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f Q_f' : Assertion)
-    (exits : List (Addr × Assertion))
+    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f Q_f' : Assertion)
+    (exits : List (Word × Assertion))
     (hperm : ∀ h, Q_f h → Q_f' h)
     (hbr : cpsBranch entry cr1 P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr2 Q_f' exits) :
@@ -673,7 +673,7 @@ theorem cpsBranch_cons_cpsNBranch_with_perm (entry : Addr) (cr1 cr2 : CodeReq)
 /-- Compose two sequential cpsBranch specs where the first's not-taken path leads
     to the second's entry, and both taken paths go to the same target.
     The two taken postconditions are merged into a common one via weakening functions. -/
-theorem cpsBranch_seq_cpsBranch (entry mid target exit_f : Addr) (cr1 cr2 : CodeReq)
+theorem cpsBranch_seq_cpsBranch (entry mid target exit_f : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
     (P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion)
     (h1 : cpsBranch entry cr1 P target Q_t1 mid Q_f1)
@@ -705,7 +705,7 @@ theorem cpsBranch_seq_cpsBranch (entry mid target exit_f : Addr) (cr1 cr2 : Code
 
 /-- Like `cpsBranch_seq_cpsBranch` but with a permutation between Q_f1 and R. -/
 theorem cpsBranch_seq_cpsBranch_with_perm
-    (entry mid target exit_f : Addr) (cr1 cr2 : CodeReq)
+    (entry mid target exit_f : Word) (cr1 cr2 : CodeReq)
     (hd : cr1.Disjoint cr2)
     (P Q_t1 Q_f1 R Q_t2 Q_f2 Q_t : Assertion)
     (h1 : cpsBranch entry cr1 P target Q_t1 mid Q_f1)
@@ -721,8 +721,8 @@ theorem cpsBranch_seq_cpsBranch_with_perm
     h2 ht1 ht2
 
 /-- Weaken postconditions of all exits in a cpsNBranch. -/
-theorem cpsNBranch_weaken_posts (entry : Addr) (cr : CodeReq)
-    (P : Assertion) (exits exits' : List (Addr × Assertion))
+theorem cpsNBranch_weaken_posts (entry : Word) (cr : CodeReq)
+    (P : Assertion) (exits exits' : List (Word × Assertion))
     (h : cpsNBranch entry cr P exits)
     (hmap : ∀ ex ∈ exits, ∃ ex' ∈ exits', ex'.1 = ex.1 ∧ ∀ h, ex.2 h → ex'.2 h) :
     cpsNBranch entry cr P exits' := by
@@ -739,7 +739,7 @@ theorem cpsNBranch_weaken_posts (entry : Addr) (cr : CodeReq)
 -- ============================================================================
 
 /-- Frame on the right: if cpsTriple P → Q, then cpsTriple (P ** F) → (Q ** F). -/
-theorem cpsTriple_frame_left (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsTriple_frame_left (entry exit_ : Word) (cr : CodeReq)
     (P Q F : Assertion) (hF : F.pcFree)
     (h : cpsTriple entry exit_ cr P Q) :
     cpsTriple entry exit_ cr (P ** F) (Q ** F) := by
@@ -749,7 +749,7 @@ theorem cpsTriple_frame_left (entry exit_ : Addr) (cr : CodeReq)
   exact ⟨k, s', hstep, hpc', holdsFor_sepConj_assoc.mpr hpost⟩
 
 /-- Frame on the left: if cpsTriple P → Q, then cpsTriple (F ** P) → (F ** Q). -/
-theorem cpsTriple_frame_right (entry exit_ : Addr) (cr : CodeReq)
+theorem cpsTriple_frame_right (entry exit_ : Word) (cr : CodeReq)
     (P Q F : Assertion) (hF : F.pcFree)
     (h : cpsTriple entry exit_ cr P Q) :
     cpsTriple entry exit_ cr (F ** P) (F ** Q) := by
@@ -759,9 +759,9 @@ theorem cpsTriple_frame_right (entry exit_ : Addr) (cr : CodeReq)
   exact ⟨k, s', hstep, hpc', holdsFor_sepConj_pull_second.mpr hpost⟩
 
 /-- Frame for cpsBranch: if cpsBranch P → Q_t | Q_f, then cpsBranch (P ** F) → (Q_t ** F) | (Q_f ** F). -/
-theorem cpsBranch_frame_left (entry : Addr) (cr : CodeReq)
-    (P : Assertion) (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion)
+theorem cpsBranch_frame_left (entry : Word) (cr : CodeReq)
+    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion)
     (F : Assertion) (hF : F.pcFree)
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr (P ** F) exit_t (Q_t ** F) exit_f (Q_f ** F) := by
@@ -773,7 +773,7 @@ theorem cpsBranch_frame_left (entry : Addr) (cr : CodeReq)
     (fun ⟨hpc', hpost⟩ => Or.inr ⟨hpc', holdsFor_sepConj_assoc.mpr hpost⟩)⟩
 
 /-- Frame on the right for cpsHaltTriple. -/
-theorem cpsHaltTriple_frame_left (entry : Addr) (cr : CodeReq)
+theorem cpsHaltTriple_frame_left (entry : Word) (cr : CodeReq)
     (P Q F : Assertion) (hF : F.pcFree)
     (h : cpsHaltTriple entry cr P Q) :
     cpsHaltTriple entry cr (P ** F) (Q ** F) := by
@@ -791,7 +791,7 @@ theorem cpsHaltTriple_frame_left (entry : Addr) (cr : CodeReq)
     h_step: when variant = n+1, one iteration either exits with Q
             or returns to entry with inv n (variant decreased by 1). -/
 theorem cpsTriple_loop
-    (entry exit_ : Addr) (cr : CodeReq)
+    (entry exit_ : Word) (cr : CodeReq)
     (inv : Nat → Assertion)
     (Q : Assertion)
     (h_base : cpsTriple entry exit_ cr (inv 0) Q)
@@ -813,7 +813,7 @@ theorem cpsTriple_loop
 
 /-- Simplified loop rule where the step spec has the same cr. -/
 theorem cpsTriple_loop_simple
-    (entry exit_ : Addr) (cr : CodeReq)
+    (entry exit_ : Word) (cr : CodeReq)
     (inv : Nat → Assertion)
     (Q : Assertion)
     (h_base : cpsTriple entry exit_ cr (inv 0) Q)
@@ -825,7 +825,7 @@ theorem cpsTriple_loop_simple
 
 /-- Loop rule with permutation on back-edge and exit postconditions. -/
 theorem cpsTriple_loop_with_perm
-    (entry exit_ : Addr) (cr : CodeReq)
+    (entry exit_ : Word) (cr : CodeReq)
     (inv : Nat → Assertion)
     (Q : Assertion)
     (inv' : Nat → Assertion)
@@ -848,7 +848,7 @@ theorem cpsTriple_loop_with_perm
 -- ============================================================================
 
 /-- Like cpsBranch_seq_cpsBranch but with same CodeReq (no disjointness needed). -/
-theorem cpsBranch_seq_cpsBranch_same_cr (entry mid target exit_f : Addr) (cr : CodeReq)
+theorem cpsBranch_seq_cpsBranch_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
     (P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion)
     (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
     (h2 : cpsBranch mid cr Q_f1 target Q_t2 exit_f Q_f2)
@@ -873,7 +873,7 @@ theorem cpsBranch_seq_cpsBranch_same_cr (entry mid target exit_f : Addr) (cr : C
 
 /-- Like cpsBranch_seq_cpsBranch_with_perm but with same CodeReq. -/
 theorem cpsBranch_seq_cpsBranch_with_perm_same_cr
-    (entry mid target exit_f : Addr) (cr : CodeReq)
+    (entry mid target exit_f : Word) (cr : CodeReq)
     (P Q_t1 Q_f1 R Q_t2 Q_f2 Q_t : Assertion)
     (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
     (hperm : ∀ h, Q_f1 h → R h)
@@ -888,10 +888,10 @@ theorem cpsBranch_seq_cpsBranch_with_perm_same_cr
     h2 ht1 ht2
 
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken path, same CodeReq. -/
-theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Addr) (cr : CodeReq)
-    (P : Assertion) (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f : Assertion)
-    (exits : List (Addr × Assertion))
+theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Word) (cr : CodeReq)
+    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f : Assertion)
+    (exits : List (Word × Assertion))
     (hbr : cpsBranch entry cr P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr Q_f exits) :
     cpsNBranch entry cr P ((exit_t, Q_t) :: exits) := by
@@ -905,10 +905,10 @@ theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Addr) (cr : CodeReq)
            ex, List.Mem.tail _ hmem, hpc2, hER⟩
 
 /-- Compose a cpsBranch with a cpsNBranch, with permutation on the not-taken path, same CodeReq. -/
-theorem cpsBranch_cons_cpsNBranch_with_perm_same_cr (entry : Addr) (cr : CodeReq)
-    (P : Assertion) (exit_t : Addr) (Q_t : Assertion)
-    (exit_f : Addr) (Q_f Q_f' : Assertion)
-    (exits : List (Addr × Assertion))
+theorem cpsBranch_cons_cpsNBranch_with_perm_same_cr (entry : Word) (cr : CodeReq)
+    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
+    (exit_f : Word) (Q_f Q_f' : Assertion)
+    (exits : List (Word × Assertion))
     (hperm : ∀ h, Q_f h → Q_f' h)
     (hbr : cpsBranch entry cr P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr Q_f' exits) :

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -139,7 +139,7 @@ theorem pcIndep_holdsFor_regIs (r : Reg) (val : Word) :
   intro s v h
   simp only [holdsFor_regIs, MachineState.getReg_setPC] at *; exact h
 
-theorem pcIndep_holdsFor_memIs (a : Addr) (val : Word) :
+theorem pcIndep_holdsFor_memIs (a : Word) (val : Word) :
     pcIndep (memIs a val).holdsFor := by
   intro s v h
   simp only [holdsFor_memIs, MachineState.getMem, MachineState.setPC] at *; exact h
@@ -190,12 +190,12 @@ theorem signExtend21_ofNat_small (n : Nat) (h : n < 2^20) :
   · rw [BitVec.msb_eq_false_iff_two_mul_lt]; simp [BitVec.toNat_ofNat]; omega
 
 /-- Load the first instruction from a program at its base address. -/
-theorem loadProgram_at_base (base : Addr) (instr : Instr) (rest : List Instr) :
+theorem loadProgram_at_base (base : Word) (instr : Instr) (rest : List Instr) :
     loadProgram base (instr :: rest) base = some instr := by
   simp [loadProgram, BitVec.sub_self]
 
 /-- Load instruction k from a program at address base + 4*k. -/
-theorem loadProgram_at_index (base : Addr) (prog : List Instr) (k : Nat)
+theorem loadProgram_at_index (base : Word) (prog : List Instr) (k : Nat)
     (hk : k < prog.length) (h4k : 4 * k < 2^64) :
     loadProgram base prog (base + BitVec.ofNat 64 (4 * k)) = prog[k]? := by
   simp [loadProgram]
@@ -216,7 +216,7 @@ theorem execInstrBr_jal_x0 (s : MachineState) (off : BitVec 21) :
 
 /-- JAL x0 spec for any code memory: pure PC jump, no register/memory changes.
     Since x0 writes are dropped, JAL x0 just updates PC. -/
-@[spec_gen_rv64] theorem jal_x0_spec_gen (offset : BitVec 21) (addr : Addr) :
+@[spec_gen_rv64] theorem jal_x0_spec_gen (offset : BitVec 21) (addr : Word) :
     cpsTriple addr (addr + signExtend21 offset)
       (CodeReq.singleton addr (.JAL .x0 offset))
       empAssertion
@@ -232,7 +232,7 @@ theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
 
 /-- JALR x0 spec: pure PC jump to (rs1 + sext(offset)) & ~1, no register changes. -/
 @[spec_gen_rv64] theorem jalr_x0_spec_gen (rs1 : Reg) (v : Word)
-    (offset : BitVec 12) (addr : Addr) :
+    (offset : BitVec 12) (addr : Word) :
     cpsTriple addr ((v + signExtend12 offset) &&& ~~~1)
       (CodeReq.singleton addr (.JALR .x0 rs1 offset))
       (rs1 ↦ᵣ v)
@@ -279,7 +279,7 @@ private theorem aAnd_pure_right_of_true {P : Assertion} {prop : Prop}
     Requires instrAt for the BNE instruction at base. -/
 theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
     (then_body : Program)
-    (base : Addr) (P : Assertion)
+    (base : Word) (P : Assertion)
     (hP : P.pcFree)
     (ht_small : 4 * (then_body.length + 1) + 4 < 2^12) :
     let else_off : BitVec 13 := BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)
@@ -354,7 +354,7 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
     Requires instrAt for both the BNE at base and the JAL at then_exit. -/
 theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
     (then_body else_body : Program)
-    (base : Addr) (P Q : Assertion)
+    (base : Word) (P Q : Assertion)
     (hP : P.pcFree) (hQ : Q.pcFree)
     (ht_small : 4 * (then_body.length + 1) + 4 < 2^12)
     (he_small : 4 * (else_body.length) + 4 < 2^20) :
@@ -533,7 +533,7 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
     Uses additive conjunction (⋒) so rs1 and rs2 may be the same register. -/
 theorem if_eq_branch_step_n (rs1 rs2 : Reg) (v1 v2 : Word)
     (then_body : Program)
-    (base : Addr) (P : Assertion)
+    (base : Word) (P : Assertion)
     (hP : P.pcFree)
     (ht_small : 4 * (then_body.length + 1) + 4 < 2^12) :
     let else_off : BitVec 13 := BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)
@@ -556,7 +556,7 @@ theorem if_eq_branch_step_n (rs1 rs2 : Reg) (v1 v2 : Word)
     Same statement as if_eq_spec; provided for API symmetry with if_eq_branch_step_n. -/
 theorem if_eq_spec_n (rs1 rs2 : Reg) (v1 v2 : Word)
     (then_body else_body : Program)
-    (base : Addr) (P Q : Assertion)
+    (base : Word) (P Q : Assertion)
     (hP : P.pcFree) (hQ : Q.pcFree)
     (ht_small : 4 * (then_body.length + 1) + 4 < 2^12)
     (he_small : 4 * (else_body.length) + 4 < 2^20) :

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -239,11 +239,11 @@ theorem execInstrBr_eq_execInstr (s : MachineState) (i : Instr)
 -- ============================================================================
 
 /-- Code memory: maps addresses to instructions. -/
-def CodeMem := Addr → Option Instr
+def CodeMem := Word → Option Instr
 
 /-- Load a program into code memory at a base address.
     Instruction k is at address base + 4*k. -/
-def loadProgram (base : Addr) (prog : List Instr) : CodeMem :=
+def loadProgram (base : Word) (prog : List Instr) : CodeMem :=
   fun addr =>
     let offset := addr - base
     let idx := offset.toNat / 4
@@ -258,17 +258,17 @@ def loadProgram (base : Addr) (prog : List Instr) : CodeMem :=
 
 /-- ProgramAt code base prog asserts that program `prog` is loaded in `code`
     at base address `base`. Instruction i is at address base + 4*i. -/
-def ProgramAt (code : CodeMem) (base : Addr) (prog : List Instr) : Prop :=
+def ProgramAt (code : CodeMem) (base : Word) (prog : List Instr) : Prop :=
   ∀ (i : Nat), i < prog.length →
     code (base + BitVec.ofNat 64 (4 * i)) = prog[i]?
 
 /-- Extract a single instruction fetch from ProgramAt. -/
-theorem ProgramAt.get {code : CodeMem} {base : Addr} {prog : List Instr}
+theorem ProgramAt.get {code : CodeMem} {base : Word} {prog : List Instr}
     (h : ProgramAt code base prog) {i : Nat} (hi : i < prog.length) :
     code (base + BitVec.ofNat 64 (4 * i)) = prog[i]? := h i hi
 
 /-- ProgramAt for the first part of a concatenated program. -/
-theorem ProgramAt.prefix {code : CodeMem} {base : Addr} {prog1 prog2 : List Instr}
+theorem ProgramAt.prefix {code : CodeMem} {base : Word} {prog1 prog2 : List Instr}
     (h : ProgramAt code base (prog1 ++ prog2)) :
     ProgramAt code base prog1 := by
   intro i hi
@@ -277,7 +277,7 @@ theorem ProgramAt.prefix {code : CodeMem} {base : Addr} {prog1 prog2 : List Inst
   rwa [List.getElem?_append_left hi] at h_main
 
 /-- ProgramAt for the second part of a concatenated program. -/
-theorem ProgramAt.suffix {code : CodeMem} {base : Addr} {prog1 prog2 : List Instr}
+theorem ProgramAt.suffix {code : CodeMem} {base : Word} {prog1 prog2 : List Instr}
     (h : ProgramAt code base (prog1 ++ prog2)) :
     ProgramAt code (base + BitVec.ofNat 64 (4 * prog1.length)) prog2 := by
   intro i hi
@@ -295,8 +295,8 @@ theorem ProgramAt.suffix {code : CodeMem} {base : Addr} {prog1 prog2 : List Inst
 
 /-- Extract a single instruction from ProgramAt with address normalization.
     Useful for converting ProgramAt to individual code hypotheses. -/
-theorem ProgramAt.fetch {code : CodeMem} {base : Addr} {prog : List Instr}
-    (h : ProgramAt code base prog) (i : Nat) (addr : Addr) (instr : Instr)
+theorem ProgramAt.fetch {code : CodeMem} {base : Word} {prog : List Instr}
+    (h : ProgramAt code base prog) (i : Nat) (addr : Word) (instr : Instr)
     (hi : i < prog.length)
     (hinstr : prog[i]? = some instr)
     (haddr : base + BitVec.ofNat 64 (4 * i) = addr) :
@@ -304,7 +304,7 @@ theorem ProgramAt.fetch {code : CodeMem} {base : Addr} {prog : List Instr}
   rw [← haddr, ← hinstr]; exact h i hi
 
 /-- loadProgram produces a ProgramAt. -/
-theorem loadProgram_programAt (base : Addr) (prog : List Instr)
+theorem loadProgram_programAt (base : Word) (prog : List Instr)
     (hlen : 4 * prog.length < 2^64) :
     ProgramAt (loadProgram base prog) base prog := by
   intro i hi

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -33,7 +33,7 @@ namespace EvmAsm.Rv64
     Code requirement: CodeReq.singleton base instr
     The `hexec` hypothesis relates `execInstrBr` to `setReg rd result` given
     that `s.pc = base` and `s.getReg rd = v`. -/
-theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : Addr)
+theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hexec : ∀ s, s.pc = base → s.getReg rd = v →
       execInstrBr s instr = (s.setReg rd result).setPC (s.pc + 4))
@@ -68,7 +68,7 @@ theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : A
     Pre:  (rs ↦ᵣ v_src) ** (rd ↦ᵣ v_old)
     Post: (rs ↦ᵣ v_src) ** (rd ↦ᵣ result) -/
 theorem generic_2reg_spec (instr : Instr) (rs rd : Reg)
-    (v_src v_old result : Word) (base : Addr)
+    (v_src v_old result : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hexec : ∀ s, s.pc = base → s.getReg rs = v_src → s.getReg rd = v_old →
       execInstrBr s instr = (s.setReg rd result).setPC (s.pc + 4))
@@ -106,7 +106,7 @@ theorem generic_2reg_spec (instr : Instr) (rs rd : Reg)
     Pre:  (rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2)
     Post: (rd ↦ᵣ result) ** (rs2 ↦ᵣ v2) -/
 theorem generic_2reg_rd_eq_rs1_spec (instr : Instr) (rd rs2 : Reg)
-    (v1 v2 result : Word) (base : Addr)
+    (v1 v2 result : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hexec : ∀ s, s.pc = base → s.getReg rd = v1 → s.getReg rs2 = v2 →
       execInstrBr s instr = (s.setReg rd result).setPC (s.pc + 4))
@@ -145,7 +145,7 @@ theorem generic_2reg_rd_eq_rs1_spec (instr : Instr) (rd rs2 : Reg)
     Pre:  (rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old)
     Post: (rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ result) -/
 theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
-    (v1 v2 v_old result : Word) (base : Addr)
+    (v1 v2 v_old result : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hexec : ∀ s, s.pc = base → s.getReg rs1 = v1 → s.getReg rs2 = v2 →
       execInstrBr s instr = (s.setReg rd result).setPC (s.pc + 4))
@@ -183,7 +183,7 @@ theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
 
 /-- Generic spec for instructions that only advance PC without changing state.
     Pre/Post: empAssertion  [frame handles the rest] -/
-theorem generic_nop_spec (instr : Instr) (base exit_ : Addr)
+theorem generic_nop_spec (instr : Instr) (base exit_ : Word)
     (hexec : ∀ s, s.pc = base → execInstrBr s instr = s.setPC exit_)
     (hstep : ∀ s, s.code s.pc = some instr → step s = some (execInstrBr s instr)) :
     cpsTriple base exit_ (CodeReq.singleton base instr)
@@ -212,7 +212,7 @@ theorem generic_nop_spec (instr : Instr) (base exit_ : Addr)
     Pre:  (rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)
     Taken (v1 ≠ v2): PC = base + signExtend13 offset, post includes ⌜v1 ≠ v2⌝
     Not taken (v1 = v2): PC = base + 4, post includes ⌜v1 = v2⌝ -/
-theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BNE rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -263,7 +263,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
          (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
 
 /-- Generic spec for BEQ: branch if equal. -/
-theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BEQ rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -318,7 +318,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
 /-- Generic spec for BLTU: branch if unsigned less than.
     Taken (ult v1 v2): PC = base + signExtend13 offset
     Not taken (¬ult v1 v2): PC = base + 4 -/
-theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BLTU rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -373,7 +373,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
 /-- Generic spec for BGE: branch if signed greater or equal.
     Taken (¬slt v1 v2): PC = base + signExtend13 offset
     Not taken (slt v1 v2): PC = base + 4 -/
-theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BGE rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -428,7 +428,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
 /-- Generic spec for BLT: branch if signed less than.
     Taken (slt v1 v2): PC = base + signExtend13 offset
     Not taken (¬slt v1 v2): PC = base + 4 -/
-theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BLT rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -483,7 +483,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
 /-- Generic spec for BGEU: branch if unsigned greater or equal.
     Taken (¬ult v1 v2): PC = base + signExtend13 offset
     Not taken (ult v1 v2): PC = base + 4 -/
-theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BGEU rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset)
@@ -538,7 +538,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
 /-- Generic spec for JAL: rd := PC + 4, PC := PC + sext(offset).
     Pre:  (rd ↦ᵣ v_old)
     Post: (rd ↦ᵣ (base + 4)) -/
-theorem generic_jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : Addr)
+theorem generic_jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + signExtend21 offset) (CodeReq.singleton base (.JAL rd offset))
       (rd ↦ᵣ v_old)
@@ -558,7 +558,7 @@ theorem generic_jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : 
 /-- Generic spec for JALR: rd := PC + 4, PC := (rs1 + sext(offset)) & ~1.
     Pre:  (rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old)
     Post: (rs1 ↦ᵣ v1) ** (rd ↦ᵣ (base + 4)) -/
-theorem generic_jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) (base : Addr)
+theorem generic_jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base ((v1 + signExtend12 offset) &&& ~~~1) (CodeReq.singleton base (.JALR rd rs1 offset))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -593,7 +593,7 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) 
     Post: (rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ mem_val) ** (addr ↦ₘ mem_val)
     where addr = v_addr + signExtend12 offset -/
 theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
-    (offset : BitVec 12) (base : Addr)
+    (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rs1 offset))
@@ -637,7 +637,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
     Post: (rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** (addr ↦ₘ v_data)
     where addr = v_addr + signExtend12 offset -/
 theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data mem_old : Word)
-    (offset : BitVec 12) (base : Addr)
+    (offset : BitVec 12) (base : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SD rs1 rs2 offset))
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** ((v_addr + signExtend12 offset) ↦ₘ mem_old))
@@ -678,7 +678,7 @@ theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data mem_old : Word)
     Pre:  (rs1 ↦ᵣ v_addr) ** (addr ↦ₘ mem_old)
     Post: (rs1 ↦ᵣ v_addr) ** (addr ↦ₘ 0) -/
 theorem generic_sd_x0_spec (rs1 : Reg) (v_addr mem_old : Word)
-    (offset : BitVec 12) (base : Addr)
+    (offset : BitVec 12) (base : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SD rs1 .x0 offset))
       ((rs1 ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ mem_old))

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -39,20 +39,20 @@ theorem extractHalfword_replaceHalfword_same (w : Word) (pos : Fin 4) (h : BitVe
 
 /-! ## getHalfword / setHalfword in terms of extractHalfword / replaceHalfword -/
 
-theorem getHalfword_eq (s : MachineState) (addr : Addr) :
+theorem getHalfword_eq (s : MachineState) (addr : Word) :
     s.getHalfword addr = extractHalfword (s.getMem (alignToDword addr)) ((byteOffset addr) / 2) := rfl
 
-theorem setHalfword_eq (s : MachineState) (addr : Addr) (h : BitVec 16) :
+theorem setHalfword_eq (s : MachineState) (addr : Word) (h : BitVec 16) :
     s.setHalfword addr h = s.setMem (alignToDword addr)
       (replaceHalfword (s.getMem (alignToDword addr)) ((byteOffset addr) / 2) h) := rfl
 
 /-! ## halfwordOffset bound -/
 
-private theorem byteOffset_lt_8' (addr : Addr) : byteOffset addr < 8 := by
+private theorem byteOffset_lt_8' (addr : Word) : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by native_decide)
 
-theorem halfwordOffset_lt_4 (addr : Addr) : (byteOffset addr) / 2 < 4 := by
+theorem halfwordOffset_lt_4 (addr : Word) : (byteOffset addr) / 2 < 4 := by
   have := byteOffset_lt_8' addr; omega
 
 /-! ## LHU generic spec
@@ -60,8 +60,8 @@ theorem halfwordOffset_lt_4 (addr : Addr) : (byteOffset addr) / 2 < 4 := by
 LHU reads a halfword from memory at a 2-byte aligned address and zero-extends it. -/
 
 theorem generic_lhu_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -105,8 +105,8 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr v_old : Word)
 LH reads a halfword from memory at a 2-byte aligned address and sign-extends it. -/
 
 theorem generic_lh_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -150,8 +150,8 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr v_old : Word)
 SH writes a halfword to memory at a 2-byte aligned address. -/
 
 theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_old : Word)
     (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -28,7 +28,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 /-- ADD rd, rs1, rs2: rd := rs1 + rs2 (all registers distinct) -/
-theorem add_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Addr)
+theorem add_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADD rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
@@ -38,7 +38,7 @@ theorem add_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rd, rs2: rd := rd + rs2 (rd = rs1, rs2 distinct) -/
-theorem add_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Addr)
+theorem add_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADD rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
@@ -48,7 +48,7 @@ theorem add_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rs1, rd: rd := rs1 + rd (rd = rs2, rs1 distinct) -/
-theorem add_spec_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word) (base : Addr)
+theorem add_spec_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADD rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
@@ -58,7 +58,7 @@ theorem add_spec_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rd, rd: rd := rd + rd = 2 * rd (all same) -/
-theorem add_spec_all_same (rd : Reg) (v : Word) (base : Addr)
+theorem add_spec_all_same (rd : Reg) (v : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADD rd rd rd))
       (rd ↦ᵣ v)
@@ -68,7 +68,7 @@ theorem add_spec_all_same (rd : Reg) (v : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rs1, rs2: rd := rs1 - rs2 (all registers distinct) -/
-theorem sub_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Addr)
+theorem sub_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SUB rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
@@ -78,7 +78,7 @@ theorem sub_spec (rd rs1 rs2 : Reg) (v1 v2 v_old : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rd, rs2: rd := rd - rs2 -/
-theorem sub_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Addr)
+theorem sub_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SUB rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
@@ -88,7 +88,7 @@ theorem sub_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rd, rd: rd := rd - rd = 0 -/
-theorem sub_spec_all_same (rd : Reg) (v : Word) (base : Addr)
+theorem sub_spec_all_same (rd : Reg) (v : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SUB rd rd rd))
       (rd ↦ᵣ v)
@@ -102,7 +102,7 @@ theorem sub_spec_all_same (rd : Reg) (v : Word) (base : Addr)
 -- ============================================================================
 
 /-- ADDI rd, rs1, imm: rd := rs1 + sext(imm) (registers distinct) -/
-theorem addi_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Addr)
+theorem addi_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -112,7 +112,7 @@ theorem addi_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Add
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADDI rd, rd, imm: rd := rd + sext(imm) (same register) -/
-theorem addi_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
+theorem addi_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI rd rd imm))
       (rd ↦ᵣ v)
@@ -126,7 +126,7 @@ theorem addi_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
 -- ============================================================================
 
 /-- ORI rd, rs1, imm: rd := rs1 | sext(imm) (registers distinct) -/
-theorem ori_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Addr)
+theorem ori_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ORI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -136,7 +136,7 @@ theorem ori_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Addr
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ORI rd, rd, imm: rd := rd | sext(imm) (same register) -/
-theorem ori_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
+theorem ori_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ORI rd rd imm))
       (rd ↦ᵣ v)
@@ -150,7 +150,7 @@ theorem ori_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
 -- ============================================================================
 
 /-- SLTI rd, rs1, imm: rd := (rs1 <s sext(imm)) ? 1 : 0 (registers distinct) -/
-theorem slti_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Addr)
+theorem slti_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SLTI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -160,7 +160,7 @@ theorem slti_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Add
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SLTI rd, rd, imm: rd := (rd <s sext(imm)) ? 1 : 0 (same register) -/
-theorem slti_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
+theorem slti_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SLTI rd rd imm))
       (rd ↦ᵣ v)
@@ -174,7 +174,7 @@ theorem slti_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
 -- ============================================================================
 
 /-- ADDIW rd, rs1, imm: rd := signExtend64(truncate32(rs1) + truncate32(sext(imm))) (registers distinct) -/
-theorem addiw_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Addr)
+theorem addiw_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADDIW rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -184,7 +184,7 @@ theorem addiw_spec (rd rs1 : Reg) (v1 v_old : Word) (imm : BitVec 12) (base : Ad
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADDIW rd, rd, imm: rd := signExtend64(truncate32(rd) + truncate32(sext(imm))) (same register) -/
-theorem addiw_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
+theorem addiw_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.ADDIW rd rd imm))
       (rd ↦ᵣ v)
@@ -199,7 +199,7 @@ theorem addiw_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Addr)
 
 /-- LUI rd, imm: rd := signExtend64(imm << 12)
     In RV64, LUI sign-extends the 32-bit result to 64 bits. -/
-theorem lui_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Addr)
+theorem lui_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LUI rd imm))
       (rd ↦ᵣ v_old)
@@ -210,7 +210,7 @@ theorem lui_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Addr)
 
 /-- AUIPC rd, imm: rd := PC + signExtend64(imm << 12)
     In RV64, AUIPC sign-extends the 32-bit shifted value before adding to PC. -/
-theorem auipc_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Addr)
+theorem auipc_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.AUIPC rd imm))
       (rd ↦ᵣ v_old)
@@ -224,7 +224,7 @@ theorem auipc_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Addr)
 -- ============================================================================
 
 /-- LD rd, offset(rs1): rd := mem[rs1 + sext(offset)] (registers distinct) -/
-theorem ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word) (offset : BitVec 12) (base : Addr)
+theorem ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rs1 offset))
@@ -233,7 +233,7 @@ theorem ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word) (offset : BitVec 12
   generic_ld_spec rd rs1 v_addr v_old mem_val offset base hrd_ne_x0 hvalid
 
 /-- LD rd, offset(rd): rd := mem[rd + sext(offset)] (same register) -/
-theorem ld_spec_same (rd : Reg) (v_addr mem_val : Word) (offset : BitVec 12) (base : Addr)
+theorem ld_spec_same (rd : Reg) (v_addr mem_val : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rd offset))
@@ -262,7 +262,7 @@ theorem ld_spec_same (rd : Reg) (v_addr mem_val : Word) (offset : BitVec 12) (ba
     exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
 
 /-- SD rs2, offset(rs1): mem[rs1 + sext(offset)] := rs2 (registers distinct) -/
-theorem sd_spec (rs1 rs2 : Reg) (v_addr v_data mem_old : Word) (offset : BitVec 12) (base : Addr)
+theorem sd_spec (rs1 rs2 : Reg) (v_addr v_data mem_old : Word) (offset : BitVec 12) (base : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SD rs1 rs2 offset))
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** ((v_addr + signExtend12 offset) ↦ₘ mem_old))
@@ -270,7 +270,7 @@ theorem sd_spec (rs1 rs2 : Reg) (v_addr v_data mem_old : Word) (offset : BitVec 
   generic_sd_spec rs1 rs2 v_addr v_data mem_old offset base hvalid
 
 /-- SD rs, offset(rs): mem[rs + sext(offset)] := rs (same register) -/
-theorem sd_spec_same (rs : Reg) (v : Word) (mem_old : Word) (offset : BitVec 12) (base : Addr)
+theorem sd_spec_same (rs : Reg) (v : Word) (mem_old : Word) (offset : BitVec 12) (base : Word)
     (hvalid : isValidDwordAccess (v + signExtend12 offset) = true) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.SD rs rs offset))
       ((rs ↦ᵣ v) ** ((v + signExtend12 offset) ↦ₘ mem_old))
@@ -298,7 +298,7 @@ theorem sd_spec_same (rs : Reg) (v : Word) (mem_old : Word) (offset : BitVec 12)
 -- ============================================================================
 
 /-- BEQ rs1, rs2, offset: branch if rs1 = rs2 (registers distinct) -/
-theorem beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BEQ rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset) ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜v1 = v2⌝)
@@ -306,7 +306,7 @@ theorem beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Add
   generic_beq_spec rs1 rs2 offset v1 v2 base
 
 /-- BEQ rs, rs, offset: branch if rs = rs (always taken, same register) -/
-theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Addr) :
+theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BEQ rs rs offset))
       (rs ↦ᵣ v)
       (base + signExtend13 offset) (rs ↦ᵣ v)
@@ -326,7 +326,7 @@ theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Addr) :
   · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ hPR
 
 /-- BNE rs1, rs2, offset: branch if rs1 ≠ rs2 (registers distinct) -/
-theorem bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BNE rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset) ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜v1 ≠ v2⌝)
@@ -334,7 +334,7 @@ theorem bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Add
   generic_bne_spec rs1 rs2 offset v1 v2 base
 
 /-- BNE rs, rs, offset: branch if rs ≠ rs (never taken, same register) -/
-theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Addr) :
+theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BNE rs rs offset))
       (rs ↦ᵣ v)
       (base + signExtend13 offset) (rs ↦ᵣ v)
@@ -358,7 +358,7 @@ theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Addr) :
 -- ============================================================================
 
 /-- BGEU rs1, rs2, offset: branch if rs1 >=u rs2 (registers distinct) -/
-theorem bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Addr) :
+theorem bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
     cpsBranch base (CodeReq.singleton base (.BGEU rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (base + signExtend13 offset) ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜¬BitVec.ult v1 v2⌝)
@@ -370,7 +370,7 @@ theorem bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Ad
 -- ============================================================================
 
 /-- JAL rd, offset: rd := PC + 4; PC := PC + sext(offset) -/
-theorem jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : Addr)
+theorem jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + signExtend21 offset) (CodeReq.singleton base (.JAL rd offset))
       (rd ↦ᵣ v_old)
@@ -378,7 +378,7 @@ theorem jal_spec (rd : Reg) (v_old : Word) (offset : BitVec 21) (base : Addr)
   generic_jal_spec rd v_old offset base hrd_ne_x0
 
 /-- JALR rd, rs1, offset: rd := PC + 4; PC := (rs1 + sext(offset)) & ~1 (distinct) -/
-theorem jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) (base : Addr)
+theorem jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base ((v1 + signExtend12 offset) &&& (~~~1)) (CodeReq.singleton base (.JALR rd rs1 offset))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
@@ -386,7 +386,7 @@ theorem jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) (base : 
   generic_jalr_spec rd rs1 v1 v_old offset base hrd_ne_x0
 
 /-- JALR rd, rd, offset: rd := PC + 4; PC := (rd + sext(offset)) & ~1 (same) -/
-theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Addr)
+theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base ((v + signExtend12 offset) &&& (~~~1)) (CodeReq.singleton base (.JALR rd rd offset))
       (rd ↦ᵣ v)
@@ -412,7 +412,7 @@ theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Addr)
 -- ============================================================================
 
 /-- MV rd, rs: rd := rs (pseudo for ADDI rd, rs, 0) -/
-theorem mv_spec (rd rs : Reg) (v v_old : Word) (base : Addr)
+theorem mv_spec (rd rs : Reg) (v v_old : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.MV rd rs))
       ((rs ↦ᵣ v) ** (rd ↦ᵣ v_old))
@@ -422,7 +422,7 @@ theorem mv_spec (rd rs : Reg) (v v_old : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- LI rd, imm: rd := imm (pseudo for loading immediate) -/
-theorem li_spec (rd : Reg) (v_old imm : Word) (base : Addr)
+theorem li_spec (rd : Reg) (v_old imm : Word) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LI rd imm))
       (rd ↦ᵣ v_old)
@@ -432,7 +432,7 @@ theorem li_spec (rd : Reg) (v_old imm : Word) (base : Addr)
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 /-- NOP: no operation (pseudo for ADDI x0, x0, 0) -/
-theorem nop_spec (base : Addr) :
+theorem nop_spec (base : Word) :
     cpsTriple base (base + 4) (CodeReq.singleton base .NOP)
       empAssertion
       empAssertion :=
@@ -445,7 +445,7 @@ theorem nop_spec (base : Addr) :
 -- ============================================================================
 
 /-- FENCE: memory fence (NOP in single-hart zkVM) -/
-theorem fence_spec (base : Addr) :
+theorem fence_spec (base : Word) :
     cpsTriple base (base + 4) (CodeReq.singleton base .FENCE)
       empAssertion
       empAssertion :=

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2646,6 +2646,36 @@ theorem sepConj_emp_left' (P : Assertion) : (empAssertion ** P) = P :=
 instance : Std.Associative (α := Assertion) sepConj := ⟨sepConj_assoc'⟩
 instance : Std.Commutative (α := Assertion) sepConj := ⟨sepConj_comm'⟩
 
+-- ---------------------------------------------------------------------------
+-- seps: list-based separation conjunction (bedrock2-style)
+-- ---------------------------------------------------------------------------
+
+/-- Fold a list of assertions into a right-associated sepConj chain.
+    Used by the xperm tactic to reduce proof term size from O(n²) to O(n).
+    `seps [a, b, c]` = `a ** (b ** (c ** empAssertion))`.
+    The trailing `empAssertion` is removed at the boundary via `sepConj_emp_right'`. -/
+def seps : List Assertion → Assertion
+  | [] => empAssertion
+  | x :: xs => x ** seps xs
+
+@[simp] theorem seps_nil : seps ([] : List Assertion) = empAssertion := rfl
+@[simp] theorem seps_cons (x : Assertion) (xs : List Assertion) :
+    seps (x :: xs) = (x ** seps xs) := rfl
+
+/-- Pick the n-th element to the front of a seps chain.
+    `seps xs = xs[n] ** seps (xs.eraseIdx n)` -/
+theorem seps_pick (xs : List Assertion) (n : Nat) (hn : n < xs.length) :
+    seps xs = (xs[n] ** seps (xs.eraseIdx n)) := by
+  induction n generalizing xs with
+  | zero =>
+    match xs, hn with
+    | x :: rest, _ => simp [seps, List.eraseIdx]
+  | succ k ih =>
+    match xs, hn with
+    | x :: rest, hn' =>
+      simp only [seps_cons, List.getElem_cons_succ, List.eraseIdx_cons_succ]
+      rw [ih rest (Nat.lt_of_succ_lt_succ hn'), sepConj_left_comm']
+
 /-- `sep_perm h` closes a goal of the form `(A₁ ** ... ** Aₙ) s` given a hypothesis `h`
     that is a permutation of the same assertions applied to the same state.
     Works by proving assertion equality via `ac_rfl` and transporting with `congrFun`.

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -26,8 +26,8 @@ namespace EvmAsm.Rv64
     `none` means "we don't own this resource". -/
 structure PartialState where
   regs : Reg → Option Word
-  mem  : Addr → Option Word
-  code : Addr → Option Instr := fun _ => none
+  mem  : Word → Option Word
+  code : Word → Option Instr := fun _ => none
   pc   : Option Word
   publicValues : Option (List (BitVec 8)) := none
   privateInput : Option (List (BitVec 8)) := none
@@ -47,7 +47,7 @@ def singletonReg (r : Reg) (v : Word) : PartialState where
   privateInput := none
 
 /-- A partial state owning just one memory cell. -/
-def singletonMem (a : Addr) (v : Word) : PartialState where
+def singletonMem (a : Word) (v : Word) : PartialState where
   regs := fun _ => none
   mem  := fun a' => if a' == a then some v else none
   code := fun _ => none
@@ -56,7 +56,7 @@ def singletonMem (a : Addr) (v : Word) : PartialState where
   privateInput := none
 
 /-- A partial state owning just one code location. -/
-def singletonCode (a : Addr) (i : Instr) : PartialState where
+def singletonCode (a : Word) (i : Instr) : PartialState where
   regs := fun _ => none
   mem  := fun _ => none
   code := fun a' => if a' == a then some i else none
@@ -212,7 +212,7 @@ theorem CompatibleWith_singletonReg (r : Reg) (v : Word) (s : MachineState) :
       simp at h; rw [← h]; exact heq
     · simp at h
 
-theorem CompatibleWith_singletonMem (a : Addr) (v : Word) (s : MachineState) :
+theorem CompatibleWith_singletonMem (a : Word) (v : Word) (s : MachineState) :
     (singletonMem a v).CompatibleWith s ↔ s.getMem a = v := by
   constructor
   · intro ⟨_, hm, _, _, _, _⟩
@@ -330,7 +330,7 @@ def regIs (r : Reg) (v : Word) : Assertion :=
 notation:50 r " ↦ᵣ " v => regIs r v
 
 /-- Memory at address a holds value v. -/
-def memIs (a : Addr) (v : Word) : Assertion :=
+def memIs (a : Word) (v : Word) : Assertion :=
   fun h => h = PartialState.singletonMem a v
 
 /-- Notation: a ↦ₘ v means memory at address a holds value v. -/
@@ -344,7 +344,7 @@ def pcIs (v : Word) : Assertion :=
 def regOwn (r : Reg) : Assertion := fun h => ∃ v, regIs r v h
 
 /-- Ownership of memory at address a with unspecified value. -/
-def memOwn (a : Addr) : Assertion := fun h => ∃ v, memIs a v h
+def memOwn (a : Word) : Assertion := fun h => ∃ v, memIs a v h
 
 /-- The empty assertion: owns no resources. -/
 def empAssertion : Assertion := fun h => h = PartialState.empty
@@ -398,7 +398,7 @@ theorem holdsFor_regIs (r : Reg) (v : Word) (s : MachineState) :
     exact ⟨_, (PartialState.CompatibleWith_singletonReg r v s).mpr heq, rfl⟩
 
 @[simp]
-theorem holdsFor_memIs (a : Addr) (v : Word) (s : MachineState) :
+theorem holdsFor_memIs (a : Word) (v : Word) (s : MachineState) :
     (memIs a v).holdsFor s ↔ s.getMem a = v := by
   simp only [Assertion.holdsFor, memIs]
   constructor
@@ -431,7 +431,7 @@ theorem holdsFor_regOwn (r : Reg) (s : MachineState) :
          s.getReg r, rfl⟩
 
 @[simp]
-theorem holdsFor_memOwn (a : Addr) (s : MachineState) :
+theorem holdsFor_memOwn (a : Word) (s : MachineState) :
     (memOwn a).holdsFor s ↔ True := by
   simp only [iff_true, memOwn, Assertion.holdsFor]
   exact ⟨_, (PartialState.CompatibleWith_singletonMem a (s.getMem a) s).mpr rfl,
@@ -440,7 +440,7 @@ theorem holdsFor_memOwn (a : Addr) (s : MachineState) :
 theorem regIs_implies_regOwn (r : Reg) (v : Word) :
     ∀ h, regIs r v h → regOwn r h := fun _ hp => ⟨v, hp⟩
 
-theorem memIs_implies_memOwn (a : Addr) (v : Word) :
+theorem memIs_implies_memOwn (a : Word) (v : Word) :
     ∀ h, memIs a v h → memOwn a h := fun _ hp => ⟨v, hp⟩
 
 -- ============================================================================
@@ -475,7 +475,7 @@ theorem singletonReg_disjoint_imp_ne {r1 r2 : Reg} {v1 v2 : Word}
   -- this says: some v1 = none ∨ some v2 = none, which is false
   cases this <;> simp_all
 
-private theorem singletonReg_disjoint_singletonMem (r : Reg) (v : Word) (a : Addr) (w : Word) :
+private theorem singletonReg_disjoint_singletonMem (r : Reg) (v : Word) (a : Word) (w : Word) :
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonMem a w) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
@@ -496,7 +496,7 @@ theorem holdsFor_sepConj_regIs_regIs {r1 r2 : Reg} {v1 v2 : Word} {s : MachineSt
        (PartialState.CompatibleWith_singletonReg r2 v2 s).mpr h2⟩,
       _, _, hd, rfl, rfl, rfl⟩
 
-theorem holdsFor_sepConj_regIs_memIs {r : Reg} {v : Word} {a : Addr} {w : Word}
+theorem holdsFor_sepConj_regIs_memIs {r : Reg} {v : Word} {a : Word} {w : Word}
     {s : MachineState} :
     ((regIs r v) ** (memIs a w)).holdsFor s ↔ s.getReg r = v ∧ s.getMem a = w := by
   constructor
@@ -538,13 +538,13 @@ theorem holdsFor_sepConj_elim_right {P Q : Assertion} {s : MachineState}
 theorem pcFree_regIs (r : Reg) (v : Word) : (regIs r v).pcFree := by
   intro h hp; rw [regIs] at hp; subst hp; rfl
 
-theorem pcFree_memIs (a : Addr) (v : Word) : (memIs a v).pcFree := by
+theorem pcFree_memIs (a : Word) (v : Word) : (memIs a v).pcFree := by
   intro h hp; rw [memIs] at hp; subst hp; rfl
 
 theorem pcFree_regOwn (r : Reg) : (regOwn r).pcFree := by
   intro h ⟨v, hv⟩; exact pcFree_regIs r v h hv
 
-theorem pcFree_memOwn (a : Addr) : (memOwn a).pcFree := by
+theorem pcFree_memOwn (a : Word) : (memOwn a).pcFree := by
   intro h ⟨v, hv⟩; exact pcFree_memIs a v h hv
 
 theorem pcFree_emp : empAssertion.pcFree := by
@@ -1012,7 +1012,7 @@ private theorem singletonReg_disjoint_singletonPublicValues (r : Reg) (v : Word)
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonPublicValues vals) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonMem_disjoint_singletonPublicValues (a : Addr) (v : Word) (vals : List (BitVec 8)) :
+private theorem singletonMem_disjoint_singletonPublicValues (a : Word) (v : Word) (vals : List (BitVec 8)) :
     (PartialState.singletonMem a v).Disjoint (PartialState.singletonPublicValues vals) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
@@ -1095,7 +1095,7 @@ private theorem singletonReg_disjoint_singletonPrivateInput (r : Reg) (v : Word)
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonPrivateInput vals) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonMem_disjoint_singletonPrivateInput (a : Addr) (v : Word) (vals : List (BitVec 8)) :
+private theorem singletonMem_disjoint_singletonPrivateInput (a : Word) (v : Word) (vals : List (BitVec 8)) :
     (PartialState.singletonMem a v).Disjoint (PartialState.singletonPrivateInput vals) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
@@ -1207,7 +1207,7 @@ theorem CompatibleWith_setReg {h : PartialState} {s : MachineState} {r : Reg} {v
     rw [this]; exact hr r' v' hv
 
 /-- If a partial state doesn't own address a, then modifying mem[a] preserves compatibility. -/
-theorem CompatibleWith_setMem {h : PartialState} {s : MachineState} {a : Addr} {v : Word}
+theorem CompatibleWith_setMem {h : PartialState} {s : MachineState} {a : Word} {v : Word}
     (hcompat : h.CompatibleWith s) (hnone : h.mem a = none) :
     h.CompatibleWith (s.setMem a v) := by
   obtain ⟨hr, hm, hc, hpc, hpv, hpi⟩ := hcompat
@@ -1483,7 +1483,7 @@ theorem holdsFor_sepConj_regIs_regIs_regIs_setReg
 
 /-- If `(a ↦ₘ v) ** R` holds for `s`, then `(a ↦ₘ v') ** R` holds for `s.setMem a v'`.
     The frame R is preserved because it's disjoint from the memory being modified. -/
-theorem holdsFor_sepConj_memIs_setMem {a : Addr} {v v' : Word} {R : Assertion}
+theorem holdsFor_sepConj_memIs_setMem {a : Word} {v v' : Word} {R : Assertion}
     {s : MachineState}
     (hPR : ((a ↦ₘ v) ** R).holdsFor s) :
     ((a ↦ₘ v') ** R).holdsFor (s.setMem a v') := by
@@ -1519,7 +1519,7 @@ theorem holdsFor_sepConj_memIs_setMem {a : Addr} {v v' : Word} {R : Assertion}
   exact (PartialState.CompatibleWith_union hdisj').mpr ⟨hc1', hc2'⟩
 
 /-- setMem preserves holdsFor for any assertion whose partial state doesn't own the address. -/
-theorem holdsFor_setMem {P : Assertion} {a : Addr} {v : Word} {s : MachineState}
+theorem holdsFor_setMem {P : Assertion} {a : Word} {v : Word} {s : MachineState}
     (hP_no_a : ∀ h, P h → h.mem a = none)
     (hP : P.holdsFor s) :
     P.holdsFor (s.setMem a v) := by
@@ -1816,13 +1816,13 @@ theorem holdsFor_liftPred_of {P : MachineState → Prop} {s : MachineState}
 -- ============================================================================
 
 /-- Code ownership at address a with instruction i. -/
-def instrAt (a : Addr) (i : Instr) : Assertion := fun h => h = PartialState.singletonCode a i
+def instrAt (a : Word) (i : Instr) : Assertion := fun h => h = PartialState.singletonCode a i
 
 /-- Notation: a ↦ᵢ i means code at address a holds instruction i. -/
 notation:50 a " ↦ᵢ " i => instrAt a i
 
 /-- Program ownership: a recursive assertion for a program. -/
-def programAt : List (Addr × Instr) → Assertion
+def programAt : List (Word × Instr) → Assertion
   | [] => empAssertion
   | (a, i) :: rest => (instrAt a i) ** (programAt rest)
 
@@ -1836,16 +1836,16 @@ theorem bv_add_ofNat_assoc {w : Nat} (a : BitVec w) (n m : Nat) :
 
 /-- Convert a program (List Instr) at a base address to address-instruction pairs.
     Each instruction occupies 4 bytes. -/
-def progIndexed (base : Addr) : List Instr → List (Addr × Instr)
+def progIndexed (base : Word) : List Instr → List (Word × Instr)
   | [] => []
   | i :: rest => (base, i) :: progIndexed (base + 4) rest
 
 /-- Program assertion at a base address: owns instrAt for every instruction. -/
-def progAt (base : Addr) (prog : List Instr) : Assertion :=
+def progAt (base : Word) (prog : List Instr) : Assertion :=
   programAt (progIndexed base prog)
 
 /-- Indexed list for append splits into indexed lists for each part. -/
-theorem progIndexed_append (base : Addr) (p1 p2 : List Instr) :
+theorem progIndexed_append (base : Word) (p1 p2 : List Instr) :
     progIndexed base (p1 ++ p2) = progIndexed base p1 ++ progIndexed (base + BitVec.ofNat 64 (4 * p1.length)) p2 := by
   induction p1 generalizing base with
   | nil => simp [progIndexed, List.nil_append, BitVec.ofNat]
@@ -1861,7 +1861,7 @@ theorem progIndexed_append (base : Addr) (p1 p2 : List Instr) :
     omega
 
 /-- programAt splits on append. -/
-theorem programAt_append (l1 l2 : List (Addr × Instr)) :
+theorem programAt_append (l1 l2 : List (Word × Instr)) :
     programAt (l1 ++ l2) = (programAt l1 ** programAt l2) := by
   induction l1 with
   | nil =>
@@ -1873,7 +1873,7 @@ theorem programAt_append (l1 l2 : List (Addr × Instr)) :
     funext h; exact propext ⟨(sepConj_assoc _ _ _ h).mpr, (sepConj_assoc _ _ _ h).mp⟩
 
 /-- progAt splits on program append. -/
-theorem progAt_append (base : Addr) (p1 p2 : List Instr) :
+theorem progAt_append (base : Word) (p1 p2 : List Instr) :
     progAt base (p1 ++ p2) = (progAt base p1 ** progAt (base + BitVec.ofNat 64 (4 * p1.length)) p2) := by
   simp only [progAt, progIndexed_append, programAt_append]
 
@@ -1883,7 +1883,7 @@ theorem progAt_append (base : Addr) (p1 p2 : List Instr) :
 
 namespace PartialState
 
-theorem CompatibleWith_singletonCode (a : Addr) (i : Instr) (s : MachineState) :
+theorem CompatibleWith_singletonCode (a : Word) (i : Instr) (s : MachineState) :
     (singletonCode a i).CompatibleWith s ↔ s.code a = some i := by
   constructor
   · intro ⟨_, _, hc, _, _, _⟩
@@ -1909,7 +1909,7 @@ end PartialState
 -- ============================================================================
 
 @[simp]
-theorem holdsFor_instrAt (a : Addr) (i : Instr) (s : MachineState) :
+theorem holdsFor_instrAt (a : Word) (i : Instr) (s : MachineState) :
     (instrAt a i).holdsFor s ↔ s.code a = some i := by
   simp only [Assertion.holdsFor, instrAt]
   constructor
@@ -1922,7 +1922,7 @@ theorem holdsFor_instrAt (a : Addr) (i : Instr) (s : MachineState) :
 -- Disjointness lemmas for singletonCode
 -- ============================================================================
 
-private theorem singletonCode_disjoint_singletonCode (a1 a2 : Addr) (i1 i2 : Instr)
+private theorem singletonCode_disjoint_singletonCode (a1 a2 : Word) (i1 i2 : Instr)
     (hne : a1 ≠ a2) :
     (PartialState.singletonCode a1 i1).Disjoint (PartialState.singletonCode a2 i2) := by
   refine ⟨fun r => Or.inl rfl, fun _ => Or.inl rfl, fun a => ?_, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
@@ -1937,23 +1937,23 @@ private theorem singletonCode_disjoint_singletonCode (a1 a2 : Addr) (i1 i2 : Ins
     · exact fun hi2 => h2 (beq_iff_eq.mpr hi2)
   · simp [h1]
 
-private theorem singletonReg_disjoint_singletonCode (r : Reg) (v : Word) (a : Addr) (i : Instr) :
+private theorem singletonReg_disjoint_singletonCode (r : Reg) (v : Word) (a : Word) (i : Instr) :
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonCode a i) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonMem_disjoint_singletonCode (a : Addr) (v : Word) (a' : Addr) (i : Instr) :
+private theorem singletonMem_disjoint_singletonCode (a : Word) (v : Word) (a' : Word) (i : Instr) :
     (PartialState.singletonMem a v).Disjoint (PartialState.singletonCode a' i) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonPC_disjoint_singletonCode (v : Word) (a : Addr) (i : Instr) :
+private theorem singletonPC_disjoint_singletonCode (v : Word) (a : Word) (i : Instr) :
     (PartialState.singletonPC v).Disjoint (PartialState.singletonCode a i) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inr rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonPublicValues_disjoint_singletonCode (vals : List (BitVec 8)) (a : Addr) (i : Instr) :
+private theorem singletonPublicValues_disjoint_singletonCode (vals : List (BitVec 8)) (a : Word) (i : Instr) :
     (PartialState.singletonPublicValues vals).Disjoint (PartialState.singletonCode a i) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inr rfl, Or.inl rfl⟩
 
-private theorem singletonPrivateInput_disjoint_singletonCode (vals : List (BitVec 8)) (a : Addr) (i : Instr) :
+private theorem singletonPrivateInput_disjoint_singletonCode (vals : List (BitVec 8)) (a : Word) (i : Instr) :
     (PartialState.singletonPrivateInput vals).Disjoint (PartialState.singletonCode a i) := by
   exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inr rfl⟩
 
@@ -1961,7 +1961,7 @@ private theorem singletonPrivateInput_disjoint_singletonCode (vals : List (BitVe
 -- pcFree for code assertions
 -- ============================================================================
 
-theorem pcFree_instrAt (a : Addr) (i : Instr) : (instrAt a i).pcFree := by
+theorem pcFree_instrAt (a : Word) (i : Instr) : (instrAt a i).pcFree := by
   intro h hp; rw [instrAt] at hp; subst hp; rfl
 
 theorem pcFree_programAt : ∀ prog, (programAt prog).pcFree
@@ -1973,7 +1973,7 @@ instance : Assertion.PCFree (instrAt a i) := ⟨pcFree_instrAt a i⟩
 
 instance : Assertion.PCFree (programAt prog) := ⟨pcFree_programAt prog⟩
 
-theorem pcFree_progAt (base : Addr) (prog : List Instr) : (progAt base prog).pcFree :=
+theorem pcFree_progAt (base : Word) (prog : List Instr) : (progAt base prog).pcFree :=
   pcFree_programAt (progIndexed base prog)
 
 instance : Assertion.PCFree (progAt base prog) := ⟨pcFree_progAt base prog⟩
@@ -1985,7 +1985,7 @@ instance : Assertion.PCFree (progAt base prog) := ⟨pcFree_progAt base prog⟩
 /-- A code requirement maps addresses to optional instructions.
     Used as a side-condition in cpsTriple instead of linear instrAt assertions.
     Unlike instrAt (which is linear), CodeReq is persistent/checked non-consumptively. -/
-def CodeReq := Addr → Option Instr
+def CodeReq := Word → Option Instr
 
 namespace CodeReq
 
@@ -1993,7 +1993,7 @@ namespace CodeReq
 def empty : CodeReq := fun _ => none
 
 /-- Singleton code requirement: exactly one instruction at one address. -/
-def singleton (a : Addr) (i : Instr) : CodeReq :=
+def singleton (a : Word) (i : Instr) : CodeReq :=
   fun a' => if a' == a then some i else none
 
 /-- Union of two code requirements (left-biased). -/
@@ -2005,11 +2005,11 @@ def SatisfiedBy (cr : CodeReq) (s : MachineState) : Prop :=
   ∀ a i, cr a = some i → s.code a = some i
 
 /-- Build a CodeReq from a list of address-instruction pairs. -/
-def ofIndexed (pairs : List (Addr × Instr)) : CodeReq :=
-  pairs.foldl (fun cr (ai : Addr × Instr) => cr.union (singleton ai.1 ai.2)) empty
+def ofIndexed (pairs : List (Word × Instr)) : CodeReq :=
+  pairs.foldl (fun cr (ai : Word × Instr) => cr.union (singleton ai.1 ai.2)) empty
 
 /-- Build a CodeReq from a program at a base address. -/
-def ofProg (base : Addr) (prog : List Instr) : CodeReq :=
+def ofProg (base : Word) (prog : List Instr) : CodeReq :=
   ofIndexed (progIndexed base prog)
 
 -- ---------------------------------------------------------------------------
@@ -2026,9 +2026,9 @@ theorem union_empty_left (cr : CodeReq) : empty.union cr = cr := by
 theorem union_empty_right (cr : CodeReq) : cr.union empty = cr := by
   funext a; simp only [union, empty]; cases cr a <;> rfl
 
-private theorem ofIndexed_foldl_acc (acc : CodeReq) (ps : List (Addr × Instr)) :
-    ps.foldl (fun cr (ai : Addr × Instr) => cr.union (singleton ai.1 ai.2)) acc =
-    acc.union (ps.foldl (fun cr (ai : Addr × Instr) => cr.union (singleton ai.1 ai.2)) empty) := by
+private theorem ofIndexed_foldl_acc (acc : CodeReq) (ps : List (Word × Instr)) :
+    ps.foldl (fun cr (ai : Word × Instr) => cr.union (singleton ai.1 ai.2)) acc =
+    acc.union (ps.foldl (fun cr (ai : Word × Instr) => cr.union (singleton ai.1 ai.2)) empty) := by
   induction ps generalizing acc with
   | nil => exact (union_empty_right acc).symm
   | cons p ps ih =>
@@ -2037,20 +2037,20 @@ private theorem ofIndexed_foldl_acc (acc : CodeReq) (ps : List (Addr × Instr)) 
     rw [show empty.union (singleton p.1 p.2) = singleton p.1 p.2 from union_empty_left _]
     exact (ih (singleton p.1 p.2)).symm
 
-theorem ofIndexed_cons (p : Addr × Instr) (ps : List (Addr × Instr)) :
+theorem ofIndexed_cons (p : Word × Instr) (ps : List (Word × Instr)) :
     ofIndexed (p :: ps) = (singleton p.1 p.2).union (ofIndexed ps) := by
   simp only [ofIndexed, List.foldl, union_empty_left]
   exact ofIndexed_foldl_acc (singleton p.1 p.2) ps
 
-theorem ofProg_cons (base : Addr) (i : Instr) (rest : List Instr) :
+theorem ofProg_cons (base : Word) (i : Instr) (rest : List Instr) :
     ofProg base (i :: rest) = (singleton base i).union (ofProg (base + 4) rest) := by
   simp only [ofProg, progIndexed]; exact ofIndexed_cons (base, i) (progIndexed (base + 4) rest)
 
-theorem ofProg_nil (base : Addr) : ofProg base [] = empty := rfl
+theorem ofProg_nil (base : Word) : ofProg base [] = empty := rfl
 
 /-- If an address doesn't match any instruction position in a program block,
     the ofProg CodeReq returns none at that address. -/
-theorem ofProg_none_range (base : Addr) (prog : List Instr) (a : Addr)
+theorem ofProg_none_range (base : Word) (prog : List Instr) (a : Word)
     (h : ∀ k : Nat, k < prog.length → a ≠ base + BitVec.ofNat 64 (4 * k)) :
     ofProg base prog a = none := by
   induction prog generalizing base with
@@ -2066,12 +2066,12 @@ theorem ofProg_none_range (base : Addr) (prog : List Instr) (a : Addr)
       have h' := h (k + 1) (by simp [List.length]; omega)
       intro heq; apply h'; rw [heq]; bv_omega)
 
-theorem ofIndexed_append (xs ys : List (Addr × Instr)) :
+theorem ofIndexed_append (xs ys : List (Word × Instr)) :
     ofIndexed (xs ++ ys) = (ofIndexed xs).union (ofIndexed ys) := by
   simp only [ofIndexed, List.foldl_append]
   exact ofIndexed_foldl_acc _ ys
 
-theorem ofProg_append (base : Addr) (p1 p2 : List Instr) :
+theorem ofProg_append (base : Word) (p1 p2 : List Instr) :
     ofProg base (p1 ++ p2) =
       (ofProg base p1).union (ofProg (base + BitVec.ofNat 64 (4 * p1.length)) p2) := by
   simp only [ofProg, progIndexed_append]
@@ -2097,7 +2097,7 @@ def CodeReq.Disjoint (cr1 cr2 : CodeReq) : Prop :=
   ∀ a, cr1 a = none ∨ cr2 a = none
 
 /-- Singleton CodeReqs at different addresses are disjoint. -/
-theorem CodeReq.Disjoint.singleton {a1 a2 : Addr} (h : a1 ≠ a2)
+theorem CodeReq.Disjoint.singleton {a1 a2 : Word} (h : a1 ≠ a2)
     (i1 i2 : Instr) : CodeReq.Disjoint (CodeReq.singleton a1 i1) (CodeReq.singleton a2 i2) := by
   intro a
   simp only [CodeReq.singleton]
@@ -2145,24 +2145,24 @@ theorem CodeReq.Disjoint.symm {cr1 cr2 : CodeReq} (hd : cr1.Disjoint cr2) :
     cr2.Disjoint cr1 := fun a => (hd a).symm
 
 /-- ofProg of empty list is disjoint from anything (left). -/
-theorem CodeReq.Disjoint.ofProg_nil_left (base : Addr) (cr : CodeReq) :
+theorem CodeReq.Disjoint.ofProg_nil_left (base : Word) (cr : CodeReq) :
     CodeReq.Disjoint (CodeReq.ofProg base []) cr :=
   CodeReq.Disjoint.empty_left cr
 
 /-- Any CodeReq is disjoint from ofProg of empty list (right). -/
-theorem CodeReq.Disjoint.ofProg_nil_right (cr : CodeReq) (base : Addr) :
+theorem CodeReq.Disjoint.ofProg_nil_right (cr : CodeReq) (base : Word) :
     CodeReq.Disjoint cr (CodeReq.ofProg base []) :=
   CodeReq.Disjoint.empty_right cr
 
 /-- Disjointness of ofProg cons on the left: peel off the head singleton. -/
-theorem CodeReq.Disjoint.ofProg_cons_left (base : Addr) (i : Instr) (rest : List Instr) (cr : CodeReq)
+theorem CodeReq.Disjoint.ofProg_cons_left (base : Word) (i : Instr) (rest : List Instr) (cr : CodeReq)
     (h1 : CodeReq.Disjoint (CodeReq.singleton base i) cr)
     (h2 : CodeReq.Disjoint (CodeReq.ofProg (base + 4) rest) cr) :
     CodeReq.Disjoint (CodeReq.ofProg base (i :: rest)) cr := by
   rw [CodeReq.ofProg_cons]; exact CodeReq.Disjoint.union_left h1 h2
 
 /-- Disjointness of ofProg cons on the right: peel off the head singleton. -/
-theorem CodeReq.Disjoint.ofProg_cons_right (cr : CodeReq) (base : Addr) (i : Instr) (rest : List Instr)
+theorem CodeReq.Disjoint.ofProg_cons_right (cr : CodeReq) (base : Word) (i : Instr) (rest : List Instr)
     (h1 : CodeReq.Disjoint cr (CodeReq.singleton base i))
     (h2 : CodeReq.Disjoint cr (CodeReq.ofProg (base + 4) rest)) :
     CodeReq.Disjoint cr (CodeReq.ofProg base (i :: rest)) := by
@@ -2171,35 +2171,35 @@ theorem CodeReq.Disjoint.ofProg_cons_right (cr : CodeReq) (base : Addr) (i : Ins
 /-- Simplify CodeReq.union applied to a concrete address, when the head is a singleton.
     This collapses `(singleton a i |> union · rest) a'` into an if-then-else
     at the ite level rather than the match-over-ite level. -/
-theorem CodeReq.union_singleton_apply (a a' : Addr) (i : Instr) (rest : CodeReq) :
+theorem CodeReq.union_singleton_apply (a a' : Word) (i : Instr) (rest : CodeReq) :
     (CodeReq.union (CodeReq.singleton a i) rest) a' =
       if a' == a then some i else rest a' := by
   simp only [CodeReq.union, CodeReq.singleton]
   split <;> simp_all
 
 /-- BEq of offset addresses: `(a + k1) == (a + k2) = (k1 == k2)`. -/
-theorem CodeReq.beq_base_offset (a : Addr) (k1 k2 : Addr) :
+theorem CodeReq.beq_base_offset (a : Word) (k1 k2 : Word) :
     ((a + k1) == (a + k2)) = (k1 == k2) := by
   rw [show (k1 == k2) = decide (k1 = k2) from rfl,
       show ((a + k1) == (a + k2)) = decide (a + k1 = a + k2) from rfl]
   congr 1; exact propext ⟨fun h => by bv_omega, fun h => by bv_omega⟩
 
 /-- BEq of (a + k) vs a: reduces to k == 0. -/
-theorem CodeReq.beq_offset_self_left (a : Addr) (k : Addr) :
+theorem CodeReq.beq_offset_self_left (a : Word) (k : Word) :
     ((a + k) == a) = (k == 0) := by
-  rw [show (k == (0 : Addr)) = decide (k = 0) from rfl,
+  rw [show (k == (0 : Word)) = decide (k = 0) from rfl,
       show ((a + k) == a) = decide (a + k = a) from rfl]
   congr 1; exact propext ⟨fun h => by bv_omega, fun h => by bv_omega⟩
 
 /-- BEq of a vs (a + k): reduces to k == 0. -/
-theorem CodeReq.beq_offset_self_right (a : Addr) (k : Addr) :
+theorem CodeReq.beq_offset_self_right (a : Word) (k : Word) :
     (a == (a + k)) = (k == 0) := by
-  rw [show (k == (0 : Addr)) = decide (k = 0) from rfl,
+  rw [show (k == (0 : Word)) = decide (k = 0) from rfl,
       show (a == (a + k)) = decide (a = a + k) from rfl]
   congr 1; exact propext ⟨fun h => by bv_omega, fun h => by bv_omega⟩
 
 /-- If head returns none, union falls through to tail. -/
-theorem CodeReq.union_none_left {head tail : CodeReq} {a : Addr}
+theorem CodeReq.union_none_left {head tail : CodeReq} {a : Word}
     (h : head a = none) : (head.union tail) a = tail a := by
   simp [CodeReq.union, h]
 
@@ -2220,7 +2220,7 @@ theorem CodeReq.union_mono_tail {cr tail1 tail2 : CodeReq}
 
 /-- A singleton's only address can be found in a target CodeReq, if target maps that address
     to the same instruction. Useful for proving singleton ⊆ target. -/
-theorem CodeReq.singleton_mono {a : Addr} {i : Instr} {cr : CodeReq}
+theorem CodeReq.singleton_mono {a : Word} {i : Instr} {cr : CodeReq}
     (h : cr a = some i) :
     ∀ a' i', CodeReq.singleton a i a' = some i' → cr a' = some i' := by
   intro a' i' hq
@@ -2230,19 +2230,19 @@ theorem CodeReq.singleton_mono {a : Addr} {i : Instr} {cr : CodeReq}
   · simp at hq
 
 /-- A singleton misses any address not equal to its own. -/
-theorem CodeReq.singleton_miss {a a' : Addr} {i : Instr}
+theorem CodeReq.singleton_miss {a a' : Word} {i : Instr}
     (hne : a' ≠ a) :
     (CodeReq.singleton a i) a' = none := by
   simp [CodeReq.singleton, beq_eq_false_iff_ne.mpr hne]
 
 /-- Skip a non-matching head of a union: if head misses at a, we look at the tail. -/
-theorem CodeReq.union_skip {head tail : CodeReq} {a : Addr} {i : Instr}
+theorem CodeReq.union_skip {head tail : CodeReq} {a : Word} {i : Instr}
     (hne : head a = none) (htail : tail a = some i) :
     (head.union tail) a = some i := by
   simp [CodeReq.union, hne, htail]
 
 /-- Hit at the head of a union. -/
-theorem CodeReq.union_hit {head tail : CodeReq} {a : Addr} {i : Instr}
+theorem CodeReq.union_hit {head tail : CodeReq} {a : Word} {i : Instr}
     (hh : head a = some i) :
     (head.union tail) a = some i := by
   simp [CodeReq.union, hh]
@@ -2268,7 +2268,7 @@ theorem CodeReq.union_split_mono {cr1 cr2 cr : CodeReq}
   | none => simp [ha] at h; exact h2 a i h
   | some j => simp [ha] at h; subst h; exact h1 a j ha
 
-theorem CodeReq.singleton_get (a : Addr) (i : Instr) :
+theorem CodeReq.singleton_get (a : Word) (i : Instr) :
     CodeReq.singleton a i a = some i := by
   simp [CodeReq.singleton]
 
@@ -2277,19 +2277,19 @@ theorem CodeReq.singleton_get (a : Addr) (i : Instr) :
 -- ---------------------------------------------------------------------------
 
 /-- Auxiliary: `base + BitVec.ofNat 64 0 = base`. -/
-private theorem ofProg_addr_zero (base : Addr) : base + BitVec.ofNat 64 0 = base := by
+private theorem ofProg_addr_zero (base : Word) : base + BitVec.ofNat 64 0 = base := by
   bv_omega
 
 /-- Auxiliary: address step for ofProg induction.
     `base + ofNat(4*(k+1)) = (base + 4) + ofNat(4*k)`. -/
-private theorem ofProg_addr_succ (base : Addr) (k : Nat) :
+private theorem ofProg_addr_succ (base : Word) (k : Nat) :
     base + BitVec.ofNat 64 (4 * (k + 1)) = (base + 4) + BitVec.ofNat 64 (4 * k) := by
   apply BitVec.eq_of_toNat_eq
   simp [BitVec.toNat_add, BitVec.toNat_ofNat]
   omega
 
 /-- Auxiliary: `base + ofNat(4*(k+1)) ≠ base` when `4*(k+1) < 2^64`. -/
-private theorem ofProg_addr_ne (base : Addr) (k : Nat) (hk : 4 * (k + 1) < 2 ^ 64) :
+private theorem ofProg_addr_ne (base : Word) (k : Nat) (hk : 4 * (k + 1) < 2 ^ 64) :
     base + BitVec.ofNat 64 (4 * (k + 1)) ≠ base := by
   intro h
   have := congrArg BitVec.toNat h
@@ -2297,12 +2297,12 @@ private theorem ofProg_addr_ne (base : Addr) (k : Nat) (hk : 4 * (k + 1) < 2 ^ 6
   omega
 
 /-- ofProg lookup at offset 0: the first instruction is at `base`. -/
-theorem CodeReq.ofProg_lookup_zero (base : Addr) (i : Instr) (rest : List Instr) :
+theorem CodeReq.ofProg_lookup_zero (base : Word) (i : Instr) (rest : List Instr) :
     (CodeReq.ofProg base (i :: rest)) base = some i := by
   rw [CodeReq.ofProg_cons]
   exact CodeReq.union_hit (CodeReq.singleton_get base i)
 
-theorem CodeReq.ofProg_lookup (base : Addr) (prog : List Instr) (k : Nat)
+theorem CodeReq.ofProg_lookup (base : Word) (prog : List Instr) (k : Nat)
     (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64) :
     (CodeReq.ofProg base prog) (base + BitVec.ofNat 64 (4 * k)) = some (prog.get ⟨k, hk⟩) := by
   induction prog generalizing base k with
@@ -2326,21 +2326,21 @@ theorem CodeReq.ofProg_lookup (base : Addr) (prog : List Instr) (k : Nat)
 /-- Variant of `ofProg_lookup` that takes an explicit address with a proof it equals
     `base + 4*k`. Avoids definitional-equality issues when the ofProg base has an offset
     (e.g., `(base + 44) + BitVec.ofNat 64 4` vs `base + 48`). -/
-theorem CodeReq.ofProg_lookup_addr (base : Addr) (prog : List Instr) (k : Nat) (addr : Addr)
+theorem CodeReq.ofProg_lookup_addr (base : Word) (prog : List Instr) (k : Nat) (addr : Word)
     (hk : k < prog.length) (hbound : 4 * prog.length < 2 ^ 64)
     (h_addr : addr = base + BitVec.ofNat 64 (4 * k)) :
     (CodeReq.ofProg base prog) addr = some (prog.get ⟨k, hk⟩) := by
   subst h_addr; exact CodeReq.ofProg_lookup base prog k hk hbound
 
 /-- Variant of ofProg_none_range with explicit length (avoids needing to reduce prog.length). -/
-theorem CodeReq.ofProg_none_range_len (base : Addr) (prog : List Instr) (n : Nat) (a : Addr)
+theorem CodeReq.ofProg_none_range_len (base : Word) (prog : List Instr) (n : Nat) (a : Word)
     (hlen : prog.length = n)
     (h : ∀ k : Nat, k < n → a ≠ base + BitVec.ofNat 64 (4 * k)) :
     CodeReq.ofProg base prog a = none :=
   CodeReq.ofProg_none_range base prog a (fun k hk => h k (hlen ▸ hk))
 
 /-- Singleton is disjoint from ofProg if the singleton's address is not in the program range. -/
-theorem CodeReq.Disjoint.singleton_ofProg {a : Addr} {i : Instr} {base : Addr} {prog : List Instr}
+theorem CodeReq.Disjoint.singleton_ofProg {a : Word} {i : Instr} {base : Word} {prog : List Instr}
     (h : CodeReq.ofProg base prog a = none) :
     CodeReq.Disjoint (CodeReq.singleton a i) (CodeReq.ofProg base prog) := by
   intro a'
@@ -2350,14 +2350,14 @@ theorem CodeReq.Disjoint.singleton_ofProg {a : Addr} {i : Instr} {base : Addr} {
   · left; simp [hb]
 
 /-- ofProg is disjoint from singleton if the singleton's address is not in the program range. -/
-theorem CodeReq.Disjoint.ofProg_singleton {a : Addr} {i : Instr} {base : Addr} {prog : List Instr}
+theorem CodeReq.Disjoint.ofProg_singleton {a : Word} {i : Instr} {base : Word} {prog : List Instr}
     (h : CodeReq.ofProg base prog a = none) :
     CodeReq.Disjoint (CodeReq.ofProg base prog) (CodeReq.singleton a i) :=
   (CodeReq.Disjoint.singleton_ofProg h).symm
 
 /-- Reverse of ofProg_none_range: if `ofProg` returns `some` at address `a`,
     then `a` must be `base + 4*k` for some `k < prog.length`. -/
-theorem CodeReq.ofProg_some_range (base : Addr) (prog : List Instr) (a : Addr) (i : Instr)
+theorem CodeReq.ofProg_some_range (base : Word) (prog : List Instr) (a : Word) (i : Instr)
     (h : (CodeReq.ofProg base prog) a = some i) :
     ∃ k, k < prog.length ∧ a = base + BitVec.ofNat 64 (4 * k) := by
   induction prog generalizing base with
@@ -2374,8 +2374,8 @@ theorem CodeReq.ofProg_some_range (base : Addr) (prog : List Instr) (a : Addr) (
 
 /-- Two ofProg blocks at non-overlapping address ranges are disjoint.
     Only requires the address-inequality predicate, not list expansion. -/
-theorem CodeReq.ofProg_disjoint_range (base1 : Addr) (prog1 : List Instr)
-    (base2 : Addr) (prog2 : List Instr)
+theorem CodeReq.ofProg_disjoint_range (base1 : Word) (prog1 : List Instr)
+    (base2 : Word) (prog2 : List Instr)
     (h : ∀ k1 k2, k1 < prog1.length → k2 < prog2.length →
       base1 + BitVec.ofNat 64 (4 * k1) ≠ base2 + BitVec.ofNat 64 (4 * k2)) :
     CodeReq.Disjoint (CodeReq.ofProg base1 prog1) (CodeReq.ofProg base2 prog2) := by
@@ -2394,8 +2394,8 @@ theorem CodeReq.ofProg_disjoint_range (base1 : Addr) (prog1 : List Instr)
       exact h k1 k2 hk1 hk2
 
 /-- Variant of ofProg_disjoint_range with explicit lengths (avoids needing to reduce prog.length). -/
-theorem CodeReq.ofProg_disjoint_range_len (base1 : Addr) (prog1 : List Instr) (n1 : Nat)
-    (base2 : Addr) (prog2 : List Instr) (n2 : Nat)
+theorem CodeReq.ofProg_disjoint_range_len (base1 : Word) (prog1 : List Instr) (n1 : Nat)
+    (base2 : Word) (prog2 : List Instr) (n2 : Nat)
     (hlen1 : prog1.length = n1) (hlen2 : prog2.length = n2)
     (h : ∀ k1 k2, k1 < n1 → k2 < n2 →
       base1 + BitVec.ofNat 64 (4 * k1) ≠ base2 + BitVec.ofNat 64 (4 * k2)) :
@@ -2408,14 +2408,14 @@ theorem CodeReq.ofProg_disjoint_range_len (base1 : Addr) (prog1 : List Instr) (n
 -- ---------------------------------------------------------------------------
 
 /-- Left (prefix) of a program append is subsumed by the full program. -/
-theorem CodeReq.ofProg_mono_append_left (base : Addr) (p1 p2 : List Instr) :
+theorem CodeReq.ofProg_mono_append_left (base : Word) (p1 p2 : List Instr) :
     ∀ a i, (CodeReq.ofProg base p1) a = some i →
            (CodeReq.ofProg base (p1 ++ p2)) a = some i := by
   rw [CodeReq.ofProg_append]; exact CodeReq.union_mono_left _ _
 
 /-- Right (suffix) of a program append is subsumed by the full program.
     Requires bound to ensure non-overlapping address ranges. -/
-theorem CodeReq.ofProg_mono_append_right (base : Addr) (p1 p2 : List Instr)
+theorem CodeReq.ofProg_mono_append_right (base : Word) (p1 p2 : List Instr)
     (hbound : 4 * (p1 ++ p2).length < 2^64) :
     ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 (4 * p1.length)) p2) a = some i →
            (CodeReq.ofProg base (p1 ++ p2)) a = some i := by
@@ -2440,7 +2440,7 @@ theorem CodeReq.ofProg_mono_append_right (base : Addr) (p1 p2 : List Instr)
 
 /-- Sub-range of a program is subsumed: if full = pre ++ mid ++ suf,
     then `ofProg (base + 4*pre.length) mid ⊆ ofProg base full`. -/
-theorem CodeReq.ofProg_mono_subrange (base : Addr) (pre mid suf : List Instr)
+theorem CodeReq.ofProg_mono_subrange (base : Word) (pre mid suf : List Instr)
     (hbound : 4 * (pre ++ mid ++ suf).length < 2^64) :
     ∀ a i, (CodeReq.ofProg (base + BitVec.ofNat 64 (4 * pre.length)) mid) a = some i →
            (CodeReq.ofProg base (pre ++ mid ++ suf)) a = some i := by
@@ -2453,7 +2453,7 @@ theorem CodeReq.ofProg_mono_subrange (base : Addr) (pre mid suf : List Instr)
 /-- Sub-range monotonicity with explicit offset: `ofProg sub_base sub ⊆ ofProg base full`
     when `sub` is a contiguous slice of `full` starting at instruction index `idx`
     (byte offset `sub_base = base + 4*idx`). -/
-theorem CodeReq.ofProg_mono_sub (base sub_base : Addr) (full sub : List Instr)
+theorem CodeReq.ofProg_mono_sub (base sub_base : Word) (full sub : List Instr)
     (idx : Nat)
     (h_addr : sub_base = base + BitVec.ofNat 64 (4 * idx))
     (h_slice : (full.drop idx).take sub.length = sub)
@@ -2559,7 +2559,7 @@ theorem CodeReq.empty_satisfiedBy (s : MachineState) : CodeReq.empty.SatisfiedBy
   fun _ _ h => by simp [CodeReq.empty] at h
 
 /-- A singleton CodeReq is satisfied iff the state has the instruction at that address. -/
-theorem CodeReq.singleton_satisfiedBy (a : Addr) (i : Instr) (s : MachineState) :
+theorem CodeReq.singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState) :
     (CodeReq.singleton a i).SatisfiedBy s ↔ s.code a = some i := by
   constructor
   · intro h; exact h a i (by simp [CodeReq.singleton])
@@ -2574,7 +2574,7 @@ theorem CodeReq.singleton_satisfiedBy (a : Addr) (i : Instr) (s : MachineState) 
       exact heq ▸ hcr ▸ h
 
 /-- An instrAt fact gives CodeReq.singleton satisfaction. -/
-theorem instrAt_singleton_satisfiedBy (a : Addr) (i : Instr) (s : MachineState)
+theorem instrAt_singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState)
     (h : (instrAt a i).holdsFor s) : (CodeReq.singleton a i).SatisfiedBy s :=
   (CodeReq.singleton_satisfiedBy a i s).mpr ((holdsFor_instrAt a i s).mp h)
 
@@ -2606,23 +2606,23 @@ theorem CodeReq.SatisfiedBy_mono {cr1 cr2 : CodeReq} (s : MachineState)
 
 /-- Addresses with same base but different offsets are not equal.
     Used by `proveAddrNe` for ~100x faster proofs vs `bv_omega`. -/
-theorem addr_ne_of_bv_ne (base a b : Addr) (h : a ≠ b) :
+theorem addr_ne_of_bv_ne (base a b : Word) (h : a ≠ b) :
     base + a ≠ base + b := by bv_omega
 
 /-- Base address is not equal to base + a when a ≠ 0. -/
-theorem addr_ne_add_right (base a : Addr) (h : a ≠ 0) :
+theorem addr_ne_add_right (base a : Word) (h : a ≠ 0) :
     base ≠ base + a := by bv_omega
 
 /-- Base + a is not equal to bare base when a ≠ 0. -/
-theorem addr_add_ne_left (base a : Addr) (h : a ≠ 0) :
+theorem addr_add_ne_left (base a : Word) (h : a ≠ 0) :
     base + a ≠ base := by bv_omega
 
 /-- Address reassociation: (base + k1) + k2 = base + sum when k1 + k2 = sum. -/
-theorem addr_reassoc (base k1 k2 sum : Addr) (h : k1 + k2 = sum) :
+theorem addr_reassoc (base k1 k2 sum : Word) (h : k1 + k2 = sum) :
     (base + k1) + k2 = base + sum := by subst h; bv_omega
 
 /-- Address addition with zero: a + 0 = a. -/
-theorem addr_add_zero_bv (a : Addr) : a + (0 : Addr) = a := by bv_omega
+theorem addr_add_zero_bv (a : Word) : a + (0 : Word) = a := by bv_omega
 
 -- ============================================================================
 -- Assertion-level equalities for AC normalization of sepConj
@@ -2685,7 +2685,7 @@ theorem seps_pick (xs : List Assertion) (n : Nat) (hn : n < xs.length) :
 syntax "sep_perm" ident : tactic
 macro_rules
   | `(tactic| sep_perm $hyp) =>
-    `(tactic| exact (congrFun (show _ = _ by delta Word Addr; dsimp (config := { failIfUnchanged := false }) only []; all_goals ac_rfl) _).mp $hyp)
+    `(tactic| exact (congrFun (show _ = _ by delta Word Word; dsimp (config := { failIfUnchanged := false }) only []; all_goals ac_rfl) _).mp $hyp)
 
 /-- `sep_eq` closes a goal of the form `⊢ f x = g x` where `f` and `g` are AC-equivalent
     `sepConj` chains. Decomposes the function application with `congrFun` and proves

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2685,7 +2685,7 @@ theorem seps_pick (xs : List Assertion) (n : Nat) (hn : n < xs.length) :
 syntax "sep_perm" ident : tactic
 macro_rules
   | `(tactic| sep_perm $hyp) =>
-    `(tactic| exact (congrFun (show _ = _ by delta Word Word; dsimp (config := { failIfUnchanged := false }) only []; all_goals ac_rfl) _).mp $hyp)
+    `(tactic| exact (congrFun (show _ = _ by dsimp (config := { failIfUnchanged := false }) only []; all_goals ac_rfl) _).mp $hyp)
 
 /-- `sep_eq` closes a goal of the form `⊢ f x = g x` where `f` and `g` are AC-equivalent
     `sepConj` chains. Decomposes the function application with `congrFun` and proves

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -29,7 +29,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem ld_spec_gen (rd rs1 : Reg) (v_addr v_old mem_val : Word)
-    (offset : BitVec 12) (addr : Addr)
+    (offset : BitVec 12) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LD rd rs1 offset))
@@ -38,7 +38,7 @@ namespace EvmAsm.Rv64
   generic_ld_spec rd rs1 v_addr v_old mem_val offset addr hrd_ne_x0 hvalid
 
 @[spec_gen_rv64] theorem sd_spec_gen (rs1 rs2 : Reg) (v_addr v_data mem_old : Word)
-    (offset : BitVec 12) (addr : Addr)
+    (offset : BitVec 12) (addr : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SD rs1 rs2 offset))
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** ((v_addr + signExtend12 offset) ↦ₘ mem_old))
@@ -46,7 +46,7 @@ namespace EvmAsm.Rv64
   generic_sd_spec rs1 rs2 v_addr v_data mem_old offset addr hvalid
 
 @[spec_gen_rv64] theorem sd_spec_gen_own (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (addr : Addr)
+    (offset : BitVec 12) (addr : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SD rs1 rs2 offset))
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** memOwn (v_addr + signExtend12 offset))
@@ -65,7 +65,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem add_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADD rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 + v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -74,7 +74,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SUB rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 - v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -83,7 +83,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem and_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.AND rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 &&& v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -92,7 +92,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem or_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.OR rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 ||| v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -101,7 +101,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem xor_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.XOR rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 ^^^ v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -110,7 +110,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTU rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0)) ** (rs2 ↦ᵣ v2)) :=
@@ -119,7 +119,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srl_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRL rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 >>> (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
@@ -128,7 +128,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sll_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLL rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 <<< (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
@@ -137,7 +137,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sra_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRA rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (BitVec.sshiftRight v1 (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
@@ -150,7 +150,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem addi_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADDI rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v + signExtend12 imm)) :=
@@ -159,7 +159,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem addi_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADDI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + signExtend12 imm))) :=
@@ -168,7 +168,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem xori_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.XORI rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v ^^^ signExtend12 imm)) :=
@@ -177,7 +177,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem andi_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ANDI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 &&& signExtend12 imm))) :=
@@ -186,7 +186,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem andi_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ANDI rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v &&& signExtend12 imm)) :=
@@ -195,7 +195,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltiu_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTIU rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (if BitVec.ult v (signExtend12 imm) then (1 : Word) else (0 : Word))) :=
@@ -204,7 +204,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem slli_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLLI rd rd shamt))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v <<< shamt.toNat)) :=
@@ -213,7 +213,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem slli_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLLI rd rs1 shamt))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 <<< shamt.toNat))) :=
@@ -222,7 +222,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srli_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRLI rd rd shamt))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v >>> shamt.toNat)) :=
@@ -231,7 +231,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srli_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRLI rd rs1 shamt))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 >>> shamt.toNat))) :=
@@ -240,7 +240,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srai_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRAI rd rd shamt))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (BitVec.sshiftRight v shamt.toNat)) :=
@@ -249,7 +249,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srai_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (shamt : BitVec 6)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRAI rd rs1 shamt))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (BitVec.sshiftRight v1 shamt.toNat))) :=
@@ -261,7 +261,7 @@ namespace EvmAsm.Rv64
 -- Pseudo instructions
 -- ============================================================================
 
-@[spec_gen_rv64] theorem li_spec_gen (rd : Reg) (v_old imm : Word) (addr : Addr)
+@[spec_gen_rv64] theorem li_spec_gen (rd : Reg) (v_old imm : Word) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LI rd imm))
       (rd ↦ᵣ v_old)
@@ -270,7 +270,7 @@ namespace EvmAsm.Rv64
     (by intro s _ _; simp [execInstrBr])
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
-@[spec_gen_rv64] theorem li_spec_gen_own (rd : Reg) (imm : Word) (addr : Addr)
+@[spec_gen_rv64] theorem li_spec_gen_own (rd : Reg) (imm : Word) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LI rd imm))
       (regOwn rd)
@@ -282,7 +282,7 @@ namespace EvmAsm.Rv64
     ⟨h, hcompat, hPQ, hR_ps, hdisj, hunion, hv, hrR⟩
   exact li_spec_gen rd v imm addr hrd_ne_x0 R hR s hcr hPR' hpc
 
-@[spec_gen_rv64] theorem mv_spec_gen (rd rs : Reg) (v v_old : Word) (addr : Addr)
+@[spec_gen_rv64] theorem mv_spec_gen (rd rs : Reg) (v v_old : Word) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MV rd rs))
       ((rs ↦ᵣ v) ** (rd ↦ᵣ v_old))
@@ -296,7 +296,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem bne_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BNE rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -306,7 +306,7 @@ namespace EvmAsm.Rv64
   generic_bne_spec rs1 rs2 offset v1 v2 addr
 
 @[spec_gen_rv64] theorem beq_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BEQ rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -316,7 +316,7 @@ namespace EvmAsm.Rv64
   generic_beq_spec rs1 rs2 offset v1 v2 addr
 
 @[spec_gen_rv64] theorem bltu_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BLTU rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -326,7 +326,7 @@ namespace EvmAsm.Rv64
   generic_bltu_spec rs1 rs2 offset v1 v2 addr
 
 @[spec_gen_rv64] theorem bge_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BGE rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -336,7 +336,7 @@ namespace EvmAsm.Rv64
   generic_bge_spec rs1 rs2 offset v1 v2 addr
 
 @[spec_gen_rv64] theorem blt_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BLT rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -349,7 +349,7 @@ namespace EvmAsm.Rv64
 -- ECALL halt spec
 -- ============================================================================
 
-@[spec_gen_rv64] theorem ecall_halt_spec_gen (exitCode : Word) (addr : Addr) :
+@[spec_gen_rv64] theorem ecall_halt_spec_gen (exitCode : Word) (addr : Word) :
     cpsHaltTriple addr (CodeReq.singleton addr .ECALL)
       ((addr ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ exitCode))
       ((addr ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ exitCode)) := by
@@ -367,7 +367,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem slt_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLT rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (if BitVec.slt v1 v2 then (1 : Word) else 0))) :=
@@ -376,7 +376,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTU rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0))) :=
@@ -385,7 +385,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTU rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0))) :=
@@ -394,7 +394,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem or_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.OR rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 ||| v2))) :=
@@ -407,7 +407,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem mul_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MUL rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 * v2))) :=
@@ -416,7 +416,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mul_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MUL rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ (v1 * v2)) ** (rs2 ↦ᵣ v2)) :=
@@ -425,7 +425,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULHU rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulhu v1 v2)) :=
@@ -434,7 +434,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULHU rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_mulhu v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -443,7 +443,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULHU rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ rv64_mulhu v1 v2)) :=
@@ -452,7 +452,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mul_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MUL rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 * v2))) :=
@@ -465,7 +465,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem divu_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.DIVU rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_divu v1 v2)) :=
@@ -474,7 +474,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem divu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.DIVU rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_divu v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -483,7 +483,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem remu_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.REMU rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_remu v1 v2)) :=
@@ -492,7 +492,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem remu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.REMU rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_remu v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -501,7 +501,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SUB rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 - v2))) :=
@@ -510,7 +510,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen (rd rs1 rs2 : Reg) (v1 v2 v_old : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SUB rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 - v2))) :=
@@ -519,7 +519,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltiu_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTIU rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.ult v1 (signExtend12 imm) then (1 : Word) else (0 : Word)))) :=
@@ -531,7 +531,7 @@ namespace EvmAsm.Rv64
     Specialized version of sd_spec_gen for x0 (always reads as 0).
     Does not require (x0 ↦ᵣ 0) in pre/post. -/
 @[spec_gen_rv64] theorem sd_x0_spec_gen (rs1 : Reg) (v_addr mem_old : Word)
-    (offset : BitVec 12) (addr : Addr)
+    (offset : BitVec 12) (addr : Word)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SD rs1 .x0 offset))
       ((rs1 ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ mem_old))
@@ -543,7 +543,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem srl_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SRL rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 >>> (v2.toNat % 64)))) :=
@@ -552,7 +552,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sll_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLL rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 <<< (v2.toNat % 64)))) :=
@@ -561,7 +561,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem add_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADD rd rs1 rd))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v2))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + v2))) :=
@@ -570,7 +570,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem add_spec_gen (rd rs1 rs2 : Reg) (v1 v2 v_old : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADD rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 + v2))) :=
@@ -585,7 +585,7 @@ namespace EvmAsm.Rv64
 /-- ADDI rd x0 imm: rd := signExtend12 imm. Clean version without (0 + signExtend12 imm).
     Requires (.x0 ↦ᵣ 0) in frame. -/
 @[spec_gen_rv64] theorem addi_x0_spec_gen (rd : Reg) (v_old : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADDI rd .x0 imm))
       ((.x0 ↦ᵣ (0 : Word)) ** (rd ↦ᵣ v_old))
       ((.x0 ↦ᵣ (0 : Word)) ** (rd ↦ᵣ (signExtend12 imm))) := by
@@ -598,7 +598,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem ld_spec_gen_same (rd : Reg) (v_addr mem_val : Word)
-    (offset : BitVec 12) (addr : Addr)
+    (offset : BitVec 12) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LD rd rd offset))
@@ -611,14 +611,14 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem ori_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ORI rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (v ||| signExtend12 imm)) :=
   ori_spec_same rd v imm addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem ori_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ORI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 ||| signExtend12 imm))) :=
@@ -629,14 +629,14 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem slti_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTI rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ (if BitVec.slt v (signExtend12 imm) then 1 else 0)) :=
   slti_spec_same rd v imm addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem slti_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.SLTI rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.slt v1 (signExtend12 imm) then 1 else 0))) :=
@@ -647,14 +647,14 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem addiw_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADDIW rd rd imm))
       (rd ↦ᵣ v)
       (rd ↦ᵣ ((v.truncate 32 + (signExtend12 imm).truncate 32 : BitVec 32).signExtend 64)) :=
   addiw_spec_same rd v imm addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem addiw_spec_gen (rd rs1 : Reg) (v_old v1 : Word) (imm : BitVec 12)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.ADDIW rd rs1 imm))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ ((v1.truncate 32 + (signExtend12 imm).truncate 32 : BitVec 32).signExtend 64))) :=
@@ -665,7 +665,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem bgeu_spec_gen (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word)
-    (addr : Addr) :
+    (addr : Word) :
     cpsBranch addr (CodeReq.singleton addr (.BGEU rs1 rs2 offset))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       (addr + signExtend13 offset)
@@ -679,22 +679,22 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem lui_spec_gen (rd : Reg) (v_old : Word) (imm : BitVec 20)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LUI rd imm))
       (rd ↦ᵣ v_old)
       (rd ↦ᵣ ((imm.zeroExtend 32 : BitVec 32) <<< 12).signExtend 64) :=
   lui_spec rd v_old imm addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem auipc_spec_gen (rd : Reg) (v_old : Word) (imm : BitVec 20)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.AUIPC rd imm))
       (rd ↦ᵣ v_old)
       (rd ↦ᵣ (addr + ((imm.zeroExtend 32 : BitVec 32) <<< 12).signExtend 64)) :=
   auipc_spec rd v_old imm addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem lbu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -709,8 +709,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem lb_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -725,8 +725,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem sb_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_old : Word)
     (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
@@ -743,7 +743,7 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem mulh_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULH rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulh v1 v2)) :=
@@ -752,7 +752,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulh_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULH rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_mulh v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -761,7 +761,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhsu_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULHSU rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulhsu v1 v2)) :=
@@ -770,7 +770,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhsu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.MULHSU rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_mulhsu v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -779,7 +779,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem div_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.DIV rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_div v1 v2)) :=
@@ -788,7 +788,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem div_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.DIV rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_div v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -797,7 +797,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem rem_spec_gen (rd rs1 rs2 : Reg) (v_old v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.REM rd rs1 rs2))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ v_old))
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_rem v1 v2)) :=
@@ -806,7 +806,7 @@ namespace EvmAsm.Rv64
     (by intro s hfetch; exact step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem rem_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
-    (addr : Addr) (hrd_ne_x0 : rd ≠ .x0) :
+    (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.REM rd rd rs2))
       ((rd ↦ᵣ v1) ** (rs2 ↦ᵣ v2))
       ((rd ↦ᵣ rv64_rem v1 v2) ** (rs2 ↦ᵣ v2)) :=
@@ -819,8 +819,8 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem lhu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -835,8 +835,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem lh_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -851,8 +851,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem sh_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_old : Word)
     (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
@@ -869,8 +869,8 @@ namespace EvmAsm.Rv64
 -- ============================================================================
 
 @[spec_gen_rv64] theorem lwu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -885,8 +885,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem lw_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -901,8 +901,8 @@ namespace EvmAsm.Rv64
     hrd_ne_x0 hrd_ne_rs1 halign hvalid
 
 @[spec_gen_rv64] theorem sw_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (addr : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (addr : Word)
+    (dwordAddr : Word) (word_old : Word)
     (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -101,7 +101,7 @@ private def proveAddrEqFast (old new_ : Expr) : MetaM (Option Expr) := do
   -- Case: old = lhs + rhs
   if old.isAppOfArity ``HAdd.hAdd 6 then
     let oldArgs := old.getAppArgs
-    -- Check it's BitVec/Addr addition
+    -- Check it's BitVec/Word addition
     unless oldArgs[0]!.isAppOfArity ``BitVec 1 do return none
     let lhs := oldArgs[4]!
     let rhs := oldArgs[5]!
@@ -193,10 +193,10 @@ private def trySimplifyTop (e : Expr) : MetaM (Expr × Option Expr) := do
     let lhs := args[4]!
     let rhs := args[5]!
     -- Fast type check: HAdd.hAdd's γ (result type) arg is args[2].
-    -- Check for BitVec n / Addr / Word directly, avoiding inferType + whnf.
+    -- Check for BitVec n / Word / Word directly, avoiding inferType + whnf.
     let γType := args[2]!
     if γType.isAppOfArity ``BitVec 1 ||
-       γType == mkConst ``EvmAsm.Rv64.Addr ||
+       γType == mkConst ``EvmAsm.Rv64.Word ||
        γType == mkConst ``EvmAsm.Rv64.Word then
       -- e + 0 → e (common after signExtend12 0 normalization)
       if let some 0 := getBvLitVal? rhs then

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -196,8 +196,8 @@ private def trySimplifyTop (e : Expr) : MetaM (Expr × Option Expr) := do
     -- Check for BitVec n / Word / Word directly, avoiding inferType + whnf.
     let γType := args[2]!
     if γType.isAppOfArity ``BitVec 1 ||
-       γType == mkConst ``EvmAsm.Rv64.Word ||
-       γType == mkConst ``EvmAsm.Rv64.Word then
+       γType == mkApp (mkConst ``BitVec) (mkNatLit 64) ||
+       γType == mkApp (mkConst ``BitVec) (mkNatLit 64) then
       -- e + 0 → e (common after signExtend12 0 normalization)
       if let some 0 := getBvLitVal? rhs then
         -- Fast path: use addr_add_zero_bv (avoids bv_omega overhead)

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -182,7 +182,7 @@ private def extractBaseAndOffset (e : Expr) : Option (Expr × Option Expr × Nat
     Falls back to `bv_omega` when the pattern doesn't match.
     ~100x faster than bv_omega for the common case (base + k1 ≠ base + k2). -/
 private def proveAddrNe (a1 a2 : Expr) : MetaM Expr := do
-  let addrType := mkConst ``EvmAsm.Rv64.Addr
+  let addrType := mkConst ``EvmAsm.Rv64.Word
   -- Try offset-based fast path
   if let some (base1, off1, k1) := extractBaseAndOffset a1 then
     if let some (base2, off2, k2) := extractBaseAndOffset a2 then
@@ -1060,7 +1060,7 @@ elab "crMono" : tactic => do
   let goal ← getMainGoal
   let _goalType ← instantiateMVars (← goal.getType)
   -- Extract cr1 and cr2 from ∀ a i, cr1 a = some i → cr2 a = some i
-  -- The type should be a pi: ∀ (a : Addr) (i : Instr), cr1 a = some i → cr2 a = some i
+  -- The type should be a pi: ∀ (a : Word) (i : Instr), cr1 a = some i → cr2 a = some i
   -- buildMonoProof handles this structurally
   -- Fall back to tactic: intro a i h; simp ... at h ⊢; split at h <;> simp_all <;> bv_omega
   let stx ← `(tactic| intro a i h; simp only [EvmAsm.Rv64.CodeReq.singleton, EvmAsm.Rv64.CodeReq.union] at *; (first | simp_all | (split at h <;> simp_all <;> bv_omega)))

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -182,7 +182,7 @@ private def extractBaseAndOffset (e : Expr) : Option (Expr × Option Expr × Nat
     Falls back to `bv_omega` when the pattern doesn't match.
     ~100x faster than bv_omega for the common case (base + k1 ≠ base + k2). -/
 private def proveAddrNe (a1 a2 : Expr) : MetaM Expr := do
-  let addrType := mkConst ``EvmAsm.Rv64.Word
+  let addrType := mkApp (mkConst ``BitVec) (mkNatLit 64)
   -- Try offset-based fast path
   if let some (base1, off1, k1) := extractBaseAndOffset a1 then
     if let some (base2, off2, k2) := extractBaseAndOffset a2 then

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -267,15 +267,26 @@ where
       let pf ← mkEqTrans pickProof step2
       return (pf, rhs)
 
+/-- Normalize an atom for hash comparison: recursively whnf with reducible
+    transparency to normalize OfNat instances and Fin proof terms. -/
+private def normalizeAtomForHash (e : Expr) : MetaM Expr :=
+  Lean.Core.transform e (pre := fun sub => do
+    let sub' ← withReducible (whnf sub)
+    if sub' == sub then return .continue
+    else return .continue sub')
+
 /-- Check if two sepConj chains are eligible for AC normalization.
-    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match. -/
+    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match
+    after reducible normalization. -/
 private def checkACEligible (lhs rhs : Expr) : MetaM Bool := do
   let lAtoms ← flattenSepConj lhs
   let rAtoms ← flattenSepConj rhs
   if lAtoms.length != rAtoms.length then return false
   if lAtoms.length < 2 then return false
-  let lHashes := lAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
-  let rHashes := rAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  let lNorm ← lAtoms.mapM normalizeAtomForHash
+  let rNorm ← rAtoms.mapM normalizeAtomForHash
+  let lHashes := lNorm.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  let rHashes := rNorm.map (·.hash) |>.toArray |>.insertionSort (· < ·)
   for i in [:lHashes.size] do
     if lHashes[i]! != rHashes[i]! then return false
   return true
@@ -306,6 +317,12 @@ private def reportAtomMismatches (lhsAtoms rhsAtoms : List Expr) : MetaM Message
     the mismatching atoms so the caller can fix the normalization. -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
+  -- Normalize both sides to canonical form:
+  -- 1. zetaReduce: inline let-bound fvars
+  -- 2. Lean.Core.transform: recursively whnf each subexpression with reducible
+  --    transparency to normalize Fin proofs, OfNat instances, etc.
+  let lhs ← Lean.Meta.zetaReduce lhs
+  let rhs ← Lean.Meta.zetaReduce rhs
   -- Inline let-bound fvars so atoms like `regIs .x7 result` become
   -- `regIs .x7 (if ... then 1 else 0)` — syntactically identical across both sides.
   let lhs ← Lean.Meta.zetaReduce lhs

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -268,9 +268,11 @@ where
       return (pf, rhs)
 
 /-- Normalize an atom for hash comparison: recursively whnf with reducible
-    transparency to normalize OfNat instances and Fin proof terms. -/
+    transparency to normalize OfNat instances and Fin proof terms.
+    Skips subexpressions with loose bound variables to avoid WHNF panics. -/
 private def normalizeAtomForHash (e : Expr) : MetaM Expr :=
   Lean.Core.transform e (pre := fun sub => do
+    if sub.hasLooseBVars then return .continue
     let sub' ← withReducible (whnf sub)
     if sub' == sub then return .continue
     else return .continue sub')
@@ -307,53 +309,93 @@ private def reportAtomMismatches (lhsAtoms rhsAtoms : List Expr) : MetaM Message
       msgs := msgs.push m!"  RHS atom {i} (hash {ra[i]!.hash}): {ra[i]!}"
   return MessageData.joinSep msgs.toList "\n"
 
+/-- Fallback pick-based permutation prover (O(n^2) in atom count).
+    Used when AC reflection is not safe (e.g., expressions with loose bvars). -/
+private partial def buildPermProofFallback (lhs rhs : Expr) : MetaM Expr := do
+  -- First reassociate both sides to right-associated form
+  let (lhsRA, lhsPf) ← reassocProof lhs
+  let (rhsRA, rhsPf) ← reassocProof rhs
+  -- Flatten LHS once (not per-atom)
+  let lhsAtoms := (← flattenSepConj lhsRA).toArray
+  let rhsAtoms := (← flattenSepConj rhsRA).toArray
+  -- Build permutation proof on right-associated forms
+  let permPf ← buildPermProofPickAux lhsRA lhsAtoms rhsAtoms
+  -- Chain: lhs = lhsRA = rhsRA = rhs
+  let step1 ← mkEqTrans lhsPf permPf
+  let rhsPfSymm ← mkEqSymm rhsPf
+  mkEqTrans step1 rhsPfSymm
+where
+  /-- Inner loop: pick each RHS atom from the LHS chain. -/
+  buildPermProofPickAux (currentLhs : Expr) (lhsAtoms : Array Expr)
+      (remainingRhs : Array Expr) (startIdx : Nat := 0) : MetaM Expr := do
+    if startIdx >= remainingRhs.size then
+      mkEqRefl currentLhs
+    else if startIdx + 1 == remainingRhs.size then
+      let target := remainingRhs[startIdx]!
+      if lhsAtoms.size == 1 then
+        if ← isDefEq currentLhs target then
+          mkEqRefl currentLhs
+        else
+          throwError "xperm: final atoms don't match:\n  LHS: {currentLhs}\n  RHS: {target}"
+      else
+        throwError "xperm: LHS has {lhsAtoms.size} atoms but only 1 remaining in RHS"
+    else
+      let target := remainingRhs[startIdx]!
+      let some idx ← findAtomIdx target lhsAtoms
+        | throwError "xperm: could not find atom in LHS matching RHS atom:\n  target: {target}\n  LHS ({lhsAtoms.size} atoms)"
+      let (pickProof, pickedRhs) ← buildPickProof currentLhs idx
+      match ← parseSepConj? pickedRhs with
+      | none =>
+        throwError "xperm: picked result is a single atom but {remainingRhs.size - startIdx} RHS atoms remain"
+      | some (pickedHead, pickedTail) =>
+        let newLhsAtoms := arrayEraseIdx lhsAtoms idx
+        let tailProof ← buildPermProofPickAux pickedTail newLhsAtoms remainingRhs (startIdx + 1)
+        let sepConjPicked := mkApp (mkConst ``EvmAsm.Rv64.sepConj) pickedHead
+        let step2 ← mkCongrArg sepConjPicked tailProof
+        mkEqTrans pickProof step2
+
 /-- The main permutation proof builder.
 
     Given LHS and RHS as sepConj chains with the same atoms
     (syntactically identical), builds a proof of `LHS = RHS`.
 
     Uses AC reflection via `buildNormProof` for O(n log n) kernel work.
-    If atoms are not syntactically identical (different Expr.hash), reports
-    the mismatching atoms so the caller can fix the normalization. -/
+    Falls back to pick-based O(n^2) algorithm if expressions contain
+    loose bvars (which would cause PANIC in AC normalization). -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
-  -- Normalize both sides to canonical form:
-  -- 1. zetaReduce: inline let-bound fvars
-  -- 2. Lean.Core.transform: recursively whnf each subexpression with reducible
-  --    transparency to normalize Fin proofs, OfNat instances, etc.
-  let lhs ← Lean.Meta.zetaReduce lhs
-  let rhs ← Lean.Meta.zetaReduce rhs
-  -- Inline let-bound fvars so atoms like `regIs .x7 result` become
-  -- `regIs .x7 (if ... then 1 else 0)` — syntactically identical across both sides.
-  let lhs ← Lean.Meta.zetaReduce lhs
-  let rhs ← Lean.Meta.zetaReduce rhs
-  let lhsAtoms ← flattenSepConj lhs
-  let rhsAtoms ← flattenSepConj rhs
-  -- Check atom count
+  -- Try AC fast path with zetaReduce
+  let lhsZ ← Lean.Meta.zetaReduce lhs
+  let rhsZ ← Lean.Meta.zetaReduce rhs
+  -- Safety check: if zetaReduce produced loose bvars, fall back
+  if lhsZ.hasLooseBVars || rhsZ.hasLooseBVars then
+    return ← buildPermProofFallback lhs rhs
+  let lhsAtoms ← flattenSepConj lhsZ
+  let rhsAtoms ← flattenSepConj rhsZ
+  -- If atom counts don't match after zetaReduce, try fallback on originals
   unless lhsAtoms.length == rhsAtoms.length do
-    throwError "xperm: atom count mismatch ({lhsAtoms.length} LHS vs {rhsAtoms.length} RHS)"
+    return ← buildPermProofFallback lhs rhs
   -- Handle trivial cases (0-1 atoms): just check isDefEq
   if lhsAtoms.length ≤ 1 then
-    if ← isDefEq lhs rhs then
-      return ← mkEqRefl lhs
+    if ← isDefEq lhsZ rhsZ then
+      return ← mkEqRefl lhsZ
     else
-      throwError "xperm: single atom doesn't match:\n  LHS: {lhs}\n  RHS: {rhs}"
-  -- Check sorted hashes match (atoms must be syntactically identical)
-  let acEligible ← checkACEligible lhs rhs
+      return ← buildPermProofFallback lhs rhs
+  -- Safety check: if any atom has loose bvars, fall back
+  if lhsAtoms.any (·.hasLooseBVars) || rhsAtoms.any (·.hasLooseBVars) then
+    return ← buildPermProofFallback lhs rhs
+  -- Check sorted hashes match (atoms must be syntactically identical for AC path)
+  let acEligible ← checkACEligible lhsZ rhsZ
   unless acEligible do
-    let diffs ← reportAtomMismatches lhsAtoms rhsAtoms
-    throwError "xperm: atoms are not syntactically identical (different Expr.hash).\n\
-      Both sides have {lhsAtoms.length} atoms but some differ structurally.\n\
-      Mismatching atoms:\n{diffs}\n\n\
-      Hint: ensure both sides use the same representation for addresses \
-      (e.g., normalize signExtend12 before calling xperm)."
+    -- Fall back to pick-based algorithm on originals (uses isDefEq for atom matching)
+    return ← buildPermProofFallback lhs rhs
   -- AC reflection: normalize each side, check normal forms match
   let op := mkConst ``EvmAsm.Rv64.sepConj
   let some pc ← Lean.Meta.AC.preContext op
     | throwError "xperm: sepConj has no Associative/Commutative instances"
-  let some (lHead, lTail) ← parseSepConj? lhs
+  let some (lHead, lTail) ← parseSepConj? lhsZ
     | throwError "xperm: LHS is not a sepConj chain"
-  let some (rHead, rTail) ← parseSepConj? rhs
+  let some (rHead, rTail) ← parseSepConj? rhsZ
     | throwError "xperm: RHS is not a sepConj chain"
   let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
     Lean.Meta.AC.buildNormProof pc lHead lTail

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -158,24 +158,145 @@ partial def reassocProof (e : Expr) : MetaM (Expr × Expr) := do
       let pf ← mkEqTrans assocPf restPf
       return (result, pf)
 
+/-- Build proof that `chain = chain ** empAssertion` (add emp at the end).
+    For `a ** (b ** c)`, returns proof: `a ** (b ** c) = a ** (b ** (c ** empAssertion))`.
+    This bridges from raw sepConj chains to the `seps` representation. -/
+private partial def buildAddEmpProof (chain : Expr) : MetaM (Expr × Expr) := do
+  match ← parseSepConj? chain with
+  | none =>
+    -- Base case: single atom `x`. Prove `x = x ** empAssertion`
+    let emp := mkConst ``EvmAsm.Rv64.empAssertion
+    let rhs := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) chain emp
+    let pf ← mkEqSymm (mkApp (mkConst ``EvmAsm.Rv64.sepConj_emp_right') chain)
+    return (pf, rhs)
+  | some (head, tail) =>
+    -- Recursive case: `head ** tail`. Add emp to tail.
+    let (tailPf, tailRhs) ← buildAddEmpProof tail
+    let sepConjHead := mkApp (mkConst ``EvmAsm.Rv64.sepConj) head
+    let pf ← mkCongrArg sepConjHead tailPf
+    let rhs := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) head tailRhs
+    return (pf, rhs)
+
+/-- Build proof that `chain ** empAssertion = chain` (remove emp from the end).
+    Inverse of `buildAddEmpProof`. -/
+private partial def buildRemoveEmpProof (chain : Expr) : MetaM (Expr × Expr) := do
+  match ← parseSepConj? chain with
+  | none =>
+    -- Shouldn't happen (chain should end with ** emp)
+    return (← mkEqRefl chain, chain)
+  | some (head, tail) =>
+    -- Check if tail is empAssertion
+    if tail == mkConst ``EvmAsm.Rv64.empAssertion then
+      -- Base: `head ** emp = head`
+      let pf := mkApp (mkConst ``EvmAsm.Rv64.sepConj_emp_right') head
+      return (pf, head)
+    else
+      -- Recursive: head ** (... ** emp)
+      let (tailPf, tailRhs) ← buildRemoveEmpProof tail
+      let sepConjHead := mkApp (mkConst ``EvmAsm.Rv64.sepConj) head
+      let pf ← mkCongrArg sepConjHead tailPf
+      let rhs := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) head tailRhs
+      return (pf, rhs)
+
+/-- Build an Expr representing a `List Assertion` literal from an Array of Assertion Exprs. -/
+private def mkAssertionList (atoms : Array Expr) : Expr :=
+  let assertionType := mkConst ``EvmAsm.Rv64.Assertion
+  atoms.foldr (init := mkApp (mkConst ``List.nil [0]) assertionType)
+    fun atom acc => mkApp3 (mkConst ``List.cons [0]) assertionType atom acc
+
+/-- Build a seps-based permutation proof: returns (proof, rhs_expr) where
+    proof : seps_chain_lhs = rhs_expr, and rhs_expr is a CONCRETE sepConj chain
+    (with empAssertion at the end), NOT an opaque `seps` application.
+
+    This is the O(n)-tactic-time permutation prover. Each pick is one `seps_pick`
+    application (O(1) in MetaM), vs O(k) `left_comm'` applications in the old algorithm. -/
+private partial def buildSepsPermProof (lhsAtoms rhsAtoms : Array Expr) :
+    MetaM (Expr × Expr) := do
+  if lhsAtoms.size != rhsAtoms.size then
+    throwError "buildSepsPermProof: atom count mismatch ({lhsAtoms.size} vs {rhsAtoms.size})"
+  let emp := mkConst ``EvmAsm.Rv64.empAssertion
+  if lhsAtoms.size == 0 then
+    let pf ← mkEqRefl emp
+    return (pf, emp)
+  if lhsAtoms.size == 1 then
+    -- seps [a] = a ** emp, rhs should also be a ** emp
+    if ← isDefEq lhsAtoms[0]! rhsAtoms[0]! then
+      let chain := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) lhsAtoms[0]! emp
+      let pf ← mkEqRefl chain
+      return (pf, chain)
+    else
+      throwError "buildSepsPermProof: single atoms don't match"
+  -- Recursive loop: pick each RHS atom from current LHS list
+  buildSepsPermAux lhsAtoms rhsAtoms 0
+where
+  buildSepsPermAux (currentAtoms : Array Expr) (rhsAtoms : Array Expr)
+      (startIdx : Nat) : MetaM (Expr × Expr) := do
+    let emp := mkConst ``EvmAsm.Rv64.empAssertion
+    if startIdx >= rhsAtoms.size then
+      return (← mkEqRefl emp, emp)
+    if startIdx + 1 == rhsAtoms.size then
+      -- Last atom: currentAtoms should have 1 element matching rhsAtoms[startIdx]
+      -- The seps form is: currentAtoms[0] ** empAssertion
+      if currentAtoms.size == 1 then
+        if ← isDefEq currentAtoms[0]! rhsAtoms[startIdx]! then
+          let chain := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) currentAtoms[0]! emp
+          return (← mkEqRefl chain, chain)
+        else
+          throwError "buildSepsPermProof: final atoms don't match"
+      else
+        throwError "buildSepsPermProof: {currentAtoms.size} atoms left but only 1 RHS remaining"
+    else
+      let target := rhsAtoms[startIdx]!
+      let some idx ← findAtomIdx target currentAtoms
+        | throwError "buildSepsPermProof: could not find RHS atom {startIdx}"
+      -- seps_pick proof: seps currentList = currentAtoms[idx] ** seps (eraseIdx currentList idx)
+      let listExpr := mkAssertionList currentAtoms
+      let idxLit := mkNatLit idx
+      let boundProof ← mkDecideProof (← mkLt (mkNatLit idx) (mkNatLit currentAtoms.size))
+      let pickProof := mkApp3 (mkConst ``EvmAsm.Rv64.seps_pick) listExpr idxLit boundProof
+      -- Recurse on tail
+      let newAtoms := (currentAtoms.extract 0 idx) ++ (currentAtoms.extract (idx + 1) currentAtoms.size)
+      let (tailProof, tailRhs) ← buildSepsPermAux newAtoms rhsAtoms (startIdx + 1)
+      -- tailProof : seps newAtoms = tailRhs (concrete chain)
+      -- Build: target ** seps newAtoms = target ** tailRhs
+      let sepConjTarget := mkApp (mkConst ``EvmAsm.Rv64.sepConj) target
+      let step2 ← mkCongrArg sepConjTarget tailProof
+      let rhs := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) target tailRhs
+      -- Chain: seps currentList = target ** seps newAtoms = target ** tailRhs
+      let pf ← mkEqTrans pickProof step2
+      return (pf, rhs)
+
 /-- The main permutation proof builder.
 
     Given LHS and RHS as sepConj chains with the same atoms
     (up to `isDefEq`), builds a proof of `LHS = RHS`.
-    Handles non-right-associated chains by first reassociating.
 
-    **Optimization**: flattens LHS once and passes the atom array through
-    recursion (avoiding O(n²) re-flattening). -/
+    **Strategy**: Uses `seps_pick` (bedrock2-style) for O(n) proof terms.
+    Each pick is a single lemma application; the kernel reduces `List.get`
+    and `List.eraseIdx` on concrete lists. Falls back to the O(n²) pick-chain
+    algorithm if the seps approach fails. -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
   -- First reassociate both sides to right-associated form
   let (lhsRA, lhsPf) ← reassocProof lhs
   let (rhsRA, rhsPf) ← reassocProof rhs
-  -- Flatten LHS once (not per-atom)
+  -- Flatten both sides to atom arrays
   let lhsAtoms := (← flattenSepConj lhsRA).toArray
   let rhsAtoms := (← flattenSepConj rhsRA).toArray
-  -- Build permutation proof on right-associated forms
-  let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
+  -- Try seps-based O(n) proof, fall back to O(n²) pick chain
+  let permPf ← try
+    -- Bridge: lhsRA = lhsRA ** empAssertion (= seps lhsAtoms by definition)
+    let (addEmpPf, _) ← buildAddEmpProof lhsRA
+    -- Permutation: seps lhsAtoms = rhs_with_emp (concrete chain ending in emp)
+    let (sepsPf, rhsWithEmp) ← buildSepsPermProof lhsAtoms rhsAtoms
+    -- Bridge: rhs_with_emp = rhsRA (remove empAssertion from concrete chain)
+    let (remEmpPf, _) ← buildRemoveEmpProof rhsWithEmp
+    -- Chain: lhsRA = lhsRA**emp = rhs**emp = rhsRA
+    let step ← mkEqTrans addEmpPf sepsPf
+    mkEqTrans step remEmpPf
+  catch e =>
+    trace[runBlock.perf.perm] "seps fast path failed ({lhsAtoms.size} atoms): {← e.toMessageData.toString}"
+    buildPermProofAux lhsRA lhsAtoms rhsAtoms
   -- Chain: lhs = lhsRA = rhsRA = rhs
   let step1 ← mkEqTrans lhsPf permPf
   let rhsPfSymm ← mkEqSymm rhsPf

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -306,6 +306,10 @@ private def reportAtomMismatches (lhsAtoms rhsAtoms : List Expr) : MetaM Message
     the mismatching atoms so the caller can fix the normalization. -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
+  -- Inline let-bound fvars so atoms like `regIs .x7 result` become
+  -- `regIs .x7 (if ... then 1 else 0)` — syntactically identical across both sides.
+  let lhs ← Lean.Meta.zetaReduce lhs
+  let rhs ← Lean.Meta.zetaReduce rhs
   let lhsAtoms ← flattenSepConj lhs
   let rhsAtoms ← flattenSepConj rhs
   -- Check atom count

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -30,6 +30,7 @@
 -/
 
 import Lean
+import Lean.Meta.Tactic.AC.Main
 import EvmAsm.Rv64.SepLogic
 import EvmAsm.Rv64.Tactics.PerfTrace
 
@@ -271,32 +272,31 @@ where
     Given LHS and RHS as sepConj chains with the same atoms
     (up to `isDefEq`), builds a proof of `LHS = RHS`.
 
-    **Strategy**: Uses `seps_pick` (bedrock2-style) for O(n) proof terms.
-    Each pick is a single lemma application; the kernel reduces `List.get`
-    and `List.eraseIdx` on concrete lists. Falls back to the O(n²) pick-chain
-    algorithm if the seps approach fails. -/
+    **Strategy**: Tries AC reflection first (O(n log n) kernel work via `buildNormProof`),
+    then falls back to seps_pick (O(n) tactic, O(n²) kernel), then to pick-chain (O(n²) both). -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
-  -- First reassociate both sides to right-associated form
+  -- Fast path: O(1) proof term via AC normalization (no simp, no side effects).
+  -- Uses Lean.Meta.AC.buildNormProof directly to build a reflection-based proof.
+  try
+    let op := mkConst ``EvmAsm.Rv64.sepConj
+    let some pc ← Lean.Meta.AC.preContext op
+      | throwError "buildPermProof: sepConj has no AC instance"
+    let (proof, _) ← Lean.Meta.AC.buildNormProof pc lhs rhs
+    -- Eagerly type-check the proof to catch kernel mismatches before returning.
+    -- Without this, kernel errors surface after the tactic completes and can't be caught.
+    let proofType ← inferType proof
+    let expectedType ← mkEq lhs rhs
+    unless ← isDefEq proofType expectedType do
+      throwError "buildACPermProof: proof type mismatch"
+    return proof
+  catch _ =>
+  -- Fall back: reassociate + pick-based permutation
   let (lhsRA, lhsPf) ← reassocProof lhs
   let (rhsRA, rhsPf) ← reassocProof rhs
-  -- Flatten both sides to atom arrays
   let lhsAtoms := (← flattenSepConj lhsRA).toArray
   let rhsAtoms := (← flattenSepConj rhsRA).toArray
-  -- Try seps-based O(n) proof, fall back to O(n²) pick chain
-  let permPf ← try
-    -- Bridge: lhsRA = lhsRA ** empAssertion (= seps lhsAtoms by definition)
-    let (addEmpPf, _) ← buildAddEmpProof lhsRA
-    -- Permutation: seps lhsAtoms = rhs_with_emp (concrete chain ending in emp)
-    let (sepsPf, rhsWithEmp) ← buildSepsPermProof lhsAtoms rhsAtoms
-    -- Bridge: rhs_with_emp = rhsRA (remove empAssertion from concrete chain)
-    let (remEmpPf, _) ← buildRemoveEmpProof rhsWithEmp
-    -- Chain: lhsRA = lhsRA**emp = rhs**emp = rhsRA
-    let step ← mkEqTrans addEmpPf sepsPf
-    mkEqTrans step remEmpPf
-  catch e =>
-    trace[runBlock.perf.perm] "seps fast path failed ({lhsAtoms.size} atoms): {← e.toMessageData.toString}"
-    buildPermProofAux lhsRA lhsAtoms rhsAtoms
+  let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
   -- Chain: lhs = lhsRA = rhsRA = rhs
   let step1 ← mkEqTrans lhsPf permPf
   let rhsPfSymm ← mkEqSymm rhsPf

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -280,116 +280,67 @@ private def checkACEligible (lhs rhs : Expr) : MetaM Bool := do
     if lHashes[i]! != rHashes[i]! then return false
   return true
 
+/-- Report which atoms differ between LHS and RHS (for diagnostics). -/
+private def reportAtomMismatches (lhsAtoms rhsAtoms : List Expr) : MetaM MessageData := do
+  let la := lhsAtoms.toArray
+  let ra := rhsAtoms.toArray
+  let lHashes := la.map (·.hash)
+  let rHashSet := Std.HashSet.ofArray (ra.map (·.hash))
+  let lHashSet := Std.HashSet.ofArray lHashes
+  let mut msgs : Array MessageData := #[]
+  for i in [:la.size] do
+    unless rHashSet.contains la[i]!.hash do
+      msgs := msgs.push m!"  LHS atom {i} (hash {la[i]!.hash}): {la[i]!}"
+  for i in [:ra.size] do
+    unless lHashSet.contains ra[i]!.hash do
+      msgs := msgs.push m!"  RHS atom {i} (hash {ra[i]!.hash}): {ra[i]!}"
+  return MessageData.joinSep msgs.toList "\n"
+
 /-- The main permutation proof builder.
 
     Given LHS and RHS as sepConj chains with the same atoms
-    (up to `isDefEq`), builds a proof of `LHS = RHS`.
+    (syntactically identical), builds a proof of `LHS = RHS`.
 
-    **Strategy**: Tries AC reflection first (O(n log n) kernel work via `buildNormProof`),
-    then falls back to seps_pick (O(n) tactic, O(n²) kernel), then to pick-chain (O(n²) both). -/
+    Uses AC reflection via `buildNormProof` for O(n log n) kernel work.
+    If atoms are not syntactically identical (different Expr.hash), reports
+    the mismatching atoms so the caller can fix the normalization. -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
-  -- Fast path: O(n log n) kernel proof via AC normalization (no simp).
-  -- Pre-check: flatten both sides and verify atoms have identical sorted hashes.
-  -- This guarantees buildNormProof will succeed, avoiding any side effects from failure.
+  let lhsAtoms ← flattenSepConj lhs
+  let rhsAtoms ← flattenSepConj rhs
+  -- Check atom count
+  unless lhsAtoms.length == rhsAtoms.length do
+    throwError "xperm: atom count mismatch ({lhsAtoms.length} LHS vs {rhsAtoms.length} RHS)"
+  -- Handle trivial cases (0-1 atoms): just check isDefEq
+  if lhsAtoms.length ≤ 1 then
+    if ← isDefEq lhs rhs then
+      return ← mkEqRefl lhs
+    else
+      throwError "xperm: single atom doesn't match:\n  LHS: {lhs}\n  RHS: {rhs}"
+  -- Check sorted hashes match (atoms must be syntactically identical)
   let acEligible ← checkACEligible lhs rhs
-  if acEligible then
-    let op := mkConst ``EvmAsm.Rv64.sepConj
-    let some pc ← Lean.Meta.AC.preContext op
-      | throwError "AC: no instance"
-    let some (lHead, lTail) ← parseSepConj? lhs
-      | throwError "AC: lhs not sepConj"
-    let some (rHead, rTail) ← parseSepConj? rhs
-      | throwError "AC: rhs not sepConj"
-    let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
-      Lean.Meta.AC.buildNormProof pc lHead lTail
-    let (rPf, rNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
-      Lean.Meta.AC.buildNormProof pc rHead rTail
-    if ← isDefEq lNorm rNorm then
-      mkEqTrans lPf (← mkEqSymm rPf)
-    else
-      -- Normal forms differ (atoms not syntactically identical) → slow path
-      let (lhsRA, lhsPf) ← reassocProof lhs
-      let (rhsRA, rhsPf) ← reassocProof rhs
-      let lhsAtoms := (← flattenSepConj lhsRA).toArray
-      let rhsAtoms := (← flattenSepConj rhsRA).toArray
-      let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
-      let step1 ← mkEqTrans lhsPf permPf
-      let rhsPfSymm ← mkEqSymm rhsPf
-      mkEqTrans step1 rhsPfSymm
-  else
-    -- Not AC-eligible → slow path
-    let (lhsRA, lhsPf) ← reassocProof lhs
-    let (rhsRA, rhsPf) ← reassocProof rhs
-    let lhsAtoms := (← flattenSepConj lhsRA).toArray
-    let rhsAtoms := (← flattenSepConj rhsRA).toArray
-    let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
-    let step1 ← mkEqTrans lhsPf permPf
-    let rhsPfSymm ← mkEqSymm rhsPf
-    mkEqTrans step1 rhsPfSymm
-where
-  /-- Inner loop: pick each RHS atom from the LHS chain.
-      `lhsAtoms` is the cached atom array (updated by erasing matched elements). -/
-  buildPermProofAux (currentLhs : Expr) (lhsAtoms : Array Expr)
-      (remainingRhs : Array Expr) (startIdx : Nat := 0) : MetaM Expr := do
-    if startIdx >= remainingRhs.size then
-      mkEqRefl currentLhs
-    else if startIdx + 1 == remainingRhs.size then
-      -- Last atom: they should be isDefEq
-      let target := remainingRhs[startIdx]!
-      if lhsAtoms.size == 1 then
-        if ← isDefEq currentLhs target then
-          mkEqRefl currentLhs
-        else
-          throwError "xperm: final atoms don't match:\n  LHS: {currentLhs}\n  RHS: {target}"
-      else
-        throwError "xperm: LHS has {lhsAtoms.size} atoms but only 1 remaining in RHS"
-    else
-      -- Early termination: if remaining LHS atoms already match RHS in order, short-circuit.
-      -- This avoids O(m²) picks when only a few atoms were rearranged (common in seqFrame).
-      if lhsAtoms.size == remainingRhs.size - startIdx then
-        let mut hashesMatch := true
-        for j in [:lhsAtoms.size] do
-          if lhsAtoms[j]!.hash != remainingRhs[startIdx + j]!.hash then
-            hashesMatch := false
-            break
-        if hashesMatch then
-          -- Hashes match — build remaining RHS chain and verify with isDefEq
-          let endIdx := remainingRhs.size
-          let mut rhsChain := remainingRhs[endIdx - 1]!
-          for j' in [:endIdx - startIdx - 1] do
-            let j := endIdx - 2 - j'
-            rhsChain := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) remainingRhs[j]! rhsChain
-          if ← withoutModifyingState (isDefEq currentLhs rhsChain) then
-            return ← mkEqRefl currentLhs
-      let target := remainingRhs[startIdx]!
-      -- Find target in cached LHS atoms (no re-flattening)
-      let some idx ← findAtomIdx target lhsAtoms
-        | throwError "xperm: could not find atom in LHS matching RHS atom:\n  target: {target}\n  LHS ({lhsAtoms.size} atoms)"
-      -- Build pick proof: currentLhs = pickedRhs (returns RHS directly, no inferType needed)
-      let (pickProof, pickedRhs) ← buildPickProof currentLhs idx
-      match ← parseSepConj? pickedRhs with
-      | none =>
-        throwError "xperm: picked result is a single atom but {remainingRhs.size - startIdx} RHS atoms remain"
-      | some (pickedHead, pickedTail) =>
-        -- Update cached atoms: remove the matched element
-        let newLhsAtoms := arrayEraseIdx lhsAtoms idx
-        if startIdx + 2 == remainingRhs.size then
-          -- Exactly 2 remaining: pickedTail should match the last RHS atom
-          let lastTarget := remainingRhs[startIdx + 1]!
-          if ← isDefEq pickedTail lastTarget then
-            let tailProof ← mkEqRefl pickedTail
-            let sepConjPicked := mkApp (mkConst ``EvmAsm.Rv64.sepConj) pickedHead
-            let step2 ← mkCongrArg sepConjPicked tailProof
-            mkEqTrans pickProof step2
-          else
-            throwError "xperm: last two atoms don't match:\n  LHS tail: {pickedTail}\n  RHS last: {lastTarget}"
-        else
-          -- Recursively process the tail with updated atom cache
-          let tailProof ← buildPermProofAux pickedTail newLhsAtoms remainingRhs (startIdx + 1)
-          let sepConjPicked := mkApp (mkConst ``EvmAsm.Rv64.sepConj) pickedHead
-          let step2 ← mkCongrArg sepConjPicked tailProof
-          mkEqTrans pickProof step2
+  unless acEligible do
+    let diffs ← reportAtomMismatches lhsAtoms rhsAtoms
+    throwError "xperm: atoms are not syntactically identical (different Expr.hash).\n\
+      Both sides have {lhsAtoms.length} atoms but some differ structurally.\n\
+      Mismatching atoms:\n{diffs}\n\n\
+      Hint: ensure both sides use the same representation for addresses \
+      (e.g., normalize signExtend12 before calling xperm)."
+  -- AC reflection: normalize each side, check normal forms match
+  let op := mkConst ``EvmAsm.Rv64.sepConj
+  let some pc ← Lean.Meta.AC.preContext op
+    | throwError "xperm: sepConj has no Associative/Commutative instances"
+  let some (lHead, lTail) ← parseSepConj? lhs
+    | throwError "xperm: LHS is not a sepConj chain"
+  let some (rHead, rTail) ← parseSepConj? rhs
+    | throwError "xperm: RHS is not a sepConj chain"
+  let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+    Lean.Meta.AC.buildNormProof pc lHead lTail
+  let (rPf, rNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+    Lean.Meta.AC.buildNormProof pc rHead rTail
+  unless ← isDefEq lNorm rNorm do
+    throwError "xperm: AC normal forms differ (atoms matched by hash but not by AC normalization)"
+  mkEqTrans lPf (← mkEqSymm rPf)
 
 /-- `xperm` tactic: proves `⊢ P = Q` where P and Q are AC-permutations of
     sepConj chains, using `isDefEq` for atom matching. -/

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -267,15 +267,26 @@ where
       let pf ← mkEqTrans pickProof step2
       return (pf, rhs)
 
+/-- Canonicalize `Word` → `BitVec 64` in an expression so that atoms elaborated
+    with different type-alias choices become syntactically identical.
+    Pure structural replacement, no MetaM/whnf needed. -/
+private partial def canonicalizeWordType (e : Expr) : Expr :=
+  let bv64 := mkApp (mkConst ``BitVec) (mkNatLit 64)
+  if e == mkConst ``EvmAsm.Rv64.Word then bv64
+  else match e with
+  | .app f a => .app (canonicalizeWordType f) (canonicalizeWordType a)
+  | _ => e
+
 /-- Check if two sepConj chains are eligible for AC normalization.
-    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match. -/
+    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match
+    after canonicalizing Word → BitVec 64. -/
 private def checkACEligible (lhs rhs : Expr) : MetaM Bool := do
   let lAtoms ← flattenSepConj lhs
   let rAtoms ← flattenSepConj rhs
   if lAtoms.length != rAtoms.length then return false
   if lAtoms.length < 2 then return false
-  let lHashes := lAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
-  let rHashes := rAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  let lHashes := lAtoms.map (canonicalizeWordType · |>.hash) |>.toArray |>.insertionSort (· < ·)
+  let rHashes := rAtoms.map (canonicalizeWordType · |>.hash) |>.toArray |>.insertionSort (· < ·)
   for i in [:lHashes.size] do
     if lHashes[i]! != rHashes[i]! then return false
   return true
@@ -326,13 +337,15 @@ partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
       Mismatching atoms:\n{diffs}\n\n\
       Hint: ensure both sides use the same representation for addresses \
       (e.g., normalize signExtend12 before calling xperm)."
-  -- AC reflection: normalize each side, check normal forms match
+  -- AC reflection: canonicalize Word→BitVec 64, then normalize each side
+  let lhsC := canonicalizeWordType lhs
+  let rhsC := canonicalizeWordType rhs
   let op := mkConst ``EvmAsm.Rv64.sepConj
   let some pc ← Lean.Meta.AC.preContext op
     | throwError "xperm: sepConj has no Associative/Commutative instances"
-  let some (lHead, lTail) ← parseSepConj? lhs
+  let some (lHead, lTail) ← parseSepConj? lhsC
     | throwError "xperm: LHS is not a sepConj chain"
-  let some (rHead, rTail) ← parseSepConj? rhs
+  let some (rHead, rTail) ← parseSepConj? rhsC
     | throwError "xperm: RHS is not a sepConj chain"
   let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
     Lean.Meta.AC.buildNormProof pc lHead lTail

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -267,26 +267,15 @@ where
       let pf ← mkEqTrans pickProof step2
       return (pf, rhs)
 
-/-- Canonicalize `Word` → `BitVec 64` in an expression so that atoms elaborated
-    with different type-alias choices become syntactically identical.
-    Pure structural replacement, no MetaM/whnf needed. -/
-private partial def canonicalizeWordType (e : Expr) : Expr :=
-  let bv64 := mkApp (mkConst ``BitVec) (mkNatLit 64)
-  if e == mkConst ``EvmAsm.Rv64.Word then bv64
-  else match e with
-  | .app f a => .app (canonicalizeWordType f) (canonicalizeWordType a)
-  | _ => e
-
 /-- Check if two sepConj chains are eligible for AC normalization.
-    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match
-    after canonicalizing Word → BitVec 64. -/
+    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match. -/
 private def checkACEligible (lhs rhs : Expr) : MetaM Bool := do
   let lAtoms ← flattenSepConj lhs
   let rAtoms ← flattenSepConj rhs
   if lAtoms.length != rAtoms.length then return false
   if lAtoms.length < 2 then return false
-  let lHashes := lAtoms.map (canonicalizeWordType · |>.hash) |>.toArray |>.insertionSort (· < ·)
-  let rHashes := rAtoms.map (canonicalizeWordType · |>.hash) |>.toArray |>.insertionSort (· < ·)
+  let lHashes := lAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  let rHashes := rAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
   for i in [:lHashes.size] do
     if lHashes[i]! != rHashes[i]! then return false
   return true
@@ -337,15 +326,13 @@ partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
       Mismatching atoms:\n{diffs}\n\n\
       Hint: ensure both sides use the same representation for addresses \
       (e.g., normalize signExtend12 before calling xperm)."
-  -- AC reflection: canonicalize Word→BitVec 64, then normalize each side
-  let lhsC := canonicalizeWordType lhs
-  let rhsC := canonicalizeWordType rhs
+  -- AC reflection: normalize each side, check normal forms match
   let op := mkConst ``EvmAsm.Rv64.sepConj
   let some pc ← Lean.Meta.AC.preContext op
     | throwError "xperm: sepConj has no Associative/Commutative instances"
-  let some (lHead, lTail) ← parseSepConj? lhsC
+  let some (lHead, lTail) ← parseSepConj? lhs
     | throwError "xperm: LHS is not a sepConj chain"
-  let some (rHead, rTail) ← parseSepConj? rhsC
+  let some (rHead, rTail) ← parseSepConj? rhs
     | throwError "xperm: RHS is not a sepConj chain"
   let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
     Lean.Meta.AC.buildNormProof pc lHead lTail

--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -267,6 +267,19 @@ where
       let pf ← mkEqTrans pickProof step2
       return (pf, rhs)
 
+/-- Check if two sepConj chains are eligible for AC normalization.
+    Requires: both are sepConj chains with ≥2 atoms, and sorted atom hashes match. -/
+private def checkACEligible (lhs rhs : Expr) : MetaM Bool := do
+  let lAtoms ← flattenSepConj lhs
+  let rAtoms ← flattenSepConj rhs
+  if lAtoms.length != rAtoms.length then return false
+  if lAtoms.length < 2 then return false
+  let lHashes := lAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  let rHashes := rAtoms.map (·.hash) |>.toArray |>.insertionSort (· < ·)
+  for i in [:lHashes.size] do
+    if lHashes[i]! != rHashes[i]! then return false
+  return true
+
 /-- The main permutation proof builder.
 
     Given LHS and RHS as sepConj chains with the same atoms
@@ -276,31 +289,44 @@ where
     then falls back to seps_pick (O(n) tactic, O(n²) kernel), then to pick-chain (O(n²) both). -/
 partial def buildPermProof (lhs rhs : Expr) : MetaM Expr :=
   withTraceNode `runBlock.perf.perm (fun _ => return m!"perm") do
-  -- Fast path: O(1) proof term via AC normalization (no simp, no side effects).
-  -- Uses Lean.Meta.AC.buildNormProof directly to build a reflection-based proof.
-  try
+  -- Fast path: O(n log n) kernel proof via AC normalization (no simp).
+  -- Pre-check: flatten both sides and verify atoms have identical sorted hashes.
+  -- This guarantees buildNormProof will succeed, avoiding any side effects from failure.
+  let acEligible ← checkACEligible lhs rhs
+  if acEligible then
     let op := mkConst ``EvmAsm.Rv64.sepConj
     let some pc ← Lean.Meta.AC.preContext op
-      | throwError "buildPermProof: sepConj has no AC instance"
-    let (proof, _) ← Lean.Meta.AC.buildNormProof pc lhs rhs
-    -- Eagerly type-check the proof to catch kernel mismatches before returning.
-    -- Without this, kernel errors surface after the tactic completes and can't be caught.
-    let proofType ← inferType proof
-    let expectedType ← mkEq lhs rhs
-    unless ← isDefEq proofType expectedType do
-      throwError "buildACPermProof: proof type mismatch"
-    return proof
-  catch _ =>
-  -- Fall back: reassociate + pick-based permutation
-  let (lhsRA, lhsPf) ← reassocProof lhs
-  let (rhsRA, rhsPf) ← reassocProof rhs
-  let lhsAtoms := (← flattenSepConj lhsRA).toArray
-  let rhsAtoms := (← flattenSepConj rhsRA).toArray
-  let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
-  -- Chain: lhs = lhsRA = rhsRA = rhs
-  let step1 ← mkEqTrans lhsPf permPf
-  let rhsPfSymm ← mkEqSymm rhsPf
-  mkEqTrans step1 rhsPfSymm
+      | throwError "AC: no instance"
+    let some (lHead, lTail) ← parseSepConj? lhs
+      | throwError "AC: lhs not sepConj"
+    let some (rHead, rTail) ← parseSepConj? rhs
+      | throwError "AC: rhs not sepConj"
+    let (lPf, lNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+      Lean.Meta.AC.buildNormProof pc lHead lTail
+    let (rPf, rNorm) ← withTheReader Core.Context (fun c => { c with maxRecDepth := 1024 }) do
+      Lean.Meta.AC.buildNormProof pc rHead rTail
+    if ← isDefEq lNorm rNorm then
+      mkEqTrans lPf (← mkEqSymm rPf)
+    else
+      -- Normal forms differ (atoms not syntactically identical) → slow path
+      let (lhsRA, lhsPf) ← reassocProof lhs
+      let (rhsRA, rhsPf) ← reassocProof rhs
+      let lhsAtoms := (← flattenSepConj lhsRA).toArray
+      let rhsAtoms := (← flattenSepConj rhsRA).toArray
+      let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
+      let step1 ← mkEqTrans lhsPf permPf
+      let rhsPfSymm ← mkEqSymm rhsPf
+      mkEqTrans step1 rhsPfSymm
+  else
+    -- Not AC-eligible → slow path
+    let (lhsRA, lhsPf) ← reassocProof lhs
+    let (rhsRA, rhsPf) ← reassocProof rhs
+    let lhsAtoms := (← flattenSepConj lhsRA).toArray
+    let rhsAtoms := (← flattenSepConj rhsRA).toArray
+    let permPf ← buildPermProofAux lhsRA lhsAtoms rhsAtoms
+    let step1 ← mkEqTrans lhsPf permPf
+    let rhsPfSymm ← mkEqSymm rhsPf
+    mkEqTrans step1 rhsPfSymm
 where
   /-- Inner loop: pick each RHS atom from the LHS chain.
       `lhsAtoms` is the cached atom array (updated by erasing matched elements). -/

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -33,10 +33,10 @@ theorem extractWord32_replaceWord32_same (w : Word) (pos : Fin 2) (v : BitVec 32
 
 /-! ## getWord32 / setWord32 in terms of extractWord32 / replaceWord32 -/
 
-theorem getWord32_eq (s : MachineState) (addr : Addr) :
+theorem getWord32_eq (s : MachineState) (addr : Word) :
     s.getWord32 addr = extractWord32 (s.getMem (alignToDword addr)) ((byteOffset addr) / 4) := rfl
 
-theorem setWord32_eq (s : MachineState) (addr : Addr) (v : BitVec 32) :
+theorem setWord32_eq (s : MachineState) (addr : Word) (v : BitVec 32) :
     s.setWord32 addr v = s.setMem (alignToDword addr)
       (replaceWord32 (s.getMem (alignToDword addr)) ((byteOffset addr) / 4) v) := rfl
 
@@ -45,8 +45,8 @@ theorem setWord32_eq (s : MachineState) (addr : Addr) (v : BitVec 32) :
 LWU reads a 32-bit word from memory at a 4-byte aligned address and zero-extends it. -/
 
 theorem generic_lwu_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -90,8 +90,8 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr v_old : Word)
 LW reads a 32-bit word from memory at a 4-byte aligned address and sign-extends it. -/
 
 theorem generic_lw_spec (rd rs1 : Reg) (v_addr v_old : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_val : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
@@ -135,8 +135,8 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr v_old : Word)
 SW writes the lower 32 bits of a register to memory at a 4-byte aligned address. -/
 
 theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
-    (offset : BitVec 12) (base : Addr)
-    (dwordAddr : Addr) (word_old : Word)
+    (offset : BitVec 12) (base : Word)
+    (dwordAddr : Word) (word_old : Word)
     (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :


### PR DESCRIPTION
## Summary

- **XPerm AC reflection**: Replace O(n²) pick-based permutation proofs with O(n log n) AC normalization via `Lean.Meta.AC.buildNormProof`. Main performance optimization for large separation logic conjunctions.
- **Atom identity fixes**: Ensure both sides of xperm permutations use identical `Expr` representations:
  - `Word`: changed from `abbrev` to `notation` (eliminates `Expr.const Word` vs `Expr.app BitVec 64` mismatch)
  - `Addr`: removed entirely, unified to `Word`
  - `getLimb` (Fin 4) → `getLimbN` (Nat): avoids Fin proof term differences across elaboration contexts
  - `zetaReduce` + recursive `whnf` normalization before AC matching
- **XPerm error reporting**: AC-only path with actionable error messages showing exactly which atoms differ
- **Fallback**: Pick-based fallback for cases with loose bound variables where AC normalization is unsafe

## Changed files (26)

**Infrastructure:**
- `Rv64/Tactics/XPerm.lean` — AC fast path, fallback, error reporting
- `Evm64/Basic.lean` — `getLimbN` helpers (`getLimb_as_getLimbN_0..3`, `getLimbN_one`, `getLimbN_ite`, `getLimbN_fromLimbs_const`)
- `Evm64/Stack.lean` — `evmWordIs` uses `getLimbN`

**Spec files (getLimb→getLimbN + simp cleanup):**
- Add, Sub, And, Or, Xor, Not, IsZero, Lt, Gt, Eq, Slt, Sgt, Dup, Swap, Push0, Byte
- Shift/{Compose,ShlCompose,SarCompose,Semantic,ShlSemantic,SarSemantic,LimbSpec}
- SignExtend/{Compose,Spec,LimbSpec}, DivMod/LimbSpec

## Test plan

- [x] `lake build` passes with 0 errors (3395 jobs)
- [x] No `sorry` in any file
- [x] All existing concrete tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)