### PR TITLE
Add infrastructure for DivMod stack-level specs

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
@@ -244,7 +244,7 @@ set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
 /-- Concrete loop body for n=4, j=0, MAX+SKIP case (BLTU not taken, borrow=0).
     Postcondition uses mulsubN4 outputs directly — no existentials. -/
-theorem divK_loop_body_n4_j0_max_skip_concrete
+private theorem divK_loop_body_n4_j0_max_skip_concrete_raw
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
@@ -342,7 +342,7 @@ set_option maxRecDepth 8192 in
 set_option maxHeartbeats 12800000 in
 /-- Concrete loop body for n=4, j=0, MAX+ADDBACK case (BLTU not taken, borrow≠0).
     Postcondition uses addbackN4 outputs directly — no existentials. -/
-theorem divK_loop_body_n4_j0_max_addback_concrete
+private theorem divK_loop_body_n4_j0_max_addback_concrete_raw
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
@@ -466,7 +466,7 @@ set_option maxHeartbeats 12800000 in
 /-- Concrete loop body for n=4, j=0, CALL+SKIP case (BLTU taken, borrow=0).
     Postcondition uses mulsubN4 outputs directly — no existentials.
     Scratch memory (ret, d, dlo, un0) updated to div128 values. -/
-theorem divK_loop_body_n4_j0_call_skip_concrete
+private theorem divK_loop_body_n4_j0_call_skip_concrete_raw
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
@@ -818,5 +818,194 @@ theorem divK_loop_body_n4_j0_call_addback_concrete
   simp only [trialQuotientN4, hbltu, ite_true] at raw
   intro_lets at raw
   exact raw (by simp [hborrow])
+
+-- ============================================================================
+-- MAX+SKIP wrapper (¬BLTU, ¬borrow)
+-- ============================================================================
+
+set_option maxHeartbeats 1600000 in
+theorem divK_loop_body_n4_j0_max_skip_concrete
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : ¬BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    ¬BitVec.ult u_top ms.2.2.2.2 →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fun h => loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+        ms.2.2.2.1 ms.2.2.2.2 q_hat ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) q_hat
+        ret_mem d_mem dlo_mem scratch_un0 h) := by
+  intro u_base q_addr q_hat ms hborrow
+  have raw := divK_loop_body_n4_j0_max_skip_concrete_raw
+    sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+    hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2
+    hv_v3 hv_u3 hv_u4 hv_q hbltu
+  simp only [trialQuotientN4, show BitVec.ult u_top v3 = false from Bool.eq_false_iff.mpr hbltu, ite_false] at raw
+  intro_lets at raw
+  exact raw (by simp [show ¬(BitVec.ult u_top ms.2.2.2.2 = true) from hborrow])
+
+-- ============================================================================
+-- MAX+ADDBACK wrapper (¬BLTU, borrow)
+-- ============================================================================
+
+set_option maxHeartbeats 1600000 in
+theorem divK_loop_body_n4_j0_max_addback_concrete
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : ¬BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    BitVec.ult u_top ms.2.2.2.2 →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fun h => loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+        ab.2.2.2.1 ms.2.2.2.2 (q_hat + signExtend12 4095)
+        ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 (q_hat + signExtend12 4095)
+        ret_mem d_mem dlo_mem scratch_un0 h) := by
+  intro u_base q_addr q_hat ms ab hborrow
+  have raw := divK_loop_body_n4_j0_max_addback_concrete_raw
+    sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+    hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2
+    hv_v3 hv_u3 hv_u4 hv_q hbltu
+  simp only [trialQuotientN4, show BitVec.ult u_top v3 = false from Bool.eq_false_iff.mpr hbltu, ite_false] at raw
+  intro_lets at raw
+  exact raw (by simp [hborrow])
+
+-- ============================================================================
+-- CALL+SKIP wrapper (BLTU, ¬borrow)
+-- ============================================================================
+
+set_option maxHeartbeats 1600000 in
+theorem divK_loop_body_n4_j0_call_skip_concrete
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    ¬BitVec.ult u_top ms.2.2.2.2 →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fun h => loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+        ms.2.2.2.1 ms.2.2.2.2 q_hat ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) q_hat
+        (base + 516) v3
+        ((v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+        ((u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) h) := by
+  intro u_base q_addr q_hat ms hborrow
+  have raw := divK_loop_body_n4_j0_call_skip_concrete_raw
+    sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+    hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0
+    halign hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu
+  simp only [trialQuotientN4, hbltu, ite_true] at raw
+  intro_lets at raw
+  exact raw (by simp [show ¬(BitVec.ult u_top ms.2.2.2.2 = true) from hborrow])
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
@@ -598,7 +598,7 @@ set_option maxHeartbeats 12800000 in
 /-- Concrete loop body for n=4, j=0, CALL+ADDBACK case (BLTU taken, borrow≠0).
     Postcondition uses addbackN4 outputs directly — no existentials.
     Scratch memory (ret, d, dlo, un0) updated to div128 values. -/
-theorem divK_loop_body_n4_j0_call_addback_concrete
+private theorem divK_loop_body_n4_j0_call_addback_concrete_raw
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
@@ -750,5 +750,73 @@ theorem divK_loop_body_n4_j0_call_addback_concrete
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by unfold loopBodyPostN4; xperm_hyp hp)
     full
+
+set_option maxHeartbeats 1600000 in
+/-- Concrete loop body for n=4, j=0, CALL+ADDBACK case (BLTU taken, borrow).
+    Clean statement using trialQuotientN4/mulsubN4/addbackN4 instead of let-chains. -/
+theorem divK_loop_body_n4_j0_call_addback_concrete
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    BitVec.ult u_top ms.2.2.2.2 →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fun h => loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+        ab.2.2.2.1 ms.2.2.2.2 (q_hat + signExtend12 4095)
+        ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 (q_hat + signExtend12 4095)
+        (base + 516) v3
+        ((v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+        ((u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) h) := by
+  intro u_base q_addr q_hat ms ab hborrow
+  have raw := divK_loop_body_n4_j0_call_addback_concrete_raw
+    sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+    hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0
+    halign hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu
+  -- Unfold trialQuotientN4 in the raw theorem type to match
+  simp only [trialQuotientN4, hbltu, ite_true] at raw
+  intro_lets at raw
+  exact raw (by simp [hborrow])
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4Concrete.lean
@@ -145,6 +145,52 @@ def loopBodyN4Output
    out_u4v, out_qv, out_retv, out_dv, out_dlov, out_sunv)
 
 -- ============================================================================
+-- Unified loop iteration output (case-splits on borrow internally)
+-- ============================================================================
+
+/-- Unified output of one n=4 loop iteration: computes trial quotient,
+    multiply-subtract, and conditionally addback. Returns
+    (q_final, un0_final, un1_final, un2_final, un3_final, u4_final). -/
+def loopIterN4 (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let q_hat := trialQuotientN4 v3 u3 u_top
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let un0 := ms.1; let un1 := ms.2.1; let un2 := ms.2.2.1
+  let un3 := ms.2.2.2.1; let c3 := ms.2.2.2.2
+  let u4_new := u_top - c3
+  if BitVec.ult u_top c3 then
+    let ab := addbackN4 un0 un1 un2 un3 u4_new v0 v1 v2 v3
+    (q_hat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2)
+  else
+    (q_hat, un0, un1, un2, un3, u4_new)
+
+/-- The mulsub carry c3 from one loop iteration. -/
+def loopIterN4_c3 (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Word :=
+  (mulsubN4 (trialQuotientN4 v3 u3 u_top) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+
+/-- Scratch memory values after loop body. -/
+def loopScratchN4 (v3 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base : Word) :
+    Word × Word × Word × Word :=
+  if BitVec.ult u_top v3 then
+    ( base + 516, v3,
+      (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat,
+      (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat )
+  else (ret_mem, d_mem, dlo_mem, scratch_un0)
+
+/-- Unified loop body postcondition for n=4, j=0.
+    All output values expressed via loopIterN4, loopIterN4_c3, loopScratchN4. -/
+def loopBodyN4_fullpost
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     ret_mem d_mem dlo_mem scratch_un0 base : Word) : Assertion :=
+  let out := loopIterN4 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let c3 := loopIterN4_c3 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let scr := loopScratchN4 v3 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base
+  loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+    out.2.2.2.2.1 c3 out.1
+    out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 out.2.2.2.2.2 out.1
+    scr.1 scr.2.1 scr.2.2.1 scr.2.2.2
+
+-- ============================================================================
 -- Semantic bridge: mulsub equation from loopBodyN4Output
 -- ============================================================================
 

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4Unified.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4Unified.lean
@@ -1,0 +1,234 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopBodyN4Unified
+
+  Unified loop body spec for n=4, j=0: combines the 4 per-case concrete specs
+  (max_skip, max_addback, call_skip, call_addback) into a single cpsTriple
+  with postcondition expressed via loopBodyN4_fullpost.
+
+  The postcondition uses externally defined functions (loopIterN4,
+  loopIterN4_c3, loopScratchN4) — no let-chains in the theorem type.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBodyN4Concrete
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- trialQuotientN4 case lemmas
+-- ============================================================================
+
+private theorem trialQuotientN4_max (v3 u3 u_top : Word) (h : ¬BitVec.ult u_top v3) :
+    trialQuotientN4 v3 u3 u_top = signExtend12 (4095 : BitVec 12) := by
+  unfold trialQuotientN4; simp [Bool.eq_false_iff.mpr h]
+
+-- ============================================================================
+-- Postcondition matching lemmas: show loopBodyN4_fullpost agrees with each
+-- concrete spec's postcondition in the corresponding case.
+-- ============================================================================
+
+/-- In the MAX+SKIP case (¬BLTU, ¬borrow), loopBodyN4_fullpost
+    equals the max_skip concrete spec's postcondition. -/
+private theorem fullpost_eq_max_skip
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base : Word)
+    (hbltu : ¬BitVec.ult u_top v3)
+    (hborrow : ¬BitVec.ult u_top
+      (mulsubN4 (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let q_hat := signExtend12 (4095 : BitVec 12)
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    loopBodyN4_fullpost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      ret_mem d_mem dlo_mem scratch_un0 base =
+    loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+      ms.2.2.2.1 ms.2.2.2.2 q_hat
+      ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) q_hat
+      ret_mem d_mem dlo_mem scratch_un0 := by
+  intro q_hat ms
+  have hq := trialQuotientN4_max v3 u3 u_top hbltu
+  have hb1 : BitVec.ult u_top v3 = false := Bool.eq_false_iff.mpr hbltu
+  have hb2 : BitVec.ult u_top (mulsubN4 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = false := Bool.eq_false_iff.mpr hborrow
+  unfold loopBodyN4_fullpost loopIterN4 loopIterN4_c3 loopScratchN4
+  simp only [hq, hb1, hb2, ite_true, ite_false, Bool.false_eq_true, ↓reduceIte]; rfl
+
+/-- In the MAX+ADDBACK case (¬BLTU, borrow), loopBodyN4_fullpost
+    equals the max_addback concrete spec's postcondition. -/
+private theorem fullpost_eq_max_addback
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base : Word)
+    (hbltu : ¬BitVec.ult u_top v3)
+    (hborrow : BitVec.ult u_top
+      (mulsubN4 (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let q_hat := signExtend12 (4095 : BitVec 12)
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    loopBodyN4_fullpost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      ret_mem d_mem dlo_mem scratch_un0 base =
+    loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+      ab.2.2.2.1 ms.2.2.2.2 (q_hat + signExtend12 4095)
+      ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 (q_hat + signExtend12 4095)
+      ret_mem d_mem dlo_mem scratch_un0 := by
+  intro q_hat ms ab
+  have hq := trialQuotientN4_max v3 u3 u_top hbltu
+  have hb1 : BitVec.ult u_top v3 = false := Bool.eq_false_iff.mpr hbltu
+  unfold loopBodyN4_fullpost loopIterN4 loopIterN4_c3 loopScratchN4
+  simp only [hq, hb1, hborrow, ite_true, ite_false, Bool.false_eq_true, ↓reduceIte]; rfl
+
+/-- In the CALL+SKIP case (BLTU, ¬borrow), loopBodyN4_fullpost
+    equals the call_skip concrete spec's postcondition. -/
+private theorem fullpost_eq_call_skip
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base : Word)
+    (hbltu : BitVec.ult u_top v3)
+    (hborrow : ¬BitVec.ult u_top
+      (mulsubN4 (trialQuotientN4 v3 u3 u_top) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    loopBodyN4_fullpost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      ret_mem d_mem dlo_mem scratch_un0 base =
+    loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+      ms.2.2.2.1 ms.2.2.2.2 q_hat
+      ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) q_hat
+      (base + 516) v3
+      ((v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+      ((u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) := by
+  intro q_hat ms
+  have hb2 : BitVec.ult u_top (mulsubN4 (trialQuotientN4 v3 u3 u_top) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = false := Bool.eq_false_iff.mpr hborrow
+  unfold loopBodyN4_fullpost loopIterN4 loopIterN4_c3 loopScratchN4
+  simp only [hbltu, hb2, ite_true, ite_false, Bool.false_eq_true, ↓reduceIte]; rfl
+
+/-- In the CALL+ADDBACK case (BLTU, borrow), loopBodyN4_fullpost
+    equals the call_addback concrete spec's postcondition. -/
+private theorem fullpost_eq_call_addback
+    (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top ret_mem d_mem dlo_mem scratch_un0 base : Word)
+    (hbltu : BitVec.ult u_top v3)
+    (hborrow : BitVec.ult u_top
+      (mulsubN4 (trialQuotientN4 v3 u3 u_top) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let q_hat := trialQuotientN4 v3 u3 u_top
+    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    loopBodyN4_fullpost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      ret_mem d_mem dlo_mem scratch_un0 base =
+    loopBodyPostN4 sp (0 : Word) v0 v1 v2 v3
+      ab.2.2.2.1 ms.2.2.2.2 (q_hat + signExtend12 4095)
+      ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 (q_hat + signExtend12 4095)
+      (base + 516) v3
+      ((v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+      ((u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) := by
+  intro q_hat ms ab
+  unfold loopBodyN4_fullpost loopIterN4 loopIterN4_c3 loopScratchN4
+  simp only [hbltu, hborrow, ite_true, ite_false, Bool.false_eq_true, ↓reduceIte]; rfl
+
+-- ============================================================================
+-- Unified loop body theorem for n=4 at j=0
+-- ============================================================================
+
+set_option maxRecDepth 8192 in
+set_option maxHeartbeats 12800000 in
+/-- Unified loop body for n=4, j=0: entry at base+448, exit at base+904.
+    Combines all 4 per-case concrete specs. Postcondition uses
+    loopBodyN4_fullpost — no let-chains in the theorem type. -/
+theorem divK_loop_body_n4_j0_unified
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - ((0 : Word) + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (loopBodyN4_fullpost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        ret_mem d_mem dlo_mem scratch_un0 base) := by
+  intro u_base q_addr
+  -- Case split: BLTU taken (u_top < v3) or not
+  by_cases hbltu : BitVec.ult u_top v3
+  · -- CALL path: trial quotient via div128
+    -- Get the mulsub carry for the borrow case split
+    let c3_val := (mulsubN4 (trialQuotientN4 v3 u3 u_top) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+    by_cases hborrow : BitVec.ult u_top c3_val
+    · -- CALL + ADDBACK
+      rw [fullpost_eq_call_addback sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        ret_mem d_mem dlo_mem scratch_un0 base hbltu hborrow]
+      have hspec := divK_loop_body_n4_j0_call_addback_concrete
+        sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+        hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0
+        halign hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu
+      intro_lets at hspec
+      have hbne : (if BitVec.ult u_top c3_val then (1 : Word) else 0) ≠ (0 : Word) := by
+        simp [hborrow]
+      exact hspec hbne
+    · -- CALL + SKIP
+      rw [fullpost_eq_call_skip sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        ret_mem d_mem dlo_mem scratch_un0 base hbltu hborrow]
+      have hspec := divK_loop_body_n4_j0_call_skip_concrete
+        sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+        hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0
+        halign hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu
+      intro_lets at hspec
+      have hbeq : (if BitVec.ult u_top c3_val then (1 : Word) else 0) = (0 : Word) := by
+        simp [hborrow]
+      exact hspec hbeq
+  · -- MAX path: trial quotient = MAX64
+    let c3_val := (mulsubN4 (signExtend12 (4095 : BitVec 12)) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+    by_cases hborrow : BitVec.ult u_top c3_val
+    · -- MAX + ADDBACK
+      rw [fullpost_eq_max_addback sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        ret_mem d_mem dlo_mem scratch_un0 base hbltu hborrow]
+      have hspec := divK_loop_body_n4_j0_max_addback_concrete
+        sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+        hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2
+        hv_v3 hv_u3 hv_u4 hv_q hbltu
+      intro_lets at hspec
+      have hbne : (if BitVec.ult u_top c3_val then (1 : Word) else 0) ≠ (0 : Word) := by
+        simp [hborrow]
+      exact hspec hbne
+    · -- MAX + SKIP
+      rw [fullpost_eq_max_skip sp v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        ret_mem d_mem dlo_mem scratch_un0 base hbltu hborrow]
+      have hspec := divK_loop_body_n4_j0_max_skip_concrete
+        sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+        hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2
+        hv_v3 hv_u3 hv_u4 hv_q hbltu
+      intro_lets at hspec
+      have hbeq : (if BitVec.ult u_top c3_val then (1 : Word) else 0) = (0 : Word) := by
+        simp [hborrow]
+      exact hspec hbeq
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/NormDefs.lean
+++ b/EvmAsm/Evm64/DivMod/NormDefs.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.DivMod.NormDefs
+
+  Standalone definitions for the normalization/denormalization computations
+  in Knuth Algorithm D. These replace let-chains in theorem type signatures,
+  making specs easier to compose and use downstream.
+
+  Normalization: left-shift a[] and b[] by the CLZ of the leading divisor limb.
+  Denormalization: right-shift the remainder back after division.
+-/
+
+import EvmAsm.Rv64.Basic
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Normalization: shift b[] and a[] left by `shift` bits
+-- ============================================================================
+
+/-- Normalize a non-leading limb by shifting left and OR-ing in bits from the
+    lower-adjacent limb. Used for b[1], b[2], b[3] and u[1], u[2], u[3]. -/
+def normLimb (prev cur shift anti_shift : Word) : Word :=
+  (cur <<< (shift.toNat % 64)) ||| (prev >>> (anti_shift.toNat % 64))
+
+/-- Normalize the lowest limb (no lower neighbor to OR in). -/
+def normLimb_lo (lo shift : Word) : Word :=
+  lo <<< (shift.toNat % 64)
+
+/-- Compute the carry limb above the top a[] limb after normalization. -/
+def normLimb_top (hi anti_shift : Word) : Word :=
+  hi >>> (anti_shift.toNat % 64)
+
+/-- Bundle: normalize all 4 b-limbs.
+    Returns (b0', b1', b2', b3') where b[] is left-shifted by `shift`. -/
+def normBLimbs (b0 b1 b2 b3 shift anti_shift : Word) :
+    Word × Word × Word × Word :=
+  ( normLimb_lo b0 shift,
+    normLimb b0 b1 shift anti_shift,
+    normLimb b1 b2 shift anti_shift,
+    normLimb b2 b3 shift anti_shift )
+
+/-- Bundle: normalize all 4 a-limbs plus carry.
+    Returns (u0, u1, u2, u3, u4) where a[] is left-shifted by `shift`
+    and u4 is the overflow carry. -/
+def normULimbs (a0 a1 a2 a3 shift anti_shift : Word) :
+    Word × Word × Word × Word × Word :=
+  ( normLimb_lo a0 shift,
+    normLimb a0 a1 shift anti_shift,
+    normLimb a1 a2 shift anti_shift,
+    normLimb a2 a3 shift anti_shift,
+    normLimb_top a3 anti_shift )
+
+-- ============================================================================
+-- Denormalization: shift remainder u[] right by `shift` bits
+-- ============================================================================
+
+/-- Denormalize a non-top remainder limb by shifting right and OR-ing in
+    bits from the higher-adjacent limb. -/
+def denormLimb (cur next shift anti_shift : Word) : Word :=
+  (cur >>> (shift.toNat % 64)) ||| (next <<< (anti_shift.toNat % 64))
+
+/-- Denormalize the top remainder limb (no higher neighbor). -/
+def denormLimb_top (hi shift : Word) : Word :=
+  hi >>> (shift.toNat % 64)
+
+/-- Bundle: denormalize 4 remainder limbs.
+    Returns (r0', r1', r2', r3') where u[] is right-shifted by `shift`. -/
+def denormRLimbs (u0 u1 u2 u3 shift anti_shift : Word) :
+    Word × Word × Word × Word :=
+  ( denormLimb u0 u1 shift anti_shift,
+    denormLimb u1 u2 shift anti_shift,
+    denormLimb u2 u3 shift anti_shift,
+    denormLimb_top u3 shift )
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `NormDefs.lean` with standalone defs for normalization/denormalization (replacing let-chains in theorem types)
- Add `loopIterN4`, `loopIterN4_c3`, `loopScratchN4`, `loopBodyN4_fullpost` defs to `LoopBodyN4Concrete.lean`
- Wrap all 4 concrete loop body specs (`max_skip`, `max_addback`, `call_skip`, `call_addback`) with clean public types using `trialQuotientN4`/`mulsubN4`/`addbackN4` instead of ~40 let-bindings
- Add `LoopBodyN4Unified.lean` with unified loop body theorem combining all 4 cases via `loopBodyN4_fullpost` postcondition

## Test plan
- [ ] `lake build EvmAsm.Evm64.DivMod.NormDefs`
- [ ] `lake build EvmAsm.Evm64.DivMod.LoopBodyN4Concrete`
- [ ] `lake build EvmAsm.Evm64.DivMod.LoopBodyN4Unified`
- [ ] Full `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)