### PR TITLE
Migrate FullPathN{1,2,3,4}Loop addr lemmas to `divmod_addr`

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNorm.lean
@@ -100,6 +100,13 @@ open EvmAsm.Rv64
 @[divmod_addr, grind =] theorem word_shl3_4 : (4 : Word) <<< 3 = (32 : Word) := by decide
 
 -- ============================================================================
+-- Algebraic identities for Word (needed when simp evaluates signExtend12
+-- to a concrete literal, leaving `0 + literal` behind).
+-- ============================================================================
+
+@[divmod_addr, grind =] theorem word_zero_add (x : Word) : (0 : Word) + x = x := BitVec.zero_add x
+
+-- ============================================================================
 -- `divmod_addr` tactic
 --
 -- Primary: `grind` (sees all @[grind =]-registered atomic facts).

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -40,43 +40,23 @@ theorem x1_val_n1 : signExtend12 (4 : BitVec 12) - (1 : Word) = (3 : Word) := by
 theorem n1_ub3_off0 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4032 := by
-  simp only [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ub3_off4088 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4024 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ub3_off4080 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4016 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) from by decide,
-    show signExtend12 (4016 : BitVec 12) = (18446744073709551536 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ub3_off4072 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4008 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) from by decide,
-    show signExtend12 (4008 : BitVec 12) = (18446744073709551528 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ub3_off4064 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4000 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) from by decide,
-    show signExtend12 (4000 : BitVec 12) = (18446744073709551520 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- u_base(2)+0 = sp+se(4040), already covered by n2_ub2_off0 (same addresses)
 -- u_base(1)+0 = sp+se(4048), already covered by n3_ub1_off0
@@ -85,10 +65,7 @@ theorem n1_ub3_off4064 (sp : Word) :
 -- q_addr(j) = sp + se(4088) - j<<<3
 theorem n1_qa3 (sp : Word) :
     sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4064 := by
-  simp only [show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (3 : Word) <<< 3 = (24 : Word) from by decide]; bv_omega
+  divmod_addr
 -- n1_qa2 = n2_qa2 (same: sp + se(4088) - 16 = sp + se(4072))
 -- n1_qa1 = n3_qa1 (same: sp + se(4088) - 8 = sp + se(4080))
 -- n1_qa0 = n3_qa0 (same: sp + se(4088) - 0 = sp + se(4088))
@@ -96,65 +73,40 @@ theorem n1_qa3 (sp : Word) :
 -- div128 hi/lo addresses for j=3
 theorem n1_uhi_3_addr (sp : Word) :
     sp + signExtend12 4056 - (3 + (1 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4024 := by
-  simp only [show (3 + (1 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ulo_3_addr (sp : Word) :
     (sp + signExtend12 4056 - (3 + (1 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4032 := by
-  simp only [show (3 + (1 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- v[n-1] address for n=1: v[0] at sp + ((1:Word) + se(4095))<<<3 + se(32)
 theorem n1_vtop_addr (sp : Word) :
     sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32 =
     sp + signExtend12 32 := by
-  simp only [show (1 : Word) + signExtend12 (4095 : BitVec 12) = (0 : Word) from by decide,
-    show (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) from by decide,
-    show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- div128 hi/lo addresses for j=2 (n=1 uses n=1 not n=2, so (j+n)=(2+1)=3)
 theorem n1_uhi_2_addr (sp : Word) :
     sp + signExtend12 4056 - (2 + (1 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4032 := by
-  simp only [show (2 + (1 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ulo_2_addr (sp : Word) :
     (sp + signExtend12 4056 - (2 + (1 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4040 := by
-  simp only [show (2 + (1 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- div128 hi/lo addresses for j=1 (n=1: (j+n)=(1+1)=2)
 theorem n1_uhi_1_addr (sp : Word) :
     sp + signExtend12 4056 - (1 + (1 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4040 := by
-  simp only [show (1 + (1 : Word)) = (2 : Word) from by decide,
-    show (2 : Word) <<< (3 : BitVec 6).toNat = (16 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ulo_1_addr (sp : Word) :
     (sp + signExtend12 4056 - (1 + (1 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4048 := by
-  simp only [show (1 + (1 : Word)) = (2 : Word) from by decide,
-    show (2 : Word) <<< (3 : BitVec 6).toNat = (16 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- div128 hi/lo addresses for j=0 (n=1: (j+n)=(0+1)=1)
 theorem n1_uhi_0_addr (sp : Word) :
     sp + signExtend12 4056 - (0 + (1 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4048 := by
-  simp only [show (0 + (1 : Word)) = (1 : Word) from by decide,
-    show (1 : Word) <<< (3 : BitVec 6).toNat = (8 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n1_ulo_0_addr (sp : Word) :
     (sp + signExtend12 4056 - (0 + (1 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4056 := by
-  simp only [show (0 + (1 : Word)) = (1 : Word) from by decide,
-    show (1 : Word) <<< (3 : BitVec 6).toNat = (8 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- ============================================================================
 -- Lift unified n=1 loop from sharedDivModCode to divCode

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -40,43 +40,23 @@ theorem x1_val_n2 : signExtend12 (4 : BitVec 12) - (2 : Word) = (2 : Word) := by
 theorem n2_ub2_off0 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4040 := by
-  simp only [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ub2_off4088 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4032 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ub2_off4080 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4024 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ub2_off4072 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4016 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) from by decide,
-    show signExtend12 (4016 : BitVec 12) = (18446744073709551536 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ub2_off4064 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4008 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) from by decide,
-    show signExtend12 (4008 : BitVec 12) = (18446744073709551528 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- u_base(1)+0 = sp+se(4048), already covered by n3_ub1_off0 (same addresses)
 -- u_base(0)+0 = sp+se(4056), already covered by n3_ub0_off0
@@ -84,63 +64,39 @@ theorem n2_ub2_off4064 (sp : Word) :
 -- q_addr(j) = sp + se(4088) - j<<<3
 theorem n2_qa2 (sp : Word) :
     sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4072 := by
-  simp only [show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (2 : Word) <<< 3 = (16 : Word) from by decide]; bv_omega
+  divmod_addr
 -- n2_qa1 = n3_qa1 (same: sp + se(4088) - 8 = sp + se(4080))
 -- n2_qa0 = n3_qa0 (same: sp + se(4088) - 0 = sp + se(4088))
 
 -- div128 hi/lo addresses for j=2
 theorem n2_uhi_2_addr (sp : Word) :
     sp + signExtend12 4056 - (2 + (2 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4024 := by
-  simp only [show (2 + (2 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ulo_2_addr (sp : Word) :
     (sp + signExtend12 4056 - (2 + (2 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4032 := by
-  simp only [show (2 + (2 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- v[n-1] address for n=2: v[1] at sp + ((2:Word) + se(4095))<<<3 + se(32)
 theorem n2_vtop_addr (sp : Word) :
     sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32 =
     sp + signExtend12 40 := by
-  simp only [show (2 : Word) + signExtend12 (4095 : BitVec 12) = (1 : Word) from by decide,
-    show (1 : Word) <<< (3 : BitVec 6).toNat = (8 : Word) from by decide,
-    show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide,
-    show signExtend12 (40 : BitVec 12) = (40 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- div128 hi/lo addresses for j=1
 theorem n2_uhi_1_addr (sp : Word) :
     sp + signExtend12 4056 - (1 + (2 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4032 := by
-  simp only [show (1 + (2 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ulo_1_addr (sp : Word) :
     (sp + signExtend12 4056 - (1 + (2 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4040 := by
-  simp only [show (1 + (2 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- div128 hi/lo addresses for j=0
 theorem n2_uhi_0_addr (sp : Word) :
     sp + signExtend12 4056 - (0 + (2 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4040 := by
-  simp only [show (0 + (2 : Word)) = (2 : Word) from by decide,
-    show (2 : Word) <<< (3 : BitVec 6).toNat = (16 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n2_ulo_0_addr (sp : Word) :
     (sp + signExtend12 4056 - (0 + (2 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4048 := by
-  simp only [show (0 + (2 : Word)) = (2 : Word) from by decide,
-    show (2 : Word) <<< (3 : BitVec 6).toNat = (16 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- ============================================================================
 -- Lift unified n=2 loop from sharedDivModCode to divCode

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -72,89 +72,48 @@ theorem x1_val_n3 : signExtend12 (4 : BitVec 12) - (3 : Word) = (1 : Word) := by
 theorem n3_ub1_off0 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4048 := by
-  simp only [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ub1_off4088 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4040 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ub1_off4080 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4032 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ub1_off4072 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4024 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ub1_off4064 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4016 := by
-  simp only [show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) from by decide,
-    show signExtend12 (4016 : BitVec 12) = (18446744073709551536 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ub0_off0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4056 := by
-  simp only [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (0 : Word) <<< 3 = (0 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_qa1 (sp : Word) :
     sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4080 := by
-  simp only [show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (1 : Word) <<< 3 = (8 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_qa0 (sp : Word) :
     sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4088 := by
-  simp only [show signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) from by decide,
-    show (3 : BitVec 6).toNat = 3 from by decide,
-    show (0 : Word) <<< 3 = (0 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_uhi_1_addr (sp : Word) :
     sp + signExtend12 4056 - (1 + (3 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4024 := by
-  simp only [show (1 + (3 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ulo_1_addr (sp : Word) :
     (sp + signExtend12 4056 - (1 + (3 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4032 := by
-  simp only [show (1 + (3 : Word)) = (4 : Word) from by decide,
-    show (4 : Word) <<< (3 : BitVec 6).toNat = (32 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_vtop_addr (sp : Word) :
     sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32 = sp + 48 := by
-  simp only [show (3 : Word) + signExtend12 (4095 : BitVec 12) = (2 : Word) from by decide,
-    show (2 : Word) <<< (3 : BitVec 6).toNat = (16 : Word) from by decide, se12_32]; bv_omega
+  divmod_addr
 theorem n3_uhi_0_addr (sp : Word) :
     sp + signExtend12 4056 - (0 + (3 : Word)) <<< (3 : BitVec 6).toNat = sp + signExtend12 4032 := by
-  simp only [show (0 + (3 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) from by decide]; bv_omega
+  divmod_addr
 theorem n3_ulo_0_addr (sp : Word) :
     (sp + signExtend12 4056 - (0 + (3 : Word)) <<< (3 : BitVec 6).toNat) + 8 = sp + signExtend12 4040 := by
-  simp only [show (0 + (3 : Word)) = (3 : Word) from by decide,
-    show (3 : Word) <<< (3 : BitVec 6).toNat = (24 : Word) from by decide,
-    show signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) from by decide,
-    show signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) from by decide]; bv_omega
+  divmod_addr
 
 -- ============================================================================
 -- Condition predicates for n=3 preloop+loop composition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -19,35 +19,33 @@ open EvmAsm.Rv64
 -- Address normalization lemmas for j=0
 -- ============================================================================
 
-private theorem j0_shift0 : (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) := by decide
-
 theorem u_base_j0 (sp : Word) :
     sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4056 := by
-  simp only [j0_shift0]; exact BitVec.sub_zero _
+  divmod_addr
 
 theorem u_base_off0_j0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
-    sp + signExtend12 4056 := by rw [u_base_j0]; bv_addr
+    sp + signExtend12 4056 := by divmod_addr
 
 theorem u_base_off4088_j0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
-    sp + signExtend12 4048 := by rw [u_base_j0]; bv_addr
+    sp + signExtend12 4048 := by divmod_addr
 
 theorem u_base_off4080_j0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
-    sp + signExtend12 4040 := by rw [u_base_j0]; bv_addr
+    sp + signExtend12 4040 := by divmod_addr
 
 theorem u_base_off4072_j0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
-    sp + signExtend12 4032 := by rw [u_base_j0]; bv_addr
+    sp + signExtend12 4032 := by divmod_addr
 
 theorem u_base_off4064_j0 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
-    sp + signExtend12 4024 := by rw [u_base_j0]; bv_addr
+    sp + signExtend12 4024 := by divmod_addr
 
 theorem q_addr_j0 (sp : Word) :
     sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4088 := by
-  simp only [j0_shift0]; exact BitVec.sub_zero _
+  divmod_addr
 
 -- ============================================================================
 -- loopExitPostN4 at j=0: address normalization to sp-relative form
@@ -71,8 +69,7 @@ theorem loopExitPostN4_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
       u_base_off4072_j0, u_base_off4064_j0, u_base_j0, q_addr_j0]
-  simp only [j0_shift0]
-  rw [show (0 : Word) + signExtend12 4095 = signExtend12 4095 from BitVec.zero_add _]
+  simp only [divmod_addr]
 
 -- ============================================================================
 -- Loop body j=0 extended to divCode (from sharedDivModCode)


### PR DESCRIPTION
Towards #263. Following #304

Add `word_zero_add` to `AddrNorm.lean` and migrate 46 address-equality lemmas across the four FullPathN*Loop files to by `divmod_addr`. Removes the now-unused `j0_shift0` helper from `FullPathN4Loop`.

## Test plan

- [x] `lake build` — 3486/3486 jobs