### PR TITLE
Add file-size guardrail script and CI step (#314)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+      - name: File-size guardrail
+        run: scripts/check-file-size.sh
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -285,6 +285,31 @@ Large composition files (>1000 lines) should be split into independent sub-files
 
 This enables parallel kernel checking. The split reduced DivMod/Compose from 87s (monolithic) to 55s (critical path through Norm.lean).
 
+### File-size guardrail
+
+The advice above is enforced mechanically by `scripts/check-file-size.sh`, which runs as the first step of the Build CI workflow:
+
+| Path | Hard cap |
+|---|---|
+| `EvmAsm/Evm64/**/Compose/**/*.lean` | 1200 lines (soft cap 1000) |
+| `EvmAsm/Evm64/**/*.lean` (everything else) | 1500 lines |
+| `Program.lean` (any directory) | exempt — concrete bytecode + tests, no proof cost |
+
+A file over cap **must** either be split or carry an opt-out comment in its first 20 lines:
+
+```lean
+-- file-size-exception: <one-line reason, ideally with a tracking issue>
+```
+
+The reason is required so the exception is visible in code review rather than a silent override. Existing oversize files are grandfathered with such comments; new files should not need them.
+
+To run the check locally:
+
+```sh
+scripts/check-file-size.sh           # exit 1 on any unexcused violation
+scripts/check-file-size.sh --report  # always exit 0; print all over-cap files
+```
+
 ## Bundling Postconditions with `let` Bindings
 
 When a composed spec's postcondition has many `let` bindings (e.g., shift

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,6 +11,7 @@ Start with:
 Before sending work for review:
 
 - Run `lake build` and confirm it succeeds with no errors and no `sorry`.
+- Run `scripts/check-file-size.sh` (or rely on CI) — Lean files under `EvmAsm/Evm64/` have line caps documented in `AGENTS.md` ("File-size guardrail"). Split rather than raise the cap; if a split is genuinely impractical, add a `-- file-size-exception: <reason>` line near the top of the file so reviewers see the exception.
 - Avoid leaving `sorry` in finished work unless the change is explicitly meant to preserve partial progress.
 - When adding a new `.lean` file, make sure it is imported so that it is included in the default build target.
 - Do not add `set_option maxHeartbeats` or `set_option maxRecDepth` to files. These are configured globally in `lakefile.toml`. If a proof times out, restructure it (split into smaller lemmas, add intermediate `have` bindings) instead of raising limits. Timeouts are usually caused by unification issues, not insufficient heartbeats.

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issue #312 (Compose subtree split). Each loop-iteration lift composes with the pre-loop in one place; grandfathered pending split into per-iteration files.
 /-
   EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issue #312 (Compose subtree split). Pre-loop / loop-body / post-loop composition lives together; grandfathered pending split.
 /-
   EvmAsm.Evm64.DivMod.Compose.FullPathN4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issue #312 (split per-limb / mulsub / addback / phase / branch / div128 into a LimbSpec/ subdirectory). Grandfathered pending split.
 /-
   EvmAsm.Evm64.DivModSpec
 

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issues #283/#266 (skip/addback unification + DIV/MOD loop factoring). Grandfathered pending consolidation.
 /-
   EvmAsm.Evm64.DivMod.LoopBody
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issue #283 (per-j iteration spec consolidation). Each j-value specialization currently lives inline; grandfathered pending unification.
 /-
   EvmAsm.Evm64.DivMod.LoopIterN1
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -1,3 +1,4 @@
+-- file-size-exception: tracked by issue #283 (per-j iteration spec consolidation). Each j-value specialization currently lives inline; grandfathered pending unification.
 /-
   EvmAsm.Evm64.DivMod.LoopIterN2
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -134,6 +134,12 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
   Conventions, layout patterns, empirical justification, rules of thumb, and
   rollout roadmap are documented in `GRIND.md` (single source of truth for
   simp/grind-set conventions; `CLAUDE.md` and `AGENTS.md` link to it).
+- **File-size guardrail** (`scripts/check-file-size.sh`, issue #314): CI step
+  enforcing per-file line caps (1200 for `Compose/**`, 1500 elsewhere; `Program.lean`
+  exempt). Files may opt out with a `-- file-size-exception: <reason>` comment in
+  the first 20 lines. 6 oversize files grandfathered with exception comments
+  pointing to their tracking issues (#312, #283, #266). Documented in `AGENTS.md`
+  ("File-size guardrail") and `CONTRIBUTING.md`.
 - **LP64 Calling Convention** (`Evm64/CallingConvention.lean`): LP64-aligned
   calling convention for the x0–x12 register subset, per zkvm-standards.
   - x1 (ra) = return address, x2 (sp) = call stack (grows down, callee-saved)

--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+#
+# check-file-size.sh — enforce the per-file line caps described in
+# AGENTS.md ("File-size guardrail") and tracked by issue #314.
+#
+# Caps (lines, inclusive):
+#   * EvmAsm/Evm64/**/Compose/**/*.lean       hard cap 1200 (soft cap 1000)
+#   * EvmAsm/Evm64/**/*.lean (everything else) hard cap 1500
+#
+# Exemptions:
+#   * Files named Program.lean are exempt — concrete bytecode + tests
+#     are intrinsically long and cheap to compile.
+#   * A file may opt out by including a line of the form
+#       -- file-size-exception: <free-form reason>
+#     anywhere in the first 20 lines. The reason is required so reviewers
+#     see *why* the file is grandfathered.
+#
+# Usage:
+#   scripts/check-file-size.sh           # exit 1 on any violation
+#   scripts/check-file-size.sh --report  # always exit 0; print summary
+#
+# The script intentionally stays POSIX/bash with no external deps so it
+# runs in CI and as a pre-commit hook without setup.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_REL="EvmAsm/Evm64"
+COMPOSE_CAP=1200
+DEFAULT_CAP=1500
+EXCEPTION_LOOKAHEAD=20
+
+mode="enforce"
+if [[ ${1:-} == "--report" ]]; then
+  mode="report"
+fi
+
+violations=0
+exempted=0
+checked=0
+
+# Collect files in deterministic order.
+mapfile -t files < <(cd "$ROOT" && find "$ROOT_REL" -name '*.lean' -type f | LC_ALL=C sort)
+
+for rel in "${files[@]}"; do
+  path="$ROOT/$rel"
+  base="${rel##*/}"
+
+  # Program.lean files are intrinsically bytecode-shaped; skip.
+  if [[ "$base" == "Program.lean" ]]; then
+    continue
+  fi
+
+  checked=$((checked + 1))
+
+  if [[ "$rel" == */Compose/* ]]; then
+    cap=$COMPOSE_CAP
+    bucket="Compose"
+  else
+    cap=$DEFAULT_CAP
+    bucket="opcode"
+  fi
+
+  lines=$(wc -l < "$path")
+
+  if (( lines <= cap )); then
+    continue
+  fi
+
+  if head -n "$EXCEPTION_LOOKAHEAD" "$path" | grep -qE '^[[:space:]]*--[[:space:]]*file-size-exception:'; then
+    exempted=$((exempted + 1))
+    if [[ "$mode" == "report" ]]; then
+      reason=$(head -n "$EXCEPTION_LOOKAHEAD" "$path" \
+        | grep -E '^[[:space:]]*--[[:space:]]*file-size-exception:' \
+        | head -n 1 \
+        | sed -E 's/^[[:space:]]*--[[:space:]]*file-size-exception:[[:space:]]*//')
+      printf '  exempt  %4d / %d lines  %s  [%s] %s\n' \
+        "$lines" "$cap" "$rel" "$bucket" "$reason"
+    fi
+    continue
+  fi
+
+  violations=$((violations + 1))
+  printf '  FAIL    %4d / %d lines  %s  [%s]\n' \
+    "$lines" "$cap" "$rel" "$bucket"
+done
+
+if [[ "$mode" == "report" ]]; then
+  printf '\nchecked %d files, %d exempted, %d over cap\n' \
+    "$checked" "$exempted" "$violations"
+  exit 0
+fi
+
+if (( violations > 0 )); then
+  cat >&2 <<EOF
+
+==================================================================
+File-size guardrail failed: $violations file(s) exceed the cap.
+
+Caps:
+  Compose/**/*.lean   $COMPOSE_CAP lines
+  other Lean files    $DEFAULT_CAP lines  (Program.lean exempt)
+
+To fix, split the file. Compose/ is the canonical pattern — see
+AGENTS.md "Parallel file splitting for Compose files". The DivMod
+Compose split took monolithic build time from 87s to 55s.
+
+If a split is genuinely impractical, add a line near the top of the
+file documenting the reason:
+
+  -- file-size-exception: <one-line reason>
+
+Reviewers will see the reason in the diff. Do not use this as a
+silent override.
+==================================================================
+EOF
+  exit 1
+fi
+
+printf 'file-size guardrail: %d files checked, all within cap (%d exempted).\n' \
+  "$checked" "$exempted"


### PR DESCRIPTION
## Summary

Closes #314.

- New `scripts/check-file-size.sh` enforces per-file line caps for Lean files under `EvmAsm/Evm64/`:
  - `Compose/**/*.lean` — hard cap 1200 lines (soft cap 1000 per existing AGENTS.md guidance)
  - other Lean files — hard cap 1500 lines
  - `Program.lean` — exempt (concrete bytecode + tests)
- Runs as the first step of the existing Build workflow so violations fail fast, before the slow Lean compile.
- Files may opt out with `-- file-size-exception: <reason>` in the first 20 lines. The reason is required so the exception is reviewable rather than a silent override.
- Six currently-oversize files are grandfathered with exception comments pointing at their tracking issues (#312, #283, #266), so the existing drift is visible in the index rather than continuing to accumulate silently.
- Documented in `AGENTS.md` ("File-size guardrail" section, alongside the existing "Parallel file splitting" guidance), `CONTRIBUTING.md`, and `PLAN.md`.

Local report after grandfathering:

```
checked 152 files, 6 exempted, 0 over cap
```

## Test plan

- [x] `scripts/check-file-size.sh --report` lists all 6 grandfathered files with reasons.
- [x] `scripts/check-file-size.sh` exits 0 on the current tree.
- [x] Synthetic 1600-line file in `EvmAsm/Evm64/` triggers exit 1 with the help text.
- [x] Same synthetic file with a `-- file-size-exception:` line at the top exits 0.
- [x] Synthetic 1300-line file under a `Compose/` subdirectory triggers exit 1 (Compose cap is tighter).
- [ ] CI: Build workflow runs the new step before lean-action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)