### PR TITLE
DivMod: Bool-parameterized unified loop composition for n=3

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -8,5 +8,6 @@ import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 import EvmAsm.Evm64.DivMod.LoopIterN3
 import EvmAsm.Evm64.DivMod.LoopIterN2
 import EvmAsm.Evm64.DivMod.LoopComposeN3
+import EvmAsm.Evm64.DivMod.LoopUnifiedN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Shift0

--- a/EvmAsm/Evm64/DivMod/LoopDefs.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs.lean
@@ -675,4 +675,118 @@ def isSkipBorrowN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 u0_orig : Word) : Prop 
       (mulsubN4_c3 q_hat v0 v1 v2 v3 u0_orig ms.1 ms.2.1 ms.2.2.1)
     then (1 : Word) else 0) = (0 : Word)
 
+-- ============================================================================
+-- Unified (Bool-parameterized) per-iteration computation for n=3
+-- Issue #262: Unify max/call branch paths via Bool parameter
+-- ============================================================================
+
+/-- Unified per-iteration computation for n=3.
+    `bltu = true` means BLTU taken (call path, trial quotient from div128).
+    `bltu = false` means BLTU not taken (max path, trial quotient = 0xFFF).
+    Internally handles both skip and addback via iterN3Call/iterN3Max. -/
+def iterN3 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  else iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+
+@[simp]
+theorem iterN3_true (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    iterN3 true v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  simp [iterN3]
+
+@[simp]
+theorem iterN3_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    iterN3 false v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  simp [iterN3]
+
+/-- Unified per-iteration postcondition for n=3.
+    Delegates to loopIterPostN3Call (call path) or loopIterPostN3Max (max path).
+    When `bltu = true` (call path), includes div128 scratch cells.
+    When `bltu = false` (max path), appends empAssertion (stripped by sepConj_emp_right'). -/
+@[irreducible]
+def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+  match bltu with
+  | true => loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  | false => loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion
+
+@[simp] theorem loopIterPostN3_call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    loopIterPostN3 true sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  delta loopIterPostN3; rfl
+
+@[simp] theorem loopIterPostN3_max (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    loopIterPostN3 false sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    (loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion) := by
+  delta loopIterPostN3; rfl
+
+-- ============================================================================
+-- Unified two-iteration loop postcondition for n=3
+-- ============================================================================
+
+/-- Unified postcondition for the n=3 two-iteration loop.
+    `bltu_1` is the BLTU outcome at j=1, `bltu_0` at j=0.
+    Delegates to existing per-path postconditions via match.
+    For max×max, scratch cells pass through unchanged (carried as parameters).
+    For other combinations, scratch cells are overwritten by div128 (params unused). -/
+@[irreducible]
+def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+  match bltu_1, bltu_0 with
+  | false, false =>
+    loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig **
+    (sp + signExtend12 3968 ↦ₘ ret_mem) **
+    (sp + signExtend12 3960 ↦ₘ d_mem) **
+    (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    (sp + signExtend12 3944 ↦ₘ scratch_un0)
+  | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+  | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+  | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+
+-- ============================================================================
+-- Unified (Bool-parameterized) per-iteration computation for n=2
+-- Issue #262: Same pattern as n=3 but div128 uses u2/u1/v1
+-- ============================================================================
+
+/-- Unified per-iteration computation for n=2.
+    `bltu = true` means BLTU taken (call path, trial quotient from div128).
+    `bltu = false` means BLTU not taken (max path, trial quotient = 0xFFF).
+    For n=2: div128 uses u_hi=u2, u_lo=u1, v_top=v1. -/
+def iterN2 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  else iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+
+@[simp]
+theorem iterN2_true (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    iterN2 true v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  simp [iterN2]
+
+@[simp]
+theorem iterN2_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    iterN2 false v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  simp [iterN2]
+
+/-- Unified per-iteration postcondition for n=2.
+    Same structure as loopIterPostN3 but delegates to loopIterPostN2Call/Max. -/
+@[irreducible]
+def loopIterPostN2 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+  match bltu with
+  | true => loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  | false => loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion
+
+@[simp] theorem loopIterPostN2_call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    loopIterPostN2 true sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+  delta loopIterPostN2; rfl
+
+@[simp] theorem loopIterPostN2_max (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+    loopIterPostN2 false sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    (loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion) := by
+  delta loopIterPostN2; rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -1,0 +1,149 @@
+/-
+  EvmAsm.Evm64.DivMod.LoopUnifiedN3
+
+  Bool-parameterized (unified) loop composition for n=3.
+  Issue #262: Unify max/call branch paths via Bool parameter.
+
+  Instead of 4 separate two-iteration composition theorems (max×max, call×call,
+  max×call, call×max), this file provides a single theorem parameterized by
+  `(bltu_1 bltu_0 : Bool)` that covers all 4 combinations.
+
+  The proofs delegate to the existing per-path theorems in LoopComposeN3.lean
+  via `cases bltu`, then bridge the pre/postconditions to the unified forms.
+-/
+
+import EvmAsm.Evm64.DivMod.LoopComposeN3
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Unified two-iteration composition (Bool×Bool parameterized)
+-- ============================================================================
+
+set_option maxRecDepth 4096 in
+set_option maxHeartbeats 12800000 in
+/-- Unified n=3 two-iteration loop composition, parameterized by `(bltu_1 bltu_0 : Bool)`.
+    Covers all 4 path combinations (max×max, call×call, max×call, call×max).
+    Precondition always includes scratch cells (loopN3PreWithScratch).
+    Postcondition is loopN3UnifiedPost which delegates to existing per-path defs. -/
+theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (base : Word)
+    -- Validity hypotheses (union of max and call requirements)
+    (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
+    (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
+    (hv_uhi_1 : isValidDwordAccess (sp + signExtend12 4056 - (1 + (3 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 + (3 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_vtop : isValidDwordAccess (sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true)
+    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
+    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
+    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
+    (hv_scratch_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hv_v0 : isValidDwordAccess (sp + signExtend12 32) = true)
+    (hv_v1 : isValidDwordAccess (sp + signExtend12 40) = true)
+    (hv_v2 : isValidDwordAccess (sp + signExtend12 48) = true)
+    (hv_v3 : isValidDwordAccess (sp + signExtend12 56) = true)
+    (hv_u0_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_u1_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088) = true)
+    (hv_u2_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080) = true)
+    (hv_u3_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072) = true)
+    (hv_u4_1 : isValidDwordAccess ((sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064) = true)
+    (hv_q1 : isValidDwordAccess (sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat) = true)
+    (hv_uhi_0 : isValidDwordAccess (sp + signExtend12 4056 - (0 + (3 : Word)) <<< (3 : BitVec 6).toNat) = true)
+    (hv_ulo_0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 + (3 : Word)) <<< (3 : BitVec 6).toNat) + 8) = true)
+    (hv_u0_0 : isValidDwordAccess ((sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0) = true)
+    (hv_q0 : isValidDwordAccess (sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat) = true)
+    -- Unified branch conditions
+    (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2) :
+    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+      (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        ret_mem d_mem dlo_mem scratch_un0)
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+        ret_mem d_mem dlo_mem scratch_un0) := by
+  -- Dispatch to existing per-path composition theorems
+  cases bltu_1 <;> cases bltu_0 <;> simp only [iterN3_true, iterN3_false] at hbltu_0
+  · -- (false, false) = max×max
+    have hbltu_1' : ¬BitVec.ult u3 v2 := by
+      rw [show BitVec.ult u3 v2 = false from hbltu_1.symm]; decide
+    have hbltu_0' : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 := by
+      rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
+    have hMM := divK_loop_n3_max_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old base
+      hv_j hv_n1 hv_uhi_1 hv_ulo_1 hv_vtop hv_v0 hv_v1 hv_v2 hv_v3
+      hv_u0_1 hv_u1_1 hv_u2_1 hv_u3_1 hv_u4_1 hv_q1
+      hv_uhi_0 hv_ulo_0 hv_u0_0 hv_q0
+      hbltu_1' hbltu_0'
+    -- Frame scratch cells (max path doesn't touch them)
+    have hMMF := cpsTriple_frame_left _ _ _ _ _
+      ((sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (by pcFree) hMM
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => by delta loopN3PreWithScratch at hp; xperm_hyp hp)
+      (fun h hp => by delta loopN3UnifiedPost; xperm_hyp hp)
+      hMMF
+  · -- (false, true) = max×call
+    have hbltu_1' : ¬BitVec.ult u3 v2 := by
+      rw [show BitVec.ult u3 v2 = false from hbltu_1.symm]; decide
+    have hbltu_0' : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 :=
+      hbltu_0.symm ▸ rfl
+    have hMC := divK_loop_n3_max_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      ret_mem d_mem dlo_mem scratch_un0 base
+      hv_j hv_n1 hv_uhi_1 hv_ulo_1 hv_vtop
+      hv_ret hv_d hv_dlo hv_scratch_un0 halign
+      hv_v0 hv_v1 hv_v2 hv_v3
+      hv_u0_1 hv_u1_1 hv_u2_1 hv_u3_1 hv_u4_1 hv_q1
+      hv_uhi_0 hv_ulo_0 hv_u0_0 hv_q0
+      hbltu_1' hbltu_0'
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by delta loopN3UnifiedPost; exact hp)
+      hMC
+  · -- (true, false) = call×max
+    have hbltu_1' : BitVec.ult u3 v2 := hbltu_1.symm ▸ rfl
+    have hbltu_0' : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 := by
+      rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
+    have hCM := divK_loop_n3_call_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      ret_mem d_mem dlo_mem scratch_un0 base
+      hv_j hv_n1 hv_uhi_1 hv_ulo_1 hv_vtop
+      hv_ret hv_d hv_dlo hv_scratch_un0 halign
+      hv_v0 hv_v1 hv_v2 hv_v3
+      hv_u0_1 hv_u1_1 hv_u2_1 hv_u3_1 hv_u4_1 hv_q1
+      hv_uhi_0 hv_ulo_0 hv_u0_0 hv_q0
+      hbltu_1' hbltu_0'
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by delta loopN3UnifiedPost; exact hp)
+      hCM
+  · -- (true, true) = call×call
+    have hbltu_1' : BitVec.ult u3 v2 := hbltu_1.symm ▸ rfl
+    have hbltu_0' : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 :=
+      hbltu_0.symm ▸ rfl
+    have hCC := divK_loop_n3_call_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      ret_mem d_mem dlo_mem scratch_un0 base
+      hv_j hv_n1 hv_uhi_1 hv_ulo_1 hv_vtop
+      hv_ret hv_d hv_dlo hv_scratch_un0 halign
+      hv_v0 hv_v1 hv_v2 hv_v3
+      hv_u0_1 hv_u1_1 hv_u2_1 hv_u3_1 hv_u4_1 hv_q1
+      hv_uhi_0 hv_ulo_0 hv_u0_0 hv_q0
+      hbltu_1' hbltu_0'
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by delta loopN3UnifiedPost; exact hp)
+      hCC
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Add `iterN3`/`iterN2` unified computation defs with `Bool` parameter (`true` = call/BLTU-taken, `false` = max/BLTU-not-taken)
- Add `loopIterPostN3`/`loopIterPostN2` unified per-iteration postconditions via `match`-based delegation to existing `@[irreducible]` defs
- Add `loopN3UnifiedPost` two-iteration postcondition covering all 4 path combinations
- Add `divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)` — single theorem replacing 4 separate compositions (max×max, call×call, max×call, call×max)

Part of #262

## Design

Uses **match-based definitions** that delegate to existing opaque defs without expanding computation chains. Bridge lemma proofs are simple `delta; rfl`. The unified composition proof dispatches via `cases bltu_1 <;> cases bltu_0` to the 4 existing per-path theorems in `LoopComposeN3.lean`.

All changes are **additive** — existing theorems and definitions are untouched.

## Remaining work (#262)

- Unified preloop+loop and full-path theorems at `FullPathN3Loop` level
- n=2 three-iteration composition using Bool params (`LoopComposeN2.lean`)
- Apply to downstream MOD variants

## Test plan

- [x] `lake build` passes (full project, 3467 jobs)
- [x] Bridge lemmas verified: `loopIterPostN3_call`, `loopIterPostN3_max`, `iterN3_true`, `iterN3_false`
- [x] Unified composition theorem type-checks with all 4 Bool combinations

🤖 Generated with [Claude Code](https://claude.com/claude-code)