### PR TITLE
Add shift=0 full n=4 DIV path: base → base+1064

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -3,3 +3,4 @@ import EvmAsm.Evm64.DivMod.LimbSpec
 import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.LoopBody
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -1,0 +1,683 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
+
+  Full n=4 DIV path composition for the shift=0 case:
+  pre-loop → loop body (j=0) → shift=0 epilogue.
+  Composes base → base+1064 for the b[3]≠0, shift=0 case.
+
+  When shift=0, normalization is identity (b'=b, u=a, u4=0).
+  Since u4=0 < b3 (b3≠0), the BLTU condition is always taken → call path only.
+  Two sub-cases: skip (borrow=0) and addback (borrow≠0).
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Address form helpers (duplicated from FullPathN4 where they are private)
+-- ============================================================================
+
+private theorem se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
+private theorem se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
+private theorem se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
+private theorem se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+
+private theorem x1_val_n4 : signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) := by decide
+
+/-- When b ≠ 0, 0 < b in unsigned ordering (BitVec.ult). -/
+private theorem ult_zero_of_ne {b : Word} (h : b ≠ 0) : BitVec.ult 0 b := by
+  unfold BitVec.ult; simp
+  exact Nat.pos_of_ne_zero (fun h0 => h (by exact BitVec.eq_of_toNat_eq h0))
+
+-- ============================================================================
+-- Condition definitions for shift=0 call path
+-- ============================================================================
+
+/-- Skip addback condition at n=4 with shift=0 call path: borrow = 0. -/
+def isSkipBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  (if BitVec.ult (0 : Word) (mulsubN4_c3 q_hat b0 b1 b2 b3 a0 a1 a2 a3)
+   then (1 : Word) else 0) = (0 : Word)
+
+/-- Addback condition at n=4 with shift=0 call path: borrow ≠ 0. -/
+def isAddbackBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  (if BitVec.ult (0 : Word) (mulsubN4_c3 q_hat b0 b1 b2 b3 a0 a1 a2 a3)
+   then (1 : Word) else 0) ≠ (0 : Word)
+
+-- ============================================================================
+-- Postcondition definitions for preloop + loop body (shift=0)
+-- ============================================================================
+
+/-- Postcondition for pre-loop + call+skip loop body at n=4, shift=0.
+    Uses unnormalized b[] and a[] directly (no shift). -/
+@[irreducible]
+def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4SkipPost sp (0 : Word) q_hat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b3) **
+  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ (0 : Word))
+
+/-- Postcondition for pre-loop + call+addback loop body at n=4, shift=0. -/
+@[irreducible]
+def preloopShift0CallAddbackPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4AddbackPost sp (0 : Word) q_hat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b3) **
+  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ (0 : Word))
+
+-- ============================================================================
+-- Pre-loop + loop body (shift=0, call+skip): base → base+904
+-- ============================================================================
+
+/-- n=4 pre-loop + call+skip loop body: base → base+904 (shift = 0). -/
+theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isSkipBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 904) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  unfold isSkipBorrowN4Shift0 at hborrow
+  have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
+  have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
+  have hv_v2 : isValidDwordAccess (sp + 48) = true := hvalid 6 (by omega)
+  have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
+  -- Pre-loop: base → base+448 (shift=0)
+  have hPre := evm_div_n4_shift0_to_loopSetup_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    hbnz hb3nz hshift_z hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift
+  -- Frame preloop with x11, j_mem, ret_mem, d_mem, dlo_mem, scratch_un0
+  have hPreF := cpsTriple_frame_left _ _ _ _ _
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) hPre
+  -- Loop body: base+448 → base+904, call+skip with v=b, u=a, u_top=0
+  have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
+  have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
+    j_mem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
+    v11_old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+    b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
+    ret_mem d_mem dlo_mem scratch_un0
+    hv_j hv_n hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
+    hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q0
+    hbltu
+  intro_lets at hLoop
+  have hLoop' := hLoop hborrow
+  -- Frame loop body with a[], q[1-3]=0, padding, shift=0
+  have hLoopF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLoop'
+  -- Compose preloop → loop body
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      simp only [x1_val_n4] at hp
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopShift0CallSkipPostN4; simp only [hshift_z] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- Unfold lemma for preloopShift0CallSkipPostN4
+-- ============================================================================
+
+/-- Unfold preloopShift0CallSkipPostN4 to expanded sp-relative form. -/
+theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
+    let q_hat := div128Quot (0 : Word) a3 b3
+    let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+     (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ q_hat) **
+     (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + signExtend12 4056) ↦ₘ ms.1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + signExtend12 4048) ↦ₘ ms.2.1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
+     ((sp + 56) ↦ₘ b3) ** ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
+     ((sp + signExtend12 4024) ↦ₘ (0 : Word) - ms.2.2.2.2) **
+     ((sp + signExtend12 4088) ↦ₘ q_hat)) **
+    (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+    (sp + signExtend12 3960 ↦ₘ b3) **
+    (sp + signExtend12 3952 ↦ₘ d_lo) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+    ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 3992) ↦ₘ (0 : Word)) := by
+  delta preloopShift0CallSkipPostN4
+  simp only [loopBodyN4SkipPost, loopExitPostN4_j0_eq, se12_32, se12_40, se12_48, se12_56]
+
+-- ============================================================================
+-- Full path postcondition for n=4 DIV (shift=0, call+skip)
+-- ============================================================================
+
+/-- Full path postcondition for n=4 DIV (shift=0, call+skip).
+    No denormalization needed since shift=0. -/
+@[irreducible]
+def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q_hat) **
+  (.x6 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (0 : Word)) **
+  (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4088) ↦ₘ q_hat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + 32) ↦ₘ q_hat) ** ((sp + 40) ↦ₘ (0 : Word)) **
+  ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4056) ↦ₘ ms.1) **
+  ((sp + signExtend12 4048) ↦ₘ ms.2.1) **
+  ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
+  ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
+  ((sp + signExtend12 4024) ↦ₘ (0 : Word) - ms.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b3) **
+  (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+
+-- ============================================================================
+-- Full n=4 DIV path (shift=0, call+skip): base → base+1064
+-- ============================================================================
+
+/-- Full n=4 DIV path: base → base+1064 (shift=0, call+skip).
+    Composes pre-loop + loop body + shift=0 epilogue. -/
+theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isSkipBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fullDivN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+  -- 1. Pre-loop + loop body: base → base+904
+  have hA := evm_div_n4_preloop_shift0_call_skip_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    ret_mem d_mem dlo_mem scratch_un0
+    hbnz hb3nz hshift_z hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
+    hv_uhi hv_ulo hv_vtop halign hborrow
+  -- 2. Post-loop: base+904 → base+1064 (shift=0 epilogue)
+  have hB := evm_div_shift0_epilogue_spec sp base
+    ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (0 : Word)
+    ms.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    ms.2.2.2.2
+    q_hat 0 0 0
+    b0 b1 b2 b3
+    rfl hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3
+  -- Frame post-loop with remaining atoms
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ ms.1) **
+     ((sp + signExtend12 4048) ↦ₘ ms.2.1) **
+     ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
+     ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
+     ((sp + signExtend12 4024) ↦ₘ (0 : Word) - ms.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b3) **
+     (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+    (by pcFree) hB
+  -- 3. Compose A + B
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      simp only [preloopShift0CallSkipPostN4_unfold] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullDivN4Shift0CallSkipPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- Pre-loop + loop body (shift=0, call+addback): base → base+904
+-- ============================================================================
+
+/-- n=4 pre-loop + call+addback loop body: base → base+904 (shift = 0). -/
+theorem evm_div_n4_preloop_shift0_call_addback_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isAddbackBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 904) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (preloopShift0CallAddbackPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  unfold isAddbackBorrowN4Shift0 at hborrow
+  have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
+  have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
+  have hv_v2 : isValidDwordAccess (sp + 48) = true := hvalid 6 (by omega)
+  have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
+  -- Pre-loop: base → base+448 (shift=0)
+  have hPre := evm_div_n4_shift0_to_loopSetup_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    hbnz hb3nz hshift_z hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift
+  have hPreF := cpsTriple_frame_left _ _ _ _ _
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) hPre
+  -- Loop body: call+addback with v=b, u=a, u_top=0
+  have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
+  have hLoop := divK_loop_body_n4_call_addback_j0_norm sp base
+    j_mem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
+    v11_old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+    b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
+    ret_mem d_mem dlo_mem scratch_un0
+    hv_j hv_n hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
+    hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q0
+    hbltu
+  intro_lets at hLoop
+  have hLoop' := hLoop hborrow
+  have hLoopF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLoop'
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      simp only [x1_val_n4] at hp
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopShift0CallAddbackPostN4; simp only [hshift_z] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- Unfold lemma for preloopShift0CallAddbackPostN4
+-- ============================================================================
+
+/-- Unfold preloopShift0CallAddbackPostN4 to expanded sp-relative form. -/
+theorem preloopShift0CallAddbackPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    preloopShift0CallAddbackPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
+    let q_hat := div128Quot (0 : Word) a3 b3
+    let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+    let c3 := ms.2.2.2.2
+    let u4_new := (0 : Word) - c3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0 b1 b2 b3
+    let q_hat' := q_hat + signExtend12 4095
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+     (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_hat') **
+     (.x2 ↦ᵣ ab.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + signExtend12 4056) ↦ₘ ab.1) **
+     ((sp + 40) ↦ₘ b1) ** ((sp + signExtend12 4048) ↦ₘ ab.2.1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + signExtend12 4040) ↦ₘ ab.2.2.1) **
+     ((sp + 56) ↦ₘ b3) ** ((sp + signExtend12 4032) ↦ₘ ab.2.2.2.1) **
+     ((sp + signExtend12 4024) ↦ₘ ab.2.2.2.2) **
+     ((sp + signExtend12 4088) ↦ₘ q_hat')) **
+    (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+    (sp + signExtend12 3960 ↦ₘ b3) **
+    (sp + signExtend12 3952 ↦ₘ d_lo) **
+    (sp + signExtend12 3944 ↦ₘ div_un0) **
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+    ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+    ((sp + signExtend12 3992) ↦ₘ (0 : Word)) := by
+  delta preloopShift0CallAddbackPostN4
+  simp only [loopBodyN4AddbackPost, mulsubN4, addbackN4, loopExitPostN4_j0_eq,
+             se12_32, se12_40, se12_48, se12_56]
+
+-- ============================================================================
+-- Full path postcondition for n=4 DIV (shift=0, call+addback)
+-- ============================================================================
+
+/-- Full path postcondition for n=4 DIV (shift=0, call+addback).
+    No denormalization needed since shift=0. -/
+@[irreducible]
+def fullDivN4Shift0CallAddbackPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+  let c3 := ms.2.2.2.2
+  let u4_new := (0 : Word) - c3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0 b1 b2 b3
+  let q_hat' := q_hat + signExtend12 4095
+  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q_hat') **
+  (.x6 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (0 : Word)) **
+  (.x2 ↦ᵣ ab.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4088) ↦ₘ q_hat') ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + 32) ↦ₘ q_hat') ** ((sp + 40) ↦ₘ (0 : Word)) **
+  ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4056) ↦ₘ ab.1) **
+  ((sp + signExtend12 4048) ↦ₘ ab.2.1) **
+  ((sp + signExtend12 4040) ↦ₘ ab.2.2.1) **
+  ((sp + signExtend12 4032) ↦ₘ ab.2.2.2.1) **
+  ((sp + signExtend12 4024) ↦ₘ ab.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat') **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b3) **
+  (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
+  (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+
+-- ============================================================================
+-- Full n=4 DIV path (shift=0, call+addback): base → base+1064
+-- ============================================================================
+
+/-- Full n=4 DIV path: base → base+1064 (shift=0, call+addback).
+    Composes pre-loop + loop body + shift=0 epilogue. -/
+theorem evm_div_n4_full_shift0_call_addback_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isAddbackBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fullDivN4Shift0CallAddbackPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let q_hat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+  let c3 := ms.2.2.2.2
+  let u4_new := (0 : Word) - c3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0 b1 b2 b3
+  let q_hat' := q_hat + signExtend12 4095
+  -- 1. Pre-loop + loop body: base → base+904
+  have hA := evm_div_n4_preloop_shift0_call_addback_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    ret_mem d_mem dlo_mem scratch_un0
+    hbnz hb3nz hshift_z hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
+    hv_uhi hv_ulo hv_vtop halign hborrow
+  -- 2. Post-loop: base+904 → base+1064 (shift=0 epilogue)
+  have hB := evm_div_shift0_epilogue_spec sp base
+    ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 (0 : Word)
+    ab.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3
+    q_hat' 0 0 0
+    b0 b1 b2 b3
+    rfl hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ ab.1) **
+     ((sp + signExtend12 4048) ↦ₘ ab.2.1) **
+     ((sp + signExtend12 4040) ↦ₘ ab.2.2.1) **
+     ((sp + signExtend12 4032) ↦ₘ ab.2.2.2.1) **
+     ((sp + signExtend12 4024) ↦ₘ ab.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) ** (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat') **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) ** (sp + signExtend12 3960 ↦ₘ b3) **
+     (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
+     (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
+    (by pcFree) hB
+  -- 3. Compose A + B
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      simp only [preloopShift0CallAddbackPostN4_unfold] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullDivN4Shift0CallAddbackPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Add `FullPathN4Shift0.lean` with full n=4 DIV compositions for the shift=0 case (base → base+1064)
- When shift=0, normalization is identity (b'=b, u=a, u4=0), and since u4=0 < b3 (b3≠0), BLTU is always taken → call path only
- Two sub-cases: `evm_div_n4_full_shift0_call_skip_spec` and `evm_div_n4_full_shift0_call_addback_spec`
- Also adds import in `DivMod.lean` to include the new file in the build (avoids circular dependency with Compose.lean)

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0` succeeds
- [x] `lean_verify` confirms no sorry, no unexpected axioms
- [x] LSP reports 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)