### PR TITLE
Extract sub_divCode_of_phaseB_left helper in PhaseAB

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -20,6 +20,21 @@ open EvmAsm.Rv64
 -- Each sub-spec's CodeReq is subsumed by divCode using structural union reasoning.
 -- ============================================================================
 
+/-- Skip the phaseA block when descending into `divCode`: any membership in
+    the phaseB block (left of the remaining union) lifts to membership in
+    `phaseA ∪ (phaseB ∪ rest)`. Used by the ten `*_sub_divCode` theorems below
+    that would otherwise repeat the disjoint-range incantation verbatim. -/
+private theorem sub_divCode_of_phaseB_left (base : Word) (rest : CodeReq) :
+    ∀ a i,
+      CodeReq.ofProg (base + phaseBOff) divK_phaseB a = some i →
+      ((CodeReq.ofProg base (divK_phaseA 1016)).union
+        ((CodeReq.ofProg (base + phaseBOff) divK_phaseB).union rest)) a = some i :=
+  CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range _ _ _ _
+      (fun k1 k2 hk1 hk2 => by
+        simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
+    (CodeReq.union_mono_left _ _)
+
 /-- Phase A code (8 instructions, block 0) is subsumed by divCode. -/
 private theorem divK_phaseA_code_sub_divCode (base : Word) :
     ∀ a i, (divK_phaseA_code base) a = some i → (divCode base) a = some i := by
@@ -55,10 +70,7 @@ private theorem divK_phaseB_init1_code_sub_divCode (base : Word) :
     (divK_phaseB.take 7) 0
     (by bv_addr) (by decide) (by decide) (by decide) a i h
   -- Skip block 0 (phaseA disjoint from phaseB), match block 1
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 /-- Phase B init2 code (ofProg sub-range of block 1) is subsumed by divCode. -/
 private theorem divK_phaseB_init2_code_sub_divCode (base : Word) :
@@ -68,10 +80,7 @@ private theorem divK_phaseB_init2_code_sub_divCode (base : Word) :
   have h1 := CodeReq.ofProg_mono_sub (base + 32) (base + 60) divK_phaseB
     (divK_phaseB.drop 7 |>.take 2) 7
     (by bv_addr) (by decide) (by decide) (by decide) a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 /-- ADDI x5 x0 4 singleton at base+68 (part of block 1: phaseB) is subsumed by divCode. -/
 private theorem addi_x5_singleton_sub_divCode (base : Word) :
@@ -84,10 +93,7 @@ private theorem addi_x5_singleton_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by decide,
       show (base + 32 : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 /-- BNE x10 x0 24 singleton at base+72 (part of block 1: phaseB) is subsumed by divCode. -/
 private theorem bne_x10_singleton_sub_divCode (base : Word) :
@@ -100,10 +106,7 @@ private theorem bne_x10_singleton_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by decide,
       show (base + 32 : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 /-- Phase B tail code (ofProg sub-range of block 1) is subsumed by divCode. -/
 private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
@@ -113,10 +116,7 @@ private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
   have h1 := CodeReq.ofProg_mono_sub (base + 32) (base + 96) divK_phaseB
     (divK_phaseB.drop 16) 16
     (by bv_addr) (by decide) (by decide) (by decide) a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- ============================================================================
 -- Section 6: signExtend13 normalization
@@ -462,10 +462,7 @@ private theorem addi_x5_3_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by decide,
       show (base + 32 : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- BNE x7 x0 16 at base+80 (index 12 of phaseB)
 private theorem bne_x7_16_sub_divCode (base : Word) :
@@ -478,10 +475,7 @@ private theorem bne_x7_16_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by decide,
       show (base + 32 : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- ADDI x5 x0 2 at base+84 (index 13 of phaseB)
 private theorem addi_x5_2_sub_divCode (base : Word) :
@@ -494,10 +488,7 @@ private theorem addi_x5_2_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by decide,
       show (base + 32 : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- BNE x6 x0 8 at base+88 (index 14 of phaseB)
 private theorem bne_x6_8_sub_divCode (base : Word) :
@@ -510,10 +501,7 @@ private theorem bne_x6_8_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by decide,
       show (base + 32 : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- ADDI x5 x0 1 at base+92 (index 15 of phaseB)
 private theorem addi_x5_1_sub_divCode (base : Word) :
@@ -526,10 +514,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
   rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by decide,
       show (base + 32 : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
-  exact CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
-      (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _) a i h1
+  exact sub_divCode_of_phaseB_left base _ a i h1
 
 -- ============================================================================
 -- Section 10c: Phase B cascade constants and address lemmas


### PR DESCRIPTION
## Summary

Mirrors the refactor in #316 (ModPhaseB) on the div side. Ten `*_sub_divCode` theorems in `Compose/PhaseAB.lean` closed the final goal with the same three-line incantation:

```lean
exact CodeReq.mono_union_right
  (CodeReq.ofProg_disjoint_range _ _ _ _
    (fun k1 k2 hk1 hk2 => by simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
  (CodeReq.union_mono_left _ _) a i h1
```

Factor it out as a private `sub_divCode_of_phaseB_left` helper so each site becomes a single `exact sub_divCode_of_phaseB_left base _ a i h1`. Net: -15 lines.

Heads-up re PR #300: that PR touches `PhaseAB.lean` with per-address bumps (+16/-16) in this same region. Rebase on top will be a small mechanical merge — the addresses and the refactor are orthogonal.

## Test plan
- [x] `lake build` passes (3487/3487, zero warnings)
- [x] No sorry/axiom added; no semantic change