### PR TITLE
Extract denorm and normB postconditions into opaque defs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -280,4 +280,74 @@ theorem loopSetupPost_unfold (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     ((sp + signExtend12 3992) ↦ₘ shift) := by
   delta loopSetupPost; rfl
 
+-- ============================================================================
+-- Postcondition bundles for denorm + epilogue paths
+-- ============================================================================
+
+/-- Postcondition for DIV denorm + epilogue (shift ≠ 0).
+    Encapsulates anti_shift and denormalized u'[0..3]. -/
+@[irreducible]
+def denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) : Assertion :=
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
+  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
+  (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
+  ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+  ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
+  ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+  ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+  ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
+  ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)
+
+theorem denormDivPost_unfold (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
+    denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3 =
+    let anti_shift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let u3' := u3 >>> (shift.toNat % 64)
+    (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
+    (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
+    ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+    ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
+    ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+    ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+    ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
+    ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3) := by
+  delta denormDivPost; rfl
+
+/-- Postcondition for MOD denorm + epilogue (shift ≠ 0).
+    Encapsulates anti_shift and denormalized u'[0..3]. -/
+@[irreducible]
+def denormModPost (sp shift u0 u1 u2 u3 : Word) : Assertion :=
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
+  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
+  (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
+  ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+  ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
+  ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
+  ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3')
+
+theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
+    denormModPost sp shift u0 u1 u2 u3 =
+    let anti_shift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let u3' := u3 >>> (shift.toNat % 64)
+    (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
+    (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
+    ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
+    ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
+    ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
+    ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3') := by
+  delta denormModPost; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -350,4 +350,47 @@ theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
     ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3') := by
   delta denormModPost; rfl
 
+-- ============================================================================
+-- Postcondition bundle for normB (PhaseAB + CLZ + PhaseC2 + NormB)
+-- ============================================================================
+
+/-- Postcondition after PhaseAB + CLZ + PhaseC2(ntaken) + NormB.
+    Encapsulates shift, anti_shift, and normalized b'[0..3]. -/
+@[irreducible]
+def normBPost (sp n_val shift b0 b1 b2 b3 : Word) : Assertion :=
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
+  (.x2 ↦ᵣ anti_shift) **
+  ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+  ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+  ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
+theorem normBPost_unfold (sp n_val shift b0 b1 b2 b3 : Word) :
+    normBPost sp n_val shift b0 b1 b2 b3 =
+    let anti_shift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let b0' := b0 <<< (shift.toNat % 64)
+    (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
+    (.x2 ↦ᵣ anti_shift) **
+    ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+    ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+    ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+    ((sp + signExtend12 3992) ↦ₘ shift) := by
+  delta normBPost; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -102,12 +102,6 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
     (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true) :
-    let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple base (base + 312) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -118,17 +112,9 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x2 ↦ᵣ anti_shift) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  intro shift anti_shift b3' b2' b1' b0'
+      (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz hvalid hv_q0 hv_q1 hv_q2 hv_q3 hv_u5 hv_u6 hv_u7 hv_n
@@ -174,7 +160,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -237,7 +223,6 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
   have hNormB := evm_div_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem hbnz hb3nz hshift_nz hvalid
     hv_q0 hv_q1 hv_q2 hv_q3 hv_u5 hv_u6 hv_u7 hv_n hv_shift
-  intro_lets at hNormB
   -- Frame NormB result with a[], u[] scratch, x1
   have hNormBf := cpsTriple_frame_left _ _ _ _ _
     ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -266,7 +251,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     (by pcFree) hNormA
   -- Compose NormB → NormA
   have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hNormBf hNormAf
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
   -- Step 3: LoopSetup ntaken (base+432 → base+448)
   -- For n=4: m = signExtend12(4) - 4 = 0, so BLT 0 < 0 is false → ntaken
   have hLS := divK_loopSetup_ntaken_spec sp (4 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -470,11 +470,6 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 912) (base + 1064) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
@@ -484,15 +479,12 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
-       (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
-       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
-       ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) := by
-  intro anti_shift u0' u1' u2' u3'
+      (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) := by
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+912 → base+1004)
   have hDenorm := divK_denorm_body_spec sp u0 u1 u2 u3 v2 v5 v7 shift base
     hv_u0 hv_u1 hv_u2 hv_u3
@@ -521,7 +513,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hDenormF hEpiF
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by delta denormDivPost; xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -539,11 +531,6 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 912) (base + 1064) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
@@ -551,13 +538,12 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
-       (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
-       ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
-       ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3')) := by
-  intro anti_shift u0' u1' u2' u3'
+      (denormModPost sp shift u0 u1 u2 u3) := by
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+912 → base+1004, modCode)
   have hDenorm := mod_denorm_body_spec sp u0 u1 u2 u3 v2 v5 v7 shift base
     hv_u0 hv_u1 hv_u2 hv_u3
@@ -583,7 +569,7 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hDenormF hEpiF
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by delta denormModPost; xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -607,11 +593,6 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 904) (base + 1064) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
@@ -622,16 +603,8 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
-       (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
-       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
-       ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) := by
-  intro anti_shift u0' u1' u2' u3'
+      (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3 **
+       ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- Step 1: Preamble (base+904 → base+912)
   have hPre := divK_denorm_preamble_spec sp shift v5 v6 v7 v2 v10 base hv_shift hshift_nz
   -- Frame preamble with u[], q[], output memory
@@ -646,7 +619,6 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
   -- Step 2: Denorm + Epilogue (base+912 → base+1064)
   have hDE := evm_div_denorm_epilogue_spec sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
     q0 q1 q2 q3 m0 m8 m16 m24 hvalid hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
-  intro_lets at hDE
   -- Frame epilogue with shift_mem
   have hDEF := cpsTriple_frame_left _ _ _ _ _
     (((sp + signExtend12 3992) ↦ₘ shift))
@@ -750,11 +722,6 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
     (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
-    let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 904) (base + 1064) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
@@ -763,14 +730,8 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
-       (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
-       ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
-       ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
-       ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3')) := by
-  intro anti_shift u0' u1' u2' u3'
+      (denormModPost sp shift u0 u1 u2 u3 **
+       ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- Step 1: Preamble (base+904 → base+912)
   have hPre := mod_denorm_preamble_spec sp shift v5 v6 v7 v2 v10 base hv_shift hshift_nz
   -- Frame preamble with u[], output memory
@@ -783,7 +744,6 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
   -- Step 2: Denorm + MOD Epilogue (base+912 → base+1064)
   have hDE := evm_mod_denorm_epilogue_spec sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
     m0 m8 m16 m24 hvalid hv_u0 hv_u1 hv_u2 hv_u3
-  intro_lets at hDE
   -- Frame epilogue with shift_mem
   have hDEF := cpsTriple_frame_left _ _ _ _ _
     (((sp + signExtend12 3992) ↦ₘ shift))

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -154,12 +154,6 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
     (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true) :
-    let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple base (base + 312) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -170,17 +164,9 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x2 ↦ᵣ anti_shift) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  intro shift anti_shift b3' b2' b1' b0'
+      (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
   have hABCLZ := evm_mod_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz hvalid hv_q0 hv_q1 hv_q2 hv_q3 hv_u5 hv_u6 hv_u7 hv_n
   have hABCLZf := cpsTriple_frame_left _ _ _ _ _
@@ -219,7 +205,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
+    (fun h hq => by delta normBPost; xperm_hyp hq)
     hFull
 
 -- ============================================================================
@@ -281,7 +267,6 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
   have hNormB := evm_mod_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem hbnz hb3nz hshift_nz hvalid
     hv_q0 hv_q1 hv_q2 hv_q3 hv_u5 hv_u6 hv_u7 hv_n hv_shift
-  intro_lets at hNormB
   have hNormBf := cpsTriple_frame_left _ _ _ _ _
     ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -307,7 +292,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
   have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hNormBf hNormAf
+    (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
   -- Step 3: LoopSetup ntaken (base+432 → base+448)
   have hLS := mod_loopSetup_ntaken_spec sp (4 : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base hv_n


### PR DESCRIPTION
## Summary
- Define `@[irreducible] denormDivPost` and `denormModPost` in `Compose/Base.lean` encapsulating 5 let bindings (anti_shift, u0'-u3') for the denorm+epilogue postconditions
- Define `@[irreducible] normBPost` encapsulating 6 let bindings (shift, anti_shift, b0'-b3') for the PhaseAB+CLZ+C2+NormB postcondition
- Update 4 denorm/preamble specs in `FullPath.lean` and 2 normB specs in `FullPath.lean`/`ModFullPath.lean`
- Preamble variants use `denormDivPost/denormModPost ** shift_mem` (framed composition)
- LoopSetup consumers use `delta normBPost at hp` in perm callbacks

## Test plan
- [x] `lake build` passes with no errors or warnings
- [x] No `sorry` introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)