### PR TITLE
Remove unnecessary set_option maxHeartbeats overrides

### DIFF
--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -105,7 +105,6 @@ theorem ret_spec' (base : Word) (ra_val : Word) :
 -- Prologue spec
 -- ============================================================================
 
-set_option maxHeartbeats 800000 in
 /-- Non-leaf prologue: allocate 16-byte frame, save ra at sp-8.
     sp_val is the ORIGINAL sp on entry.
     After prologue: sp = sp_val - 16, ra saved at mem[sp_val - 8]. -/
@@ -131,7 +130,6 @@ theorem cc_prologue_spec (base sp_val ra_val old_slot : Word)
 -- Epilogue spec
 -- ============================================================================
 
-set_option maxHeartbeats 800000 in
 /-- Non-leaf epilogue: restore ra, deallocate frame, return.
     sp_val is the FRAME sp (= original - 16).
     After epilogue: sp = sp_val + 16 (= original), ra restored, jumps to saved_ra. -/

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -38,7 +38,6 @@ theorem dup_pair_spec (sp : Word)
 -- Low-level generic DUP spec
 -- ============================================================================
 
-set_option maxHeartbeats 6400000 in
 /-- Generic DUPn spec (low level): copies 4 dword limbs from src (at nsp+n*32) to dst (at nsp).
     Requires 1 ≤ n ≤ 16 (valid EVM DUP range). -/
 theorem evm_dup_spec (nsp base : Word)
@@ -119,7 +118,6 @@ theorem evm_dup_spec (nsp base : Word)
 -- EvmWord-level DUP spec
 -- ============================================================================
 
-set_option maxHeartbeats 3200000 in
 /-- DUPn spec at evmWordIs level: copies the nth stack element to new top position. -/
 theorem evm_dup_evmword_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
@@ -156,7 +154,6 @@ theorem evm_dup_evmword_spec (nsp base : Word)
 -- Stack-level DUP spec
 -- ============================================================================
 
-set_option maxHeartbeats 3200000 in
 /-- DUPn stack spec: copies the (n-1)-th element (0-indexed) from the stack
     to a new top position, leaving the rest unchanged. -/
 theorem evm_dup_stack_spec (nsp base : Word)

--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -39,7 +39,6 @@ private theorem ite_word_01 (c : Prop) [Decidable c] :
   split <;> simp
 
 -- Combined carry: (carry_a ||| carry_b).toNat = (a + b + cin) / 2^64
-set_option maxHeartbeats 400000 in
 private theorem combined_carry_toNat (x y cin : Word) (hcin : cin.toNat ≤ 1) :
     let psum := x + y
     let ca := if BitVec.ult psum y then (1 : Word) else 0
@@ -55,7 +54,6 @@ private theorem combined_carry_toNat (x y cin : Word) (hcin : cin.toNat ≤ 1) :
   have : (x.toNat + y.toNat) % 2^64 < 2^64 := Nat.mod_lt _ (by omega)
   omega
 
-set_option maxHeartbeats 800000 in
 /-- Each limb of a + b equals the carry-chain result at that limb position. -/
 theorem add_carry_chain_correct (a b : EvmWord) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
@@ -236,7 +234,6 @@ private theorem sub_limb_toNat {a_limb b_limb borrow : Word}
   have hb := b_limb.isLt
   rcases hborrow with h | h <;> simp only [h] <;> omega
 
-set_option maxHeartbeats 800000 in
 /-- Each limb of a - b equals the borrow-chain result at that limb position. -/
 theorem sub_borrow_chain_correct (a b : EvmWord) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0

--- a/EvmAsm/Evm64/EvmWordArith/Comparison.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Comparison.lean
@@ -16,7 +16,6 @@ namespace EvmWord
 -- LT correctness: borrow chain = unsigned less-than
 -- ============================================================================
 
-set_option maxHeartbeats 400000 in
 theorem lt_borrow_chain_correct (a b : EvmWord) :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
     let a1 := a.getLimb 1; let b1 := b.getLimb 1

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -15,7 +15,6 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-set_option maxHeartbeats 6400000 in
 /-- PUSH0: writes 4 zero limbs at nsp, moves SP backward by 32.
     5 instructions = 20 bytes. nsp is the NEW stack pointer (after decrement). -/
 theorem evm_push0_spec (nsp base : Word)

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -40,7 +40,7 @@ theorem swap_limb_spec (sp : Word)
 -- Low-level generic SWAP spec
 -- ============================================================================
 
-set_option maxHeartbeats 6400000 in
+set_option maxHeartbeats 800000 in
 /-- Generic SWAPn spec (low level): swaps 4 dword limbs at sp (top) with 4 at sp+n*32 (nth).
     Requires 1 ≤ n ≤ 16 (valid EVM SWAP range). -/
 theorem evm_swap_spec (sp base : Word)


### PR DESCRIPTION
## Summary
- Removes 10 `set_option maxHeartbeats` overrides that aren't needed — the default heartbeat budget suffices for each theorem.
- Lowers `evm_swap_spec` from 6400000 → 800000 (4x default → still well under the prior 32x default).

Per [AGENTS.md](https://github.com/Verified-zkEVM/evm-asm/blob/main/AGENTS.md):
> Do NOT add `set_option maxHeartbeats` to any file unless you are in `Evm64/Shift/` composition files.

Touched files:
- `EvmWordArith/Comparison.lean` — `lt_borrow_chain_correct`
- `EvmWordArith/Arithmetic.lean` — `combined_carry_toNat`, `add_carry_chain_correct`, `sub_borrow_chain_correct`
- `CallingConvention.lean` — `cc_prologue_spec`, `cc_epilogue_spec`
- `Push0/Spec.lean` — `evm_push0_spec`
- `Dup/Spec.lean` — `evm_dup_spec`, `evm_dup_evmword_spec`, `evm_dup_stack_spec`
- `Swap/Spec.lean` — `evm_swap_spec` (lowered, not removed; this one really does need some headroom)

## Test plan
- [x] `lake build EvmAsm.Evm64` succeeds locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)