### PR TITLE
Make loopBodyPostN{1,2,3,4} parametric (issue #89)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/DivN1Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN1Full.lean
@@ -623,16 +623,15 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=3 looped back to base+448, now execute j=2 then j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN1 at j=3
-    change loopBodyPostN1 sp (3 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
-      j3_q_addr_eq] at hLP2
-    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN1 existentials at j=3
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
+      j3_q_addr_eq] at hLP2_atoms
+    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=2 combined_spec with j=3 output values
     -- After j=3: x1=2, x5=24, x6=sp+SE12(4032), x7=sp+SE12(4064),
     -- x10=x10v_j3, x11=x11v_j3, x2=x2v_j3
@@ -698,16 +697,15 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
     · -- j=2 loop-back: now execute j=1 then j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN1 at j=2
-      change loopBodyPostN1 sp (2 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-        j2_q_addr_eq] at hLP3
-      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
+      -- Destructure loopBodyPostN1 existentials at j=2
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+        j2_q_addr_eq] at hLP3_atoms
+      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       -- Build j=1 combined_spec with j=2 output values
       -- After j=2: x1=1, x5=16, x6=sp+SE12(4040), x7=sp+SE12(4072)
       -- u window at j=1: u0 at SE12(4048)=u1, u1 at SE12(4040)=un0v_j2,
@@ -771,16 +769,15 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
       · -- j=1 loop-back: now execute j=0
         obtain ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        -- Unfold and canonicalize loopBodyPostN1 at j=1
-        change loopBodyPostN1 sp (1 : Word) b0' b1' b2' b3' h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-          j1_q_addr_eq] at hLP4
-        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hLP4
+        -- Destructure loopBodyPostN1 existentials at j=1
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+          j1_q_addr_eq] at hLP4_atoms
+        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hLP4_atoms
         -- Build j=0 spec with j=1 output values
         -- After j=1: x1=0, x5=8, x6=sp+SE12(4048), x7=sp+SE12(4080)
         -- u window at j=0: u0 at SE12(4056)=u0, u1 at SE12(4048)=un0v_j1,
@@ -844,15 +841,14 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
         obtain ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, hQF5, hF5⟩ := hQ5F
         refine ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, ?_, hF5⟩
         obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF5
-        change loopBodyPostN1 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-        unfold loopBodyPostN1 at hJ0post
-        simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-          j0_q_addr_eq] at hJ0post
-        simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hJ0post
         obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
           retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        unfold loopBodyPostN1 at hJ0_atoms
+        simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+          j0_q_addr_eq] at hJ0_atoms
+        simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hJ0_atoms
         have hCombined5 : sepConj _ _ h_qf5 :=
           ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -862,15 +858,14 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
         refine ⟨k1 + k2 + k3 + k4, s4, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3) hstep4, hpc4, ?_⟩
         refine ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        change loopBodyPostN1 sp (1 : Word) b0' b1' b2' b3' h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-          j1_q_addr_eq] at hLP4
-        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hLP4
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+          j1_q_addr_eq] at hLP4_atoms
+        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hLP4_atoms
         have hCombined4 : sepConj _ _ h_qf4 :=
           ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4_atoms, hFrame4⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -880,15 +875,14 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN1 sp (2 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-        j2_q_addr_eq] at hLP3
-      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+        j2_q_addr_eq] at hLP3_atoms
+      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un3v_j2, _, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -898,15 +892,14 @@ theorem evm_div_n1_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN1 sp (3 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
-      j3_q_addr_eq] at hLP2
-    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
+      j3_q_addr_eq] at hLP2_atoms
+    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un2v_j3, _, un3v_j3, _, u4v_j3, qv_j3, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN1FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN1FullShift0.lean
@@ -616,16 +616,15 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=3 looped back to base+448, now execute j=2 then j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN1 at j=3
-    change loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
-      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2
-    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero_s0n1] at hLP2
+    -- Destructure loopBodyPostN1 existentials at j=3
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
+      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2_atoms
+    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero_s0n1] at hLP2_atoms
     -- Build j=2 combined_spec with j=3 output values
     -- After j=3: x1=2, x5=24, x6=sp+SE12(4032), x7=sp+SE12(4064),
     -- x10=x10v_j3, x11=x11v_j3, x2=x2v_j3
@@ -691,16 +690,15 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
     · -- j=2 loop-back: now execute j=1 then j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN1 at j=2
-      change loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
-        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3
-      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero_s0n1] at hLP3
+      -- Destructure loopBodyPostN1 existentials at j=2
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
+        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3_atoms
+      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero_s0n1] at hLP3_atoms
       -- Build j=1 combined_spec with j=2 output values
       -- After j=2: x1=1, x5=16, x6=sp+SE12(4040), x7=sp+SE12(4072)
       -- u window at j=1: u0 at SE12(4048)=a1, u1 at SE12(4040)=un0v_j2,
@@ -764,16 +762,15 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
       · -- j=1 loop-back: now execute j=0
         obtain ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        -- Unfold and canonicalize loopBodyPostN1 at j=1
-        change loopBodyPostN1 sp (1 : Word) b0 b1 b2 b3 h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
-          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4
-        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hLP4
+        -- Destructure loopBodyPostN1 existentials at j=1
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
+          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4_atoms
+        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hLP4_atoms
         -- Build j=0 spec with j=1 output values
         -- After j=1: x1=0, x5=8, x6=sp+SE12(4048), x7=sp+SE12(4080)
         -- u window at j=0: u0 at SE12(4056)=a0, u1 at SE12(4048)=un0v_j1,
@@ -837,15 +834,14 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
         obtain ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, hQF5, hF5⟩ := hQ5F
         refine ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, ?_, hF5⟩
         obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF5
-        change loopBodyPostN1 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-        unfold loopBodyPostN1 at hJ0post
-        simp only [j0_u0_addr_eq_s0n1, j0_u1_addr_eq_s0n1, j0_u2_addr_eq_s0n1, j0_u3_addr_eq_s0n1,
-          j0_u4_addr_eq_s0n1, j0_q_addr_eq_s0n1] at hJ0post
-        simp only [j0_u_base_eq_s0n1, j0_shl3_eq_s0n1, j0_j'_eq_s0n1, j0_sub_zero_s0n1, j0_q_sub_zero_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hJ0post
         obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
           retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        unfold loopBodyPostN1 at hJ0_atoms
+        simp only [j0_u0_addr_eq_s0n1, j0_u1_addr_eq_s0n1, j0_u2_addr_eq_s0n1, j0_u3_addr_eq_s0n1,
+          j0_u4_addr_eq_s0n1, j0_q_addr_eq_s0n1] at hJ0_atoms
+        simp only [j0_u_base_eq_s0n1, j0_shl3_eq_s0n1, j0_j'_eq_s0n1, j0_sub_zero_s0n1, j0_q_sub_zero_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hJ0_atoms
         have hCombined5 : sepConj _ _ h_qf5 :=
           ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -855,15 +851,14 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
         refine ⟨k1 + k2 + k3 + k4, s4, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3) hstep4, hpc4, ?_⟩
         refine ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        change loopBodyPostN1 sp (1 : Word) b0 b1 b2 b3 h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
-          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4
-        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hLP4
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
+          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4_atoms
+        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hLP4_atoms
         have hCombined4 : sepConj _ _ h_qf4 :=
           ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4_atoms, hFrame4⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -873,15 +868,14 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
-        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3
-      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero_s0n1] at hLP3
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
+        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3_atoms
+      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero_s0n1] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un3v_j2, _, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -891,15 +885,14 @@ theorem evm_div_n1_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
-      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2
-    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero_s0n1] at hLP2
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
+      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2_atoms
+    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero_s0n1] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un2v_j3, _, un3v_j3, _, u4v_j3, qv_j3, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN2Full.lean
@@ -566,16 +566,15 @@ theorem evm_div_n2_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=2 looped back to base+448, now execute j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN2 at j=2
-    change loopBodyPostN2 sp (2 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-      j2_q_addr_eq] at hLP2
-    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN2 existentials at j=2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+      j2_q_addr_eq] at hLP2_atoms
+    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=1 combined_spec with j=2 output values
     -- After j=2: x1=1, x5=16, x6=sp+SE12(4040), x7=sp+SE12(4072),
     -- x10=x10v_j2, x11=x11v_j2, x2=x2v_j2
@@ -641,16 +640,15 @@ theorem evm_div_n2_preloop_loopbody_spec (sp base : Word)
     · -- j=1 loop-back: now execute j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN2 at j=1
-      change loopBodyPostN2 sp (1 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-        j1_q_addr_eq] at hLP3
-      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
+      -- Destructure loopBodyPostN2 existentials at j=1
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+        j1_q_addr_eq] at hLP3_atoms
+      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       -- Build j=0 spec with j=1 output values
       -- After j=1: x1=0, x5=8, x6=sp+SE12(4048), x7=sp+SE12(4080),
       -- x10=x10v_j1, x11=x11v_j1, x2=x2v_j1
@@ -716,17 +714,16 @@ theorem evm_div_n2_preloop_loopbody_spec (sp base : Word)
       obtain ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
       refine ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
       obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF4
-      change loopBodyPostN2 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-      unfold loopBodyPostN2 at hJ0post
+      obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
+        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0post_atoms⟩ := hJ0post
+      unfold loopBodyPostN2 at hJ0post_atoms
       simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-        j0_q_addr_eq] at hJ0post
+        j0_q_addr_eq] at hJ0post_atoms
       simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
         signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hJ0post
-      obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
-        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        word_add_zero] at hJ0post_atoms
       have hCombined4 : sepConj _ _ h_qf4 :=
-        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
+        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post_atoms, hFR0⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
         by xperm_hyp hCombined4⟩
     · -- j=1 exit case: j=1 exited to base+904 directly
@@ -734,15 +731,14 @@ theorem evm_div_n2_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN2 sp (1 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-        j1_q_addr_eq] at hLP3
-      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+        j1_q_addr_eq] at hLP3_atoms
+      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
@@ -752,15 +748,14 @@ theorem evm_div_n2_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN2 sp (2 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-      j2_q_addr_eq] at hLP2
-    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+      j2_q_addr_eq] at hLP2_atoms
+    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un3v_j2, _, u4v_j2, qv_j2, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN2FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN2FullShift0.lean
@@ -572,15 +572,14 @@ theorem evm_div_n2_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=2 looped back to base+448, now execute j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN2 at j=2
-    change loopBodyPostN2 sp (2 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
-      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2
-    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
+    -- Destructure loopBodyPostN2 existentials at j=2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
+      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2_atoms
+    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     -- Build j=1 spec with j=2 output values (window shift)
     have hJ1 := divK_loop_body_n2_combined_spec sp
       (1 : Word) (2 : Word) (16 : Word) (sp + signExtend12 4040) (sp + signExtend12 4072)
@@ -639,15 +638,14 @@ theorem evm_div_n2_shift0_preloop_loopbody_spec (sp base : Word)
     · -- Loop-back case: j=1 looped back to base+448, now execute j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN2 at j=1
-      change loopBodyPostN2 sp (1 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3
-      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3
+      -- Destructure loopBodyPostN2 existentials at j=1
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3_atoms
+      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3_atoms
       -- Build j=0 spec with j=1 output values
       have hLB0 := divK_loop_body_n2_j0_spec sp
         (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -707,16 +705,15 @@ theorem evm_div_n2_shift0_preloop_loopbody_spec (sp base : Word)
       obtain ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
       refine ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
       obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF4
-      change loopBodyPostN2 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-      unfold loopBodyPostN2 at hJ0post
-      simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0,
-        j0_u4_addr_eq_s0, j0_q_addr_eq_s0] at hJ0post
-      simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post
       obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
-        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0post_atoms⟩ := hJ0post
+      unfold loopBodyPostN2 at hJ0post_atoms
+      simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0,
+        j0_u4_addr_eq_s0, j0_q_addr_eq_s0] at hJ0post_atoms
+      simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post_atoms
       have hCombined4 : sepConj _ _ h_qf4 :=
-        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
+        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post_atoms, hFR0⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
         by xperm_hyp hCombined4⟩
     · -- Exit case: j=1 exited to base+904 directly (theoretically unreachable at j=1)
@@ -724,14 +721,13 @@ theorem evm_div_n2_shift0_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN2 sp (1 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3
-      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3_atoms
+      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
@@ -741,14 +737,13 @@ theorem evm_div_n2_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN2 sp (2 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
-      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2
-    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
+      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2_atoms
+    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un3v_j2, _, u4v_j2, qv_j2, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN3Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN3Full.lean
@@ -460,16 +460,15 @@ theorem evm_div_n3_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=1 looped back to base+448, now execute j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN3 at j=1
-    change loopBodyPostN3 sp (1 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN3 existentials at j=1
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=0 spec with j=1 output values (window shift)
     have hLB0 := divK_loop_body_n3_j0_spec sp
       (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -529,15 +528,14 @@ theorem evm_div_n3_preloop_loopbody_spec (sp base : Word)
     obtain ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
     refine ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
     obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF3
-    change loopBodyPostN3 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-    unfold loopBodyPostN3 at hJ0post
-    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-      j0_q_addr_eq] at hJ0post
-    simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hJ0post
     obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
       retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+    unfold loopBodyPostN3 at hJ0_atoms
+    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+      j0_q_addr_eq] at hJ0_atoms
+    simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hJ0_atoms
     have hCombined3 : sepConj _ _ h_qf3 :=
       ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,
@@ -547,15 +545,14 @@ theorem evm_div_n3_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN3 sp (1 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN3FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN3FullShift0.lean
@@ -451,15 +451,14 @@ theorem evm_div_n3_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=1 looped back to base+448, now execute j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN3 at j=1
-    change loopBodyPostN3 sp (1 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-      j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP2
-    simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
+    -- Destructure loopBodyPostN3 existentials at j=1
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+      j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP2_atoms
+    simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     -- Build j=0 spec with j=1 output values (window shift)
     have hLB0 := divK_loop_body_n3_j0_spec sp
       (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -519,14 +518,13 @@ theorem evm_div_n3_shift0_preloop_loopbody_spec (sp base : Word)
     obtain ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
     refine ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
     obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF3
-    change loopBodyPostN3 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-    unfold loopBodyPostN3 at hJ0post
-    simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0,
-      j0_u4_addr_eq_s0, j0_q_addr_eq_s0] at hJ0post
-    simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post
     obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
       retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+    unfold loopBodyPostN3 at hJ0_atoms
+    simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0,
+      j0_u4_addr_eq_s0, j0_q_addr_eq_s0] at hJ0_atoms
+    simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0_atoms
     have hCombined3 : sepConj _ _ h_qf3 :=
       ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,
@@ -536,14 +534,13 @@ theorem evm_div_n3_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN3 sp (1 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-      j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP2
-    simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+      j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP2_atoms
+    simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/DivN4Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN4Full.lean
@@ -191,7 +191,9 @@ theorem evm_div_n4_preloop_loopbody_spec (sp base : Word)
        ((sp + signExtend12 3976) ↦ₘ j_old) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) ** ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) ** ((sp + signExtend12 3944) ↦ₘ scratch_un0))
-      (loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' **
+      ((fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -391,21 +393,20 @@ theorem evm_div_n4_full_spec (sp base : Word)
   -- Destructure holdsFor and sep conj
   obtain ⟨h_full, hcompat1, h_qframe, h_f, heq_outer, hdisj_outer, hQFrame, hF_heap⟩ := hQF
   obtain ⟨h_lp, h_frame, heq_inner, hdisj_inner, hLP, hFrame⟩ := hQFrame
-  -- Expand loopBodyPostN4
-  change loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' h_lp at hLP
+  -- Destructure loopBodyPostN4 existentials
+  obtain ⟨x2v, x10v, x11v, un0v, un1v, un2v, un3v, u4v, qv,
+    retv, dv, dlov, sunv, hLP_atoms⟩ := hLP
   -- Unfold loopBodyPostN4 WITHOUT unfolding signExtend12 (which would destroy atom identity)
-  unfold loopBodyPostN4 at hLP
+  unfold loopBodyPostN4 at hLP_atoms
   -- Simplify let-bindings and address expressions
   -- First: canonicalize compound addresses (u0-u4, q) that use the full u_base/q_addr patterns
   -- These must fire BEFORE j0_u_base_eq which partially simplifies
   simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-    j0_q_addr_eq] at hLP
+    j0_q_addr_eq] at hLP_atoms
   -- Second: simplify remaining expressions (u_base in registers, j', signExtend12, etc.)
   simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
     signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-    word_add_zero] at hLP
-  obtain ⟨x2v, x10v, x11v, un0v, un1v, un2v, un3v, u4v, qv,
-    retv, dv, dlov, sunv, hLP_atoms⟩ := hLP
+    word_add_zero] at hLP_atoms
   -- Get post-loop chain with concrete values
   -- v2=x2v, v5=0, v6=sp+SE12(4056), v7=sp+SE12(4088), v10=x10v
   -- q0=qv, q1=0, q2=0, q3=0, m0=b0', m8=b1', m16=b2', m24=b3'

--- a/EvmAsm/Evm64/DivMod/Compose/DivN4FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/DivN4FullShift0.lean
@@ -181,7 +181,9 @@ theorem evm_div_n4_shift0_preloop_loopbody_spec (sp base : Word)
        ((sp + signExtend12 3976) ↦ₘ j_old) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) ** ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) ** ((sp + signExtend12 3944) ↦ₘ scratch_un0))
-      (loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 **
+      ((fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -355,16 +357,15 @@ theorem evm_div_n4_shift0_full_spec (sp base : Word)
   -- Destructure holdsFor and sep conj
   obtain ⟨h_full, hcompat1, h_qframe, h_f, heq_outer, hdisj_outer, hQFrame, hF_heap⟩ := hQF
   obtain ⟨h_lp, h_frame, heq_inner, hdisj_inner, hLP, hFrame⟩ := hQFrame
-  -- Expand loopBodyPostN4
-  change loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 h_lp at hLP
-  unfold loopBodyPostN4 at hLP
-  -- Simplify addresses
-  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-    j0_q_addr_eq] at hLP
-  simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
-    signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP
+  -- Destructure loopBodyPostN4 existentials
   obtain ⟨x2v, x10v, x11v, un0v, un1v, un2v, un3v, u4v, qv,
     retv, dv, dlov, sunv, hLP_atoms⟩ := hLP
+  unfold loopBodyPostN4 at hLP_atoms
+  -- Simplify addresses
+  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+    j0_q_addr_eq] at hLP_atoms
+  simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
+    signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP_atoms
   -- Get post-loop chain for shift=0 DIV
   -- v2=x2v, v5=0, v6=sp+SE12(4056), v7=sp+SE12(4088), v10=x10v
   -- q0=qv, q1=0, q2=0, q3=0, m0=b0, m8=b1, m16=b2, m24=b3

--- a/EvmAsm/Evm64/DivMod/Compose/ModN1Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN1Full.lean
@@ -623,16 +623,15 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=3 looped back to base+448, now execute j=2 then j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN1 at j=3
-    change loopBodyPostN1 sp (3 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
-      j3_q_addr_eq] at hLP2
-    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN1 existentials at j=3
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
+      j3_q_addr_eq] at hLP2_atoms
+    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=2 combined_spec with j=3 output values
     -- After j=3: x1=2, x5=24, x6=sp+SE12(4032), x7=sp+SE12(4064),
     -- x10=x10v_j3, x11=x11v_j3, x2=x2v_j3
@@ -698,16 +697,15 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
     · -- j=2 loop-back: now execute j=1 then j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN1 at j=2
-      change loopBodyPostN1 sp (2 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-        j2_q_addr_eq] at hLP3
-      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
+      -- Destructure loopBodyPostN1 existentials at j=2
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+        j2_q_addr_eq] at hLP3_atoms
+      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       -- Build j=1 combined_spec with j=2 output values
       -- After j=2: x1=1, x5=16, x6=sp+SE12(4040), x7=sp+SE12(4072)
       -- u window at j=1: u0 at SE12(4048)=u1, u1 at SE12(4040)=un0v_j2,
@@ -771,16 +769,15 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
       · -- j=1 loop-back: now execute j=0
         obtain ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        -- Unfold and canonicalize loopBodyPostN1 at j=1
-        change loopBodyPostN1 sp (1 : Word) b0' b1' b2' b3' h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-          j1_q_addr_eq] at hLP4
-        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hLP4
+        -- Destructure loopBodyPostN1 existentials at j=1
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+          j1_q_addr_eq] at hLP4_atoms
+        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hLP4_atoms
         -- Build j=0 spec with j=1 output values
         -- After j=1: x1=0, x5=8, x6=sp+SE12(4048), x7=sp+SE12(4080)
         -- u window at j=0: u0 at SE12(4056)=u0, u1 at SE12(4048)=un0v_j1,
@@ -844,15 +841,14 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
         obtain ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, hQF5, hF5⟩ := hQ5F
         refine ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, ?_, hF5⟩
         obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF5
-        change loopBodyPostN1 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-        unfold loopBodyPostN1 at hJ0post
-        simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-          j0_q_addr_eq] at hJ0post
-        simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hJ0post
         obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
           retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        unfold loopBodyPostN1 at hJ0_atoms
+        simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+          j0_q_addr_eq] at hJ0_atoms
+        simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hJ0_atoms
         have hCombined5 : sepConj _ _ h_qf5 :=
           ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
         -- Existential ordering: (u5out q1out u6out q2out u7out q3out)
@@ -863,15 +859,14 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
         refine ⟨k1 + k2 + k3 + k4, s4, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3) hstep4, hpc4, ?_⟩
         refine ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        change loopBodyPostN1 sp (1 : Word) b0' b1' b2' b3' h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-          j1_q_addr_eq] at hLP4
-        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero] at hLP4
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+          j1_q_addr_eq] at hLP4_atoms
+        simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero] at hLP4_atoms
         have hCombined4 : sepConj _ _ h_qf4 :=
           ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4_atoms, hFrame4⟩
         -- Existential ordering: (u5out q1out u6out q2out u7out q3out)
@@ -882,15 +877,14 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN1 sp (2 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-        j2_q_addr_eq] at hLP3
-      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+        j2_q_addr_eq] at hLP3_atoms
+      simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       -- Existential ordering: (u5out q1out u6out q2out u7out q3out)
@@ -901,15 +895,14 @@ theorem evm_mod_n1_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN1 sp (3 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
-      j3_q_addr_eq] at hLP2
-    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq, j3_u1_addr_eq, j3_u2_addr_eq, j3_u3_addr_eq, j3_u4_addr_eq,
+      j3_q_addr_eq] at hLP2_atoms
+    simp only [j3_u_base_eq, j3_shl3_eq, j3_j'_eq, j3_sub_24, j3_q_sub_24,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     -- Existential ordering: (u5out q1out u6out q2out u7out q3out)

--- a/EvmAsm/Evm64/DivMod/Compose/ModN1FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN1FullShift0.lean
@@ -616,16 +616,15 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=3 looped back to base+448, now execute j=2 then j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN1 at j=3
-    change loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
-      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2
-    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero_s0n1] at hLP2
+    -- Destructure loopBodyPostN1 existentials at j=3
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
+      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2_atoms
+    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero_s0n1] at hLP2_atoms
     -- Build j=2 combined_spec with j=3 output values
     have hJ2 := divK_loop_body_n1_combined_spec
       sp (2 : Word) (3 : Word) (24 : Word) (sp + signExtend12 4032) (sp + signExtend12 4064)
@@ -685,16 +684,15 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
     · -- j=2 loop-back: now execute j=1 then j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN1 at j=2
-      change loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
-        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3
-      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero_s0n1] at hLP3
+      -- Destructure loopBodyPostN1 existentials at j=2
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
+        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3_atoms
+      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero_s0n1] at hLP3_atoms
       -- Build j=1 combined_spec with j=2 output values
       have hJ1 := divK_loop_body_n1_combined_spec
         sp (1 : Word) (2 : Word) (16 : Word) (sp + signExtend12 4040) (sp + signExtend12 4072)
@@ -754,16 +752,15 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
       · -- j=1 loop-back: now execute j=0
         obtain ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        -- Unfold and canonicalize loopBodyPostN1 at j=1
-        change loopBodyPostN1 sp (1 : Word) b0 b1 b2 b3 h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
-          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4
-        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hLP4
+        -- Destructure loopBodyPostN1 existentials at j=1
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
+          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4_atoms
+        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hLP4_atoms
         -- Build j=0 spec with j=1 output values
         have hLB0 := divK_loop_body_n1_j0_spec sp
           (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -823,15 +820,14 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
         obtain ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, hQF5, hF5⟩ := hQ5F
         refine ⟨h_res5, hcompat5, h_qf5, h_f5, hdisj5, heq5, ?_, hF5⟩
         obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF5
-        change loopBodyPostN1 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-        unfold loopBodyPostN1 at hJ0post
-        simp only [j0_u0_addr_eq_s0n1, j0_u1_addr_eq_s0n1, j0_u2_addr_eq_s0n1, j0_u3_addr_eq_s0n1,
-          j0_u4_addr_eq_s0n1, j0_q_addr_eq_s0n1] at hJ0post
-        simp only [j0_u_base_eq_s0n1, j0_shl3_eq_s0n1, j0_j'_eq_s0n1, j0_sub_zero_s0n1, j0_q_sub_zero_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hJ0post
         obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
           retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        unfold loopBodyPostN1 at hJ0_atoms
+        simp only [j0_u0_addr_eq_s0n1, j0_u1_addr_eq_s0n1, j0_u2_addr_eq_s0n1, j0_u3_addr_eq_s0n1,
+          j0_u4_addr_eq_s0n1, j0_q_addr_eq_s0n1] at hJ0_atoms
+        simp only [j0_u_base_eq_s0n1, j0_shl3_eq_s0n1, j0_j'_eq_s0n1, j0_sub_zero_s0n1, j0_q_sub_zero_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hJ0_atoms
         have hCombined5 : sepConj _ _ h_qf5 :=
           ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -841,15 +837,14 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
         refine ⟨k1 + k2 + k3 + k4, s4, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3) hstep4, hpc4, ?_⟩
         refine ⟨h_full4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
         obtain ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4, hFrame4⟩ := hQF4
-        change loopBodyPostN1 sp (1 : Word) b0 b1 b2 b3 h_lp4 at hLP4
-        unfold loopBodyPostN1 at hLP4
-        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
-          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4
-        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
-          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-          word_add_zero_s0n1] at hLP4
         obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
           retv_j1, dv_j1, dlov_j1, sunv_j1, hLP4_atoms⟩ := hLP4
+        unfold loopBodyPostN1 at hLP4_atoms
+        simp only [j1_u0_addr_eq_s0n1, j1_u1_addr_eq_s0n1, j1_u2_addr_eq_s0n1, j1_u3_addr_eq_s0n1,
+          j1_u4_addr_eq_s0n1, j1_q_addr_eq_s0n1] at hLP4_atoms
+        simp only [j1_u_base_eq_s0n1, j1_shl3_eq_s0n1, j1_j'_eq_s0n1, j1_sub_8_s0n1, j1_q_sub_8_s0n1,
+          signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+          word_add_zero_s0n1] at hLP4_atoms
         have hCombined4 : sepConj _ _ h_qf4 :=
           ⟨h_lp4, h_frame4, hdisj_i4, heq_i4, hLP4_atoms, hFrame4⟩
         exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -859,15 +854,17 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN1 at hLP3
-      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
-        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3
-      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero_s0n1] at hLP3
+      change (∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h_lp3) at hLP3
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN1 at hLP3_atoms
+      simp only [j2_u0_addr_eq_s0n1, j2_u1_addr_eq_s0n1, j2_u2_addr_eq_s0n1, j2_u3_addr_eq_s0n1,
+        j2_u4_addr_eq_s0n1, j2_q_addr_eq_s0n1] at hLP3_atoms
+      simp only [j2_u_base_eq_s0n1, j2_shl3_eq_s0n1, j2_j'_eq_s0n1, j2_sub_16_s0n1, j2_q_sub_16_s0n1,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero_s0n1] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un3v_j2, _, u4v_j2, qv_j2, u4v_j3, qv_j3, _, _, _, _, _,
@@ -877,15 +874,17 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN1 at hLP2
-    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
-      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2
-    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero_s0n1] at hLP2
+    change (∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+      (retv dv dlov sunv : Word),
+      loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h_lp2) at hLP2
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN1 at hLP2_atoms
+    simp only [j3_u0_addr_eq_s0n1, j3_u1_addr_eq_s0n1, j3_u2_addr_eq_s0n1, j3_u3_addr_eq_s0n1,
+      j3_u4_addr_eq_s0n1, j3_q_addr_eq_s0n1] at hLP2_atoms
+    simp only [j3_u_base_eq_s0n1, j3_shl3_eq_s0n1, j3_j'_eq_s0n1, j3_sub_24_s0n1,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero_s0n1] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, un2v_j3, _, un3v_j3, _, u4v_j3, qv_j3, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/ModN1FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN1FullShift0.lean
@@ -854,9 +854,6 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change (∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
-        (retv dv dlov sunv : Word),
-        loopBodyPostN1 sp (2 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h_lp3) at hLP3
       obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
         retv_j2, dv_j2, dlov_j2, sunv_j2, hLP3_atoms⟩ := hLP3
       unfold loopBodyPostN1 at hLP3_atoms
@@ -874,9 +871,6 @@ theorem evm_mod_n1_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change (∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
-      (retv dv dlov sunv : Word),
-      loopBodyPostN1 sp (3 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h_lp2) at hLP2
     obtain ⟨x2v_j3, x10v_j3, x11v_j3, un0v_j3, un1v_j3, un2v_j3, un3v_j3, u4v_j3, qv_j3,
       retv_j3, dv_j3, dlov_j3, sunv_j3, hLP2_atoms⟩ := hLP2
     unfold loopBodyPostN1 at hLP2_atoms

--- a/EvmAsm/Evm64/DivMod/Compose/ModN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN2Full.lean
@@ -566,16 +566,15 @@ theorem evm_mod_n2_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=2 looped back to base+448, now handle j=1 and j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN2 at j=2
-    change loopBodyPostN2 sp (2 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-      j2_q_addr_eq] at hLP2
-    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN2 existentials at j=2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+      j2_q_addr_eq] at hLP2_atoms
+    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=1 combined_spec with j=2 output values (window shift)
     have hJ1 := divK_loop_body_n2_combined_spec
       sp (1 : Word) (2 : Word) (16 : Word) (sp + signExtend12 4040) (sp + signExtend12 4072)
@@ -633,16 +632,15 @@ theorem evm_mod_n2_preloop_loopbody_spec (sp base : Word)
     · -- Loop-back case: j=1 looped back to base+448, now execute j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN2 at j=1
-      change loopBodyPostN2 sp (1 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-        j1_q_addr_eq] at hLP3
-      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
+      -- Destructure loopBodyPostN2 existentials at j=1
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+        j1_q_addr_eq] at hLP3_atoms
+      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       -- Build j=0 spec with j=1 output values (window shift)
       have hLB0 := divK_loop_body_n2_j0_spec sp
         (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -703,17 +701,16 @@ theorem evm_mod_n2_preloop_loopbody_spec (sp base : Word)
       obtain ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
       refine ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
       obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF4
-      change loopBodyPostN2 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-      unfold loopBodyPostN2 at hJ0post
+      obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
+        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0post_atoms⟩ := hJ0post
+      unfold loopBodyPostN2 at hJ0post_atoms
       simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-        j0_q_addr_eq] at hJ0post
+        j0_q_addr_eq] at hJ0post_atoms
       simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
         signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hJ0post
-      obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
-        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        word_add_zero] at hJ0post_atoms
       have hCombined4 : sepConj _ _ h_qf4 :=
-        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
+        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post_atoms, hFR0⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, u4v_j2, qv_j1, qv_j2, _, _, _, _, _,
         by xperm_hyp hCombined4⟩
     · -- Exit case: j=1 exited to base+904 directly (theoretically unreachable at j=1)
@@ -722,15 +719,14 @@ theorem evm_mod_n2_preloop_loopbody_spec (sp base : Word)
         hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN2 sp (1 : Word) b0' b1' b2' b3' h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-        j1_q_addr_eq] at hLP3
-      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-        word_add_zero] at hLP3
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+        j1_q_addr_eq] at hLP3_atoms
+      simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+        signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+        word_add_zero] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, u4v_j2, qv_j1, qv_j2, _, _, _, _, _,
@@ -740,15 +736,14 @@ theorem evm_mod_n2_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN2 sp (2 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
-      j2_q_addr_eq] at hLP2
-    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq, j2_u1_addr_eq, j2_u2_addr_eq, j2_u3_addr_eq, j2_u4_addr_eq,
+      j2_q_addr_eq] at hLP2_atoms
+    simp only [j2_u_base_eq, j2_shl3_eq, j2_j'_eq, j2_sub_16, j2_q_sub_16,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     -- In the exit case from j=2, we only have j=2 outputs, need to provide

--- a/EvmAsm/Evm64/DivMod/Compose/ModN2FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN2FullShift0.lean
@@ -554,15 +554,14 @@ theorem evm_mod_n2_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=2 looped back to base+448, now execute j=1 then j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN2 at j=2
-    change loopBodyPostN2 sp (2 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0, j2_u4_addr_eq_s0,
-      j2_q_addr_eq_s0] at hLP2
-    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
+    -- Destructure loopBodyPostN2 existentials at j=2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0, j2_u4_addr_eq_s0,
+      j2_q_addr_eq_s0] at hLP2_atoms
+    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     -- Build j=1 spec with j=2 output values (window shift)
     have hJ1 := divK_loop_body_n2_combined_spec sp
       (1 : Word) (2 : Word) (16 : Word) (sp + signExtend12 4040) (sp + signExtend12 4072)
@@ -621,15 +620,14 @@ theorem evm_mod_n2_shift0_preloop_loopbody_spec (sp base : Word)
     · -- Loop-back case: j=1 looped back to base+448, now execute j=0
       obtain ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      -- Unfold and canonicalize loopBodyPostN2 at j=1
-      change loopBodyPostN2 sp (1 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3
-      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3
+      -- Destructure loopBodyPostN2 existentials at j=1
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3_atoms
+      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3_atoms
       -- Build j=0 spec with j=1 output values (window shift)
       have hLB0 := divK_loop_body_n2_j0_spec sp
         (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -689,16 +687,15 @@ theorem evm_mod_n2_shift0_preloop_loopbody_spec (sp base : Word)
       obtain ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, hQF4, hF4⟩ := hQ4F
       refine ⟨h_res4, hcompat4, h_qf4, h_f4, hdisj4, heq4, ?_, hF4⟩
       obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF4
-      change loopBodyPostN2 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-      unfold loopBodyPostN2 at hJ0post
-      simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0, j0_u4_addr_eq_s0,
-        j0_q_addr_eq_s0] at hJ0post
-      simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post
       obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
-        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+        retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0post_atoms⟩ := hJ0post
+      unfold loopBodyPostN2 at hJ0post_atoms
+      simp only [j0_u0_addr_eq_s0, j0_u1_addr_eq_s0, j0_u2_addr_eq_s0, j0_u3_addr_eq_s0, j0_u4_addr_eq_s0,
+        j0_q_addr_eq_s0] at hJ0post_atoms
+      simp only [j0_shl3_eq_s0, j0_j'_eq_s0, j0_sub_zero_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post_atoms
       have hCombined4 : sepConj _ _ h_qf4 :=
-        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
+        ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post_atoms, hFR0⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
         by xperm_hyp hCombined4⟩
     · -- Exit case: j=1 exited to base+904 directly (theoretically unreachable at j=1)
@@ -706,14 +703,13 @@ theorem evm_mod_n2_shift0_preloop_loopbody_spec (sp base : Word)
       refine ⟨k1 + k2 + k3, s3, stepN_add_eq _ _ _ _ _ (stepN_add_eq _ _ _ _ _ hstep1 hstep2) hstep3, hpc3, ?_⟩
       refine ⟨h_full3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
       obtain ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3, hFrame3⟩ := hQF3
-      change loopBodyPostN2 sp (1 : Word) b0 b1 b2 b3 h_lp3 at hLP3
-      unfold loopBodyPostN2 at hLP3
-      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
-        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3
-      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
-        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3
       obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
         retv_j1, dv_j1, dlov_j1, sunv_j1, hLP3_atoms⟩ := hLP3
+      unfold loopBodyPostN2 at hLP3_atoms
+      simp only [j1_u0_addr_eq_s0, j1_u1_addr_eq_s0, j1_u2_addr_eq_s0, j1_u3_addr_eq_s0,
+        j1_u4_addr_eq_s0, j1_q_addr_eq_s0] at hLP3_atoms
+      simp only [j1_shl3_eq_s0, j1_j'_eq_s0, j1_sub_8_s0,
+        signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP3_atoms
       have hCombined3 : sepConj _ _ h_qf3 :=
         ⟨h_lp3, h_frame3, hdisj_i3, heq_i3, hLP3_atoms, hFrame3⟩
       exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, u4v_j2, qv_j2, _, _, _, _, _,
@@ -723,14 +719,13 @@ theorem evm_mod_n2_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN2 sp (2 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN2 at hLP2
-    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
-      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2
-    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
     obtain ⟨x2v_j2, x10v_j2, x11v_j2, un0v_j2, un1v_j2, un2v_j2, un3v_j2, u4v_j2, qv_j2,
       retv_j2, dv_j2, dlov_j2, sunv_j2, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN2 at hLP2_atoms
+    simp only [j2_u0_addr_eq_s0, j2_u1_addr_eq_s0, j2_u2_addr_eq_s0, j2_u3_addr_eq_s0,
+      j2_u4_addr_eq_s0, j2_q_addr_eq_s0] at hLP2_atoms
+    simp only [j2_shl3_eq_s0, j2_j'_eq_s0, j2_sub_16_s0,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     -- Need to provide dummy witnesses for the j=1 and j=0 slots

--- a/EvmAsm/Evm64/DivMod/Compose/ModN3Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN3Full.lean
@@ -460,16 +460,15 @@ theorem evm_mod_n3_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=1 looped back to base+448, now execute j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN3 at j=1
-    change loopBodyPostN3 sp (1 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
+    -- Destructure loopBodyPostN3 existentials at j=1
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     -- Build j=0 spec with j=1 output values (window shift)
     have hLB0 := divK_loop_body_n3_j0_spec sp
       (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -529,15 +528,14 @@ theorem evm_mod_n3_preloop_loopbody_spec (sp base : Word)
     obtain ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
     refine ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
     obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF3
-    change loopBodyPostN3 sp (0 : Word) b0' b1' b2' b3' h_j0 at hJ0post
-    unfold loopBodyPostN3 at hJ0post
-    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-      j0_q_addr_eq] at hJ0post
-    simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hJ0post
     obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
       retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+    unfold loopBodyPostN3 at hJ0_atoms
+    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+      j0_q_addr_eq] at hJ0_atoms
+    simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hJ0_atoms
     have hCombined3 : sepConj _ _ h_qf3 :=
       ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,
@@ -547,15 +545,14 @@ theorem evm_mod_n3_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN3 sp (1 : Word) b0' b1' b2' b3' h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
-      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-      word_add_zero] at hLP2
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_u_base_eq, j1_shl3_eq, j1_j'_eq, j1_sub_8, j1_q_sub_8,
+      signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+      word_add_zero] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/ModN3FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN3FullShift0.lean
@@ -403,15 +403,14 @@ theorem evm_mod_n3_shift0_preloop_loopbody_spec (sp base : Word)
   · -- Loop-back case: j=1 looped back to base+448, now execute j=0
     obtain ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, hQF2, hF2⟩ := hQ2F
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    -- Unfold and canonicalize loopBodyPostN3 at j=1
-    change loopBodyPostN3 sp (1 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_shl3_eq, j1_j'_eq, j1_sub_8,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
+    -- Destructure loopBodyPostN3 existentials at j=1
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_shl3_eq, j1_j'_eq, j1_sub_8,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     -- Build j=0 spec with j=1 output values (window shift)
     have hLB0 := divK_loop_body_n3_j0_spec sp
       (1 : Word) (8 : Word) (sp + signExtend12 4048) (sp + signExtend12 4080)
@@ -471,14 +470,13 @@ theorem evm_mod_n3_shift0_preloop_loopbody_spec (sp base : Word)
     obtain ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, hQF3, hF3⟩ := hQ3F
     refine ⟨h_res3, hcompat3, h_qf3, h_f3, hdisj3, heq3, ?_, hF3⟩
     obtain ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0post, hFR0⟩ := hQF3
-    change loopBodyPostN3 sp (0 : Word) b0 b1 b2 b3 h_j0 at hJ0post
-    unfold loopBodyPostN3 at hJ0post
-    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-      j0_q_addr_eq] at hJ0post
-    simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0post
     obtain ⟨x2v_j0, x10v_j0, x11v_j0, un0v_j0, un1v_j0, un2v_j0, un3v_j0, u4v_j0, qv_j0,
       retv_j0, dv_j0, dlov_j0, sunv_j0, hJ0_atoms⟩ := hJ0post
+    unfold loopBodyPostN3 at hJ0_atoms
+    simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+      j0_q_addr_eq] at hJ0_atoms
+    simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hJ0_atoms
     have hCombined3 : sepConj _ _ h_qf3 :=
       ⟨h_j0, h_fr0, hdisj_j0, heq_j0, hJ0_atoms, hFR0⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,
@@ -488,14 +486,13 @@ theorem evm_mod_n3_shift0_preloop_loopbody_spec (sp base : Word)
     refine ⟨k1 + k2, s2, stepN_add_eq _ _ _ _ _ hstep1 hstep2, hpc2, ?_⟩
     refine ⟨h_full2, hcompat2, h_qf2, h_f2, hdisj2, heq2, ?_, hF2⟩
     obtain ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2, hFrame2⟩ := hQF2
-    change loopBodyPostN3 sp (1 : Word) b0 b1 b2 b3 h_lp2 at hLP2
-    unfold loopBodyPostN3 at hLP2
-    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
-      j1_q_addr_eq] at hLP2
-    simp only [j1_shl3_eq, j1_j'_eq, j1_sub_8,
-      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2
     obtain ⟨x2v_j1, x10v_j1, x11v_j1, un0v_j1, un1v_j1, un2v_j1, un3v_j1, u4v_j1, qv_j1,
       retv_j1, dv_j1, dlov_j1, sunv_j1, hLP2_atoms⟩ := hLP2
+    unfold loopBodyPostN3 at hLP2_atoms
+    simp only [j1_u0_addr_eq, j1_u1_addr_eq, j1_u2_addr_eq, j1_u3_addr_eq, j1_u4_addr_eq,
+      j1_q_addr_eq] at hLP2_atoms
+    simp only [j1_shl3_eq, j1_j'_eq, j1_sub_8,
+      signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP2_atoms
     have hCombined2 : sepConj _ _ h_qf2 :=
       ⟨h_lp2, h_frame2, hdisj_i2, heq_i2, hLP2_atoms, hFrame2⟩
     exact ⟨_, _, _, _, _, _, _, _, _, _, _, _, _, u4v_j1, qv_j1, _, _, _, _, _,

--- a/EvmAsm/Evm64/DivMod/Compose/ModN4Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN4Full.lean
@@ -192,7 +192,9 @@ theorem evm_mod_n4_preloop_loopbody_spec (sp base : Word)
        ((sp + signExtend12 3976) ↦ₘ j_old) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) ** ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) ** ((sp + signExtend12 3944) ↦ₘ scratch_un0))
-      (loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' **
+      ((fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -373,18 +375,17 @@ theorem evm_mod_n4_full_spec (sp base : Word)
   -- Destructure holdsFor and sep conj
   obtain ⟨h_full, hcompat1, h_qframe, h_f, heq_outer, hdisj_outer, hQFrame, hF_heap⟩ := hQF
   obtain ⟨h_lp, h_frame, heq_inner, hdisj_inner, hLP, hFrame⟩ := hQFrame
-  -- Expand loopBodyPostN4
-  change loopBodyPostN4 sp (0 : Word) b0' b1' b2' b3' h_lp at hLP
-  -- Unfold loopBodyPostN4 WITHOUT unfolding signExtend12 (which would destroy atom identity)
-  unfold loopBodyPostN4 at hLP
-  -- Simplify let-bindings and address expressions
-  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-    j0_q_addr_eq] at hLP
-  simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
-    signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
-    word_add_zero] at hLP
+  -- Destructure loopBodyPostN4 existentials
   obtain ⟨x2v, x10v, x11v, un0v, un1v, un2v, un3v, u4v, qv,
     retv, dv, dlov, sunv, hLP_atoms⟩ := hLP
+  -- Unfold loopBodyPostN4 WITHOUT unfolding signExtend12 (which would destroy atom identity)
+  unfold loopBodyPostN4 at hLP_atoms
+  -- Simplify let-bindings and address expressions
+  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+    j0_q_addr_eq] at hLP_atoms
+  simp only [j0_u_base_eq, j0_shl3_eq, j0_j'_eq, j0_sub_zero, j0_q_sub_zero,
+    signExtend12_0, signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56,
+    word_add_zero] at hLP_atoms
   -- Get post-loop chain for MOD
   -- v2=x2v, v5=0, v6=sp+SE12(4056), v7=sp+SE12(4088), v10=x10v
   -- m0=b0', m8=b1', m16=b2', m24=b3'

--- a/EvmAsm/Evm64/DivMod/Compose/ModN4FullShift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModN4FullShift0.lean
@@ -182,7 +182,9 @@ theorem evm_mod_n4_shift0_preloop_loopbody_spec (sp base : Word)
        ((sp + signExtend12 3976) ↦ₘ j_old) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) ** ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) ** ((sp + signExtend12 3944) ↦ₘ scratch_un0))
-      (loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 **
+      ((fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -352,14 +354,14 @@ theorem evm_mod_n4_shift0_full_spec (sp base : Word)
   obtain ⟨k1, s1, hstep1, hpc1, hQF⟩ := hPLLB F hF st hcr hPF hpc
   obtain ⟨h_full, hcompat1, h_qframe, h_f, heq_outer, hdisj_outer, hQFrame, hF_heap⟩ := hQF
   obtain ⟨h_lp, h_frame, heq_inner, hdisj_inner, hLP, hFrame⟩ := hQFrame
-  change loopBodyPostN4 sp (0 : Word) b0 b1 b2 b3 h_lp at hLP
-  unfold loopBodyPostN4 at hLP
-  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
-    j0_q_addr_eq] at hLP
-  simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
-    signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP
+  -- Destructure loopBodyPostN4 existentials
   obtain ⟨x2v, x10v, x11v, un0v, un1v, un2v, un3v, u4v, qv,
     retv, dv, dlov, sunv, hLP_atoms⟩ := hLP
+  unfold loopBodyPostN4 at hLP_atoms
+  simp only [j0_u0_addr_eq, j0_u1_addr_eq, j0_u2_addr_eq, j0_u3_addr_eq, j0_u4_addr_eq,
+    j0_q_addr_eq] at hLP_atoms
+  simp only [j0_shl3_eq, j0_j'_eq, j0_sub_zero,
+    signExtend12_32, signExtend12_40, signExtend12_48, signExtend12_56] at hLP_atoms
   -- Get post-loop chain for shift=0 MOD
   have hDE := evm_mod_shift0_epilogue_spec sp base
     un0v un1v un2v un3v ((clzResult b3).1)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -822,29 +822,28 @@ theorem divK_loop_body_n1_call_addback_spec
     Path-dependent outputs are existentially quantified.
     Both cpsBranch exits share this postcondition. -/
 def loopBodyPostN1
-    (sp j v0 v1 v2 v3 : Word) : Assertion :=
-  fun h =>
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let j' := j + signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    ∃ (x2v x10v x11v : Word)
-      (un0v un1v un2v un3v u4v qv : Word)
-      (retv dv dlov sunv : Word),
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-     (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-     (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
-     (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-     ((u_base + signExtend12 4064) ↦ₘ u4v) **
-     (q_addr ↦ₘ qv) **
-     (sp + signExtend12 3968 ↦ₘ retv) **
-     (sp + signExtend12 3960 ↦ₘ dv) **
-     (sp + signExtend12 3952 ↦ₘ dlov) **
-     (sp + signExtend12 3944 ↦ₘ sunv)) h
+    (sp j v0 v1 v2 v3 : Word)
+    (x2v x10v x11v : Word)
+    (un0v un1v un2v un3v u4v qv : Word)
+    (retv dv dlov sunv : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let j' := j + signExtend12 4095
+  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
+  (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
+  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  (q_addr ↦ₘ qv) **
+  (sp + signExtend12 3968 ↦ₘ retv) **
+  (sp + signExtend12 3960 ↦ₘ dv) **
+  (sp + signExtend12 3952 ↦ₘ dlov) **
+  (sp + signExtend12 3944 ↦ₘ sunv)
 
 set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
@@ -896,9 +895,13 @@ theorem divK_loop_body_n1_combined_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + 448)
-      (loopBodyPostN1 sp j v0 v1 v2 v3)
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN1 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h)
       (base + 904)
-      (loopBodyPostN1 sp j v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN1 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u1 < v0?)
   by_cases hbltu : BitVec.ult u1 v0
@@ -968,9 +971,9 @@ theorem divK_loop_body_n1_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         HS0
     · -- Call + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1005,9 +1008,9 @@ theorem divK_loop_body_n1_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         HA0
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1056,9 +1059,9 @@ theorem divK_loop_body_n1_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         HSf
     · -- Max + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1098,9 +1101,9 @@ theorem divK_loop_body_n1_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         HAf
 
 
@@ -1157,7 +1160,9 @@ theorem divK_loop_body_n1_j0_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyPostN1 sp (0 : Word) v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN1 sp (0 : Word) v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u1 < v0?)
   by_cases hbltu : BitVec.ult u1 v0
@@ -1259,7 +1264,7 @@ theorem divK_loop_body_n1_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         full
     · -- Call + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1324,7 +1329,7 @@ theorem divK_loop_body_n1_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v0, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v0, d_lo, div_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         full
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1400,7 +1405,7 @@ theorem divK_loop_body_n1_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         fullf
     · -- Max + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1467,7 +1472,7 @@ theorem divK_loop_body_n1_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN1; xperm_hyp hp⟩)
         fullf
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -823,29 +823,28 @@ theorem divK_loop_body_n2_call_addback_spec
     Path-dependent outputs are existentially quantified.
     Both cpsBranch exits share this postcondition. -/
 def loopBodyPostN2
-    (sp j v0 v1 v2 v3 : Word) : Assertion :=
-  fun h =>
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let j' := j + signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    ∃ (x2v x10v x11v : Word)
-      (un0v un1v un2v un3v u4v qv : Word)
-      (retv dv dlov sunv : Word),
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-     (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-     (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
-     (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-     ((u_base + signExtend12 4064) ↦ₘ u4v) **
-     (q_addr ↦ₘ qv) **
-     (sp + signExtend12 3968 ↦ₘ retv) **
-     (sp + signExtend12 3960 ↦ₘ dv) **
-     (sp + signExtend12 3952 ↦ₘ dlov) **
-     (sp + signExtend12 3944 ↦ₘ sunv)) h
+    (sp j v0 v1 v2 v3 : Word)
+    (x2v x10v x11v : Word)
+    (un0v un1v un2v un3v u4v qv : Word)
+    (retv dv dlov sunv : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let j' := j + signExtend12 4095
+  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
+  (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
+  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  (q_addr ↦ₘ qv) **
+  (sp + signExtend12 3968 ↦ₘ retv) **
+  (sp + signExtend12 3960 ↦ₘ dv) **
+  (sp + signExtend12 3952 ↦ₘ dlov) **
+  (sp + signExtend12 3944 ↦ₘ sunv)
 
 set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
@@ -897,9 +896,13 @@ theorem divK_loop_body_n2_combined_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + 448)
-      (loopBodyPostN2 sp j v0 v1 v2 v3)
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN2 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h)
       (base + 904)
-      (loopBodyPostN2 sp j v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN2 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u2 < v1?)
   by_cases hbltu : BitVec.ult u2 v1
@@ -969,9 +972,9 @@ theorem divK_loop_body_n2_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         HS0
     · -- Call + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1006,9 +1009,9 @@ theorem divK_loop_body_n2_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         HA0
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1057,9 +1060,9 @@ theorem divK_loop_body_n2_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         HSf
     · -- Max + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1099,9 +1102,9 @@ theorem divK_loop_body_n2_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         HAf
 
 
@@ -1158,7 +1161,9 @@ theorem divK_loop_body_n2_j0_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyPostN2 sp (0 : Word) v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN2 sp (0 : Word) v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u2 < v1?)
   by_cases hbltu : BitVec.ult u2 v1
@@ -1260,7 +1265,7 @@ theorem divK_loop_body_n2_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         full
     · -- Call + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1325,7 +1330,7 @@ theorem divK_loop_body_n2_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v1, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v1, d_lo, div_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         full
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1401,7 +1406,7 @@ theorem divK_loop_body_n2_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         fullf
     · -- Max + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1468,7 +1473,7 @@ theorem divK_loop_body_n2_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN2; xperm_hyp hp⟩)
         fullf
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -823,29 +823,28 @@ theorem divK_loop_body_n3_call_addback_spec
     Path-dependent outputs are existentially quantified.
     Both cpsBranch exits share this postcondition. -/
 def loopBodyPostN3
-    (sp j v0 v1 v2 v3 : Word) : Assertion :=
-  fun h =>
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let j' := j + signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    ∃ (x2v x10v x11v : Word)
-      (un0v un1v un2v un3v u4v qv : Word)
-      (retv dv dlov sunv : Word),
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-     (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-     (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
-     (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-     ((u_base + signExtend12 4064) ↦ₘ u4v) **
-     (q_addr ↦ₘ qv) **
-     (sp + signExtend12 3968 ↦ₘ retv) **
-     (sp + signExtend12 3960 ↦ₘ dv) **
-     (sp + signExtend12 3952 ↦ₘ dlov) **
-     (sp + signExtend12 3944 ↦ₘ sunv)) h
+    (sp j v0 v1 v2 v3 : Word)
+    (x2v x10v x11v : Word)
+    (un0v un1v un2v un3v u4v qv : Word)
+    (retv dv dlov sunv : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let j' := j + signExtend12 4095
+  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
+  (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
+  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  (q_addr ↦ₘ qv) **
+  (sp + signExtend12 3968 ↦ₘ retv) **
+  (sp + signExtend12 3960 ↦ₘ dv) **
+  (sp + signExtend12 3952 ↦ₘ dlov) **
+  (sp + signExtend12 3944 ↦ₘ sunv)
 
 set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
@@ -897,9 +896,13 @@ theorem divK_loop_body_n3_combined_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + 448)
-      (loopBodyPostN3 sp j v0 v1 v2 v3)
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN3 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h)
       (base + 904)
-      (loopBodyPostN3 sp j v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN3 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u3 < v2?)
   by_cases hbltu : BitVec.ult u3 v2
@@ -969,9 +972,9 @@ theorem divK_loop_body_n3_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         HS0
     · -- Call + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1006,9 +1009,9 @@ theorem divK_loop_body_n3_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         HA0
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1057,9 +1060,9 @@ theorem divK_loop_body_n3_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         HSf
     · -- Max + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1099,9 +1102,9 @@ theorem divK_loop_body_n3_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         HAf
 
 
@@ -1158,7 +1161,9 @@ theorem divK_loop_body_n3_j0_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyPostN3 sp (0 : Word) v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN3 sp (0 : Word) v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u3 < v2?)
   by_cases hbltu : BitVec.ult u3 v2
@@ -1260,7 +1265,7 @@ theorem divK_loop_body_n3_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         full
     · -- Call + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1325,7 +1330,7 @@ theorem divK_loop_body_n3_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v2, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v2, d_lo, div_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         full
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1401,7 +1406,7 @@ theorem divK_loop_body_n3_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         fullf
     · -- Max + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1468,7 +1473,7 @@ theorem divK_loop_body_n3_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN3; xperm_hyp hp⟩)
         fullf
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -819,32 +819,32 @@ theorem divK_loop_body_n4_call_addback_spec
 -- ============================================================================
 
 /-- Postcondition for one loop iteration at n=4.
-    Path-dependent outputs are existentially quantified.
-    Both cpsBranch exits share this postcondition. -/
+    Output values are concrete parameters (not existentially quantified),
+    preserving the relationship between outputs and inputs for semantic
+    correctness proofs. -/
 def loopBodyPostN4
-    (sp j v0 v1 v2 v3 : Word) : Assertion :=
-  fun h =>
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let j' := j + signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    ∃ (x2v x10v x11v : Word)
-      (un0v un1v un2v un3v u4v qv : Word)
-      (retv dv dlov sunv : Word),
-    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-     (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-     (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
-     (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-     ((u_base + signExtend12 4064) ↦ₘ u4v) **
-     (q_addr ↦ₘ qv) **
-     (sp + signExtend12 3968 ↦ₘ retv) **
-     (sp + signExtend12 3960 ↦ₘ dv) **
-     (sp + signExtend12 3952 ↦ₘ dlov) **
-     (sp + signExtend12 3944 ↦ₘ sunv)) h
+    (sp j v0 v1 v2 v3 : Word)
+    (x2v x10v x11v : Word)
+    (un0v un1v un2v un3v u4v qv : Word)
+    (retv dv dlov sunv : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let j' := j + signExtend12 4095
+  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
+  (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
+  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  (q_addr ↦ₘ qv) **
+  (sp + signExtend12 3968 ↦ₘ retv) **
+  (sp + signExtend12 3960 ↦ₘ dv) **
+  (sp + signExtend12 3952 ↦ₘ dlov) **
+  (sp + signExtend12 3944 ↦ₘ sunv)
 
 set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
@@ -896,9 +896,13 @@ theorem divK_loop_body_n4_combined_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + 448)
-      (loopBodyPostN4 sp j v0 v1 v2 v3)
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h)
       (base + 904)
-      (loopBodyPostN4 sp j v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp j v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u_top < v3?)
   by_cases hbltu : BitVec.ult u_top v3
@@ -968,9 +972,9 @@ theorem divK_loop_body_n4_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         HS0
     · -- Call + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1005,9 +1009,9 @@ theorem divK_loop_body_n4_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         HA0
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1056,9 +1060,9 @@ theorem divK_loop_body_n4_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         HSf
     · -- Max + addback (borrow ≠ 0)
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1098,9 +1102,9 @@ theorem divK_loop_body_n4_combined_spec
       exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         HAf
 
 
@@ -1157,7 +1161,9 @@ theorem divK_loop_body_n4_j0_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3) := by
+      (fun h => ∃ (x2v x10v x11v : Word) (un0v un1v un2v un3v u4v qv : Word)
+        (retv dv dlov sunv : Word),
+        loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3 x2v x10v x11v un0v un1v un2v un3v u4v qv retv dv dlov sunv h) := by
   intro u_base q_addr
   -- Case split on BLTU (u_top < v3?)
   by_cases hbltu : BitVec.ult u_top v3
@@ -1259,7 +1265,7 @@ theorem divK_loop_body_n4_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         full
     · -- Call + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1324,7 +1330,7 @@ theorem divK_loop_body_n4_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          base + 516, v3, d_lo, div_un0, by xperm_hyp hp⟩)
+          base + 516, v3, d_lo, div_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         full
   · -- BLTU not taken: max path
     let q_hat := signExtend12 (4095 : BitVec 12)
@@ -1400,7 +1406,7 @@ theorem divK_loop_body_n4_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨un3, c3, q_hat, un0, un1, un2, un3, u4_new, q_hat,
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         fullf
     · -- Max + addback
       let upc0 := un0 + (signExtend12 0 : Word)
@@ -1467,7 +1473,7 @@ theorem divK_loop_body_n4_j0_spec
       exact cpsTriple_consequence _ _ _ _ _ _ _
         (fun h hp => by xperm_hyp hp)
         (fun h hp => ⟨aun3, c3, q_hat', aun0, aun1, aun2, aun3, aun4, q_hat',
-          ret_mem, d_mem, dlo_mem, scratch_un0, by xperm_hyp hp⟩)
+          ret_mem, d_mem, dlo_mem, scratch_un0, by unfold loopBodyPostN4; xperm_hyp hp⟩)
         fullf
 
 end EvmAsm.Evm64

--- a/PLAN.md
+++ b/PLAN.md
@@ -414,8 +414,17 @@ All phases below target **Evm64** primarily. Files are under `EvmAsm/Evm64/`.
   - Stack spec bridge: `DivLimbBridge.lean` — `ne_zero_iff_getLimbN_or` (EvmWord nonzero ↔ limbs OR
     nonzero), `getLimbN_fromLimbs_match` / `getLimbN_fromLimbs_{0,1,2,3}` (fromLimbs round-trip for
     reconstructing evmWordIs from individual memory cells) (done)
-  - Remaining: prove algorithm output satisfies Nat-level Euclidean property
-    (carry chain analysis connecting specific register expressions to val256 equations)
+  - **Semantic correctness path (two steps):**
+    - Step 1: Make `loopBodyPostN{1,2,3,4}` parametric — move existentially quantified output
+      values (x2v, x10v, x11v, un0v..un3v, u4v, qv, retv, dv, dlov, sunv) to definition
+      parameters. Theorems (`divK_loop_body_nk_combined_spec`, `_j0_spec`) wrap with `∃` in
+      their statements. Callers unchanged (still `obtain` from `∃`).
+      Status: N4 done, N1/N2/N3 in progress
+    - Step 2: Remove `∃` from theorem statements — expose concrete let-bindings (from div128,
+      mulsub, addback sub-specs) in postconditions instead. Callers use `intro_lets` to get
+      named local definitions like `q_trial := ...`, `un0 := ...` with known values.
+      This enables applying `mulsub_register_4limb_val256` → `single_iteration_correct` →
+      `val256_euclidean_to_div_mod` to prove semantic correctness.
   - Stack-level specs with `evmWordIs (sp+32) (EvmWord.div a b)` / `(EvmWord.mod a b)` in postcondition
   - Combined spec merging b=0 + b≠0 into single `evm_div_stack_spec`/`evm_mod_stack_spec`
 


### PR DESCRIPTION
## Summary
- Move 13 existentially quantified output variables from inside `loopBodyPostN{1,2,3,4}` definitions to their parameters
- Theorem statements wrap with `∃` instead, keeping callers largely unchanged
- This is **step 1** of the semantic correctness path: making definitions parametric so step 2 can expose concrete let-bindings

Step 2 (future PR): replace the `∃` in theorem statements with concrete let-bindings from the div128/mulsub/addback sub-specs, enabling callers to reason about output values in terms of inputs.

## Files changed (21)
- `LoopBodyN{1,2,3,4}.lean`: parametric definitions + updated theorem postconditions
- `{Div,Mod}N{1,2,3,4}Full{,Shift0}.lean`: updated callers (obtain before unfold)
- `PLAN.md`: documented two-step semantic correctness plan

## Test plan
- [x] `lake build` succeeds (3473 jobs, 0 errors)
- [x] All existing proofs preserved (mechanical refactoring only)
- [x] N4 verified independently before N1-N3

🤖 Generated with [Claude Code](https://claude.com/claude-code)