### PR TITLE
Add n=4 j=0 loop body cpsTriple specs and cpsBranch combinators

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -137,4 +137,148 @@ theorem divK_loop_body_n4_max_skip_j0_spec
     (fun h hp => by delta loopBodyN4SkipPost mulsubN4 loopExitPostN4; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
+-- ============================================================================
+-- n=4, BLTU not-taken (max path) + BEQ addback, j=0 → cpsTriple to base+904
+-- ============================================================================
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 6400000 in
+/-- Loop body cpsTriple for n=4, max+addback, j=0.
+    Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
+theorem divK_loop_body_n4_max_addback_j0_spec
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : ¬BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat : Word := signExtend12 4095  -- MAX64
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    -- Hypothesis: borrow ≠ 0
+    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old))
+      (loopBodyN4AddbackPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+  intro u_base q_hat q_addr hborrow
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := u_top - c3
+  -- Addback intermediates
+  let upc0 := un0 + (signExtend12 0 : Word)
+  let ac1_0 := if BitVec.ult upc0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let aun0 := upc0 + v0
+  let ac2_0 := if BitVec.ult aun0 v0 then (1 : Word) else 0
+  let aco0 := ac1_0 ||| ac2_0
+  let upc1 := un1 + aco0
+  let ac1_1 := if BitVec.ult upc1 aco0 then (1 : Word) else 0
+  let aun1 := upc1 + v1
+  let ac2_1 := if BitVec.ult aun1 v1 then (1 : Word) else 0
+  let aco1 := ac1_1 ||| ac2_1
+  let upc2 := un2 + aco1
+  let ac1_2 := if BitVec.ult upc2 aco1 then (1 : Word) else 0
+  let aun2 := upc2 + v2
+  let ac2_2 := if BitVec.ult aun2 v2 then (1 : Word) else 0
+  let aco2 := ac1_2 ||| ac2_2
+  let upc3 := un3 + aco2
+  let ac1_3 := if BitVec.ult upc3 aco2 then (1 : Word) else 0
+  let aun3 := upc3 + v3
+  let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
+  let aco3 := ac1_3 ||| ac2_3
+  let aun4 := u4_new + aco3
+  let q_hat' := q_hat + signExtend12 4095
+  let j' := (0 : Word) + signExtend12 4095
+  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- 1. Trial max full (base+448 → base+516)
+  have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
+    u_top u3 v3 base hv_j hv_n1 hv_uhi hv_ulo hv_vtop hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n4 sp (0 : Word)] at TF
+  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
+  rw [vtop_eq_v3_n4 sp] at TF
+  -- 2. Mulsub + correction addback (base+516 → base+880)
+  have MCA := divK_mulsub_correction_addback_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    (0 : Word) u3 vtop_base u_top v3 v2_old base
+    hv_j hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4
+  intro_lets at MCA
+  have MCA0 := MCA hborrow
+  -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
+  have SL := divK_store_loop_j0_spec sp q_hat' aun4 aco3 q_old base hv_q
+  intro_lets at SL
+  -- 4. Frame TF
+  have TFf := cpsTriple_frame_left _ _ _ _ _
+    ((.x2 ↦ᵣ v2_old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     (q_addr ↦ₘ q_old))
+    (by pcFree) TF
+  -- 5. Compose TF + MCA0
+  seqFrame TFf MCA0
+  -- 6. Frame store_loop_j0 with remaining atoms
+  have SLf := cpsTriple_frame_left _ _ _ _ _
+    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
+     ((u_base + signExtend12 4064) ↦ₘ aun4) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)))
+    (by pcFree) SL
+  -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
+  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
+  -- 8. Permute final cpsTriple to match target
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by delta loopBodyN4AddbackPost mulsubN4 addbackN4 loopExitPostN4; rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -1,0 +1,140 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopIterN4
+
+  Loop body cpsTriple specs for n=4 at j=0.
+  These are the j=0-specialized versions of the LoopBodyN4 cpsBranch specs,
+  using divK_store_loop_j0_spec to eliminate the loop-back branch and
+  produce clean cpsTriples from base+448 to base+904.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopBodyN4
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- n=4, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTriple to base+904
+-- ============================================================================
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 6400000 in
+/-- Loop body cpsTriple for n=4, max+skip, j=0.
+    Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
+theorem divK_loop_body_n4_max_skip_j0_spec
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (base : Word)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_u0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_u1 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_u2 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u3 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hbltu : ¬BitVec.ult u_top v3) :
+    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let q_hat : Word := signExtend12 4095  -- MAX64
+    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    -- Hypothesis: borrow = 0
+    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       (q_addr ↦ₘ q_old))
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+  intro u_base q_hat q_addr hborrow
+  -- Expand mulsub computation locally
+  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let fs0 := p0_lo + (signExtend12 0 : Word)
+  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
+  let pc0 := ba0 + p0_hi
+  let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
+  let un0 := u0 - fs0; let c0 := pc0 + bs0
+  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let fs1 := p1_lo + c0
+  let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
+  let pc1 := ba1 + p1_hi
+  let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
+  let un1 := u1 - fs1; let c1 := pc1 + bs1
+  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let fs2 := p2_lo + c1
+  let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
+  let pc2 := ba2 + p2_hi
+  let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
+  let un2 := u2 - fs2; let c2 := pc2 + bs2
+  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let fs3 := p3_lo + c2
+  let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
+  let pc3 := ba3 + p3_hi
+  let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
+  let un3 := u3 - fs3; let c3 := pc3 + bs3
+  let u4_new := u_top - c3
+  let j' := (0 : Word) + signExtend12 4095
+  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- 1. Trial max full (base+448 → base+516)
+  have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
+    u_top u3 v3 base hv_j hv_n1 hv_uhi hv_ulo hv_vtop hbltu
+  dsimp only [] at TF
+  rw [u_addr_eq_n4 sp (0 : Word)] at TF
+  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
+  rw [vtop_eq_v3_n4 sp] at TF
+  -- 2. Mulsub + correction skip (base+516 → base+880)
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    (0 : Word) u3 vtop_base u_top v3 v2_old base
+    hv_j hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4
+  intro_lets at MCS
+  have MCS0 := MCS hborrow
+  -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
+  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base hv_q
+  intro_lets at SL
+  -- 4. Frame TF with mulsub cells
+  have TFf := cpsTriple_frame_left _ _ _ _ _
+    ((.x2 ↦ᵣ v2_old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     (q_addr ↦ₘ q_old))
+    (by pcFree) TF
+  -- 5. Compose TF + MCS0
+  seqFrame TFf MCS0
+  -- 6. Frame store_loop_j0 with remaining atoms
+  have SLf := cpsTriple_frame_left _ _ _ _ _
+    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
+     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)))
+    (by pcFree) SL
+  -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
+  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
+  -- 8. Permute final cpsTriple to match target
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by delta loopBodyN4SkipPost mulsubN4 loopExitPostN4; rw [sepConj_assoc'] at hp; xperm_hyp hp)
+    full
+
+end EvmAsm.Evm64

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -200,6 +200,24 @@ theorem cpsBranch_merge (entry l_t l_f exit_ : Word) (cr1 cr_t cr_f : CodeReq)
     obtain ⟨k2, s2, hstep2, hpc2, hR⟩ := h_f F hF s1 hcrf' hQ_f hpc_f
     exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hR⟩
 
+/-- Like cpsBranch_merge but with the same CodeReq for all three specs.
+    No disjointness needed since code requirements are shared. -/
+theorem cpsBranch_merge_same_cr (entry l_t l_f exit_ : Word) (cr : CodeReq)
+    (P Q_t Q_f R : Assertion)
+    (hbr   : cpsBranch entry cr P l_t Q_t l_f Q_f)
+    (h_t   : cpsTriple l_t exit_ cr Q_t R)
+    (h_f   : cpsTriple l_f exit_ cr Q_f R) :
+    cpsTriple entry exit_ cr P R := by
+  intro F hF s hcr hPF hpc
+  obtain ⟨k1, s1, hstep1, hbranch⟩ := hbr F hF s hcr hPF hpc
+  rcases hbranch with ⟨hpc_t, hQ_t⟩ | ⟨hpc_f, hQ_f⟩
+  · have hcr' := CodeReq.SatisfiedBy_preserved cr k1 s s1 hstep1 hcr
+    obtain ⟨k2, s2, hstep2, hpc2, hR⟩ := h_t F hF s1 hcr' hQ_t hpc_t
+    exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hR⟩
+  · have hcr' := CodeReq.SatisfiedBy_preserved cr k1 s s1 hstep1 hcr
+    obtain ⟨k2, s2, hstep2, hpc2, hR⟩ := h_f F hF s1 hcr' hQ_f hpc_f
+    exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hR⟩
+
 /-- Extract the taken path from a cpsBranch when the not-taken postcondition
     is unsatisfiable (e.g., contains a contradictory pure fact). -/
 theorem cpsBranch_elim_taken (entry l_t l_f : Word) (cr : CodeReq)

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -909,6 +909,39 @@ theorem cpsBranch_seq_cpsBranch_with_perm_same_cr
       (fun _ hp => hp) (fun _ hp => hp) hperm h1)
     h2 ht1 ht2
 
+/-- Compose a cpsBranch (ntaken exit) with a cpsTriple, same CodeReq.
+    The taken exit is passed through with a postcondition weakening. -/
+theorem cpsBranch_seq_cpsTriple_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
+    (P Q_t1 Q_f1 Q_f2 Q_t : Assertion)
+    (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
+    (h2 : cpsTriple mid exit_f cr Q_f1 Q_f2)
+    (ht1 : ∀ h, Q_t1 h → Q_t h) :
+    cpsBranch entry cr P target Q_t exit_f Q_f2 := by
+  intro R hR s hcr hPR hpc
+  obtain ⟨k1, s1, hstep1, hbranch1⟩ := h1 R hR s hcr hPR hpc
+  rcases hbranch1 with ⟨hpc_t1, hQ_t1R⟩ | ⟨hpc_f1, hQ_f1R⟩
+  · exact ⟨k1, s1, hstep1, Or.inl ⟨hpc_t1, by
+      obtain ⟨hp, hcompat, hpq⟩ := hQ_t1R
+      exact ⟨hp, hcompat, sepConj_mono_left ht1 hp hpq⟩⟩⟩
+  · have hcr' := CodeReq.SatisfiedBy_preserved cr k1 s s1 hstep1 hcr
+    obtain ⟨k2, s2, hstep2, hpc2, hQ_f2R⟩ := h2 R hR s1 hcr' hQ_f1R hpc_f1
+    exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2,
+           Or.inr ⟨hpc2, hQ_f2R⟩⟩
+
+/-- Like cpsBranch_seq_cpsTriple_same_cr but with a permutation between Q_f1 and the
+    cpsTriple precondition. -/
+theorem cpsBranch_seq_cpsTriple_with_perm_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
+    (P Q_t1 Q_f1 R Q_f2 Q_t : Assertion)
+    (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
+    (hperm : ∀ h, Q_f1 h → R h)
+    (h2 : cpsTriple mid exit_f cr R Q_f2)
+    (ht1 : ∀ h, Q_t1 h → Q_t h) :
+    cpsBranch entry cr P target Q_t exit_f Q_f2 :=
+  cpsBranch_seq_cpsTriple_same_cr entry mid target exit_f cr P Q_t1 R Q_f2 Q_t
+    (cpsBranch_consequence entry cr _ _ _ _ _ _ _ _
+      (fun _ hp => hp) (fun _ hp => hp) hperm h1)
+    h2 ht1
+
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken path, same CodeReq. -/
 theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Word) (cr : CodeReq)
     (P : Assertion) (exit_t : Word) (Q_t : Assertion)


### PR DESCRIPTION
## Summary
- **CPSSpec.lean**: Three new combinators for composing cpsBranch with cpsTriple:
  - `cpsBranch_seq_cpsTriple_same_cr` / `_with_perm_same_cr`: extend cpsBranch ntaken exit
  - `cpsBranch_merge_same_cr`: merge both exits to single target
- **LoopIterN4.lean**: Two n=4 j=0 cpsTriple specs (base+448 → base+904):
  - `divK_loop_body_n4_max_skip_j0_spec` (borrow = 0)
  - `divK_loop_body_n4_max_addback_j0_spec` (borrow ≠ 0)

These eliminate the BGE loop-back branch at j=0 (since j'=-1 < 0), producing clean cpsTriples instead of cpsBranch specs. This is a prerequisite for composing the n=4 full path (pre-loop + loop body + denorm + epilogue).

Call path variants (BLTU taken, div128) to follow.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.LoopIterN4` passes (0 sorry)
- [x] Full `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)