### PR TITLE
Run Build CI during merge queue

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary
- Add the `merge_group` trigger to `.github/workflows/build.yml` so the Lean build runs on merge-queue check runs, allowing it to serve as a required status for GitHub merge queues.

## Test plan
- [x] Enable merge queue on the repo (repo settings → branches → protection rule for `main` → "Require merge queue") and mark `build` as a required status check.
- [ ] Queue a trial PR; confirm the Build workflow fires on the `merge_group` event and gates the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)