### PR TITLE
feat: expand Reg to all 32 RISC-V integer registers (x0-x31)

### DIFF
--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -11,17 +11,40 @@ namespace EvmAsm.Rv64
 -- Registers
 -- ============================================================================
 
-/-- A small subset of RISC-V integer registers. -/
+/-- The 32 RISC-V integer registers. -/
 inductive Reg where
-  | x0  -- hardwired zero
-  | x1  -- ra
-  | x2  -- sp
+  | x0  -- zero (hardwired zero)
+  | x1  -- ra (return address)
+  | x2  -- sp (stack pointer)
+  | x3  -- gp (global pointer)
+  | x4  -- tp (thread pointer)
   | x5  -- t0
   | x6  -- t1
   | x7  -- t2
+  | x8  -- s0/fp (frame pointer)
+  | x9  -- s1
   | x10 -- a0
   | x11 -- a1
   | x12 -- a2
+  | x13 -- a3
+  | x14 -- a4
+  | x15 -- a5
+  | x16 -- a6
+  | x17 -- a7
+  | x18 -- s2
+  | x19 -- s3
+  | x20 -- s4
+  | x21 -- s5
+  | x22 -- s6
+  | x23 -- s7
+  | x24 -- s8
+  | x25 -- s9
+  | x26 -- s10
+  | x27 -- s11
+  | x28 -- t3
+  | x29 -- t4
+  | x30 -- t5
+  | x31 -- t6
   deriving DecidableEq, BEq, Repr, Hashable
 
 instance : LawfulBEq Reg where
@@ -34,12 +57,35 @@ def toNat : Reg → Nat
   | x0  => 0
   | x1  => 1
   | x2  => 2
+  | x3  => 3
+  | x4  => 4
   | x5  => 5
   | x6  => 6
   | x7  => 7
+  | x8  => 8
+  | x9  => 9
   | x10 => 10
   | x11 => 11
   | x12 => 12
+  | x13 => 13
+  | x14 => 14
+  | x15 => 15
+  | x16 => 16
+  | x17 => 17
+  | x18 => 18
+  | x19 => 19
+  | x20 => 20
+  | x21 => 21
+  | x22 => 22
+  | x23 => 23
+  | x24 => 24
+  | x25 => 25
+  | x26 => 26
+  | x27 => 27
+  | x28 => 28
+  | x29 => 29
+  | x30 => 30
+  | x31 => 31
 
 instance : ToString Reg where
   toString r := s!"x{r.toNat}"

--- a/EvmAsm/Rv64/SailEquiv/StateRel.lean
+++ b/EvmAsm/Rv64/SailEquiv/StateRel.lean
@@ -29,12 +29,35 @@ def regToRegidx : Reg → regidx
   | .x0  => regidx.Regidx 0
   | .x1  => regidx.Regidx 1
   | .x2  => regidx.Regidx 2
+  | .x3  => regidx.Regidx 3
+  | .x4  => regidx.Regidx 4
   | .x5  => regidx.Regidx 5
   | .x6  => regidx.Regidx 6
   | .x7  => regidx.Regidx 7
+  | .x8  => regidx.Regidx 8
+  | .x9  => regidx.Regidx 9
   | .x10 => regidx.Regidx 10
   | .x11 => regidx.Regidx 11
   | .x12 => regidx.Regidx 12
+  | .x13 => regidx.Regidx 13
+  | .x14 => regidx.Regidx 14
+  | .x15 => regidx.Regidx 15
+  | .x16 => regidx.Regidx 16
+  | .x17 => regidx.Regidx 17
+  | .x18 => regidx.Regidx 18
+  | .x19 => regidx.Regidx 19
+  | .x20 => regidx.Regidx 20
+  | .x21 => regidx.Regidx 21
+  | .x22 => regidx.Regidx 22
+  | .x23 => regidx.Regidx 23
+  | .x24 => regidx.Regidx 24
+  | .x25 => regidx.Regidx 25
+  | .x26 => regidx.Regidx 26
+  | .x27 => regidx.Regidx 27
+  | .x28 => regidx.Regidx 28
+  | .x29 => regidx.Regidx 29
+  | .x30 => regidx.Regidx 30
+  | .x31 => regidx.Regidx 31
 
 -- ============================================================================
 -- Register mapping: Rv64.Reg → Register (SAIL state key, for non-x0)
@@ -46,12 +69,35 @@ def regToSailReg : Reg → Option Register
   | .x0  => none
   | .x1  => some Register.x1
   | .x2  => some Register.x2
+  | .x3  => some Register.x3
+  | .x4  => some Register.x4
   | .x5  => some Register.x5
   | .x6  => some Register.x6
   | .x7  => some Register.x7
+  | .x8  => some Register.x8
+  | .x9  => some Register.x9
   | .x10 => some Register.x10
   | .x11 => some Register.x11
   | .x12 => some Register.x12
+  | .x13 => some Register.x13
+  | .x14 => some Register.x14
+  | .x15 => some Register.x15
+  | .x16 => some Register.x16
+  | .x17 => some Register.x17
+  | .x18 => some Register.x18
+  | .x19 => some Register.x19
+  | .x20 => some Register.x20
+  | .x21 => some Register.x21
+  | .x22 => some Register.x22
+  | .x23 => some Register.x23
+  | .x24 => some Register.x24
+  | .x25 => some Register.x25
+  | .x26 => some Register.x26
+  | .x27 => some Register.x27
+  | .x28 => some Register.x28
+  | .x29 => some Register.x29
+  | .x30 => some Register.x30
+  | .x31 => some Register.x31
 
 /-- Pure register lookup: read an integer register value from SAIL state.
     Returns 0 for x0, or looks up in the ExtDHashMap for others.
@@ -61,12 +107,35 @@ noncomputable def sailRegVal (s : SailState) (r : Reg) : Option (BitVec 64) :=
   | .x0  => some 0#64  -- x0 is hardwired zero
   | .x1  => s.regs.get? Register.x1
   | .x2  => s.regs.get? Register.x2
+  | .x3  => s.regs.get? Register.x3
+  | .x4  => s.regs.get? Register.x4
   | .x5  => s.regs.get? Register.x5
   | .x6  => s.regs.get? Register.x6
   | .x7  => s.regs.get? Register.x7
+  | .x8  => s.regs.get? Register.x8
+  | .x9  => s.regs.get? Register.x9
   | .x10 => s.regs.get? Register.x10
   | .x11 => s.regs.get? Register.x11
   | .x12 => s.regs.get? Register.x12
+  | .x13 => s.regs.get? Register.x13
+  | .x14 => s.regs.get? Register.x14
+  | .x15 => s.regs.get? Register.x15
+  | .x16 => s.regs.get? Register.x16
+  | .x17 => s.regs.get? Register.x17
+  | .x18 => s.regs.get? Register.x18
+  | .x19 => s.regs.get? Register.x19
+  | .x20 => s.regs.get? Register.x20
+  | .x21 => s.regs.get? Register.x21
+  | .x22 => s.regs.get? Register.x22
+  | .x23 => s.regs.get? Register.x23
+  | .x24 => s.regs.get? Register.x24
+  | .x25 => s.regs.get? Register.x25
+  | .x26 => s.regs.get? Register.x26
+  | .x27 => s.regs.get? Register.x27
+  | .x28 => s.regs.get? Register.x28
+  | .x29 => s.regs.get? Register.x29
+  | .x30 => s.regs.get? Register.x30
+  | .x31 => s.regs.get? Register.x31
 
 -- ============================================================================
 -- Running SAIL computations
@@ -102,7 +171,7 @@ def reconstructDword (mem : Std.ExtHashMap Nat (BitVec 8)) (addr : Nat) : BitVec
 /-- The abstraction relation between Rv64.MachineState and SAIL state.
     Asserts register and memory agreement only. -/
 structure StateRel (s_rv : MachineState) (s_sail : SailState) : Prop where
-  /-- Registers agree on the 9-register subset. -/
+  /-- Registers agree on all 32 integer registers. -/
   reg_agree : ∀ (r : Reg), sailRegVal s_sail r = some (s_rv.getReg r)
   /-- Memory agrees: SAIL bytes reconstruct to Rv64 doublewords. -/
   mem_agree : ∀ (a : BitVec 64),


### PR DESCRIPTION
Previously only 9 registers were modeled (x0-x2, x5-x7, x10-x12). This adds the remaining 23 (x3-x4, x8-x9, x13-x31) to enable programs using the full register file — callee-saved registers, more temporaries, and argument registers a3-a7.