### PR TITLE
Migrate Spec + LoopUnifiedN{1,2,3} to named offsets (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -70,7 +70,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     -- Unified branch conditions
     (hbltu_1 : bltu_1 = BitVec.ult u1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -412,7 +412,7 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
@@ -533,7 +533,7 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
@@ -658,7 +658,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
@@ -768,7 +768,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
@@ -924,7 +924,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
@@ -1084,7 +1084,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
         (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
         (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
         (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -66,7 +66,7 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     -- Unified branch conditions
     (hbltu_1 : bltu_1 = BitVec.ult u2 v1)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -410,7 +410,7 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
@@ -531,7 +531,7 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
@@ -656,7 +656,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
       (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -63,7 +63,7 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     -- Unified branch conditions
     (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2) :
-    cpsTriple (base + 448) (base + 904) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -31,7 +31,7 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v10 : Word)
     (hbz : b = 0)
     (hvalid : ValidMemRange sp 8) :
-    cpsTriple base (base + 1064) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs (sp + 32) b)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -94,7 +94,7 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v10 : Word)
     (hbz : b = 0)
     (hvalid : ValidMemRange sp 8) :
-    cpsTriple base (base + 1064) (modCode base)
+    cpsTriple base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs (sp + 32) b)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **


### PR DESCRIPTION
## Summary
- Phase 2 of #301, following up on #306.
- Replaces hardcoded address literals with named offsets from `DivMod.Compose.Offsets` in four more files: `DivMod/Spec.lean` and `DivMod/LoopUnifiedN{1,2,3}.lean`.

## What changed
- `base + 448`  → `base + loopBodyOff` (12 occurrences)
- `base + 904`  → `base + denormOff` (12 occurrences)
- `base + 1064` → `base + nopOff` (2 occurrences, both in `Spec.lean`)

All sites are uniform `cpsTriple` pre/post-PC arguments. Because the offsets are `abbrev … : Word := LITERAL`, every substitution is definitionally transparent — no proof bodies needed to change.

Remaining DivMod files that still reference raw block-boundary literals can migrate in follow-up PRs (~50 files, ~580 occurrences). Each future PR can stay small and independent thanks to the transparent `abbrev` approach.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec EvmAsm.Evm64.DivMod.LoopUnifiedN1 EvmAsm.Evm64.DivMod.LoopUnifiedN2 EvmAsm.Evm64.DivMod.LoopUnifiedN3` — 3374 jobs, ok
- [x] `lake build` (full) — 3487 jobs, no regressions
- [x] No `sorry` / `native_decide` / `bv_decide` introduced

Refs #301.

🤖 Generated with [Claude Code](https://claude.com/claude-code)