### PR TITLE
Replace bv_omega with bv_addr for 82% smaller proof terms

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,7 +199,7 @@ Each EVM opcode follows a three-level proof hierarchy:
 2. **Composition** (`Compose.lean`, `ShlCompose.lean`, `SarCompose.lean`): Hierarchical composition of limb specs into full-program theorems. Includes:
    - `xyzCode` definition (`CodeReq.unionAll` of per-phase `CodeReq.ofProg` blocks)
    - Subsumption lemmas (structural `skipBlock` + `union_mono_left`, no `native_decide` on full programs)
-   - Address normalization lemmas (`bv_omega` proofs)
+   - Address normalization lemmas (`bv_addr` proofs — see Build Performance section)
    - Path composition (zero-path/sign-fill for shift >= 256, body-path for shift < 256)
    - Bridge lemmas connecting per-limb results to `getLimb (result) i`
 3. **Semantic** (`Semantic.lean`, `ShlSemantic.lean`, `SarSemantic.lean`): Stack-level `evmWordIs` spec. Lifts composition to `EvmWord` assertions using `cpsTriple_consequence` + `xperm_hyp`.
@@ -209,7 +209,7 @@ Each EVM opcode follows a three-level proof hierarchy:
 Each shift Compose file (~1000-1200 lines) follows this structure:
 1. **Section 1**: `xyzCode` definition as `CodeReq.unionAll` of per-phase `ofProg` blocks + length lemmas + `skipBlock` macro + helpers (`singleton_sub_ofProg`, `CodeReq_union_sub_both`, `regIs_to_regOwn`)
 2. **Section 2**: Subsumption lemmas — structural reasoning via `skipBlock` + `union_mono_left` (following the DivMod pattern). For union-chain `_code` definitions (Phase A, Phase C, sign-fill), split into bridge sub-lemma (`chain_code ⊆ ofProg small_block`) + structural sub-lemma (`ofProg small_block ⊆ xyzCode`)
-3. **Section 3**: Address normalization — `bv_omega` proofs for all offset arithmetic
+3. **Section 3**: Address normalization — `bv_addr` proofs for all offset arithmetic (see Build Performance section)
 4. **Section 4**: Zero-path or sign-fill composition — instruction-by-instruction Phase A chain + branch elimination + path composition
 5. **Section 5**: Phase C dispatch — `cpsNBranch` with cascade steps
 6. **Section 6**: Bridge lemmas — connect limb formulas to `getLimb (operation value n)`
@@ -247,6 +247,39 @@ The `xperm` tactic uses AC reflection (`Lean.Meta.AC.buildNormProof`) for O(n lo
 4. **Fin proof term differences**: `getLimb ⟨0, proof₁⟩` vs `getLimb ⟨0, proof₂⟩` where `proof₁` and `proof₂` are different terms for `0 < 4`. **Not yet fixed.** Workaround: use `getLimbN` (Nat index) instead of `getLimb` (Fin 4 index) in new code.
 
 **Rule for new code**: When writing theorem statements that go through `xperm_hyp`, ensure both sides of the permutation use identical expressions (not just isDefEq). Avoid `Fin` literals and use `Nat` indices where possible.
+
+## Build Performance
+
+### `bv_addr` vs `bv_omega` for address arithmetic
+
+For address offset equalities like `(base + 228) + 24 = base + 252`, use `bv_addr` instead of `bv_omega`:
+
+```lean
+-- GOOD: tiny proof term (add_assoc + rfl), fast kernel checking
+have : (base + 228 : Word) + 24 = base + 252 := by bv_addr
+
+-- BAD: large proof term (bitvec_to_nat conversion + Presburger arithmetic)
+have : (base + 228 : Word) + 24 = base + 252 := by bv_omega
+```
+
+`bv_addr` is defined as `(simp only [BitVec.add_assoc]; rfl)` in `Rv64/Tactics/SeqFrame.lean`. It works for any `(a + k₁) + k₂ = a + k₃` where k₁, k₂, k₃ are concrete and a is a variable.
+
+**When to use `bv_addr`**: Address offset equalities, `ofProg_mono_sub` address arguments, pre-computed address theorems.
+
+**When to keep `bv_omega`**: Address inequalities (`≠`), range bounds (`< 2^64`), `skipBlock` disjointness proofs.
+
+**For signExtend patterns**: `rw [signExtend13_1016]; bv_addr` (normalize signExtend first, then use bv_addr).
+
+Impact: olean sizes drop 50-80% (e.g., LoopBody 16MB → 2.8MB), kernel checking time drops proportionally.
+
+### Parallel file splitting for Compose files
+
+Large composition files (>1000 lines) should be split into independent sub-files under a `Compose/` directory:
+- `Compose/Base.lean`: shared definitions (`divCode`, `modCode`, `skipBlock`, length lemmas)
+- Independent sub-files (PhaseAB, CLZ, Norm, NormA, Div128, Epilogue) that all import only Base
+- `Compose.lean`: lightweight re-export of all sub-files
+
+This enables parallel kernel checking. The split reduced DivMod/Compose from 87s (monolithic) to 55s (critical path through Norm.lean).
 
 ## Roadmap (PLAN.md)
 

--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -61,7 +61,7 @@ private theorem clz_init_sub (base : Word) :
   exact divK_clz_code_sub_divCode base a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + 116) divK_clz 0
       (by native_decide) (by native_decide)) a i (by rwa [show (base + 116 : Word) =
-        base + 116 + BitVec.ofNat 64 (4 * 0) from by bv_omega] at h))
+        base + 116 + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
 
 -- CLZ stage parameters: (SRLI_K, SLLI_M_s, ADDI_M_a, instruction_index)
 -- Stage 0: K=32, M_s=32, M_a=32, index 1 (after init at index 0)
@@ -94,13 +94,13 @@ noncomputable def clzResult (val : Word) : Word × Word :=
   (c5, v4)
 
 -- Address lemmas for CLZ stages
-private theorem clz_addr0 (base : Word) : (base + 116 : Word) + 4 = base + 120 := by bv_omega
-private theorem clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_omega
-private theorem clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_omega
-private theorem clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_omega
-private theorem clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_omega
-private theorem clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_omega
-private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + 212 := by bv_omega
+private theorem clz_addr0 (base : Word) : (base + 116 : Word) + 4 = base + 120 := by bv_addr
+private theorem clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_addr
+private theorem clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_addr
+private theorem clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_addr
+private theorem clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_addr
+private theorem clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_addr
+private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + 212 := by bv_addr
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     After stage: val' = if (val>>>K≠0) then val else val<<<M_s,
@@ -169,7 +169,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S0
   have S0e := cpsTriple_extend_code (hmono := clz_stage_sub base 32 32 32 1
     (by native_decide) (by native_decide) (by native_decide)) S0
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_omega] at S0e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_addr] at S0e
   rw [clz_addr1] at S0e
   seqFrame Ief S0e
   -- Abbreviations for stage 0 results
@@ -182,7 +182,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S1
   have S1e := cpsTriple_extend_code (hmono := clz_stage_sub base 48 16 16 5
     (by native_decide) (by native_decide) (by native_decide)) S1
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_omega] at S1e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_addr] at S1e
   rw [clz_addr2] at S1e
   seqFrame IefS0e S1e
   -- Stage 2: K=56, M_s=8, M_a=8 (base+152 → base+168)
@@ -193,7 +193,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S2
   have S2e := cpsTriple_extend_code (hmono := clz_stage_sub base 56 8 8 9
     (by native_decide) (by native_decide) (by native_decide)) S2
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_omega] at S2e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_addr] at S2e
   rw [clz_addr3] at S2e
   seqFrame IefS0eS1e S2e
   -- Stage 3: K=60, M_s=4, M_a=4 (base+168 → base+184)
@@ -204,7 +204,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S3
   have S3e := cpsTriple_extend_code (hmono := clz_stage_sub base 60 4 4 13
     (by native_decide) (by native_decide) (by native_decide)) S3
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_omega] at S3e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_addr] at S3e
   rw [clz_addr4] at S3e
   seqFrame IefS0eS1eS2e S3e
   -- Stage 4: K=62, M_s=2, M_a=2 (base+184 → base+200)
@@ -215,7 +215,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S4
   have S4e := cpsTriple_extend_code (hmono := clz_stage_sub base 62 2 2 17
     (by native_decide) (by native_decide) (by native_decide)) S4
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_omega] at S4e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_addr] at S4e
   rw [clz_addr5] at S4e
   seqFrame IefS0eS1eS2eS3e S4e
   -- Stage 5 (last): K=63 (base+200 → base+212)
@@ -226,7 +226,7 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
   dsimp only [] at S5
   have S5e := cpsTriple_extend_code (hmono := clz_last_sub base 21
     (by native_decide) (by native_decide) (by native_decide)) S5
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_omega] at S5e
+  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_addr] at S5e
   rw [clz_addr6] at S5e
   seqFrame IefS0eS1eS2eS3eS4e S5e
   -- Final permutation

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -52,14 +52,14 @@ private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + 1068) divK_div128 k hk (by native_decide)) a i h)
 
--- Abbreviation for repeated `by native_decide` / `by bv_omega` calls
+-- Abbreviation for repeated `by native_decide` / `by bv_addr` calls
 -- Each block's subsumption uses: CodeReq_union_sub (d128_sub ...) (CodeReq_union_sub ...)
 
 -- Address normalization: block entry offsets relative to (base + 1068)
-private theorem d128_off_40 (base : Word) : (base + 1068 : Word) + 40 = base + 1108 := by bv_omega
-private theorem d128_off_100 (base : Word) : (base + 1068 : Word) + 100 = base + 1168 := by bv_omega
-private theorem d128_off_120 (base : Word) : (base + 1068 : Word) + 120 = base + 1188 := by bv_omega
-private theorem d128_off_180 (base : Word) : (base + 1068 : Word) + 180 = base + 1248 := by bv_omega
+private theorem d128_off_40 (base : Word) : (base + 1068 : Word) + 40 = base + 1108 := by bv_addr
+private theorem d128_off_100 (base : Word) : (base + 1068 : Word) + 100 = base + 1168 := by bv_addr
+private theorem d128_off_120 (base : Word) : (base + 1068 : Word) + 120 = base + 1188 := by bv_addr
+private theorem d128_off_180 (base : Word) : (base + 1068 : Word) + 180 = base + 1248 := by bv_addr
 
 -- ============================================================================
 -- div128_spec: compose 5 block specs into single subroutine theorem.
@@ -133,20 +133,20 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- ================================================================
   have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
     ret_mem d_mem dlo_mem un0_mem (base + 1068) hv_ret hv_d hv_dlo hv_un0
-  rw [show (base + 1068 : Word) + 40 = base + 1108 from by bv_omega] at hph1
+  rw [show (base + 1068 : Word) + 40 = base + 1108 from by bv_addr] at hph1
   -- Extend phase1 cr to divCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1068)+{0,4,...,36}, indices 0-9
-    exact CodeReq_union_sub (d128_sub base 0 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 1 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 2 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 3 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 4 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 5 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 6 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 7 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 8 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (d128_sub base 9 _ _ (by native_decide) (by bv_omega) (by native_decide)))))))))))
+    exact CodeReq_union_sub (d128_sub base 0 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 1 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 2 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 3 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 4 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 5 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 6 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 7 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 8 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (d128_sub base 9 _ _ (by native_decide) (by bv_addr) (by native_decide)))))))))))
     hph1
   -- Frame phase1 with x0=0 (not used by phase1)
   have hph1f := cpsTriple_frame_left _ _ _ _ _
@@ -158,23 +158,23 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- ================================================================
   have hst1 := divK_div128_step1_spec sp u_hi d_hi un1 d_lo un0 d d_lo
     (base + 1108) hv_dlo
-  rw [show (base + 1108 : Word) + 60 = base + 1168 from by bv_omega] at hst1
+  rw [show (base + 1108 : Word) + 60 = base + 1168 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 10 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 11 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 12 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 13 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 14 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 15 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 16 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 17 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 18 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 19 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 20 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 21 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 22 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 23 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (d128_sub base 24 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))))))
+    exact CodeReq_union_sub (d128_sub base 10 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 11 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 12 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 13 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 14 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 15 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 16 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 17 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 18 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 19 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 20 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 21 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 22 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 23 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (d128_sub base 24 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))))))
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
   have hst1f := cpsTriple_frame_left _ _ _ _ _
@@ -190,13 +190,13 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- ================================================================
   have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo d_lo
     (base + 1168) hv_dlo
-  rw [show (base + 1168 : Word) + 20 = base + 1188 from by bv_omega] at hcu
+  rw [show (base + 1168 : Word) + 20 = base + 1188 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 25 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 26 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 27 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 28 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (d128_sub base 29 _ _ (by native_decide) (by bv_omega) (by native_decide))))))
+    exact CodeReq_union_sub (d128_sub base 25 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 26 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 27 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 28 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (d128_sub base 29 _ _ (by native_decide) (by bv_addr) (by native_decide))))))
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frame_left _ _ _ _ _
@@ -216,23 +216,23 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 d_hi cu_q1_dlo cu_rhat_un1 un1 d_lo un0
     (base + 1188) hv_dlo hv_un0
-  rw [show (base + 1188 : Word) + 60 = base + 1248 from by bv_omega] at hst2
+  rw [show (base + 1188 : Word) + 60 = base + 1248 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 30 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 31 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 32 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 33 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 34 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 35 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 36 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 37 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 38 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 39 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 40 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 41 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 42 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 43 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (d128_sub base 44 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))))))
+    exact CodeReq_union_sub (d128_sub base 30 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 31 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 32 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 33 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 34 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 35 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 36 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 37 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 38 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 39 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 40 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 41 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 42 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 43 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (d128_sub base 44 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frame_left _ _ _ _ _
@@ -251,10 +251,10 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   have hend := divK_div128_end_spec sp q1' q0' ret_addr un0 ret_addr
     (base + 1248) hv_ret halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 45 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 46 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (d128_sub base 47 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (d128_sub base 48 _ _ (by native_decide) (by bv_omega) (by native_decide)))))
+    exact CodeReq_union_sub (d128_sub base 45 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 46 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (d128_sub base 47 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (d128_sub base 48 _ _ (by native_decide) (by bv_addr) (by native_decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -68,12 +68,12 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   intro anti_shift u0' u1' u2' u3'
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+912 → base+920): compute anti_shift
   have haddi := addi_x0_spec_gen .x2 v2 0 (base + 912) (by nofun)
-  rw [show (base + 912 : Word) + 4 = base + 916 from by bv_omega] at haddi
+  rw [show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 912) divK_denorm
         [.ADDI .x2 .x0 0] 2
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) haddi
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) haddi
   -- Frame ADDI with x12, x5, x7, x6, and all memory
   have haddief := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ shift) **
@@ -82,14 +82,14 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     (by pcFree) haddie
   have hsub := sub_spec_gen_rd_eq_rs1 .x2 .x6
     (signExtend12 (0 : BitVec 12)) shift (base + 916) (by nofun)
-  rw [show (base + 916 : Word) + 4 = base + 920 from by bv_omega] at hsub
+  rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at hsub
   have hsube := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + 904) divK_denorm 3
           (by native_decide) (by native_decide)
         rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
-            show (base + 904 : Word) + 12 = base + 916 from by bv_omega] at hlookup
+            show (base + 904 : Word) + 12 = base + 916 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTriple_frame_left _ _ _ _ _
@@ -102,12 +102,12 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   -- Merge u[0] with u[1] (base+920 → base+944)
   have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 920)
     hv_u0 hv_u1
-  rw [show (base + 920 : Word) + 24 = base + 944 from by bv_omega] at hm0
+  rw [show (base + 920 : Word) + 24 = base + 944 from by bv_addr] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 920) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm0
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm0
   have hm0ef := cpsTriple_frame_left _ _ _ _ _
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
@@ -118,12 +118,12 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
     u0' (u1 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 944)
     hv_u1 hv_u2
-  rw [show (base + 944 : Word) + 24 = base + 968 from by bv_omega] at hm1
+  rw [show (base + 944 : Word) + 24 = base + 968 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 944) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm1
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm1
   have hm1ef := cpsTriple_frame_left _ _ _ _ _
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4032) ↦ₘ u3))
@@ -134,12 +134,12 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
     u1' (u2 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 968)
     hv_u2 hv_u3
-  rw [show (base + 968 : Word) + 24 = base + 992 from by bv_omega] at hm2
+  rw [show (base + 968 : Word) + 24 = base + 992 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 968) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm2
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1'))
@@ -148,12 +148,12 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+992 → base+1004)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 992) hv_u3
-  rw [show (base + 992 : Word) + 12 = base + 1004 from by bv_omega] at hl
+  rw [show (base + 992 : Word) + 12 = base + 1004 from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 904) (base + 992) divK_denorm
         (divK_denorm_last_prog 4032) 22
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hl
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _
     ((.x7 ↦ᵣ (u3 <<< (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
@@ -205,22 +205,22 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
   -- Load phase (base+1004 → base+1020)
   have hload := divK_epilogue_load_spec 4088 4080 4072 4064 sp q0 q1 q2 q3 v5 v6 v7 v10
     (base + 1004) hv_q0 hv_q1 hv_q2 hv_q3
-  rw [show (base + 1004 : Word) + 16 = base + 1020 from by bv_omega] at hload
+  rw [show (base + 1004 : Word) + 16 = base + 1020 from by bv_addr] at hload
   have hloade := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 1004) (base + 1004) (divK_div_epilogue 24)
         (divK_epilogue_load_prog 4088 4080 4072 4064) 0
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hload
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hload
   -- Store phase (base+1020 → base+1064 via JAL)
   have hstore := divK_epilogue_store_spec sp (base + 1020) q0 q1 q2 q3 m0 m8 m16 m24 24 hvalid
   rw [show (base + 1020 : Word) + 20 + signExtend21 24 = base + 1064 from by
-        rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_omega]
+        rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by native_decide]; bv_addr]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 1004) (base + 1020) (divK_div_epilogue 24)
         (divK_epilogue_store_prog 24) 4
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hstore
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hstore
   -- Frame load with output memory
   have hloadef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) ** ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
@@ -297,8 +297,8 @@ theorem evm_mod_bzero_spec (sp base : Word)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
   rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
-        rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
+        rw [signExtend13_1016]; bv_addr,
+      show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -316,7 +316,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
   -- Step 5: ZeroPath (base+1044 → base+1064)
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_modCode base)
     (divK_zeroPath_spec sp (base + 1044) b0 b1 b2 b3 hvalid)
-  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_omega] at hzp
+  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_addr] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -354,8 +354,8 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
   rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
-        rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
+        rw [signExtend13_1016]; bv_addr,
+      show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -26,7 +26,7 @@ private theorem beq_shift_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 212) (divK_phaseC2 172) 3
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
-      show (base + 212 : Word) + 12 = base + 224 from by bv_omega] at hlookup
+      show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -42,7 +42,7 @@ private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base :
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + 212) hv_shift
-  rw [show (base + 212 : Word) + 12 = base + 224 from by bv_omega] at hbody
+  rw [show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_divCode base) hbody
 
 set_option maxRecDepth 2048 in
@@ -59,8 +59,8 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
-        rw [signExtend13_172]; bv_omega,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_omega] at hbeq_raw
+        rw [signExtend13_172]; bv_addr,
+      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -91,8 +91,8 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
-        rw [signExtend13_172]; bv_omega,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_omega] at hbeq_raw
+        rw [signExtend13_172]; bv_addr,
+      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -165,12 +165,12 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_56]; exact hvalid.get (show 7 < 8 from by omega))
     (by rw [se12_48]; exact hvalid.get (show 6 < 8 from by omega))
   simp only [se12_56, se12_48] at hm1
-  rw [show (base + 228 : Word) + 24 = base + 252 from by bv_omega] at hm1
+  rw [show (base + 228 : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 228) divK_normB
         (divK_normB_merge_prog 56 48) 0
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm1
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm1
   -- Frame merge1 with b[0], b[1] (not touched by merge1)
   have hm1ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1))
@@ -181,12 +181,12 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_48]; exact hvalid.get (show 6 < 8 from by omega))
     (by rw [se12_40]; exact hvalid.get (show 5 < 8 from by omega))
   simp only [se12_48, se12_40] at hm2
-  rw [show (base + 252 : Word) + 24 = base + 276 from by bv_omega] at hm2
+  rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 252) divK_normB
         (divK_normB_merge_prog 48 40) 6
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm2
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hm2e
@@ -198,12 +198,12 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     (by rw [se12_40]; exact hvalid.get (show 5 < 8 from by omega))
     (by rw [se12_32]; exact hvalid.get (show 4 < 8 from by omega))
   simp only [se12_40, se12_32] at hm3
-  rw [show (base + 276 : Word) + 24 = base + 300 from by bv_omega] at hm3
+  rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 276) divK_normB
         (divK_normB_merge_prog 40 32) 12
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hm3
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hm3
   have hm3ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hm3e
@@ -213,12 +213,12 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
   have hl := divK_normB_last_spec 32 sp b0 b1' shift (base + 300)
     (by rw [se12_32]; exact hvalid.get (show 4 < 8 from by omega))
   simp only [se12_32] at hl
-  rw [show (base + 300 : Word) + 12 = base + 312 from by bv_omega] at hl
+  rw [show (base + 300 : Word) + 12 = base + 312 from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 228) (base + 300) divK_normB
         (divK_normB_last_prog 32) 18
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hl
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _
     ((.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
      ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -84,12 +84,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + 312)
     (by rw [se12_24]; exact hvalid.get (show 3 < 8 from by omega)) hv_u4
   simp only [se12_24] at htop
-  rw [show (base + 312 : Word) + 12 = base + 324 from by bv_omega] at htop
+  rw [show (base + 312 : Word) + 12 = base + 324 from by bv_addr] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 312) (divK_normA 40)
         (divK_normA_top_prog 24 4024) 0
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) htop
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) htop
   -- Frame top with x6, x10, a[0..2], u[0..3]
   have htopef := cpsTriple_frame_left _ _ _ _ _
     ((.x10 ↦ᵣ v10) ** (.x6 ↦ᵣ shift) **
@@ -102,12 +102,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift anti_shift u3_old (base + 324)
     (by rw [se12_16]; exact hvalid.get (show 2 < 8 from by omega)) hv_u3
   simp only [se12_16] at hma1
-  rw [show (base + 324 : Word) + 20 = base + 344 from by bv_omega] at hma1
+  rw [show (base + 324 : Word) + 20 = base + 344 from by bv_addr] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 324) (divK_normA 40)
         (divK_normA_mergeA_prog 16 4032) 3
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hma1
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hma1
   have hma1ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4024) ↦ₘ u4) **
@@ -121,12 +121,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     shift anti_shift u2_old (base + 344)
     (by rw [se12_8]; exact hvalid.get (show 1 < 8 from by omega)) hv_u2
   simp only [se12_8] at hmb
-  rw [show (base + 344 : Word) + 20 = base + 364 from by bv_omega] at hmb
+  rw [show (base + 344 : Word) + 20 = base + 364 from by bv_addr] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 344) (divK_normA 40)
         (divK_normA_mergeB_prog 8 4040) 8
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hmb
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hmb
   have hmbef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 0) ↦ₘ a0) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -139,12 +139,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     shift anti_shift u1_old (base + 364)
     (by rw [se12_0]; exact hvalid.get (show 0 < 8 from by omega)) hv_u1
   simp only [se12_0] at hma2
-  rw [show (base + 364 : Word) + 20 = base + 384 from by bv_omega] at hma2
+  rw [show (base + 364 : Word) + 20 = base + 384 from by bv_addr] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 364) (divK_normA 40)
         (divK_normA_mergeA_prog 0 4048) 13
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hma2
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hma2
   have hma2ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -154,12 +154,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     (fun h hp => by xperm_hyp hp) h123 hma2ef
   -- Last: u[0] = a[0]<<<shift (base+384 → base+392)
   have hlast := divK_normA_last_spec 4056 sp a0 shift u0_old (base + 384) hv_u0
-  rw [show (base + 384 : Word) + 8 = base + 392 from by bv_omega] at hlast
+  rw [show (base + 384 : Word) + 8 = base + 392 from by bv_addr] at hlast
   have hlaste := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
       (CodeReq.ofProg_mono_sub (base + 312) (base + 384) (divK_normA 40)
         (divK_normA_last_prog 4056) 18
-        (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h)) hlast
+        (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h)) hlast
   have hlastef := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -172,14 +172,14 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   -- JAL x0 40 at base+392 → base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
   rw [show (base + 392 : Word) + signExtend21 40 = base + 432 from by
-        rw [signExtend21_40]; bv_omega] at hjal
+        rw [signExtend21_40]; bv_addr] at hjal
   have hjale := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_normA_code_sub_divCode base a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + 312) (divK_normA 40) 20
           (by native_decide) (by native_decide)
-        rw [show (base + 312 : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_omega]
+        rw [show (base + 312 : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_addr]
           at hlookup
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
@@ -243,7 +243,7 @@ theorem divK_copyAU_full_spec (sp : Word)
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
   have hcopy := divK_copyAU_spec sp (base + 396) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
     hvalid hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
-  rw [show (base + 396 : Word) + 36 = base + 432 from by bv_omega] at hcopy
+  rw [show (base + 396 : Word) + 36 = base + 432 from by bv_addr] at hcopy
   exact cpsTriple_extend_code (divK_copyAU_code_sub_divCode base) hcopy
 
 -- ============================================================================
@@ -266,7 +266,7 @@ private theorem blt_loopSetup_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 432) (divK_loopSetup 460) 3
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by native_decide,
-      show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hlookup
+      show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -286,12 +286,12 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec sp n v1 v5 460 (base + 432) hv_n
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hbody
+  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 460 m (0 : Word) (base + 444)
   rw [show (base + 444 : Word) + signExtend13 460 = base + 904 from by
-        rw [signExtend13_460]; bv_omega,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_omega] at hblt_raw
+        rw [signExtend13_460]; bv_addr,
+      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -320,12 +320,12 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
   have hbody := divK_loopSetup_body_spec sp n v1 v5 460 (base + 432) hv_n
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_omega] at hbody
+  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 460 m (0 : Word) (base + 444)
   rw [show (base + 444 : Word) + signExtend13 460 = base + 904 from by
-        rw [signExtend13_460]; bv_omega,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_omega] at hblt_raw
+        rw [signExtend13_460]; bv_addr,
+      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -51,7 +51,7 @@ private theorem divK_phaseB_init1_code_sub_divCode (base : Word) :
   -- Lift from init1 sub-range to full phaseB block
   have h1 := CodeReq.ofProg_mono_sub (base + 32) (base + 32) divK_phaseB
     (divK_phaseB.take 7) 0
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+    (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h
   -- Skip block 0 (phaseA disjoint from phaseB), match block 1
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -65,7 +65,7 @@ private theorem divK_phaseB_init2_code_sub_divCode (base : Word) :
   intro a i h
   have h1 := CodeReq.ofProg_mono_sub (base + 32) (base + 60) divK_phaseB
     (divK_phaseB.drop 7 |>.take 2) 7
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+    (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
       (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
@@ -80,7 +80,7 @@ private theorem addi_x5_singleton_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 9
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by native_decide,
-      show (base + 32 : Word) + 36 = base + 68 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -96,7 +96,7 @@ private theorem bne_x10_singleton_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 10
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by native_decide,
-      show (base + 32 : Word) + 40 = base + 72 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -110,7 +110,7 @@ private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
   intro a i h
   have h1 := CodeReq.ofProg_mono_sub (base + 32) (base + 96) divK_phaseB
     (divK_phaseB.drop 16) 16
-    (by bv_omega) (by native_decide) (by native_decide) (by native_decide) a i h
+    (by bv_addr) (by native_decide) (by native_decide) (by native_decide) a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
       (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
@@ -138,23 +138,23 @@ private theorem divK_phaseB_n4_nm1_x8 :
 private theorem divK_se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by native_decide
 
 -- Address normalization lemmas for phaseB composition (separate theorems for heartbeat budget)
-private theorem phB_off_4 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem phB_off_8 (base : Word) : (base + 32 : Word) + 8 = base + 40 := by bv_omega
-private theorem phB_off_12 (base : Word) : (base + 32 : Word) + 12 = base + 44 := by bv_omega
-private theorem phB_off_16 (base : Word) : (base + 32 : Word) + 16 = base + 48 := by bv_omega
-private theorem phB_off_20 (base : Word) : (base + 32 : Word) + 20 = base + 52 := by bv_omega
-private theorem phB_off_24 (base : Word) : (base + 32 : Word) + 24 = base + 56 := by bv_omega
-private theorem phB_off_28 (base : Word) : (base + 32 : Word) + 28 = base + 60 := by bv_omega
-private theorem phB_i2_4 (base : Word) : (base + 60 : Word) + 4 = base + 64 := by bv_omega
-private theorem phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_omega
-private theorem phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_omega
-private theorem phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_omega
-private theorem phB_t_4 (base : Word) : (base + 96 : Word) + 4 = base + 100 := by bv_omega
-private theorem phB_t_8 (base : Word) : (base + 96 : Word) + 8 = base + 104 := by bv_omega
-private theorem phB_t_12 (base : Word) : (base + 96 : Word) + 12 = base + 108 := by bv_omega
-private theorem phB_t_16 (base : Word) : (base + 96 : Word) + 16 = base + 112 := by bv_omega
-private theorem phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + 116 := by bv_omega
-private theorem phB_sp24_32 (sp : Word) : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_omega
+private theorem phB_off_4 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_addr
+private theorem phB_off_8 (base : Word) : (base + 32 : Word) + 8 = base + 40 := by bv_addr
+private theorem phB_off_12 (base : Word) : (base + 32 : Word) + 12 = base + 44 := by bv_addr
+private theorem phB_off_16 (base : Word) : (base + 32 : Word) + 16 = base + 48 := by bv_addr
+private theorem phB_off_20 (base : Word) : (base + 32 : Word) + 20 = base + 52 := by bv_addr
+private theorem phB_off_24 (base : Word) : (base + 32 : Word) + 24 = base + 56 := by bv_addr
+private theorem phB_off_28 (base : Word) : (base + 32 : Word) + 28 = base + 60 := by bv_addr
+private theorem phB_i2_4 (base : Word) : (base + 60 : Word) + 4 = base + 64 := by bv_addr
+private theorem phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+private theorem phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr
+private theorem phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
+private theorem phB_t_4 (base : Word) : (base + 96 : Word) + 4 = base + 100 := by bv_addr
+private theorem phB_t_8 (base : Word) : (base + 96 : Word) + 8 = base + 104 := by bv_addr
+private theorem phB_t_12 (base : Word) : (base + 96 : Word) + 12 = base + 108 := by bv_addr
+private theorem phB_t_16 (base : Word) : (base + 96 : Word) + 16 = base + 112 := by bv_addr
+private theorem phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + 116 := by bv_addr
+private theorem phB_sp24_32 (sp : Word) : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_addr
 
 -- ============================================================================
 -- Section 6b: Opaque memory bundle for phaseB invariant cells
@@ -214,8 +214,8 @@ theorem evm_div_bzero_spec (sp base : Word)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
   rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
-        rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
+        rw [signExtend13_1016]; bv_addr,
+      show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -235,7 +235,7 @@ theorem evm_div_bzero_spec (sp base : Word)
   -- Extend to divCode CodeReq
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_divCode base)
     (divK_zeroPath_spec sp (base + 1044) b0 b1 b2 b3 hvalid)
-  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_omega] at hzp
+  rw [show (base + 1044 : Word) + 20 = base + 1064 from by bv_addr] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -274,8 +274,8 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
   rw [show (base + 28 : Word) + signExtend13 1016 = base + 1044 from by
-        rw [signExtend13_1016]; bv_omega,
-      show (base + 28 : Word) + 4 = base + 32 from by bv_omega] at hbeq_raw
+        rw [signExtend13_1016]; bv_addr,
+      show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -360,7 +360,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne_raw
+        rw [signExtend13_24]; bv_addr, phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -458,7 +458,7 @@ private theorem addi_x5_3_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 11
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by native_decide,
-      show (base + 32 : Word) + 44 = base + 76 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -474,7 +474,7 @@ private theorem bne_x7_16_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 12
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by native_decide,
-      show (base + 32 : Word) + 48 = base + 80 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -490,7 +490,7 @@ private theorem addi_x5_2_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 13
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by native_decide,
-      show (base + 32 : Word) + 52 = base + 84 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -506,7 +506,7 @@ private theorem bne_x6_8_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 14
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by native_decide,
-      show (base + 32 : Word) + 56 = base + 88 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -522,7 +522,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
   have hlookup := CodeReq.ofProg_lookup (base + 32) divK_phaseB 15
     (by native_decide) (by native_decide)
   rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by native_decide,
-      show (base + 32 : Word) + 60 = base + 92 from by bv_omega] at hlookup
+      show (base + 32 : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range _ _ _ _
@@ -552,16 +552,16 @@ private theorem divK_phaseB_n1_nm1_x8 :
   native_decide
 
 -- Cascade address normalization
-private theorem phB_step1_4 (base : Word) : (base + 76 : Word) + 4 = base + 80 := by bv_omega
-private theorem phB_step1_8 (base : Word) : (base + 80 : Word) + 4 = base + 84 := by bv_omega
-private theorem phB_step2_4 (base : Word) : (base + 84 : Word) + 4 = base + 88 := by bv_omega
-private theorem phB_step2_8 (base : Word) : (base + 88 : Word) + 4 = base + 92 := by bv_omega
-private theorem phB_fall_4 (base : Word) : (base + 92 : Word) + 4 = base + 96 := by bv_omega
+private theorem phB_step1_4 (base : Word) : (base + 76 : Word) + 4 = base + 80 := by bv_addr
+private theorem phB_step1_8 (base : Word) : (base + 80 : Word) + 4 = base + 84 := by bv_addr
+private theorem phB_step2_4 (base : Word) : (base + 84 : Word) + 4 = base + 88 := by bv_addr
+private theorem phB_step2_8 (base : Word) : (base + 88 : Word) + 4 = base + 92 := by bv_addr
+private theorem phB_fall_4 (base : Word) : (base + 92 : Word) + 4 = base + 96 := by bv_addr
 
 -- Tail memory address normalization
-private theorem phB_sp16_32 (sp : Word) : (sp + (16 : Word) + (32 : Word)) = sp + 48 := by bv_omega
-private theorem phB_sp8_32 (sp : Word) : (sp + (8 : Word) + (32 : Word)) = sp + 40 := by bv_omega
-private theorem phB_sp0_32 (sp : Word) : (sp + (0 : Word) + (32 : Word)) = sp + 32 := by bv_omega
+private theorem phB_sp16_32 (sp : Word) : (sp + (16 : Word) + (32 : Word)) = sp + 48 := by bv_addr
+private theorem phB_sp8_32 (sp : Word) : (sp + (8 : Word) + (32 : Word)) = sp + 40 := by bv_addr
+private theorem phB_sp0_32 (sp : Word) : (sp + (0 : Word) + (32 : Word)) = sp + 32 := by bv_addr
 
 -- ============================================================================
 -- Section 10d: Phase B n=3 (b[3]=0, b[2]≠0)
@@ -646,7 +646,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -681,7 +681,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -806,7 +806,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -841,7 +841,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -876,7 +876,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [signExtend13_8]; bv_omega, phB_step2_8] at hbne2_raw
+        rw [signExtend13_8]; bv_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -1002,7 +1002,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [signExtend13_24]; bv_omega, phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -1037,7 +1037,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [signExtend13_16]; bv_omega, phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -1072,7 +1072,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [signExtend13_8]; bv_omega, phB_step2_8] at hbne2_raw
+        rw [signExtend13_8]; bv_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -103,7 +103,7 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
   have hbody := divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10 hvalid
   -- 2. BEQ: branch at base + 28, drop pure facts
   have hbeq_raw := beq_spec_gen .x5 .x0 1016 bor (0 : Word) (base + 28)
-  have ha1 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+  have ha1 : (base + 28 : Word) + 4 = base + 32 := by bv_addr
   rw [ha1] at hbeq_raw
   have hbeq := cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun _ hp => hp)
@@ -668,7 +668,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
   intro cr post
   have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem shift0_off base hv_shift
   have hbeq_raw := beq_spec_gen .x6 .x0 shift0_off shift (0 : Word) (base + 12)
-  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_omega
+  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   rw [ha1] at hbeq_raw
   have hbeq : cpsBranch (base + 12) _
       ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
@@ -741,7 +741,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
     runBlock I0
   -- 2. BNE at base + 4, drop pure facts
   have hbne_raw := bne_spec_gen rx .x0 bne_off check (0 : Word) (base + 4)
-  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha1] at hbne_raw
   have hbne : cpsBranch (base + 4) _
       ((rx ↦ᵣ check) ** (.x0 ↦ᵣ (0 : Word)))
@@ -832,7 +832,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
   intro m cr post
   have hbody := divK_loopSetup_body_spec sp n v1 v5 blt_off base hv_n
   have hblt_raw := blt_spec_gen .x1 .x0 blt_off m (0 : Word) (base + 12)
-  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_omega
+  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   rw [ha1] at hblt_raw
   have hblt : cpsBranch (base + 12) _
       ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
@@ -914,8 +914,8 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
   -- 2. BNE at base+4: taken → base+16
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   -- 3. Frame BNE with x5, x6
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -980,8 +980,8 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   -- 2. BNE at base+4
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   -- 3. Frame BNE with x5, x6
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -1064,8 +1064,8 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
   simp only [h63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
@@ -1118,8 +1118,8 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
   simp only [h63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
@@ -1424,7 +1424,7 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
     runBlock I0
   -- 2. BGE, drop pure facts
   have hbge_raw := bge_spec_gen .x1 .x0 loop_back_off j' 0 (base + 4)
-  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha1] at hbge_raw
   have hbge : cpsBranch (base + 4) _
       ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
@@ -1639,7 +1639,7 @@ theorem divK_trial_max_spec (v11_old : Word) (base : Word) :
   have I0 := addi_x0_spec_gen .x11 v11_old 4095 base (by nofun)
   have I1 := jal_x0_spec_gen 8 (base + 4)
   rw [hj] at I1
-  have ha : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+  have ha : (base + 4 : Word) + 8 = base + 12 := by bv_addr
   rw [ha] at I1
   runBlock I0 I1
 
@@ -2009,8 +2009,8 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
   -- 2. BEQ at base+4 (keep pure facts)
   have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   -- 3. Frame BEQ with x10, x7, x6
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2127,8 +2127,8 @@ theorem divK_div128_prodcheck1_merged_spec
   -- 2. BLTU at base+16, strip pure
   have hbltu_raw := bltu_spec_gen .x1 .x5 (8 : BitVec 13) rhat_un1 q_dlo (base + 16)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
-  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [hsig]; bv_omega
-  have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_omega
+  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [hsig]; bv_addr
+  have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   -- 3. Frame BLTU with remaining atoms
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2202,7 +2202,7 @@ theorem divK_div128_prodcheck1_merged_spec
     have hj : signExtend21 (12 : BitVec 21) = (12 : Word) := by native_decide
     have I_jal := jal_x0_spec_gen 12 (base + 20)
     rw [hj] at I_jal
-    have ha_jal : (base + 20 : Word) + 12 = base + 32 := by bv_omega
+    have ha_jal : (base + 20 : Word) + 12 = base + 32 := by bv_addr
     rw [ha_jal] at I_jal
     -- Extend JAL CR from singleton to cr
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 20) (.JAL .x0 12) a = some i →
@@ -2278,8 +2278,8 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
   -- 2. BEQ at base+4 (keep pure facts)
   have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
   have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_omega
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   -- 3. Frame BEQ with x5, x11, x6
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2394,8 +2394,8 @@ theorem divK_div128_prodcheck2_merged_spec
   -- 2. BLTU at base+20
   have hbltu_raw := bltu_spec_gen .x1 .x7 (8 : BitVec 13) rhat2_un0 q0_dlo (base + 20)
   have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by native_decide
-  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [hsig]; bv_omega
-  have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [hsig]; bv_addr
+  have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   -- 3. Frame BLTU
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -2465,7 +2465,7 @@ theorem divK_div128_prodcheck2_merged_spec
     have hj : signExtend21 (8 : BitVec 21) = (8 : Word) := by native_decide
     have I_jal := jal_x0_spec_gen 8 (base + 24)
     rw [hj] at I_jal
-    have ha_jal : (base + 24 : Word) + 8 = base + 32 := by bv_omega
+    have ha_jal : (base + 24 : Word) + 8 = base + 32 := by bv_addr
     rw [ha_jal] at I_jal
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 24) (.JAL .x0 8) a = some i →
         cr a = some i := by
@@ -2578,10 +2578,10 @@ theorem divK_div128_step1_spec
     (by pcFree) h1
   -- Sub-spec 2: clamp q1 [13]-[16]
   have h2_raw := divK_div128_clamp_q1_merged_spec q1 rhat d_hi (q1 * d_hi) (base + 12)
-  have : (base + 12 : Word) + 4 = base + 16 := by bv_omega
-  have : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-  have : (base + 12 : Word) + 12 = base + 24 := by bv_omega
-  have : (base + 12 : Word) + 16 = base + 28 := by bv_omega
+  have : (base + 12 : Word) + 4 = base + 16 := by bv_addr
+  have : (base + 12 : Word) + 8 = base + 20 := by bv_addr
+  have : (base + 12 : Word) + 12 = base + 24 := by bv_addr
+  have : (base + 12 : Word) + 16 = base + 28 := by bv_addr
   simp only [*] at h2_raw
   have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
     cpsTriple_extend_code (h := h2_raw) (hmono := by
@@ -2606,14 +2606,14 @@ theorem divK_div128_step1_spec
   -- Sub-spec 3: prodcheck1 [17]-[24]
   have h3_raw := divK_div128_prodcheck1_merged_spec sp q1c rhatc d_hi un1
     v1_old hi dlo (base + 28) hv
-  have : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-  have : (base + 28 : Word) + 8 = base + 36 := by bv_omega
-  have : (base + 28 : Word) + 12 = base + 40 := by bv_omega
-  have : (base + 28 : Word) + 16 = base + 44 := by bv_omega
-  have : (base + 28 : Word) + 20 = base + 48 := by bv_omega
-  have : (base + 28 : Word) + 24 = base + 52 := by bv_omega
-  have : (base + 28 : Word) + 28 = base + 56 := by bv_omega
-  have : (base + 28 : Word) + 32 = base + 60 := by bv_omega
+  have : (base + 28 : Word) + 4 = base + 32 := by bv_addr
+  have : (base + 28 : Word) + 8 = base + 36 := by bv_addr
+  have : (base + 28 : Word) + 12 = base + 40 := by bv_addr
+  have : (base + 28 : Word) + 16 = base + 44 := by bv_addr
+  have : (base + 28 : Word) + 20 = base + 48 := by bv_addr
+  have : (base + 28 : Word) + 24 = base + 52 := by bv_addr
+  have : (base + 28 : Word) + 28 = base + 56 := by bv_addr
+  have : (base + 28 : Word) + 32 = base + 60 := by bv_addr
   simp only [*] at h3_raw
   have h3 : cpsTriple (base + 28) (base + 60) cr _ _ :=
     cpsTriple_extend_code (h := h3_raw) (hmono := by
@@ -2722,10 +2722,10 @@ theorem divK_div128_step2_spec
     (by pcFree) h1
   -- Sub-spec 2: clamp q0 [33]-[36]
   have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 d_hi (q0 * d_hi) (base + 12)
-  have : (base + 12 : Word) + 4 = base + 16 := by bv_omega
-  have : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-  have : (base + 12 : Word) + 12 = base + 24 := by bv_omega
-  have : (base + 12 : Word) + 16 = base + 28 := by bv_omega
+  have : (base + 12 : Word) + 4 = base + 16 := by bv_addr
+  have : (base + 12 : Word) + 8 = base + 20 := by bv_addr
+  have : (base + 12 : Word) + 12 = base + 24 := by bv_addr
+  have : (base + 12 : Word) + 16 = base + 28 := by bv_addr
   simp only [*] at h2_raw
   have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
     cpsTriple_extend_code (h := h2_raw) (hmono := by
@@ -2750,14 +2750,14 @@ theorem divK_div128_step2_spec
   -- Sub-spec 3: prodcheck2 [37]-[44]
   have h3_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c hi
     un21 dlo un0 (base + 28) hv_dlo hv_un0
-  have : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-  have : (base + 28 : Word) + 8 = base + 36 := by bv_omega
-  have : (base + 28 : Word) + 12 = base + 40 := by bv_omega
-  have : (base + 28 : Word) + 16 = base + 44 := by bv_omega
-  have : (base + 28 : Word) + 20 = base + 48 := by bv_omega
-  have : (base + 28 : Word) + 24 = base + 52 := by bv_omega
-  have : (base + 28 : Word) + 28 = base + 56 := by bv_omega
-  have : (base + 28 : Word) + 32 = base + 60 := by bv_omega
+  have : (base + 28 : Word) + 4 = base + 32 := by bv_addr
+  have : (base + 28 : Word) + 8 = base + 36 := by bv_addr
+  have : (base + 28 : Word) + 12 = base + 40 := by bv_addr
+  have : (base + 28 : Word) + 16 = base + 44 := by bv_addr
+  have : (base + 28 : Word) + 20 = base + 48 := by bv_addr
+  have : (base + 28 : Word) + 24 = base + 52 := by bv_addr
+  have : (base + 28 : Word) + 28 = base + 56 := by bv_addr
+  have : (base + 28 : Word) + 32 = base + 60 := by bv_addr
   simp only [*] at h3_raw
   have h3 : cpsTriple (base + 28) (base + 60) cr _ _ :=
     cpsTriple_extend_code (h := h3_raw) (hmono := by

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -57,11 +57,11 @@ private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
 -- ============================================================================
 
 -- Mulsub limb base addresses (instrs [22]-[65])
-private theorem lb_ms0 (base : Word) : (base + 448 : Word) + 88 = base + 536 := by bv_omega
-private theorem lb_ms1 (base : Word) : (base + 536 : Word) + 44 = base + 580 := by bv_omega
-private theorem lb_ms2 (base : Word) : (base + 580 : Word) + 44 = base + 624 := by bv_omega
-private theorem lb_ms3 (base : Word) : (base + 624 : Word) + 44 = base + 668 := by bv_omega
-private theorem lb_ms_end (base : Word) : (base + 668 : Word) + 44 = base + 712 := by bv_omega
+private theorem lb_ms0 (base : Word) : (base + 448 : Word) + 88 = base + 536 := by bv_addr
+private theorem lb_ms1 (base : Word) : (base + 536 : Word) + 44 = base + 580 := by bv_addr
+private theorem lb_ms2 (base : Word) : (base + 580 : Word) + 44 = base + 624 := by bv_addr
+private theorem lb_ms3 (base : Word) : (base + 624 : Word) + 44 = base + 668 := by bv_addr
+private theorem lb_ms_end (base : Word) : (base + 668 : Word) + 44 = base + 712 := by bv_addr
 
 -- ============================================================================
 -- Section 3: Mulsub 4-limbs composition
@@ -146,17 +146,17 @@ theorem divK_mulsub_4limbs_spec
     hv_v0 hv_u0
   rw [lb_ms1] at L0
   have L0e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 22 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 23 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 24 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 25 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 26 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 27 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 28 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 29 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 30 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 31 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 32 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))
+    exact CodeReq_union_sub (lb_sub base 22 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 23 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 24 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 25 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 26 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 27 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 28 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 29 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 30 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 31 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 32 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))
     L0
   -- Limb 1: instrs [33]-[43] at base+580
   have L1 := divK_mulsub_limb_spec sp u_base q_hat c0
@@ -164,17 +164,17 @@ theorem divK_mulsub_4limbs_spec
     hv_v1 hv_u1
   rw [lb_ms2] at L1
   have L1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 33 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 34 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 35 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 36 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 37 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 38 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 39 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 40 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 41 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 42 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 43 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))
+    exact CodeReq_union_sub (lb_sub base 33 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 34 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 35 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 36 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 37 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 38 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 39 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 40 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 41 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 42 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 43 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))
     L1
   -- Frame L0 with memory for limbs 1-3 (so seqFrame can find L1's precondition atoms)
   have L0f := cpsTriple_frame_left _ _ _ _ _
@@ -190,17 +190,17 @@ theorem divK_mulsub_4limbs_spec
     hv_v2 hv_u2
   rw [lb_ms3] at L2
   have L2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 44 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 45 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 46 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 47 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 48 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 49 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 50 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 51 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 52 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 53 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 54 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))
+    exact CodeReq_union_sub (lb_sub base 44 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 45 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 46 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 47 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 48 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 49 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 50 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 51 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 52 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 53 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 54 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))
     L2
   -- Compose (L0+L1) + L2
   seqFrame L0fL1e L2e
@@ -210,17 +210,17 @@ theorem divK_mulsub_4limbs_spec
     hv_v3 hv_u3
   rw [lb_ms_end] at L3
   have L3e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 55 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 56 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 57 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 58 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 59 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 60 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 61 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 62 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 63 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 64 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 65 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))
+    exact CodeReq_union_sub (lb_sub base 55 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 56 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 57 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 58 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 59 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 60 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 61 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 62 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 63 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 64 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 65 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))
     L3
   -- Compose (L0+L1+L2) + L3
   seqFrame L0fL1eL2e L3e
@@ -238,13 +238,13 @@ theorem divK_mulsub_4limbs_spec
 -- ============================================================================
 
 -- Addback base addresses (instrs [71]-[107])
-private theorem lb_ab_init (base : Word) : (base + 448 : Word) + 284 = base + 732 := by bv_omega
-private theorem lb_ab0 (base : Word) : (base + 732 : Word) + 4 = base + 736 := by bv_omega
-private theorem lb_ab0_end (base : Word) : (base + 736 : Word) + 32 = base + 768 := by bv_omega
-private theorem lb_ab1_end (base : Word) : (base + 768 : Word) + 32 = base + 800 := by bv_omega
-private theorem lb_ab2_end (base : Word) : (base + 800 : Word) + 32 = base + 832 := by bv_omega
-private theorem lb_ab3_end (base : Word) : (base + 832 : Word) + 32 = base + 864 := by bv_omega
-private theorem lb_abf_end (base : Word) : (base + 864 : Word) + 16 = base + 880 := by bv_omega
+private theorem lb_ab_init (base : Word) : (base + 448 : Word) + 284 = base + 732 := by bv_addr
+private theorem lb_ab0 (base : Word) : (base + 732 : Word) + 4 = base + 736 := by bv_addr
+private theorem lb_ab0_end (base : Word) : (base + 736 : Word) + 32 = base + 768 := by bv_addr
+private theorem lb_ab1_end (base : Word) : (base + 768 : Word) + 32 = base + 800 := by bv_addr
+private theorem lb_ab2_end (base : Word) : (base + 800 : Word) + 32 = base + 832 := by bv_addr
+private theorem lb_ab3_end (base : Word) : (base + 832 : Word) + 32 = base + 864 := by bv_addr
+private theorem lb_abf_end (base : Word) : (base + 864 : Word) + 16 = base + 880 := by bv_addr
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -315,7 +315,7 @@ theorem divK_addback_full_spec
   have I := divK_addback_init_spec v7_init (base + 732)
   rw [lb_ab0] at I
   have Ie := cpsTriple_extend_code (hmono := by
-    exact lb_sub base 71 _ _ (by native_decide) (by bv_omega) (by native_decide)) I
+    exact lb_sub base 71 _ _ (by native_decide) (by bv_addr) (by native_decide)) I
   -- Frame init with all addback state
   have If := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x11 ↦ᵣ q_hat) **
@@ -331,14 +331,14 @@ theorem divK_addback_full_spec
     v5_init v2_init v0 u0 32 0 (base + 736) hv_v0 hv_u0
   rw [lb_ab0_end] at A0
   have A0e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 72 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 73 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 74 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 75 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 76 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 77 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 78 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 79 _ _ (by native_decide) (by bv_omega) (by native_decide)))))))))
+    exact CodeReq_union_sub (lb_sub base 72 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 73 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 74 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 75 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 76 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 77 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 78 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 79 _ _ (by native_decide) (by bv_addr) (by native_decide)))))))))
     A0
   -- Compose init + limb 0
   seqFrame If A0e
@@ -347,14 +347,14 @@ theorem divK_addback_full_spec
     ac2_0 aun0 v1 u1 40 4088 (base + 768) hv_v1 hv_u1
   rw [lb_ab1_end] at A1
   have A1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 80 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 81 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 82 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 83 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 84 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 85 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 86 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 87 _ _ (by native_decide) (by bv_omega) (by native_decide)))))))))
+    exact CodeReq_union_sub (lb_sub base 80 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 81 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 82 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 83 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 84 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 85 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 86 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 87 _ _ (by native_decide) (by bv_addr) (by native_decide)))))))))
     A1
   seqFrame IfA0e A1e
   -- Limb 2: instrs [88]-[95] at base+800
@@ -362,14 +362,14 @@ theorem divK_addback_full_spec
     ac2_1 aun1 v2 u2 48 4080 (base + 800) hv_v2 hv_u2
   rw [lb_ab2_end] at A2
   have A2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 88 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 89 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 90 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 91 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 92 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 93 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 94 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 95 _ _ (by native_decide) (by bv_omega) (by native_decide)))))))))
+    exact CodeReq_union_sub (lb_sub base 88 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 89 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 90 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 91 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 92 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 93 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 94 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 95 _ _ (by native_decide) (by bv_addr) (by native_decide)))))))))
     A2
   seqFrame IfA0eA1e A2e
   -- Limb 3: instrs [96]-[103] at base+832
@@ -377,24 +377,24 @@ theorem divK_addback_full_spec
     ac2_2 aun2 v3 u3 56 4072 (base + 832) hv_v3 hv_u3
   rw [lb_ab3_end] at A3
   have A3e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 96 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 97 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 98 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 99 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 100 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 101 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 102 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 103 _ _ (by native_decide) (by bv_omega) (by native_decide)))))))))
+    exact CodeReq_union_sub (lb_sub base 96 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 97 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 98 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 99 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 100 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 101 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 102 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 103 _ _ (by native_decide) (by bv_addr) (by native_decide)))))))))
     A3
   seqFrame IfA0eA1eA2e A3e
   -- Final: instrs [104]-[107] at base+864
   have AF := divK_addback_final_spec u_base aco3 q_hat ac2_3 u4 4064 (base + 864) hv_u4
   rw [lb_abf_end] at AF
   have AFe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 104 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 105 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 106 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 107 _ _ (by native_decide) (by bv_omega) (by native_decide)))))
+    exact CodeReq_union_sub (lb_sub base 104 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 105 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 106 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 107 _ _ (by native_decide) (by bv_addr) (by native_decide)))))
     AF
   seqFrame IfA0eA1eA2eA3e AFe
   -- Final permutation
@@ -409,10 +409,10 @@ theorem divK_addback_full_spec
 -- ============================================================================
 
 -- Address normalization for mulsub_setup
-private theorem lb_ms_setup (base : Word) : (base + 516 : Word) + 20 = base + 536 := by bv_omega
+private theorem lb_ms_setup (base : Word) : (base + 516 : Word) + 20 = base + 536 := by bv_addr
 
 -- Address normalization for sub_carry
-private theorem lb_sc (base : Word) : (base + 712 : Word) + 16 = base + 728 := by bv_omega
+private theorem lb_sc (base : Word) : (base + 712 : Word) + 16 = base + 728 := by bv_addr
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 1600000 in
@@ -501,11 +501,11 @@ theorem divK_mulsub_full_spec
   have S := divK_mulsub_setup_spec sp q_hat j v1_old v5_old v6_old v10_old (base + 516) hv_j
   rw [lb_ms_setup] at S
   have Se := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 17 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 18 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 19 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 20 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 21 _ _ (by native_decide) (by bv_omega) (by native_decide)))))) S
+    exact CodeReq_union_sub (lb_sub base 17 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 18 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 19 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 20 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 21 _ _ (by native_decide) (by bv_addr) (by native_decide)))))) S
   -- Frame setup with all memory + x7/x2 for mulsub
   have Sf := cpsTriple_frame_left _ _ _ _ _
     ((.x7 ↦ᵣ v7_old) ** (.x2 ↦ᵣ v2_old) **
@@ -525,10 +525,10 @@ theorem divK_mulsub_full_spec
   have SC := divK_sub_carry_spec u_base c3 bs3 fs3 u_top 4064 (base + 712) hv_u4
   rw [lb_sc] at SC
   have SCe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 66 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 67 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 68 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 69 _ _ (by native_decide) (by bv_omega) (by native_decide))))) SC
+    exact CodeReq_union_sub (lb_sub base 66 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 67 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 68 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 69 _ _ (by native_decide) (by bv_addr) (by native_decide))))) SC
   -- Compose (setup+mulsub) + sub_carry
   seqFrame SfM SCe
   -- Final permutation
@@ -544,9 +544,9 @@ theorem divK_mulsub_full_spec
 
 private theorem lb_beq_taken (base : Word) : (base + 728 : Word) + signExtend13 (152 : BitVec 13) = base + 880 := by
   have : signExtend13 (152 : BitVec 13) = (152 : Word) := by native_decide
-  rw [this]; bv_omega
+  rw [this]; bv_addr
 
-private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 732 := by bv_omega
+private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 732 := by bv_addr
 
 -- ============================================================================
 -- Section 6a: Correction skip spec (borrow = 0)
@@ -577,7 +577,7 @@ theorem divK_correction_skip_spec
   have hbeq := beq_spec_gen .x7 .x0 (152 : BitVec 13) (0 : Word) 0 (base + 728)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
   have hbeq_ext := cpsBranch_extend_code (hmono :=
-    lb_sub base 70 _ _ (by native_decide) (by bv_omega) (by native_decide)) hbeq
+    lb_sub base 70 _ _ (by native_decide) (by bv_addr) (by native_decide)) hbeq
   -- Eliminate not-taken path (⌜0 ≠ 0⌝ is False)
   have skip := cpsBranch_elim_taken _ _ _ _ _ _ _ hbeq_ext (fun hp hQf => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
@@ -672,7 +672,7 @@ theorem divK_correction_addback_spec
   have hbeq := beq_spec_gen .x7 .x0 (152 : BitVec 13) borrow 0 (base + 728)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
   have hbeq_ext := cpsBranch_extend_code (hmono :=
-    lb_sub base 70 _ _ (by native_decide) (by bv_omega) (by native_decide)) hbeq
+    lb_sub base 70 _ _ (by native_decide) (by bv_addr) (by native_decide)) hbeq
   -- Eliminate taken path (⌜borrow = 0⌝ contradicts hb)
   have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ hbeq_ext (fun hp hQt => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
@@ -711,8 +711,8 @@ theorem divK_correction_addback_spec
 -- Instrs [0]-[12] at base+448 → base+500.
 -- ============================================================================
 
-private theorem lb_save_j (base : Word) : (base + 448 : Word) + 4 = base + 452 := by bv_omega
-private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 500 := by bv_omega
+private theorem lb_save_j (base : Word) : (base + 448 : Word) + 4 = base + 452 := by bv_addr
+private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 500 := by bv_addr
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -749,7 +749,7 @@ theorem divK_save_trial_load_spec
   have SJ := divK_save_j_spec sp j j_old (base + 448) hv_j
   rw [lb_save_j] at SJ
   have SJe := cpsTriple_extend_code (hmono :=
-    lb_sub base 0 _ _ (by native_decide) (by bv_omega) (by native_decide)) SJ
+    lb_sub base 0 _ _ (by native_decide) (by bv_addr) (by native_decide)) SJ
   -- Frame save_j with trial_load state
   have SJf := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -764,18 +764,18 @@ theorem divK_save_trial_load_spec
   dsimp only [] at TL
   rw [lb_trial_load] at TL
   have TLe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 1 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 2 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 3 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 4 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 5 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 6 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 7 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 8 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 9 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 10 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 11 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 12 _ _ (by native_decide) (by bv_omega) (by native_decide))))))))))))) TL
+    exact CodeReq_union_sub (lb_sub base 1 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 2 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 3 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 4 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 5 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 6 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 7 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 8 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 9 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 10 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 11 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 12 _ _ (by native_decide) (by bv_addr) (by native_decide))))))))))))) TL
   -- 3. Compose save_j + trial_load
   seqFrame SJf TLe
   -- Final permutation
@@ -795,13 +795,13 @@ theorem divK_save_trial_load_spec
 -- Address normalization for trial quotient
 private theorem lb_bltu_taken (base : Word) : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
   have : signExtend13 (12 : BitVec 13) = (12 : Word) := by native_decide
-  rw [this]; bv_omega
-private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_omega
-private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_omega
+  rw [this]; bv_addr
+private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_addr
+private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_addr
 private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (556 : BitVec 21) = base + 1068 := by
   have : signExtend21 (556 : BitVec 21) = (556 : Word) := by native_decide
-  rw [this]; bv_omega
-private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_omega
+  rw [this]; bv_addr
+private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_addr
 
 -- ============================================================================
 -- Section 8a: Trial quotient NOT-TAKEN path (u_hi >= v_top)
@@ -818,8 +818,8 @@ private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
   dsimp only [] at TM
   rw [lb_trial_max_end] at TM
   exact cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 14 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 15 _ _ (by native_decide) (by bv_omega) (by native_decide))) TM
+    exact CodeReq_union_sub (lb_sub base 14 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 15 _ _ (by native_decide) (by bv_addr) (by native_decide))) TM
 
 -- ============================================================================
 -- Section 8b: Trial quotient TAKEN path (u_hi < v_top)
@@ -889,7 +889,7 @@ theorem divK_trial_call_path_spec
   have J := jal_spec .x2 v2_old (556 : BitVec 21) (base + 512) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
   have Je := cpsTriple_extend_code (hmono :=
-    lb_sub base 16 _ _ (by native_decide) (by bv_omega) (by native_decide)) J
+    lb_sub base 16 _ _ (by native_decide) (by bv_addr) (by native_decide)) J
   -- 2. div128 subroutine: base+1068 → base+516
   have D := div128_spec sp (base + 516) v_top u_lo u_hi base
     j vtop_base v11_old ret_mem d_mem dlo_mem un0_mem
@@ -922,12 +922,12 @@ theorem divK_trial_call_path_spec
 -- ============================================================================
 
 -- Address normalization for store_qj and loop control
-private theorem lb_sqj (base : Word) : (base + 880 : Word) + 16 = base + 896 := by bv_omega
+private theorem lb_sqj (base : Word) : (base + 880 : Word) + 16 = base + 896 := by bv_addr
 private theorem lb_lc_taken (base : Word) :
     (base + 896 : Word) + 4 + signExtend13 (7740 : BitVec 13) = base + 448 := by
   have : signExtend13 (7740 : BitVec 13) = (18446744073709551164 : Word) := by native_decide
-  rw [this]; bv_omega
-private theorem lb_lc_exit (base : Word) : (base + 896 : Word) + 8 = base + 904 := by bv_omega
+  rw [this]; bv_addr
+private theorem lb_lc_exit (base : Word) : (base + 896 : Word) + 8 = base + 904 := by bv_addr
 
 set_option maxRecDepth 4096 in
 set_option maxHeartbeats 800000 in
@@ -960,17 +960,17 @@ theorem divK_store_loop_spec
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 108 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 109 _ _ (by native_decide) (by bv_omega) (by native_decide))
-     (CodeReq_union_sub (lb_sub base 110 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 111 _ _ (by native_decide) (by bv_omega) (by native_decide))))) SQ
+    exact CodeReq_union_sub (lb_sub base 108 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 109 _ _ (by native_decide) (by bv_addr) (by native_decide))
+     (CodeReq_union_sub (lb_sub base 110 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 111 _ _ (by native_decide) (by bv_addr) (by native_decide))))) SQ
   -- 2. Loop control: instrs [112]-[113] at base+896
   have LC := divK_loop_control_spec j (7740 : BitVec 13) (base + 896)
   dsimp only [] at LC
   rw [lb_lc_taken, lb_lc_exit] at LC
   have LCe := cpsBranch_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 112 _ _ (by native_decide) (by bv_omega) (by native_decide))
-      (lb_sub base 113 _ _ (by native_decide) (by bv_omega) (by native_decide))) LC
+    exact CodeReq_union_sub (lb_sub base 112 _ _ (by native_decide) (by bv_addr) (by native_decide))
+      (lb_sub base 113 _ _ (by native_decide) (by bv_addr) (by native_decide))) LC
   -- 3. Add x0 to store_qj via frame, then reshape via consequence
   have SQx0 : cpsTriple (base + 880) (base + 896) (divCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
@@ -1269,7 +1269,7 @@ theorem divK_trial_max_full_spec
   have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) u_hi v_top (base + 500)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranch_extend_code (hmono :=
-    lb_sub base 13 _ _ (by native_decide) (by bv_omega) (by native_decide)) hbltu_raw
+    lb_sub base 13 _ _ (by native_decide) (by bv_addr) (by native_decide)) hbltu_raw
   -- Eliminate taken path (⌜BitVec.ult u_hi v_top⌝ contradicts hbltu)
   have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ hbltu_ext (fun hp hQt => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
@@ -1381,7 +1381,7 @@ theorem divK_trial_call_full_spec
   have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) u_hi v_top (base + 500)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranch_extend_code (hmono :=
-    lb_sub base 13 _ _ (by native_decide) (by bv_omega) (by native_decide)) hbltu_raw
+    lb_sub base 13 _ _ (by native_decide) (by bv_addr) (by native_decide)) hbltu_raw
   -- Eliminate ntaken path (⌜¬BitVec.ult u_hi v_top⌝ contradicts hbltu)
   have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ hbltu_ext (fun hp hQf => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -56,16 +56,16 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
                  hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
                  hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
@@ -116,16 +116,16 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       unfold evmWordIs at hp
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
                  hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega,
+      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
+                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
+                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
                  hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -1067,6 +1067,13 @@ elab "crMono" : tactic => do
   let _ ← Lean.Elab.runTactic goal stx
   replaceMainGoal []
 
+/-- Lightweight address arithmetic: proves `(a + k₁) + k₂ = a + k₃` via
+    BitVec associativity + constant folding. Generates much smaller kernel
+    proof terms than `bv_omega` (one `add_assoc` rewrite + `rfl` vs full
+    Presburger arithmetic proof). -/
+macro "bv_addr" : tactic =>
+  `(tactic| (simp only [BitVec.add_assoc]; rfl))
+
 /-- `crDisjoint` proves a goal of the form `CodeReq.Disjoint cr1 cr2`
     by structural recursion on union/singleton, using bv_omega for address inequality. -/
 elab "crDisjoint" : tactic => do


### PR DESCRIPTION
## Summary
- Add `bv_addr` tactic: `(simp only [BitVec.add_assoc]; rfl)` for address offset arithmetic
- Replace 374 of 411 `bv_omega` calls across DivMod files with `bv_addr`
- Document `bv_addr` vs `bv_omega` best practice in AGENTS.md

### Olean size reductions

| File | Before | After | Reduction |
|------|--------|-------|-----------|
| LoopBody | 16MB | 2.8MB | **-82%** |
| Div128 | 5.8MB | 1.1MB | **-81%** |
| CLZ | 1.5MB | 315K | **-79%** |
| PhaseAB | 5.8MB | 1.9MB | **-67%** |
| LimbSpec | 14MB | 5.3MB | **-62%** |
| Norm | 1.7MB | 595K | **-65%** |

### Why this works

`bv_omega` = `(try simp [bitvec_to_nat]) <;> omega` — converts BitVec to Nat then runs Presburger arithmetic. For a trivial `(base + 228) + 24 = base + 252`, this generates a large proof term with Nat conversion chains + integer arithmetic proofs.

`bv_addr` = `simp only [BitVec.add_assoc]; rfl` — reassociates to `base + (228 + 24)`, then the kernel constant-folds `228 + 24 = 252` and checks `rfl`. Proof term is just one `add_assoc` application + `Eq.refl`.

## Test plan
- [x] `lake build` passes (3402 jobs, 0 errors)
- [x] 37 remaining `bv_omega` calls verified to be non-address-equality (inequalities, range bounds, skipBlock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)