### PR TITLE
feat(rlp): add pure-fact Phase 1 classifier spec

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -347,4 +347,123 @@ theorem rlp_phase1_classifier_spec (v5 v10 : Word) (base : Word)
   simp only [rlp_phase1_exit_post_unfold]
   exact hcr_eq ▸ n1
 
+-- ============================================================================
+-- Spec: 5-exit classifier with per-step dispatch facts
+-- ============================================================================
+
+set_option maxHeartbeats 1600000 in
+/-- Pure-fact variant of `rlp_phase1_classifier_spec`: each exit post carries
+    the `⌜BitVec.ult v5 k_i⌝` (or negation, for the fall-through) fact from
+    the corresponding BLTU. Downstream handlers can combine these with the
+    exit PC to discriminate the RLP categories.
+
+    Note: this variant only carries the **current** step's dispatch fact at
+    each exit, not the accumulated chain of prior negations. For full range
+    identification (e.g., `0x80 ≤ p < 0xB8` at exit `e2`), a handler must
+    either re-read the prefix byte or combine with a prior-negation chain
+    that a future accumulated variant would provide. -/
+theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
+    (off1 off2 off3 off4 : BitVec 13)
+    (e1 e2 e3 e4 e5 : Word)
+    (he1 : (base + 4) + signExtend13 off1 = e1)
+    (he2 : (base + 12) + signExtend13 off2 = e2)
+    (he3 : (base + 20) + signExtend13 off3 = e3)
+    (he4 : (base + 28) + signExtend13 off4 = e4)
+    (he5 : base + 32 = e5) :
+    let k1 := (0 : Word) + signExtend12 0x80
+    let k2 := (0 : Word) + signExtend12 0xB8
+    let k3 := (0 : Word) + signExtend12 0xC0
+    let k4 := (0 : Word) + signExtend12 0xF8
+    let code := rlp_phase1_classifier_code off1 off2 off3 off4 base
+    cpsNBranch base code
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
+      [(e1, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k1) **
+            ⌜BitVec.ult v5 k1⌝),
+       (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k2) **
+            ⌜BitVec.ult v5 k2⌝),
+       (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k3) **
+            ⌜BitVec.ult v5 k3⌝),
+       (e4, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k4) **
+            ⌜BitVec.ult v5 k4⌝),
+       (e5, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k4) **
+            ⌜¬ BitVec.ult v5 k4⌝)] := by
+  -- Step specs WITH pure facts preserved.
+  have cs1 := rlp_phase1_step_spec v5 v10 0x80 off1 base e1 he1
+  have cs2 := rlp_phase1_step_spec v5 ((0 : Word) + signExtend12 0x80)
+    0xB8 off2 (base + 8) e2 (by
+      rw [show (base + 8 : Word) + 4 = base + 12 from by bv_omega]; exact he2)
+  have cs3 := rlp_phase1_step_spec v5 ((0 : Word) + signExtend12 0xB8)
+    0xC0 off3 (base + 16) e3 (by
+      rw [show (base + 16 : Word) + 4 = base + 20 from by bv_omega]; exact he3)
+  have cs4 := rlp_phase1_step_spec v5 ((0 : Word) + signExtend12 0xC0)
+    0xF8 off4 (base + 24) e4 (by
+      rw [show (base + 24 : Word) + 4 = base + 28 from by bv_omega]; exact he4)
+  -- Align fall-through PCs.
+  rw [show (base + 24 : Word) + 8 = e5 from by rw [← he5]; bv_omega] at cs4
+  rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at cs2
+  rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at cs3
+  -- Disjointness (same shape as the plain classifier spec).
+  let cr1 := rlp_phase1_step_code 0x80 off1 base
+  let cr2 := rlp_phase1_step_code 0xB8 off2 (base + 8)
+  let cr3 := rlp_phase1_step_code 0xC0 off3 (base + 16)
+  let cr4 := rlp_phase1_step_code 0xF8 off4 (base + 24)
+  have hd12 : cr1.Disjoint cr2 := step_code_Disjoint_8 _ _ _ _ _
+  have hd13 : cr1.Disjoint cr3 := step_code_Disjoint_16 _ _ _ _ _
+  have hd14 : cr1.Disjoint cr4 := step_code_Disjoint_24 _ _ _ _ _
+  have hd23 : cr2.Disjoint cr3 := by
+    have := step_code_Disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
+    rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at this
+    exact this
+  have hd24 : cr2.Disjoint cr4 := by
+    have := step_code_Disjoint_16 0xB8 0xF8 off2 off4 (base + 8)
+    rw [show (base + 8 : Word) + 16 = base + 24 from by bv_omega] at this
+    exact this
+  have hd34 : cr3.Disjoint cr4 := by
+    have := step_code_Disjoint_8 0xC0 0xF8 off3 off4 (base + 16)
+    rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at this
+    exact this
+  -- Fallthrough cpsNBranch preserving step 4's pure fact.
+  have ft : cpsNBranch e5 CodeReq.empty
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x10 ↦ᵣ ((0 : Word) + signExtend12 0xF8)) **
+       ⌜¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)
+      [(e5, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+            (.x10 ↦ᵣ ((0 : Word) + signExtend12 0xF8)) **
+            ⌜¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)] :=
+    cpsNBranch_refl e5 _ _ (fun _ hp => hp)
+  -- Chain step 4 + fallthrough (no perm: step4.fall = ft.pre).
+  have n4 := cpsBranch_cons_cpsNBranch (base + 24) cr4 CodeReq.empty
+    (CodeReq.Disjoint.empty_right cr4)
+    _ e4 _ e5 _ _ cs4 ft
+  have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
+    intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
+  -- Chain step 3 + n4: strip `⌜¬ult v5 k3⌝` from step3.fall to match n4.pre.
+  have hd3_rest : cr3.Disjoint (cr4.union CodeReq.empty) := by
+    rw [hunion_empty]; exact hd34
+  have n3 := cpsBranch_cons_cpsNBranch_with_perm (base + 16) cr3
+    (cr4.union CodeReq.empty) hd3_rest
+    _ e3 _ (base + 24) _ _ _
+    (sepConj_strip_pure_end3 _ _ _ _) cs3 n4
+  -- Chain step 2 + n3.
+  have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
+    rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 8) cr2
+    (cr3.union (cr4.union CodeReq.empty)) hd2_rest
+    _ e2 _ (base + 16) _ _ _
+    (sepConj_strip_pure_end3 _ _ _ _) cs2 n3
+  -- Chain step 1 + n2.
+  have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
+    rw [hunion_empty]
+    exact CodeReq.Disjoint.union_right hd12 (CodeReq.Disjoint.union_right hd13 hd14)
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr1
+    (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
+    _ e1 _ (base + 8) _ _ _
+    (sepConj_strip_pure_end3 _ _ _ _) cs1 n2
+  -- Collapse the trailing `empty` and match the goal's classifier_code.
+  have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
+      rlp_phase1_classifier_code off1 off2 off3 off4 base := by
+    simp only [hunion_empty]; rfl
+  show cpsNBranch base (rlp_phase1_classifier_code off1 off2 off3 off4 base) _ _
+  exact hcr_eq ▸ n1
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -351,7 +351,24 @@ theorem rlp_phase1_classifier_spec (v5 v10 : Word) (base : Word)
 -- Spec: 5-exit classifier with per-step dispatch facts
 -- ============================================================================
 
-set_option maxHeartbeats 1600000 in
+/-- Bundled exit postcondition with a dispatch fact: the register-ownership
+    triple (`x10 ↦ᵣ k_val`) conjoined with `⌜fact⌝`. Wrapped `@[irreducible]`
+    to keep `let` bindings out of the classifier theorem statement — see
+    AGENTS.md ("Bundling Postconditions with `let` Bindings"). -/
+@[irreducible]
+def rlp_phase1_exit_post_pure
+    (v5 : Word) (k : BitVec 12) (fact : Prop) : Assertion :=
+  let k_val := (0 : Word) + signExtend12 k
+  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜fact⌝
+
+/-- Unfold lemma for `rlp_phase1_exit_post_pure`. -/
+theorem rlp_phase1_exit_post_pure_unfold
+    (v5 : Word) (k : BitVec 12) (fact : Prop) :
+    rlp_phase1_exit_post_pure v5 k fact =
+    ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜fact⌝) := by
+  delta rlp_phase1_exit_post_pure; rfl
+
 /-- Pure-fact variant of `rlp_phase1_classifier_spec`: each exit post carries
     the `⌜BitVec.ult v5 k_i⌝` (or negation, for the fall-through) fact from
     the corresponding BLTU. Downstream handlers can combine these with the
@@ -370,23 +387,18 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
     (he3 : (base + 20) + signExtend13 off3 = e3)
     (he4 : (base + 28) + signExtend13 off4 = e4)
     (he5 : base + 32 = e5) :
-    let k1 := (0 : Word) + signExtend12 0x80
-    let k2 := (0 : Word) + signExtend12 0xB8
-    let k3 := (0 : Word) + signExtend12 0xC0
-    let k4 := (0 : Word) + signExtend12 0xF8
-    let code := rlp_phase1_classifier_code off1 off2 off3 off4 base
-    cpsNBranch base code
+    cpsNBranch base (rlp_phase1_classifier_code off1 off2 off3 off4 base)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      [(e1, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k1) **
-            ⌜BitVec.ult v5 k1⌝),
-       (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k2) **
-            ⌜BitVec.ult v5 k2⌝),
-       (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k3) **
-            ⌜BitVec.ult v5 k3⌝),
-       (e4, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k4) **
-            ⌜BitVec.ult v5 k4⌝),
-       (e5, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k4) **
-            ⌜¬ BitVec.ult v5 k4⌝)] := by
+      [(e1, rlp_phase1_exit_post_pure v5 0x80
+              (BitVec.ult v5 ((0 : Word) + signExtend12 0x80))),
+       (e2, rlp_phase1_exit_post_pure v5 0xB8
+              (BitVec.ult v5 ((0 : Word) + signExtend12 0xB8))),
+       (e3, rlp_phase1_exit_post_pure v5 0xC0
+              (BitVec.ult v5 ((0 : Word) + signExtend12 0xC0))),
+       (e4, rlp_phase1_exit_post_pure v5 0xF8
+              (BitVec.ult v5 ((0 : Word) + signExtend12 0xF8))),
+       (e5, rlp_phase1_exit_post_pure v5 0xF8
+              (¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)))] := by
   -- Step specs WITH pure facts preserved.
   have cs1 := rlp_phase1_step_spec v5 v10 0x80 off1 base e1 he1
   have cs2 := rlp_phase1_step_spec v5 ((0 : Word) + signExtend12 0x80)
@@ -463,7 +475,8 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
   have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
       rlp_phase1_classifier_code off1 off2 off3 off4 base := by
     simp only [hunion_empty]; rfl
-  show cpsNBranch base (rlp_phase1_classifier_code off1 off2 off3 off4 base) _ _
+  -- Unfold `rlp_phase1_exit_post_pure` so n1's explicit posts match.
+  simp only [rlp_phase1_exit_post_pure_unfold]
   exact hcr_eq ▸ n1
 
 end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -580,13 +580,16 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
 
 ### EL.3 RLP RISC-V Decoder (in progress)
 - **Files**: `EvmAsm/Rv64/RLP/`
-- Phase 1: Prefix classifier (cascade BLTUs, 5 exits) — ✅ plain spec landed
+- Phase 1: Prefix classifier (cascade BLTUs, 5 exits) — ✅ both variants landed
   - `rlp_phase1_step_spec` (per-step with pure ult fact),
-    `rlp_phase1_step_spec_plain` (strips pure facts),
-    `rlp_phase1_classifier_spec` (full 5-exit `cpsNBranch` at boundaries
-    0x80, 0xB8, 0xC0, 0xF8).
-  - Pure-fact-propagating variant (each exit carries the accumulated
-    `ult`/`¬ult` chain identifying the category) still pending.
+    `rlp_phase1_step_spec_plain` (strips pure facts).
+  - `rlp_phase1_classifier_spec` — plain 5-exit `cpsNBranch` at boundaries
+    0x80, 0xB8, 0xC0, 0xF8 (no dispatch facts).
+  - `rlp_phase1_classifier_spec_pure` — per-step dispatch facts at each
+    exit (`⌜ult v5 k_i⌝` for taken exits, `⌜¬ ult v5 k4⌝` for fall-through).
+  - Optional accumulated-chain variant (each exit carries *all* prior
+    negations plus the current taken fact) not yet implemented; downstream
+    phases that only need the current-step fact can use `_pure` as-is.
 - Phase 2: Length extraction (short inline + long big-endian loop)
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)


### PR DESCRIPTION
## Summary

Follow-up to #324. Adds `rlp_phase1_classifier_spec_pure`, a variant of the 5-exit `cpsNBranch` where each exit post carries the corresponding BLTU dispatch fact:

| Exit | Category      | Pure fact             |
|------|---------------|-----------------------|
| `e1` | single byte   | `⌜ult v5 0x80⌝`       |
| `e2` | short string  | `⌜ult v5 0xB8⌝`       |
| `e3` | long string   | `⌜ult v5 0xC0⌝`       |
| `e4` | short list    | `⌜ult v5 0xF8⌝`       |
| `e5` | long list     | `⌜¬ ult v5 0xF8⌝`     |

## How it's built

- Reuses `rlp_phase1_step_spec` (the per-step spec *with* pure facts preserved) rather than `_plain`.
- Chains via `cpsBranch_cons_cpsNBranch_with_perm`. The `hperm` callback strips the prior step's fall-through pure fact (via `sepConj_strip_pure_end3`) to match the next step's clean precondition.
- The taken-side pure fact survives in `(exit_t, Q_t) :: exits`, so each exit keeps its step-local dispatch witness.
- Fall-through `cpsNBranch_refl` at `e5` is constructed with `⌜¬ ult v5 0xF8⌝` already in the precondition, so it flows directly from step 4's fall post (no perm needed there).

## Scope note

This variant carries only the **current step's** fact at each exit, not the accumulated chain of prior negations. Downstream handlers that need full range identification (e.g., `0x80 ≤ p < 0xB8` at `e2`) will either re-read the prefix byte or use a later accumulated-chain variant that frames a running prefix `Prop` through each step. That accumulated variant is deferred.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (file is now 455 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] Single 1.6M-heartbeat bound (up from 800k on the plain variant — precedent: `shr_phase_c_spec_pure` uses 6.4M for an analogous 4-exit proof)

## PR stacking

Base branch: `el3-phase1-classifier-compose` (#324). Will retarget as #323 / #324 land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)