### PR TITLE
docs(agents): require conventional commit format for PR titles

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,10 @@ The project includes concrete test cases using `native_decide`:
 - Main branch: `main`
 - Create feature branches for new work
 - Use meaningful commit messages with Co-Authored-By line for AI contributions
+- **PR titles must follow conventional commit format**: `type[(scope)]: subject`
+  (e.g. `refactor: extract shared Shift Compose helpers`,
+  `fix(shr): address canonicalization in sign-fill path`). The PR summary bot
+  flags titles that don't match this format.
 
 ## References
 


### PR DESCRIPTION
## Summary
- PR #321's summary bot flagged its title for not matching the conventional commit format `type[(scope)]: subject`.
- Add a bullet under AGENTS.md's Git Workflow section documenting the expected PR title format, with examples.

## Test plan
- [x] No code changes; docs-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)