### PR TITLE
Add N1 loop exit defs and wrap max_skip with loopBodyN1SkipPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -17,6 +17,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
+import EvmAsm.Evm64.DivMod.LoopDefs
 
 open EvmAsm.Rv64.Tactics
 
@@ -87,37 +88,10 @@ theorem divK_loop_body_n1_max_skip_spec
     (hv_q : isValidDwordAccess (sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat) = true)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat := signExtend12 4095  -- MAX64
-    -- Mulsub intermediates
-    let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
-    let fs0 := p0_lo + (signExtend12 0 : Word)
-    let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-    let pc0 := ba0 + p0_hi
-    let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-    let un0 := u0 - fs0; let c0 := pc0 + bs0
-    let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
-    let fs1 := p1_lo + c0
-    let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-    let pc1 := ba1 + p1_hi
-    let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-    let un1 := u1 - fs1; let c1 := pc1 + bs1
-    let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
-    let fs2 := p2_lo + c1
-    let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-    let pc2 := ba2 + p2_hi
-    let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-    let un2 := u2 - fs2; let c2 := pc2 + bs2
-    let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
-    let fs3 := p3_lo + c2
-    let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-    let pc3 := ba3 + p3_hi
-    let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-    let un3 := u3 - fs3; let c3 := pc3 + bs3
-    let u4_new := u_top - c3
-    let j' := j + signExtend12 4095
+    let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + 448) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -130,38 +104,37 @@ theorem divK_loop_body_n1_max_skip_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      -- Taken exit: loop back to base+448
-      (base + 448)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-       (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-       (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_hat) **
-       (.x2 ↦ᵣ un3) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4_new) **
-       (q_addr ↦ₘ q_hat))
-      -- Not-taken exit: exit loop to base+904
-      (base + 904)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-       (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-       (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_hat) **
-       (.x2 ↦ᵣ un3) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4_new) **
-       (q_addr ↦ₘ q_hat)) := by
-  intro u_base q_hat
-        p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
-        p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
-        p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
-        p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3 u4_new
-        j' q_addr hborrow
+      (base + 448) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + 904) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+  intro u_base q_hat q_addr hborrow
+  -- Expand mulsub computation locally for intermediate steps
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := u_top - c3
+  let j' := j + signExtend12 4095
   -- Abbreviation for vtop_base (register value, not a memory address)
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516), instantiated with n=1, u_hi=u1, u_lo=u0, v_top=v0
@@ -211,8 +184,8 @@ theorem divK_loop_body_n1_max_skip_spec
   -- 8. Permute final cpsBranch to match target
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    (fun h hp => by delta loopBodyN1SkipPost mulsubN4 loopExitPostN1; rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    (fun h hp => by delta loopBodyN1SkipPost mulsubN4 loopExitPostN1; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopDefs.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs.lean
@@ -151,4 +151,44 @@ def loopBodyN4AddbackPost (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : As
 def mulsubN4_c3 (q_hat v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Word :=
   (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
 
+-- ============================================================================
+-- Loop exit postcondition for n=1
+-- Same assertion shape as n=4, but with (1 : Word) for the n-value cell.
+-- ============================================================================
+
+/-- Loop exit postcondition for n=1. -/
+@[irreducible]
+def loopExitPostN1 (sp j q_f c3 un0_f un1_f un2_f un3_f u4_f
+    v0 v1 v2 v3 : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let j' := j + signExtend12 4095
+  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
+  (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_f) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_f) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_f) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_f) **
+  ((u_base + signExtend12 4064) ↦ₘ u4_f) **
+  (q_addr ↦ₘ q_f)
+
+/-- Full mulsub-skip postcondition for n=1 loop body. -/
+@[irreducible]
+def loopBodyN1SkipPost (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  loopExitPostN1 sp j q_hat ms.2.2.2.2 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+
+/-- Full mulsub-addback postcondition for n=1 loop body. -/
+@[irreducible]
+def loopBodyN1AddbackPost (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let un0 := ms.1; let un1 := ms.2.1; let un2 := ms.2.2.1
+  let un3 := ms.2.2.2.1; let c3 := ms.2.2.2.2
+  let u4_new := u_top - c3
+  let ab := addbackN4 un0 un1 un2 un3 u4_new v0 v1 v2 v3
+  loopExitPostN1 sp j (q_hat + signExtend12 4095) c3 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `loopExitPostN1`, `loopBodyN1SkipPost`, `loopBodyN1AddbackPost` to `LoopDefs.lean` (same shape as N4 but `(1 : Word)` for n-value)
- Transform `divK_loop_body_n1_max_skip_spec`: remove 28 mulsub let bindings from type
- Both cpsBranch exits use `loopBodyN1SkipPost`, borrow condition uses `mulsubN4_c3`

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.LoopBodyN1` passes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)