### PR TITLE
Remove bv_addr preference from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,6 @@ Before sending work for review:
 
 - Keep imports at the top of the file.
 - Follow the naming conventions and proof patterns documented in [`AGENTS.md`](AGENTS.md).
-- Use `bv_addr` (not `bv_omega`) for address offset equalities — see the Build Performance section of `AGENTS.md`.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
- Remove the style note recommending `bv_addr` over `bv_omega` for address offset equalities, since `bv_addr` is often not powerful enough

## Test plan
- [x] Documentation-only change, no build impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)