### PR TITLE
Full n=3 DIV paths (base→base+1064): preloop+loop+denorm composition

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -427,6 +427,58 @@ exact ⟨k1 + k2, s2, stepN_add_eq ..., hpc2, ...⟩
 
 `DivN4Full.lean` imports both `LoopBodyN4` and `FullPath.lean`. Since `LoopBody.lean` → `Compose.lean` already forms a chain, do NOT add `DivN4Full` to `Compose.lean`'s imports — it would create a cycle. `DivN4Full` stands alone.
 
+## XPerm Scaling Limits and Sub-Assertion Bundling
+
+`xperm_hyp` is O(n^2) in the number of atoms, with each pair comparison
+potentially triggering deep WHNF reduction. At ~36 atoms with complex
+sub-expressions (e.g., `iterN3Call` + `iterN3Max` iteration results), this
+can exceed the 200k heartbeat budget even in a dedicated theorem.
+
+### Symptoms
+
+- `xperm_hyp hp` times out in perm/consequence callbacks
+- The same proof structure works for simpler atom expressions (e.g., all
+  `iterN3Max`) but fails when atom values involve mixed function calls
+- The let-binding chain itself passes `sorry` tests — the timeout is
+  specifically in the `xperm` atom matching
+
+### Solution: bundle sub-assertions as `@[irreducible] def`
+
+Wrap logical groups of atoms into `@[irreducible] def`s so that `xperm`
+sees a few opaque atoms instead of 36 individual ones:
+
+```lean
+-- Instead of 20 flat atoms for denorm input:
+@[irreducible]
+def denormInputN3 (sp shift u0 u1 u2 u3 q0 q1 b0' b1' b2' b3' : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** ... ** ((sp + 56) ↦ₘ b3')
+
+-- And 16 flat atoms for the frame:
+@[irreducible]
+def denormFrameN3 (sp base r0_u4 r1_u4 r0_q a0 a1 a2 a3 b2' u2 : Word) : Assertion :=
+  ((sp + 0) ↦ₘ a0) ** ... ** (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+```
+
+Then `xperm` only matches 2-3 opaque atoms instead of 36, avoiding
+the O(n^2) blowup. Each sub-assertion is unfolded via `delta` only
+when needed (e.g., in the denorm epilogue's own pre-weakening callback).
+
+### When to apply
+
+When a composition has **30+ atoms** in the intermediate assertion and
+the atom values involve **two or more complex functions** (e.g., mixed
+`iterN3Call`/`iterN3Max` results). Same-function compositions (all
+`iterN3Max`) tend to stay within budget because `isDefEq` is faster
+when comparing structurally similar expressions.
+
+### Guideline for new compositions
+
+- Keep each `xperm` call to **≤ 20 atoms** with complex sub-expressions
+- For multi-iteration loops, define per-iteration postconditions as
+  `@[irreducible] def`s (already done: `loopBodyN3SkipPost`, etc.)
+- For full-path compositions, also bundle the denorm input and frame
+  groups as `@[irreducible] def`s
+
 ## Roadmap (PLAN.md)
 
 The project roadmap is maintained in `PLAN.md`. See `CLAUDE.md` for the

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1727,88 +1727,12 @@ theorem evm_div_n3_call_max_denorm_comp (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) b0' b1' b2' b3'
     u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  -- xperm on 36 call×max atoms exceeds heartbeat budget. Needs sub-assertion
+  -- bundling (@[irreducible] defs for denorm input / frame groups) to reduce
+  -- atom count for xperm. See issue #245 for the general approach.
   sorry
 
--- Old copy removed — replaced by evm_div_n3_call_max_denorm' above.
--- Keeping the denorm_comp theorem that references it.
-private theorem evm_div_n3_call_max_denorm_old (sp base shift b0' b1' b2' b3' u2 : Word)
-    (r0_un0 r0_un1 r0_un2 r0_un3 r0_u4 r0_q : Word)
-    (r1_q r1_u4 : Word) (c3_0 : Word)
-    (a0 a1 a2 a3 : Word)
-    (hshift_nz : shift ≠ 0) (hvalid : ValidMemRange sp 8)
-    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
-    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
-    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
-    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
-    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
-    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
-    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
-    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
-    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
-    cpsTriple (base + 904) (base + 1064) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
-       (.x2 ↦ᵣ r0_un3) ** (.x10 ↦ᵣ c3_0) **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ r0_un0) ** ((sp + signExtend12 4048) ↦ₘ r0_un1) **
-       ((sp + signExtend12 4040) ↦ₘ r0_un2) ** ((sp + signExtend12 4032) ↦ₘ r0_un3) **
-       ((sp + signExtend12 4088) ↦ₘ r0_q) ** ((sp + signExtend12 4080) ↦ₘ r1_q) **
-       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
-       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
-       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
-       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ b2') **
-       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
-      (denormDivPost sp shift r0_un0 r0_un1 r0_un2 r0_un3 r0_q r1_q 0 0 **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
-       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
-       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
-       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ b2') **
-       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u2)) := by
-  have hB := evm_div_preamble_denorm_epilogue_spec sp base
-    r0_un0 r0_un1 r0_un2 r0_un3 shift
-    r0_un3 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
-    c3_0 r0_q r1_q 0 0
-    b0' b1' b2' b3'
-    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
-  have hBF := cpsTriple_frame_left _ _ _ _ _
-    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4024) ↦ₘ r0_u4) **
-     ((sp + signExtend12 4016) ↦ₘ r1_u4) **
-     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ b2') **
-     (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
-    (by pcFree) hB
-  exact cpsTriple_consequence _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by rw [sepConj_assoc'] at hq; xperm_hyp hq)
-    hBF
+-- (Old evm_div_n3_call_max_denorm removed — superseded by evm_div_n3_call_max_denorm' above)
 
 /-- Full n=3 DIV path: base → base+1064 (shift ≠ 0, call×max). -/
 theorem evm_div_n3_full_call_max_spec (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1286,4 +1286,383 @@ theorem evm_div_n3_full_max_max_spec (sp base : Word)
     (fun h hq => by delta fullDivN3MaxMaxPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Full n=3 DIV path (call×call, shift≠0): base → base+1064
+-- ============================================================================
+
+@[irreducible]
+def fullDivN3CallCallPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Call b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Call b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 0 0 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b2') **
+  (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+  (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1)
+
+theorem evm_div_n3_full_call_call_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu_1 : isCallTrialN3_j1 a3 b1 b2)
+    (hbltu_0 : isCallTrialN3_j0_afterCall a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
+       ((sp + signExtend12 3960) ↦ₘ d_mem) **
+       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (fullDivN3CallCallPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Call b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Call b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  have hA := evm_div_n3_preloop_call_call_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    ret_mem d_mem dlo_mem scratch_un0
+    hbnz hb3z hb2nz hshift_nz hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
+    halign hbltu_1 hbltu_0
+  have hB := evm_div_preamble_denorm_epilogue_spec sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    (let q_hat := div128Quot r1.2.2.2.1 r1.2.2.1 b2'
+     (mulsubN4 q_hat b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2)
+    r0.1 r1.1 0 0
+    b0' b1' b2' b3'
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b2') **
+     (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1))
+    (by pcFree) hB
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      delta preloopN3CallCallPost at hp
+      simp only [loopN3CallCallPost, loopIterPostN3Call, loopExitPostN3_j0_eq,
+        n3_ub1_off4064, n3_qa1, se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullDivN3CallCallPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- Full n=3 DIV path (max×call, shift≠0): base → base+1064
+-- ============================================================================
+
+@[irreducible]
+def fullDivN3MaxCallPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Call b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 0 0 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b2') **
+  (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+  (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1)
+
+theorem evm_div_n3_full_max_call_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu_1 : isMaxTrialN3_j1 a3 b1 b2)
+    (hbltu_0 : isCallTrialN3_j0_afterMax a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
+       ((sp + signExtend12 3960) ↦ₘ d_mem) **
+       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (fullDivN3MaxCallPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Call b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  have hA := evm_div_n3_preloop_max_call_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    ret_mem d_mem dlo_mem scratch_un0
+    hbnz hb3z hb2nz hshift_nz hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
+    halign hbltu_1 hbltu_0
+  have hB := evm_div_preamble_denorm_epilogue_spec sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    (let q_hat := div128Quot r1.2.2.2.1 r1.2.2.1 b2'
+     (mulsubN4 q_hat b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2)
+    r0.1 r1.1 0 0
+    b0' b1' b2' b3'
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b2') **
+     (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+     (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.2.1))
+    (by pcFree) hB
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      delta preloopN3MaxCallPost at hp
+      simp only [loopN3MaxCallPost, loopIterPostN3Call, loopExitPostN3_j0_eq,
+        n3_ub1_off4064, n3_qa1, se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullDivN3MaxCallPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- Full n=3 DIV path (call×max, shift≠0): base → base+1064
+-- ============================================================================
+
+@[irreducible]
+def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Call b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 0 0 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  -- scratch cells from j=1 call (unchanged by j=0 max):
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b2') **
+  (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+
+theorem evm_div_n3_full_call_max_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu_1 : isCallTrialN3_j1 a3 b1 b2)
+    (hbltu_0 : isMaxTrialN3_j0_afterCall a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
+       ((sp + signExtend12 3960) ↦ₘ d_mem) **
+       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (fullDivN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  -- TODO: WHNF timeout with iterN3Call(j=1) + iterN3Max(j=0) let-binding chain.
+  -- Needs helper inst theorem that splits the denorm composition from preloop.
+  sorry
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -8,6 +8,7 @@
 
 import EvmAsm.Evm64.DivMod.LoopComposeN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
 
 open EvmAsm.Rv64.Tactics
 
@@ -1123,6 +1124,166 @@ theorem evm_div_n3_preloop_call_max_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by delta preloopN3CallMaxPost; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- loopExitPostN3 at j=0: address normalization to sp-relative form
+-- ============================================================================
+
+/-- At j=0, loopExitPostN3 normalizes to sp-relative addresses. -/
+theorem loopExitPostN3_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
+    v0 v1 v2 v3 : Word) :
+    loopExitPostN3 sp (0 : Word) q_f c3 un0_f un1_f un2_f un3_f u4_f v0 v1 v2 v3 =
+    ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+     (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
+     (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0_f) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1_f) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2_f) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3_f) **
+     ((sp + signExtend12 4024) ↦ₘ u4_f) **
+     ((sp + signExtend12 4088) ↦ₘ q_f)) := by
+  simp only [loopExitPostN3_unfold]
+  rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+      u_base_off4072_j0, u_base_off4064_j0, u_base_j0, q_addr_j0]
+  simp only [show (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) from by decide]
+  rw [show (0 : Word) + signExtend12 4095 = signExtend12 4095 from BitVec.zero_add _]
+
+-- No standalone unfold lemma — the 2-iteration N3 postcondition is too deeply
+-- nested for simp to prove the equality. Instead, unfold directly in perm callbacks.
+
+-- ============================================================================
+-- Full n=3 DIV path (max×max, shift≠0): base → base+1064
+-- ============================================================================
+
+/-- Full path postcondition for n=3 DIV (shift ≠ 0, max×max).
+    Computes normalized b[], u[], runs two max-path loop iterations,
+    then denormalizes remainder and outputs quotient. -/
+@[irreducible]
+def fullDivN3MaxMaxPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 0 0 **
+  ((sp + signExtend12 3992) ↦ₘ shift) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1)
+
+/-- Full n=3 DIV path: base → base+1064 (shift ≠ 0, max×max).
+    Composes pre-loop + two-iteration loop + denorm + epilogue. -/
+theorem evm_div_n3_full_max_max_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
+    (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
+    (hv_u5 : isValidDwordAccess (sp + signExtend12 4016) = true)
+    (hv_u6 : isValidDwordAccess (sp + signExtend12 4008) = true)
+    (hv_u7 : isValidDwordAccess (sp + signExtend12 4000) = true)
+    (hv_n  : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_j  : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hbltu_1 : isMaxTrialN3_j1 a3 b1 b2)
+    (hbltu_0 : isMaxTrialN3_j0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem))
+      (fullDivN3MaxMaxPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Max b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let c3_0 := (mulsubN4 (signExtend12 4095 : Word) b0' b1' b2' b3'
+    u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  -- 1. Pre-loop + loop body: base → base+904
+  have hA := evm_div_n3_preloop_max_max_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    hbnz hb3z hb2nz hshift_nz hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hbltu_1 hbltu_0
+  -- 2. Post-loop: base+904 → base+1064
+  have hB := evm_div_preamble_denorm_epilogue_spec sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3_0 r0.1 r1.1 0 0
+    b0' b1' b2' b3'
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  -- Frame post-loop with remainder atoms
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1))
+    (by pcFree) hB
+  -- 3. Compose A + B
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by
+      delta preloopN3MaxMaxPost at hp
+      simp only [loopN3MaxPost, loopIterPostN3Max, loopExitPostN3_j0_eq,
+        n3_ub1_off4064, n3_qa1, se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullDivN3MaxMaxPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
     hFull
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1608,6 +1608,7 @@ def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
+/-- Full n=3 DIV path: base → base+1064 (shift ≠ 0, call×max). -/
 theorem evm_div_n3_full_call_max_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
     (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
@@ -1661,8 +1662,9 @@ theorem evm_div_n3_full_call_max_spec (sp base : Word)
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
-  -- TODO: WHNF timeout with iterN3Call(j=1) + iterN3Max(j=0) let-binding chain.
-  -- Needs helper inst theorem that splits the denorm composition from preloop.
+  -- WHNF timeout: iterN3Call(j=1) + iterN3Max(j=0) let-binding chain exceeds heartbeat
+  -- limit. Needs intermediate composition with explicit postcondition def to break the
+  -- chain while keeping xperm matching possible.
   sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1610,14 +1610,128 @@ def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 -- ============================================================================
 -- Helper infrastructure for call×max (WHNF timeout with direct 14-let chain).
--- Split into: (1) denorm cpsTriple with r0/r1 as params, (2) perm + compose.
--- The main theorem only references opaque @[irreducible] defs in its type,
--- avoiding WHNF chains. The denorm helper takes r0/r1 as params (short chain).
+-- Strategy: pre-prove assertion-level lemmas as separate theorems, each with
+-- its own heartbeat budget. The main theorem just chains opaque defs.
 -- ============================================================================
 
-/-- Denorm epilogue helper for call×max. Takes r0/r1 components as explicit params
-    (no iterN3Call/iterN3Max chain). Precondition is flat (not @[irreducible]). -/
-private theorem evm_div_n3_call_max_denorm (sp base shift b0' b1' b2' b3' u2 : Word)
+/-- Denorm epilogue helper for call×max (moved before denorm_comp for dependency order).
+    Takes r0/r1 components as explicit params (no iterN3Call/iterN3Max chain). -/
+private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u2 : Word)
+    (r0_un0 r0_un1 r0_un2 r0_un3 r0_u4 r0_q : Word)
+    (r1_q r1_u4 : Word) (c3_0 : Word)
+    (a0 a1 a2 a3 : Word)
+    (hshift_nz : shift ≠ 0) (hvalid : ValidMemRange sp 8)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
+    cpsTriple (base + 904) (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+       (.x2 ↦ᵣ r0_un3) ** (.x10 ↦ᵣ c3_0) **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4056) ↦ₘ r0_un0) ** ((sp + signExtend12 4048) ↦ₘ r0_un1) **
+       ((sp + signExtend12 4040) ↦ₘ r0_un2) ** ((sp + signExtend12 4032) ↦ₘ r0_un3) **
+       ((sp + signExtend12 4088) ↦ₘ r0_q) ** ((sp + signExtend12 4080) ↦ₘ r1_q) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+       (sp + signExtend12 3960 ↦ₘ b2') **
+       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+      (denormDivPost sp shift r0_un0 r0_un1 r0_un2 r0_un3 r0_q r1_q 0 0 **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+       (sp + signExtend12 3960 ↦ₘ b2') **
+       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u2)) := by
+  have hB := evm_div_preamble_denorm_epilogue_spec sp base
+    r0_un0 r0_un1 r0_un2 r0_un3 shift
+    r0_un3 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3_0 r0_q r1_q 0 0
+    b0' b1' b2' b3'
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+     ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b2') **
+     (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+    (by pcFree) hB
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hBF
+
+/-- Denorm composition for call×max: preloopN3CallMaxPost → fullDivN3CallMaxPost.
+    Separate theorem with own heartbeat budget. No intermediate def needed —
+    directly composes the denorm epilogue with the preloop postcondition. -/
+theorem evm_div_n3_call_max_denorm_comp (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : (clzResult b2).1 ≠ 0) (hvalid : ValidMemRange sp 8)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
+    cpsTriple (base + 904) (base + 1064) (divCode base)
+      (preloopN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b2).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let r1 := iterN3Call b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)
+  let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let c3_0 := (mulsubN4 (signExtend12 4095 : Word) b0' b1' b2' b3'
+    u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  sorry
+
+-- Old copy removed — replaced by evm_div_n3_call_max_denorm' above.
+-- Keeping the denorm_comp theorem that references it.
+private theorem evm_div_n3_call_max_denorm_old (sp base shift b0' b1' b2' b3' u2 : Word)
     (r0_un0 r0_un1 r0_un2 r0_un3 r0_u4 r0_q : Word)
     (r1_q r1_u4 : Word) (c3_0 : Word)
     (a0 a1 a2 a3 : Word)
@@ -1750,7 +1864,7 @@ theorem evm_div_n3_full_call_max_spec (sp base : Word)
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
-  -- 1. Preloop+loop: base → base+904 (no let bindings needed)
+  -- 1. Preloop+loop: base → base+904
   have hA := evm_div_n3_preloop_call_max_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
     q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
@@ -1759,6 +1873,11 @@ theorem evm_div_n3_full_call_max_spec (sp base : Word)
     hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
     hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
     halign hbltu_1 hbltu_0
-  sorry
+  -- 2. Denorm composition (separate theorem, own heartbeat budget)
+  have hD := evm_div_n3_call_max_denorm_comp sp base a0 a1 a2 a3 b0 b1 b2 b3
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  -- 3. Compose preloop+denorm
+  exact cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hA hD
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1608,6 +1608,94 @@ def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
+-- ============================================================================
+-- Helper infrastructure for call×max (WHNF timeout with direct 14-let chain).
+-- Split into: (1) denorm cpsTriple with r0/r1 as params, (2) perm + compose.
+-- The main theorem only references opaque @[irreducible] defs in its type,
+-- avoiding WHNF chains. The denorm helper takes r0/r1 as params (short chain).
+-- ============================================================================
+
+/-- Denorm epilogue helper for call×max. Takes r0/r1 components as explicit params
+    (no iterN3Call/iterN3Max chain). Precondition is flat (not @[irreducible]). -/
+private theorem evm_div_n3_call_max_denorm (sp base shift b0' b1' b2' b3' u2 : Word)
+    (r0_un0 r0_un1 r0_un2 r0_un3 r0_u4 r0_q : Word)
+    (r1_q r1_u4 : Word) (c3_0 : Word)
+    (a0 a1 a2 a3 : Word)
+    (hshift_nz : shift ≠ 0) (hvalid : ValidMemRange sp 8)
+    (hv_shift : isValidDwordAccess (sp + signExtend12 3992) = true)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4080) = true)
+    (hv_q2 : isValidDwordAccess (sp + signExtend12 4072) = true)
+    (hv_q3 : isValidDwordAccess (sp + signExtend12 4064) = true)
+    (hv_u0 : isValidDwordAccess (sp + signExtend12 4056) = true)
+    (hv_u1 : isValidDwordAccess (sp + signExtend12 4048) = true)
+    (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
+    (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
+    cpsTriple (base + 904) (base + 1064) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+       (.x2 ↦ᵣ r0_un3) ** (.x10 ↦ᵣ c3_0) **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + signExtend12 4056) ↦ₘ r0_un0) ** ((sp + signExtend12 4048) ↦ₘ r0_un1) **
+       ((sp + signExtend12 4040) ↦ₘ r0_un2) ** ((sp + signExtend12 4032) ↦ₘ r0_un3) **
+       ((sp + signExtend12 4088) ↦ₘ r0_q) ** ((sp + signExtend12 4080) ↦ₘ r1_q) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
+       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+       (sp + signExtend12 3960 ↦ₘ b2') **
+       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+      (denormDivPost sp shift r0_un0 r0_un1 r0_un2 r0_un3 r0_q r1_q 0 0 **
+       ((sp + signExtend12 3992) ↦ₘ shift) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+       (sp + signExtend12 3960 ↦ₘ b2') **
+       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u2)) := by
+  have hB := evm_div_preamble_denorm_epilogue_spec sp base
+    r0_un0 r0_un1 r0_un2 r0_un3 shift
+    r0_un3 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3_0 r0_q r1_q 0 0
+    b0' b1' b2' b3'
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  have hBF := cpsTriple_frame_left _ _ _ _ _
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+     ((sp + signExtend12 4016) ↦ₘ r1_u4) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b2') **
+     (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+    (by pcFree) hB
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hBF
+
 /-- Full n=3 DIV path: base → base+1064 (shift ≠ 0, call×max). -/
 theorem evm_div_n3_full_call_max_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
@@ -1662,9 +1750,15 @@ theorem evm_div_n3_full_call_max_spec (sp base : Word)
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN3CallMaxPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
-  -- WHNF timeout: iterN3Call(j=1) + iterN3Max(j=0) let-binding chain exceeds heartbeat
-  -- limit. Needs intermediate composition with explicit postcondition def to break the
-  -- chain while keeping xperm matching possible.
+  -- 1. Preloop+loop: base → base+904 (no let bindings needed)
+  have hA := evm_div_n3_preloop_call_max_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    ret_mem d_mem dlo_mem scratch_un0
+    hbnz hb3z hb2nz hshift_nz hvalid
+    hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3 hv_u4
+    hv_u5 hv_u6 hv_u7 hv_n hv_shift hv_j hv_ret hv_d hv_dlo hv_scratch_un0
+    halign hbltu_1 hbltu_0
   sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1606,7 +1606,7 @@ def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b2') **
   (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u3)
 
 -- ============================================================================
 -- Helper infrastructure for call×max (WHNF timeout with direct 14-let chain).
@@ -1614,9 +1614,10 @@ def fullDivN3CallMaxPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 -- its own heartbeat budget. The main theorem just chains opaque defs.
 -- ============================================================================
 
-/-- Denorm epilogue helper for call×max (moved before denorm_comp for dependency order).
-    Takes r0/r1 components as explicit params (no iterN3Call/iterN3Max chain). -/
-private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u2 : Word)
+/-- Denorm epilogue helper for call×max. Takes r0/r1 as explicit params (short WHNF).
+    Precondition atom order matches preloopN3CallMaxPost's unfolded form exactly,
+    so the perm callback in denorm_comp can use `exact hp` (no xperm needed). -/
+private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u3 : Word)
     (r0_un0 r0_un1 r0_un2 r0_un3 r0_u4 r0_q : Word)
     (r1_q r1_u4 : Word) (c3_0 : Word)
     (a0 a1 a2 a3 : Word)
@@ -1631,29 +1632,34 @@ private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u2 : 
     (hv_u2 : isValidDwordAccess (sp + signExtend12 4040) = true)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true) :
     cpsTriple (base + 904) (base + 1064) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
-       (.x2 ↦ᵣ r0_un3) ** (.x10 ↦ᵣ c3_0) **
-       ((sp + signExtend12 3992) ↦ₘ shift) **
-       ((sp + signExtend12 4056) ↦ₘ r0_un0) ** ((sp + signExtend12 4048) ↦ₘ r0_un1) **
-       ((sp + signExtend12 4040) ↦ₘ r0_un2) ** ((sp + signExtend12 4032) ↦ₘ r0_un3) **
-       ((sp + signExtend12 4088) ↦ₘ r0_q) ** ((sp + signExtend12 4080) ↦ₘ r1_q) **
-       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-       ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
-       ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ r0_u4) **
-       ((sp + signExtend12 4016) ↦ₘ r1_u4) **
-       ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-       (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-       (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0_q) **
-       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ b2') **
-       (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+      -- Flat left-associated chain matching preloopN3CallMaxPost's unfolded order:
+      (-- loopExitPostN3 at j=0:
+      (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
+      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
+      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3_0) ** (.x11 ↦ᵣ r0_q) **
+      (.x2 ↦ᵣ r0_un3) ** (.x0 ↦ᵣ (0 : Word)) **
+      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
+      ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ r0_un0) **
+      ((sp + 40) ↦ₘ b1') ** ((sp + signExtend12 4048) ↦ₘ r0_un1) **
+      ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ r0_un2) **
+      ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ r0_un3) **
+      ((sp + signExtend12 4024) ↦ₘ r0_u4) **
+      ((sp + signExtend12 4088) ↦ₘ r0_q) **
+      -- carry from j=1:
+      ((sp + signExtend12 4016) ↦ₘ r1_u4) ** ((sp + signExtend12 4080) ↦ₘ r1_q) **
+      -- scratch from j=1 call:
+      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+      (sp + signExtend12 3960 ↦ₘ b2') **
+      (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
+      (sp + signExtend12 3944 ↦ₘ div128Un0 u3) **
+      -- outer frame:
+      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ shift))
       (denormDivPost sp shift r0_un0 r0_un1 r0_un2 r0_un3 r0_q r1_q 0 0 **
        ((sp + signExtend12 3992) ↦ₘ shift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -1668,7 +1674,8 @@ private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u2 : 
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ b2') **
        (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-       (sp + signExtend12 3944 ↦ₘ div128Un0 u2)) := by
+       (sp + signExtend12 3944 ↦ₘ div128Un0 u3)) := by
+  -- Apply denorm epilogue (takes 20 atoms), frame with remaining 16
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
     r0_un0 r0_un1 r0_un2 r0_un3 shift
     r0_un3 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
@@ -1688,8 +1695,9 @@ private theorem evm_div_n3_call_max_denorm' (sp base shift b0' b1' b2' b3' u2 : 
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ b2') **
      (sp + signExtend12 3952 ↦ₘ div128DLo b2') **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u3))
     (by pcFree) hB
+  -- xperm on parameterized atoms (r0_un0 etc.) is cheap — no deep WHNF
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by rw [sepConj_assoc'] at hq; xperm_hyp hq)
@@ -1727,10 +1735,21 @@ theorem evm_div_n3_call_max_denorm_comp (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   let r0 := iterN3Max b0' b1' b2' b3' u0 r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) b0' b1' b2' b3'
     u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
-  -- xperm on 36 call×max atoms exceeds heartbeat budget. Needs sub-assertion
-  -- bundling (@[irreducible] defs for denorm input / frame groups) to reduce
-  -- atom count for xperm. See issue #245 for the general approach.
-  sorry
+  -- Use denorm helper with r0/r1 as params (no WHNF chain).
+  -- Pre-weakening is `exact hp` (no xperm) because the denorm helper's precondition
+  -- atom order matches the preloop postcondition's unfolded order exactly.
+  have hD := evm_div_n3_call_max_denorm' sp base shift b0' b1' b2' b3' u3
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.2.2.2.2.2 r0.1
+    r1.1 r1.2.2.2.2.2 c3_0 a0 a1 a2 a3
+    hshift_nz hvalid hv_shift hv_q0 hv_q1 hv_q2 hv_q3 hv_u0 hv_u1 hv_u2 hv_u3
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by
+      delta preloopN3CallMaxPost at hp
+      simp only [loopN3CallMaxPost, loopIterPostN3Max, loopExitPostN3_j0_eq,
+        n3_ub1_off4064, n3_qa1, se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by delta fullDivN3CallMaxPost; xperm_hyp hq)
+    hD
 
 -- (Old evm_div_n3_call_max_denorm removed — superseded by evm_div_n3_call_max_denorm' above)
 


### PR DESCRIPTION
## Summary
- Compose preloop+loop (base→base+904) with denorm+epilogue (base+904→base+1064) for all 4 n=3 DIV variants (shift≠0)
- 3 fully proven: max×max, call×call, max×call
- 1 sorry: call×max (WHNF timeout from iterN3Call+iterN3Max let-binding chain, needs helper inst theorem)
- Adds `loopExitPostN3_j0_eq` for j=0 address normalization
- Adds bundled `@[irreducible]` postconditions: `fullDivN3MaxMaxPost`, `fullDivN3CallCallPost`, `fullDivN3MaxCallPost`, `fullDivN3CallMaxPost`

## Test plan
- [x] `lake build` passes (1 sorry in call×max variant)
- [ ] Fix call×max WHNF timeout in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)