### PR TITLE
Introduce named block-offset constants for DivMod proofs (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.DivMod.LimbSpec
 import EvmAsm.Evm64.DivMod.AddrNorm
+import EvmAsm.Evm64.DivMod.Compose.Offsets
 
 open EvmAsm.Rv64.Tactics
 
@@ -52,43 +53,45 @@ macro "skipBlock" : tactic =>
 -- ============================================================================
 
 /-- The full evm_div code split into 14 per-phase CodeReq.ofProg blocks.
-    This is the canonical CodeReq for all composed specs. -/
+    This is the canonical CodeReq for all composed specs.
+    Block offsets are named constants defined in `Compose.Offsets` — see
+    that file for the canonical layout and drift checks. -/
 abbrev divCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
-    CodeReq.ofProg base (divK_phaseA 1016),             -- block 0
-    CodeReq.ofProg (base + 32) divK_phaseB,              -- block 1
-    CodeReq.ofProg (base + 116) divK_clz,                -- block 2
-    CodeReq.ofProg (base + 212) (divK_phaseC2 172),      -- block 3
-    CodeReq.ofProg (base + 228) divK_normB,              -- block 4
-    CodeReq.ofProg (base + 312) (divK_normA 40),         -- block 5
-    CodeReq.ofProg (base + 396) divK_copyAU,             -- block 6
-    CodeReq.ofProg (base + 432) (divK_loopSetup 460),    -- block 7
-    CodeReq.ofProg (base + 448) (divK_loopBody 556 7740),-- block 8
-    CodeReq.ofProg (base + 904) divK_denorm,             -- block 9
-    CodeReq.ofProg (base + 1004) (divK_div_epilogue 24), -- block 10
-    CodeReq.ofProg (base + 1044) divK_zeroPath,          -- block 11
-    CodeReq.ofProg (base + 1064) (ADDI .x0 .x0 0),      -- block 12
-    CodeReq.ofProg (base + 1068) divK_div128             -- block 13
+    CodeReq.ofProg  base                  (divK_phaseA 1016),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 460),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 556 7740),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
+    CodeReq.ofProg (base + epilogueOff)   (divK_div_epilogue 24), -- block 10
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 11
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),       -- block 12
+    CodeReq.ofProg (base + div128Off)     divK_div128             -- block 13
   ]
 
 /-- The full evm_mod code split into 14 per-phase CodeReq.ofProg blocks.
     Identical to divCode except block 10 uses divK_mod_epilogue. -/
 abbrev modCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
-    CodeReq.ofProg base (divK_phaseA 1016),
-    CodeReq.ofProg (base + 32) divK_phaseB,
-    CodeReq.ofProg (base + 116) divK_clz,
-    CodeReq.ofProg (base + 212) (divK_phaseC2 172),
-    CodeReq.ofProg (base + 228) divK_normB,
-    CodeReq.ofProg (base + 312) (divK_normA 40),
-    CodeReq.ofProg (base + 396) divK_copyAU,
-    CodeReq.ofProg (base + 432) (divK_loopSetup 460),
-    CodeReq.ofProg (base + 448) (divK_loopBody 556 7740),
-    CodeReq.ofProg (base + 904) divK_denorm,
-    CodeReq.ofProg (base + 1004) (divK_mod_epilogue 24),  -- block 10 differs from divCode
-    CodeReq.ofProg (base + 1044) divK_zeroPath,
-    CodeReq.ofProg (base + 1064) (ADDI .x0 .x0 0),
-    CodeReq.ofProg (base + 1068) divK_div128
+    CodeReq.ofProg  base                  (divK_phaseA 1016),
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,
+    CodeReq.ofProg (base + clzOff)        divK_clz,
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),
+    CodeReq.ofProg (base + normBOff)      divK_normB,
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 460),
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 556 7740),
+    CodeReq.ofProg (base + denormOff)     divK_denorm,
+    CodeReq.ofProg (base + epilogueOff)   (divK_mod_epilogue 24), -- block 10 differs from divCode
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),
+    CodeReq.ofProg (base + div128Off)     divK_div128
   ]
 
 -- ============================================================================
@@ -100,49 +103,49 @@ abbrev modCode (base : Word) : CodeReq :=
     for DIV and MOD. -/
 abbrev sharedDivModCode (base : Word) : CodeReq :=
   CodeReq.unionAll [
-    CodeReq.ofProg base (divK_phaseA 1016),             -- block 0
-    CodeReq.ofProg (base + 32) divK_phaseB,              -- block 1
-    CodeReq.ofProg (base + 116) divK_clz,                -- block 2
-    CodeReq.ofProg (base + 212) (divK_phaseC2 172),      -- block 3
-    CodeReq.ofProg (base + 228) divK_normB,              -- block 4
-    CodeReq.ofProg (base + 312) (divK_normA 40),         -- block 5
-    CodeReq.ofProg (base + 396) divK_copyAU,             -- block 6
-    CodeReq.ofProg (base + 432) (divK_loopSetup 460),    -- block 7
-    CodeReq.ofProg (base + 448) (divK_loopBody 556 7740),-- block 8
-    CodeReq.ofProg (base + 904) divK_denorm,             -- block 9
+    CodeReq.ofProg  base                  (divK_phaseA 1016),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 460),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 556 7740),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
     -- NO epilogue block (this is where divCode and modCode differ)
-    CodeReq.ofProg (base + 1044) divK_zeroPath,          -- block 10 (was 11)
-    CodeReq.ofProg (base + 1064) (ADDI .x0 .x0 0),      -- block 11 (was 12)
-    CodeReq.ofProg (base + 1068) divK_div128             -- block 12 (was 13)
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 10 (was 11)
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),       -- block 11 (was 12)
+    CodeReq.ofProg (base + div128Off)     divK_div128             -- block 12 (was 13)
   ]
 
 -- Per-block subsumption: each shared block ⊆ divCode.
 -- Blocks 0-9 are at the same union positions; blocks 10-12 (shared) = blocks 11-13 (divCode).
 private theorem shared_b0_div (b : Word) : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1016)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
-private theorem shared_b1_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 32) divK_phaseB) a = some i → (divCode b) a = some i := by
+private theorem shared_b1_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b2_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 116) divK_clz) a = some i → (divCode b) a = some i := by
+private theorem shared_b2_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b3_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 212) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
+private theorem shared_b3_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b4_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 228) divK_normB) a = some i → (divCode b) a = some i := by
+private theorem shared_b4_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b5_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 312) (divK_normA 40)) a = some i → (divCode b) a = some i := by
+private theorem shared_b5_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b6_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 396) divK_copyAU) a = some i → (divCode b) a = some i := by
+private theorem shared_b6_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b7_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 432) (divK_loopSetup 460)) a = some i → (divCode b) a = some i := by
+private theorem shared_b7_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 460)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b8_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 448) (divK_loopBody 556 7740)) a = some i → (divCode b) a = some i := by
+private theorem shared_b8_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 556 7740)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b9_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 904) divK_denorm) a = some i → (divCode b) a = some i := by
+private theorem shared_b9_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b10_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1044) divK_zeroPath) a = some i → (divCode b) a = some i := by
+private theorem shared_b10_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b11_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1064) (ADDI .x0 .x0 0 : Program)) a = some i → (divCode b) a = some i := by
+private theorem shared_b11_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b12_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1068) divK_div128) a = some i → (divCode b) a = some i := by
+private theorem shared_b12_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
 
 /-- sharedDivModCode ⊆ divCode: every shared block is also in divCode. -/
@@ -167,29 +170,29 @@ theorem sharedDivModCode_sub_divCode (base : Word) :
 -- Per-block subsumption: each shared block ⊆ modCode.
 private theorem shared_b0_mod (b : Word) : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1016)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
-private theorem shared_b1_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 32) divK_phaseB) a = some i → (modCode b) a = some i := by
+private theorem shared_b1_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b2_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 116) divK_clz) a = some i → (modCode b) a = some i := by
+private theorem shared_b2_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b3_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 212) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
+private theorem shared_b3_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b4_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 228) divK_normB) a = some i → (modCode b) a = some i := by
+private theorem shared_b4_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b5_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 312) (divK_normA 40)) a = some i → (modCode b) a = some i := by
+private theorem shared_b5_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b6_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 396) divK_copyAU) a = some i → (modCode b) a = some i := by
+private theorem shared_b6_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b7_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 432) (divK_loopSetup 460)) a = some i → (modCode b) a = some i := by
+private theorem shared_b7_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 460)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b8_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 448) (divK_loopBody 556 7740)) a = some i → (modCode b) a = some i := by
+private theorem shared_b8_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 556 7740)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b9_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 904) divK_denorm) a = some i → (modCode b) a = some i := by
+private theorem shared_b9_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b10_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1044) divK_zeroPath) a = some i → (modCode b) a = some i := by
+private theorem shared_b10_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b11_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1064) (ADDI .x0 .x0 0 : Program)) a = some i → (modCode b) a = some i := by
+private theorem shared_b11_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b12_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + 1068) divK_div128) a = some i → (modCode b) a = some i := by
+private theorem shared_b12_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
 /-- sharedDivModCode ⊆ modCode: every shared block is also in modCode. -/
 theorem sharedDivModCode_sub_modCode (base : Word) :

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -1,0 +1,118 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.Offsets
+
+  Named constants for byte offsets of each DivMod code block from the program
+  base. Canonical source of truth for `divCode`, `modCode`, `sharedDivModCode`,
+  and all downstream proofs that reference block boundaries.
+
+  Issue #301: Previously the offsets were hardcoded literals (`base + 448`,
+  `base + 904`, ...) scattered across ~40 files. Adding a single instruction
+  to one block would cascade into 500+ line diffs and error-prone sed-based
+  replacements. Named offsets localize the knowledge to this file; the
+  `drift_check_*` examples below fail at compile time if a block length
+  changes without updating the corresponding offset, pointing reviewers at
+  the exact constant that must be bumped.
+
+  Layout of `divCode` / `modCode` (all values in bytes from program base):
+
+    [phaseAOff    =   0] divK_phaseA        (32 bytes)
+    [phaseBOff    =  32] divK_phaseB        (84 bytes)
+    [clzOff       = 116] divK_clz           (96 bytes)
+    [phaseC2Off   = 212] divK_phaseC2       (16 bytes)
+    [normBOff     = 228] divK_normB         (84 bytes)
+    [normAOff     = 312] divK_normA         (84 bytes)
+    [copyAUOff    = 396] divK_copyAU        (36 bytes)
+    [loopSetupOff = 432] divK_loopSetup     (16 bytes)
+    [loopBodyOff  = 448] divK_loopBody     (456 bytes)
+    [denormOff    = 904] divK_denorm       (100 bytes)
+    [epilogueOff  =1004] divK_{div,mod}_epilogue (40 bytes)
+    [zeroPathOff  =1044] divK_zeroPath      (20 bytes)
+    [nopOff       =1064] ADDI x0, x0, 0      (4 bytes)
+    [div128Off    =1068] divK_div128       (196 bytes)
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Block start offsets (in bytes, as Word for direct use in `base + off`)
+-- ============================================================================
+
+/-- Offset of `divK_phaseA` (the entry block). -/
+abbrev phaseAOff    : Word :=    0
+/-- Offset of `divK_phaseB` (b=0 branch + leading-limb analysis). -/
+abbrev phaseBOff    : Word :=   32
+/-- Offset of `divK_clz` (count leading zeros for shift amount). -/
+abbrev clzOff       : Word :=  116
+/-- Offset of `divK_phaseC2` (branch on shift=0 fast path). -/
+abbrev phaseC2Off   : Word :=  212
+/-- Offset of `divK_normB` (normalize divisor b). -/
+abbrev normBOff     : Word :=  228
+/-- Offset of `divK_normA` (normalize dividend a). -/
+abbrev normAOff     : Word :=  312
+/-- Offset of `divK_copyAU` (copy a[] into u[] scratch). -/
+abbrev copyAUOff    : Word :=  396
+/-- Offset of `divK_loopSetup` (initialize loop counter j). -/
+abbrev loopSetupOff : Word :=  432
+/-- Offset of `divK_loopBody` (Knuth Algorithm D main loop body). -/
+abbrev loopBodyOff  : Word :=  448
+/-- Offset of `divK_denorm` (denormalize result back to original shift). -/
+abbrev denormOff    : Word :=  904
+/-- Offset of the epilogue (`divK_div_epilogue` for DIV, `divK_mod_epilogue`
+    for MOD; both are 40 bytes). -/
+abbrev epilogueOff  : Word := 1004
+/-- Offset of `divK_zeroPath` (b=0 quick return with result 0). -/
+abbrev zeroPathOff  : Word := 1044
+/-- Offset of the NOP separator between `divK_zeroPath` and `divK_div128`.
+    Ensures the subroutine entry differs from any block exit PC. -/
+abbrev nopOff       : Word := 1064
+/-- Offset of `divK_div128` (the 128÷64 long-division subroutine). -/
+abbrev div128Off    : Word := 1068
+
+-- ============================================================================
+-- Consistency / drift checks
+--
+-- Each `drift_check_*` below ties an offset to the sum of the previous offset
+-- plus the previous block's length × 4 (bytes per RV64 instruction). If a
+-- block grows or shrinks without the corresponding offset being updated, the
+-- affected check fails at compile time with a clear error pointing at the
+-- stale constant. This localizes address maintenance to this one file.
+--
+-- These are `example` declarations so they participate in the kernel check
+-- without polluting the name space. They resolve by `decide` (all inputs
+-- reduce to concrete numerals).
+-- ============================================================================
+
+/-- phaseBOff = phaseAOff + 4 · |divK_phaseA 1016|. -/
+example : phaseBOff = phaseAOff + 4 * (divK_phaseA 1016).length := by decide
+/-- clzOff = phaseBOff + 4 · |divK_phaseB|. -/
+example : clzOff = phaseBOff + 4 * divK_phaseB.length := by decide
+/-- phaseC2Off = clzOff + 4 · |divK_clz|. -/
+example : phaseC2Off = clzOff + 4 * divK_clz.length := by decide
+/-- normBOff = phaseC2Off + 4 · |divK_phaseC2 172|. -/
+example : normBOff = phaseC2Off + 4 * (divK_phaseC2 172).length := by decide
+/-- normAOff = normBOff + 4 · |divK_normB|. -/
+example : normAOff = normBOff + 4 * divK_normB.length := by decide
+/-- copyAUOff = normAOff + 4 · |divK_normA 40|. -/
+example : copyAUOff = normAOff + 4 * (divK_normA 40).length := by decide
+/-- loopSetupOff = copyAUOff + 4 · |divK_copyAU|. -/
+example : loopSetupOff = copyAUOff + 4 * divK_copyAU.length := by decide
+/-- loopBodyOff = loopSetupOff + 4 · |divK_loopSetup 460|. -/
+example : loopBodyOff = loopSetupOff + 4 * (divK_loopSetup 460).length := by decide
+/-- denormOff = loopBodyOff + 4 · |divK_loopBody 556 7740|. -/
+example : denormOff = loopBodyOff + 4 * (divK_loopBody 556 7740).length := by decide
+/-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
+example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
+/-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|
+    (DIV and MOD epilogues share the same length). -/
+example : zeroPathOff = epilogueOff + 4 * (divK_div_epilogue 24).length := by decide
+example : zeroPathOff = epilogueOff + 4 * (divK_mod_epilogue 24).length := by decide
+/-- nopOff = zeroPathOff + 4 · |divK_zeroPath|. -/
+example : nopOff = zeroPathOff + 4 * divK_zeroPath.length := by decide
+/-- div128Off = nopOff + 4 (single NOP instruction). -/
+example : div128Off = nopOff + 4 := by decide
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -22,7 +22,7 @@ open EvmAsm.Rv64
 
 /-- The loopBody ofProg (block 8) is subsumed by sharedDivModCode. -/
 private theorem divK_loopBody_ofProg_sub_sharedCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 448) (divK_loopBody 556 7740)) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + loopBodyOff) (divK_loopBody 556 7740)) a = some i →
       (sharedDivModCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -32,14 +32,14 @@ private theorem divK_loopBody_ofProg_sub_sharedCode (base : Word) :
 /-- Helper: singleton at index k of divK_loopBody ⊆ sharedDivModCode base. -/
 private theorem lb_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < (divK_loopBody 556 7740).length)
-    (h_addr : addr = (base + 448) + BitVec.ofNat 64 (4 * k))
+    (h_addr : addr = (base + loopBodyOff) + BitVec.ofNat 64 (4 * k))
     (h_instr : (divK_loopBody 556 7740).get ⟨k, hk⟩ = instr) :
     ∀ a i, CodeReq.singleton addr instr a = some i →
       (sharedDivModCode base) a = some i := by
   subst h_addr; subst h_instr
   exact fun a i h => divK_loopBody_ofProg_sub_sharedCode base a i
     (CodeReq.singleton_mono
-      (CodeReq.ofProg_lookup (base + 448) (divK_loopBody 556 7740) k hk (by decide)) a i h)
+      (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 556 7740) k hk (by decide)) a i h)
 
 /-- Helper: combine two subsumption proofs over a union. -/
 private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
@@ -54,12 +54,12 @@ private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
 
 -- ============================================================================
 -- Section 2: Address normalization lemmas
--- Loop body base = base + 448.
--- Instruction [k] is at base + 448 + 4*k.
+-- Loop body base = base + loopBodyOff.
+-- Instruction [k] is at base + loopBodyOff + 4*k.
 -- ============================================================================
 
 -- Mulsub limb base addresses (instrs [22]-[65])
-private theorem lb_ms0 (base : Word) : (base + 448 : Word) + 88 = base + 536 := by bv_addr
+private theorem lb_ms0 (base : Word) : (base + loopBodyOff : Word) + 88 = base + 536 := by bv_addr
 private theorem lb_ms1 (base : Word) : (base + 536 : Word) + 44 = base + 580 := by bv_addr
 private theorem lb_ms2 (base : Word) : (base + 580 : Word) + 44 = base + 624 := by bv_addr
 private theorem lb_ms3 (base : Word) : (base + 624 : Word) + 44 = base + 668 := by bv_addr
@@ -240,7 +240,7 @@ theorem divK_mulsub_4limbs_spec
 -- ============================================================================
 
 -- Addback base addresses (instrs [71]-[107])
-private theorem lb_ab_init (base : Word) : (base + 448 : Word) + 284 = base + 732 := by bv_addr
+private theorem lb_ab_init (base : Word) : (base + loopBodyOff : Word) + 284 = base + 732 := by bv_addr
 private theorem lb_ab0 (base : Word) : (base + 732 : Word) + 4 = base + 736 := by bv_addr
 private theorem lb_ab0_end (base : Word) : (base + 736 : Word) + 32 = base + 768 := by bv_addr
 private theorem lb_ab1_end (base : Word) : (base + 768 : Word) + 32 = base + 800 := by bv_addr
@@ -713,7 +713,7 @@ theorem divK_correction_addback_spec
 -- Instrs [0]-[12] at base+448 → base+500.
 -- ============================================================================
 
-private theorem lb_save_j (base : Word) : (base + 448 : Word) + 4 = base + 452 := by bv_addr
+private theorem lb_save_j (base : Word) : (base + loopBodyOff : Word) + 4 = base + 452 := by bv_addr
 private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 500 := by bv_addr
 
 set_option maxRecDepth 4096 in
@@ -731,7 +731,7 @@ theorem divK_save_trial_load_spec
     (hv_vtop : isValidDwordAccess (sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) = true) :
     let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 500) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + 500) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
@@ -748,7 +748,7 @@ theorem divK_save_trial_load_spec
        (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
   intro u_addr vtop_base
   -- 1. Save j: instr [0] at base+448
-  have SJ := divK_save_j_spec sp j j_old (base + 448) hv_j
+  have SJ := divK_save_j_spec sp j j_old (base + loopBodyOff) hv_j
   rw [lb_save_j] at SJ
   have SJe := cpsTriple_extend_code (hmono :=
     lb_sub base 0 _ _ (by decide) (by bv_addr) (by decide)) SJ
@@ -926,7 +926,7 @@ theorem divK_trial_call_path_spec
 -- Address normalization for store_qj and loop control
 private theorem lb_sqj (base : Word) : (base + 880 : Word) + 16 = base + 896 := by bv_addr
 private theorem lb_lc_taken (base : Word) :
-    (base + 896 : Word) + 4 + signExtend13 (7740 : BitVec 13) = base + 448 := by
+    (base + 896 : Word) + 4 + signExtend13 (7740 : BitVec 13) = base + loopBodyOff := by
   have : signExtend13 (7740 : BitVec 13) = (18446744073709551164 : Word) := by decide
   rw [this]; bv_addr
 private theorem lb_lc_exit (base : Word) : (base + 896 : Word) + 8 = base + 904 := by bv_addr
@@ -948,7 +948,7 @@ theorem divK_store_loop_spec
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_old))
-      (base + 448)
+      (base + loopBodyOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_hat))
@@ -987,7 +987,7 @@ theorem divK_store_loop_spec
   have LCp : cpsBranch (base + 896) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) ** (q_addr ↦ₘ q_hat))
-      (base + 448)
+      (base + loopBodyOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) ** (q_addr ↦ₘ q_hat))
       (base + 904)
@@ -1047,7 +1047,7 @@ theorem divK_store_loop_j0_spec
     exact lb_sub base 112 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7740 at base+900 (instr [113]) — RAW with pure condition
   have hbge_raw := bge_spec_gen .x1 .x0 (7740 : BitVec 13) j' (0 : Word) (base + 900)
-  rw [show (base + 900 : Word) + signExtend13 (7740 : BitVec 13) = base + 448 from by
+  rw [show (base + 900 : Word) + signExtend13 (7740 : BitVec 13) = base + loopBodyOff from by
         rw [show signExtend13 (7740 : BitVec 13) = (18446744073709551164 : Word) from by decide]
         bv_addr,
       show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at hbge_raw
@@ -1110,7 +1110,7 @@ theorem divK_store_loop_jgt0_spec
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - j_x8
     let j' := j + signExtend12 4095
-    cpsTriple (base + 880) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + 880) (base + loopBodyOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_old))
@@ -1134,7 +1134,7 @@ theorem divK_store_loop_jgt0_spec
     exact lb_sub base 112 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7740 at base+900 (instr [113]) — RAW with pure condition
   have hbge_raw := bge_spec_gen .x1 .x0 (7740 : BitVec 13) j' (0 : Word) (base + 900)
-  rw [show (base + 900 : Word) + signExtend13 (7740 : BitVec 13) = base + 448 from by
+  rw [show (base + 900 : Word) + signExtend13 (7740 : BitVec 13) = base + loopBodyOff from by
         rw [show signExtend13 (7740 : BitVec 13) = (18446744073709551164 : Word) from by decide]
         bv_addr,
       show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at hbge_raw
@@ -1422,7 +1422,7 @@ theorem divK_trial_max_full_spec
     (hbltu : ¬BitVec.ult u_hi v_top) :
     let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 516) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -1524,7 +1524,7 @@ theorem divK_trial_call_full_spec
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0_div
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + 448) (base + 516) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **


### PR DESCRIPTION
## Summary
- First step toward resolving #301: localizes DivMod block-offset maintenance to a single file and replaces hardcoded literals at the canonical layout site.
- Adds `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` defining `abbrev Word` constants for every block boundary (`phaseAOff` … `div128Off`) plus compile-time **drift checks**: each `example : offN = offPrev + 4 * blockPrev.length` fails at compile time if a block grows/shrinks, pointing the reviewer directly at the stale constant.
- Migrates `Compose/Base.lean` (`divCode`, `modCode`, `sharedDivModCode`, and all 26 `shared_bN_{div,mod}` subsumption lemmas) and the block-boundary references in `DivMod/LoopBody.lean` (18 occurrences of `base + 448` → `base + loopBodyOff`).

## Design notes
- Offsets are `abbrev … : Word := LITERAL`, so every use reduces definitionally to the existing `base + N` — no proof changes were needed. `skipBlock` / `bv_omega` / `bv_addr` all see the same numeric values as before.
- The drift `example`s are the robustness payoff: if someone adds an instruction to, say, `divK_loopBody`, the `denormOff` / `epilogueOff` / … checks fail at build time and the fix is localized to one file.
- This PR is deliberately narrow. ~54 other DivMod files still reference literals; they can migrate incrementally without churn risk. Fully-computed offsets (e.g. `denormOff := loopBodyOff + 4 * (divK_loopBody …).length`) are a possible future step; since all usages flow through `Offsets.lean`, only that file would change.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.Offsets` — drift checks pass
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.Base` — 3313 jobs
- [x] `lake build EvmAsm.Evm64.DivMod.LoopBody` — 3337 jobs
- [x] `lake build` (full) — 3487 jobs, no regressions
- [x] No `sorry` / `native_decide` / `bv_decide` introduced

Refs #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)