### PR TITLE
Add generalized trial quotient bound and unconditional mulsub borrow bound for n≤3

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -1,8 +1,13 @@
 /-
   EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 
-  Mathematical foundations for div128 correctness: half-word OR-combine,
-  128-bit Euclidean uniqueness, and trial quotient bounds (Knuth TAOCP 4.3.1).
+  Mathematical foundations for div128 correctness and multi-limb division:
+  - Half-word OR-combine (non-overlapping shift+OR = add)
+  - 128-bit Euclidean uniqueness
+  - Trial quotient bounds (Knuth TAOCP 4.3.1): generalized and 256→128 level
+  - Product check correction: reduces overestimate from ≤ 2 to ≤ 1
+  - Full half-round theorem (overflow + product check)
+  - Mulsub borrow bound for n ≤ 3 (v3 = 0): c3 ≤ 1 unconditionally
 -/
 
 import EvmAsm.Evm64.EvmWordArith.MultiLimb
@@ -266,6 +271,68 @@ theorem half_round_overestimate_le_one (u_hi un1 d_hi d_lo q r : Nat)
   · -- Upper bound: q' ≤ q_true + 1
     exact correction_step_overestimate_le_one u_hi un1 d_hi d_lo q r (2^32)
       hd_pos hr hq_mul hq_le
+
+-- ============================================================================
+-- Generalized trial quotient bound (any base)
+-- ============================================================================
+
+/-- Generalized trial quotient bound: ⌊(u_hi * Bk + u_rest) / (d_hi * Bk + d_rest)⌋ ≤ ⌊u_hi / d_hi⌋.
+    Works for any "base" Bk (e.g., 2^32, 2^64, 2^128). The trial quotient using only the
+    top portions never underestimates the true quotient. -/
+theorem trial_quotient_ge_general (u_hi u_rest d_hi d_rest Bk : Nat)
+    (hd_hi : 0 < d_hi) (hu_rest : u_rest < Bk) :
+    (u_hi * Bk + u_rest) / (d_hi * Bk + d_rest) ≤ u_hi / d_hi := by
+  have hBk : 0 < Bk := by omega
+  have hd_pos : 0 < d_hi * Bk + d_rest := by positivity
+  have : (u_hi * Bk + u_rest) / (d_hi * Bk + d_rest) < u_hi / d_hi + 1 :=
+    (Nat.div_lt_iff_lt_mul hd_pos).mpr (by
+      have hq : u_hi < d_hi * (u_hi / d_hi + 1) := Nat.lt_mul_div_succ u_hi hd_hi
+      calc u_hi * Bk + u_rest
+          < (u_hi + 1) * Bk := by nlinarith
+        _ ≤ d_hi * (u_hi / d_hi + 1) * Bk := by nlinarith
+        _ = (u_hi / d_hi + 1) * (d_hi * Bk) := by ring
+        _ ≤ (u_hi / d_hi + 1) * (d_hi * Bk + d_rest) := by nlinarith)
+  omega
+
+-- ============================================================================
+-- val256 ↔ val128 decomposition
+-- ============================================================================
+
+/-- val256 decomposes into two val128 halves: val256 l0 l1 l2 l3 = val128 l3 l2 * 2^128 + val128 l1 l0. -/
+theorem val256_eq_val128_pair (l0 l1 l2 l3 : Word) :
+    val256 l0 l1 l2 l3 = val128 l3 l2 * 2 ^ 128 + val128 l1 l0 := by
+  unfold val256 val128; ring
+
+/-- val256 with top limb zero: val256 l0 l1 l2 0 = l2 * 2^128 + val128 l1 l0. -/
+theorem val256_top_zero (l0 l1 l2 : Word) :
+    val256 l0 l1 l2 0 = l2.toNat * 2 ^ 128 + val128 l1 l0 := by
+  unfold val256 val128; simp; ring
+
+-- ============================================================================
+-- Trial quotient bound: 256-bit ÷ 192-bit level
+-- ============================================================================
+
+/-- Trial quotient bound at the 64-bit level: the trial quotient val128(u3,u2)/v2
+    never underestimates the true quotient val256(u0,u1,u2,u3)/val256(v0,v1,v2,0).
+    This is the 256→128 analogue of `trial_quotient_ge`. -/
+theorem trial_quotient_ge_256 (u0 u1 u2 u3 v0 v1 v2 : Word) (hv2 : v2 ≠ 0) :
+    val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 ≤ val128 u3 u2 / v2.toNat := by
+  rw [val256_eq_val128_pair u0 u1 u2 u3, val256_top_zero v0 v1 v2]
+  exact trial_quotient_ge_general (val128 u3 u2) (val128 u1 u0)
+    v2.toNat (val128 v1 v0) (2 ^ 128)
+    (Nat.pos_of_ne_zero (by intro h; apply hv2; exact BitVec.eq_of_toNat_eq h))
+    (val128_bound u1 u0)
+
+-- ============================================================================
+-- val256 bound with zero top limb
+-- ============================================================================
+
+/-- When the top limb is zero, val256 < 2^192. -/
+theorem val256_lt_pow192 (l0 l1 l2 : Word) :
+    val256 l0 l1 l2 0 < 2 ^ 192 := by
+  unfold val256; simp
+  have h0 := l0.isLt; have h1 := l1.isLt; have h2 := l2.isLt
+  nlinarith
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivAccumulate
+import EvmAsm.Evm64.EvmWordArith.Div128Lemmas
 import EvmAsm.Evm64.DivMod.LoopSemantic
 
 namespace EvmAsm.Evm64
@@ -277,7 +278,46 @@ theorem mulsubN4_c3_ne_zero_imp_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1 :=
   (mulsubN4_c3_eq_zero_or_one q v0 v1 v2 v3 u0 u1 u2 u3 hbnz hq_over |>.resolve_left hc3_nz)
 
--- Note: Remaining missing piece for full semantic bridge:
--- Call path trial quotient overestimate (Knuth's Theorem B for div128)
+-- ============================================================================
+-- Mulsub borrow bound for n ≤ 3 (v3 = 0): c3 ≤ 1 unconditionally
+-- ============================================================================
+
+-- When v3 = 0, val256(v) < 2^192, so q * val256(v) < 2^64 * 2^192 = 2^256
+-- for any 64-bit q. This gives c3 ≤ 1 without any overestimate hypothesis.
+
+/-- When the top divisor limb v3 = 0, the mulsub borrow c3 ≤ 1 for ANY
+    64-bit trial quotient q, without needing any overestimate bound.
+
+    Proof: from `mulsubN4_val256_eq`, c3 * 2^256 = val256(un) + q * val256(v) - val256(u).
+    Since val256(un) < 2^256 and val256(v) < 2^192 (because v3 = 0):
+    q * val256(v) ≤ (2^64-1) * (2^192-1) < 2^256.
+    So c3 * 2^256 < 2^256 + 2^256 = 2 * 2^256, hence c3 ≤ 1. -/
+theorem mulsubN4_c3_le_one_v3_zero (q v0 v1 v2 u0 u1 u2 u3 : Word) :
+    (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2.toNat ≤ 1 := by
+  have hmulsub := mulsubN4_val256_eq q v0 v1 v2 0 u0 u1 u2 u3
+  simp only [] at hmulsub
+  let ms := mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3
+  let c3 := ms.2.2.2.2
+  have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have hv_bound := val256_lt_pow192 v0 v1 v2
+  have hq_bound := q.isLt
+  have hqv_bound : q.toNat * val256 v0 v1 v2 0 < 2 ^ 256 := by nlinarith
+  have hc3_bound : c3.toNat * 2 ^ 256 < 2 * 2 ^ 256 := by
+    show ms.2.2.2.2.toNat * 2 ^ 256 < 2 * 2 ^ 256; nlinarith
+  show c3.toNat ≤ 1
+  have h256_pos : (0 : Nat) < 2 ^ 256 := by positivity
+  have : c3.toNat < 2 := (Nat.mul_lt_mul_right h256_pos).mp hc3_bound
+  omega
+
+/-- When c3 ≠ 0 and v3 = 0, the borrow is exactly 1.
+    Immediate from `mulsubN4_c3_le_one_v3_zero`. -/
+theorem mulsubN4_c3_eq_one_v3_zero (q v0 v1 v2 u0 u1 u2 u3 : Word)
+    (hc3_nz : (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 ≠ 0) :
+    (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2 = 1 := by
+  have h := mulsubN4_c3_le_one_v3_zero q v0 v1 v2 u0 u1 u2 u3
+  have hc3_pos : 0 < (mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3).2.2.2.2.toNat := by
+    exact Nat.pos_of_ne_zero (by intro h0; exact hc3_nz (BitVec.eq_of_toNat_eq h0))
+  have h1 : (1 : Word).toNat = 1 := by decide
+  exact BitVec.eq_of_toNat_eq (by omega)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Generalized trial quotient bound (`trial_quotient_ge_general`) for any base, plus 256→128 instantiation
- val256 decomposition lemmas (`val256_eq_val128_pair`, `val256_top_zero`, `val256_lt_pow192`)
- **Unconditional mulsub borrow bound for n≤3** (`mulsubN4_c3_le_one_v3_zero`): when `v3 = 0`, the mulsub borrow `c3 ≤ 1` for ANY 64-bit quotient `q`, without needing any overestimate hypothesis. This is because `val256(v) < 2^192` when `v3 = 0`, so `q * val256(v) < 2^256`.

## Finding: div128 trial quotient overestimates by 2 (missing product check)

While working on the bitvector bridge, I discovered that `div128Quot` can overestimate the true quotient digit by 2 in the n≤3 case. Knuth's Algorithm D requires a product check at the 64-bit level (comparing `q̂ * v[n-2]` with `r̂ * b + u[j+n-2]`) to reduce the overestimate from ≤2 to ≤1. This check is absent from the current implementation.

**Concrete counterexample (n=3):**
```
v = (2^64-1, 2^64-1, 2^63, 0)  -- normalized divisor with large lower limbs
u = (0, 0, 0, 2^62+1)          -- dividend with u3 < v2

div128Quot(u3, u2, v2) = 2^63 + 2   (exact 128÷64 quotient)
True quotient digit:     2^63
After addback:           2^63 + 1    ← still off by 1
```

Verified computationally:
```lean
#eval (div128Quot u3_ex u2_ex v2_ex).toNat                          -- 9223372036854775810 = 2^63+2
#eval val256 0 0 0 u3_ex / val256 v0_ex v1_ex v2_ex 0               -- 9223372036854775808 = 2^63
#eval (iterN3Call v0_ex v1_ex v2_ex 0 0 0 0 u3_ex 0).1              -- 9223372036854775809 = 2^63+1 (wrong)
#eval (iterN3Call v0_ex v1_ex v2_ex 0 0 0 0 u3_ex 0).2.2.2.2.2     -- 2^64-1 (u_top wraps, should be 0)
```

**Impact:** The semantic correctness bridge (connecting loop output to `EvmWord.div`/`EvmWord.mod`) cannot be completed for the n≤3 call path without either fixing the algorithm or adding a 64-bit product check.

## Test plan
- [x] `lake build` passes
- [x] All new theorems verified axiom-free (except standard `propext`/`Classical.choice`/`Quot.sound`)
- [x] Counterexample verified computationally via `#eval`

🤖 Generated with [Claude Code](https://claude.com/claude-code)