### PR TITLE
feat(rlp): add accumulated-chain Phase 1 classifier spec

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -483,37 +483,6 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
 -- Spec: 5-exit classifier with accumulated dispatch facts
 -- ============================================================================
 
-/-- Merge a trailing framed pure fact into the existing pure fact at depth 3,
-    swapping the order:
-    `(A ** B ** C ** ⌜P⌝) ** ⌜Q⌝ → A ** B ** C ** ⌜Q ∧ P⌝`.
-
-    The outer left-associated shape is what `cpsBranch_frame_left` produces
-    when framed with `⌜Q⌝`; the inner right-associated shape is what the
-    accumulated-chain classifier spec consumes. -/
-private theorem sepConj_merge_pure_and_end3
-    (A B C : Assertion) (P Q : Prop) :
-    ∀ h, ((A ** B ** C ** ⌜P⌝) ** ⌜Q⌝) h → (A ** B ** C ** ⌜Q ∧ P⌝) h := by
-  intro h hp
-  obtain ⟨hL, hR, _hdLR, huLR, hL_prop, ⟨eR, hQ⟩⟩ := hp
-  subst eR
-  rw [PartialState.union_empty_right] at huLR
-  subst huLR
-  refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right ?_)) _ hL_prop
-  intro h' ⟨eh, hP⟩
-  exact ⟨eh, hQ, hP⟩
-
-/-- Reshape a right-associated 4-chain into the left-associated outer form
-    produced by `cpsBranch_frame_left` on a 3-chain pre-assertion:
-    `A ** B ** C ** D → (A ** B ** C) ** D`. -/
-private theorem sepConj_chain_push_outer
-    (A B C D : Assertion) :
-    ∀ h, (A ** B ** C ** D) h → ((A ** B ** C) ** D) h := by
-  intro h hp
-  refine (sepConj_assoc _ _ _ _).mpr ?_
-  refine sepConj_mono_right ?_ _ hp
-  intro h' hp'
-  exact (sepConj_assoc _ _ _ _).mpr hp'
-
 /-- Cascade step with accumulator: frames `rlp_phase1_step_spec` with a pure
     prefix `⌜Acc⌝` and merges it with the step's own dispatch fact into a
     single `⌜Acc ∧ …⌝` conjunction.

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -479,4 +479,219 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
   simp only [rlp_phase1_exit_post_pure_unfold]
   exact hcr_eq ▸ n1
 
+-- ============================================================================
+-- Spec: 5-exit classifier with accumulated dispatch facts
+-- ============================================================================
+
+/-- Merge a trailing framed pure fact into the existing pure fact at depth 3,
+    swapping the order:
+    `(A ** B ** C ** ⌜P⌝) ** ⌜Q⌝ → A ** B ** C ** ⌜Q ∧ P⌝`.
+
+    The outer left-associated shape is what `cpsBranch_frame_left` produces
+    when framed with `⌜Q⌝`; the inner right-associated shape is what the
+    accumulated-chain classifier spec consumes. -/
+private theorem sepConj_merge_pure_and_end3
+    (A B C : Assertion) (P Q : Prop) :
+    ∀ h, ((A ** B ** C ** ⌜P⌝) ** ⌜Q⌝) h → (A ** B ** C ** ⌜Q ∧ P⌝) h := by
+  intro h hp
+  obtain ⟨hL, hR, _hdLR, huLR, hL_prop, ⟨eR, hQ⟩⟩ := hp
+  subst eR
+  rw [PartialState.union_empty_right] at huLR
+  subst huLR
+  refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right ?_)) _ hL_prop
+  intro h' ⟨eh, hP⟩
+  exact ⟨eh, hQ, hP⟩
+
+/-- Reshape a right-associated 4-chain into the left-associated outer form
+    produced by `cpsBranch_frame_left` on a 3-chain pre-assertion:
+    `A ** B ** C ** D → (A ** B ** C) ** D`. -/
+private theorem sepConj_chain_push_outer
+    (A B C D : Assertion) :
+    ∀ h, (A ** B ** C ** D) h → ((A ** B ** C) ** D) h := by
+  intro h hp
+  refine (sepConj_assoc _ _ _ _).mpr ?_
+  refine sepConj_mono_right ?_ _ hp
+  intro h' hp'
+  exact (sepConj_assoc _ _ _ _).mpr hp'
+
+/-- Cascade step with accumulator: frames `rlp_phase1_step_spec` with a pure
+    prefix `⌜Acc⌝` and merges it with the step's own dispatch fact into a
+    single `⌜Acc ∧ …⌝` conjunction.
+
+    Chains cleanly: step `i`'s fall post becomes `regs ** ⌜Acc ∧ ¬ult_i⌝`,
+    which is exactly step `i+1`'s pre shape with `Acc' := Acc ∧ ¬ult_i`. -/
+theorem rlp_phase1_step_spec_acc (Acc : Prop) (v5 v10 : Word)
+    (k : BitVec 12) (offset : BitVec 13) (base target : Word)
+    (htarget : (base + 4) + signExtend13 offset = target) :
+    let k_val := (0 : Word) + signExtend12 k
+    let code := rlp_phase1_step_code k offset base
+    cpsBranch base code
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜Acc⌝)
+      target
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
+         ⌜Acc ∧ BitVec.ult v5 k_val⌝)
+      (base + 8)
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
+         ⌜Acc ∧ ¬ BitVec.ult v5 k_val⌝) := by
+  have h := rlp_phase1_step_spec v5 v10 k offset base target htarget
+  -- Frame `rlp_phase1_step_spec` with `⌜Acc⌝` on the right.
+  have hf := cpsBranch_frame_left base _ _ target _ (base + 8) _
+    ⌜Acc⌝ (pcFree_pure Acc) h
+  -- hf has pre `(regs_3chain) ** ⌜Acc⌝`; target theorem has the 4-chain
+  -- `regs ** ⌜Acc⌝`. Reshape via the associativity helper.
+  exact cpsBranch_consequence _ _ _ _ target _ _ (base + 8) _ _
+    (sepConj_chain_push_outer _ _ _ _)
+    (sepConj_merge_pure_and_end3 _ _ _ _ _)
+    (sepConj_merge_pure_and_end3 _ _ _ _ _)
+    hf
+
+/-- Bundled exit postcondition with a single accumulated dispatch fact. -/
+@[irreducible]
+def rlp_phase1_exit_post_acc
+    (v5 : Word) (k : BitVec 12) (Acc : Prop) : Assertion :=
+  let k_val := (0 : Word) + signExtend12 k
+  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜Acc⌝
+
+/-- Unfold lemma for `rlp_phase1_exit_post_acc`. -/
+theorem rlp_phase1_exit_post_acc_unfold
+    (v5 : Word) (k : BitVec 12) (Acc : Prop) :
+    rlp_phase1_exit_post_acc v5 k Acc =
+    ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜Acc⌝) := by
+  delta rlp_phase1_exit_post_acc; rfl
+
+/-- Accumulated-chain variant of `rlp_phase1_classifier_spec`. Each exit
+    post carries the **full** conjunction of prior "not-taken" facts plus
+    (for taken exits) the current "taken" fact, so downstream handlers can
+    prove tight range bounds like `0x80 ≤ p < 0xB8` at exit `e2`.
+
+    Reading the exit facts (with `k_i := (0 : Word) + signExtend12 K_i`):
+    * `e1`: `ult v5 k1`                                    — i.e. `p < 0x80`
+    * `e2`: `¬ ult v5 k1 ∧ ult v5 k2`                      — i.e. `0x80 ≤ p < 0xB8`
+    * `e3`: `(¬ ult v5 k1 ∧ ¬ ult v5 k2) ∧ ult v5 k3`      — i.e. `0xB8 ≤ p < 0xC0`
+    * `e4`: `((¬…k1 ∧ ¬…k2) ∧ ¬…k3) ∧ ult v5 k4`           — i.e. `0xC0 ≤ p < 0xF8`
+    * `e5`: `((¬…k1 ∧ ¬…k2) ∧ ¬…k3) ∧ ¬ ult v5 k4`         — i.e. `0xF8 ≤ p`
+
+    The nested `And` shape reflects the left-to-right accumulator build-up
+    via `rlp_phase1_step_spec_acc`; consumers may reassociate with `And.assoc`. -/
+theorem rlp_phase1_classifier_spec_acc (v5 v10 : Word) (base : Word)
+    (off1 off2 off3 off4 : BitVec 13)
+    (e1 e2 e3 e4 e5 : Word)
+    (he1 : (base + 4) + signExtend13 off1 = e1)
+    (he2 : (base + 12) + signExtend13 off2 = e2)
+    (he3 : (base + 20) + signExtend13 off3 = e3)
+    (he4 : (base + 28) + signExtend13 off4 = e4)
+    (he5 : base + 32 = e5) :
+    cpsNBranch base (rlp_phase1_classifier_code off1 off2 off3 off4 base)
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
+      [(e1, rlp_phase1_exit_post_acc v5 0x80
+              (BitVec.ult v5 ((0 : Word) + signExtend12 0x80))),
+       (e2, rlp_phase1_exit_post_acc v5 0xB8
+              (¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+                 BitVec.ult v5 ((0 : Word) + signExtend12 0xB8))),
+       (e3, rlp_phase1_exit_post_acc v5 0xC0
+              ((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+                ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+                 BitVec.ult v5 ((0 : Word) + signExtend12 0xC0))),
+       (e4, rlp_phase1_exit_post_acc v5 0xF8
+              (((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+                 ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+                 ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xC0)) ∧
+                 BitVec.ult v5 ((0 : Word) + signExtend12 0xF8))),
+       (e5, rlp_phase1_exit_post_acc v5 0xF8
+              (((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+                 ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+                 ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xC0)) ∧
+                 ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)))] := by
+  -- Step 1 has no prior accumulator, so use the plain step spec directly;
+  -- its pre is just `regs` (no ⌜True⌝ prefix) and taken/fall posts already
+  -- carry the dispatch fact as a single pure atom. Steps 2..4 then pick up
+  -- the accumulator chain via `rlp_phase1_step_spec_acc`.
+  have cs1 := rlp_phase1_step_spec v5 v10 0x80 off1 base e1 he1
+  have cs2 := rlp_phase1_step_spec_acc
+    (¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80))
+    v5 ((0 : Word) + signExtend12 0x80)
+    0xB8 off2 (base + 8) e2 (by
+      rw [show (base + 8 : Word) + 4 = base + 12 from by bv_omega]; exact he2)
+  have cs3 := rlp_phase1_step_spec_acc
+    (¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+      ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8))
+    v5 ((0 : Word) + signExtend12 0xB8)
+    0xC0 off3 (base + 16) e3 (by
+      rw [show (base + 16 : Word) + 4 = base + 20 from by bv_omega]; exact he3)
+  have cs4 := rlp_phase1_step_spec_acc
+    ((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+       ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+       ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xC0))
+    v5 ((0 : Word) + signExtend12 0xC0)
+    0xF8 off4 (base + 24) e4 (by
+      rw [show (base + 24 : Word) + 4 = base + 28 from by bv_omega]; exact he4)
+  rw [show (base + 24 : Word) + 8 = e5 from by rw [← he5]; bv_omega] at cs4
+  rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at cs2
+  rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at cs3
+  -- Disjointness (same as plain spec).
+  let cr1 := rlp_phase1_step_code 0x80 off1 base
+  let cr2 := rlp_phase1_step_code 0xB8 off2 (base + 8)
+  let cr3 := rlp_phase1_step_code 0xC0 off3 (base + 16)
+  let cr4 := rlp_phase1_step_code 0xF8 off4 (base + 24)
+  have hd12 : cr1.Disjoint cr2 := step_code_Disjoint_8 _ _ _ _ _
+  have hd13 : cr1.Disjoint cr3 := step_code_Disjoint_16 _ _ _ _ _
+  have hd14 : cr1.Disjoint cr4 := step_code_Disjoint_24 _ _ _ _ _
+  have hd23 : cr2.Disjoint cr3 := by
+    have := step_code_Disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
+    rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at this
+    exact this
+  have hd24 : cr2.Disjoint cr4 := by
+    have := step_code_Disjoint_16 0xB8 0xF8 off2 off4 (base + 8)
+    rw [show (base + 8 : Word) + 16 = base + 24 from by bv_omega] at this
+    exact this
+  have hd34 : cr3.Disjoint cr4 := by
+    have := step_code_Disjoint_8 0xC0 0xF8 off3 off4 (base + 16)
+    rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at this
+    exact this
+  -- Fallthrough cpsNBranch at e5, carrying cs4's fall-post accumulator.
+  have ft : cpsNBranch e5 CodeReq.empty
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x10 ↦ᵣ ((0 : Word) + signExtend12 0xF8)) **
+       ⌜((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+          ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+          ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xC0)) ∧
+         ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)
+      [(e5, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
+            (.x10 ↦ᵣ ((0 : Word) + signExtend12 0xF8)) **
+            ⌜((¬ BitVec.ult v5 ((0 : Word) + signExtend12 0x80) ∧
+                ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xB8)) ∧
+                ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xC0)) ∧
+               ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)] :=
+    cpsNBranch_refl e5 _ _ (fun _ hp => hp)
+  -- Chain step 4 + ft (no perm needed: cs4.fall matches ft.pre).
+  have n4 := cpsBranch_cons_cpsNBranch (base + 24) cr4 CodeReq.empty
+    (CodeReq.Disjoint.empty_right cr4)
+    _ e4 _ e5 _ _ cs4 ft
+  have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
+    intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
+  -- Chain remaining steps (no perm needed: each cs_i's fall matches cs_{i+1}'s pre).
+  have hd3_rest : cr3.Disjoint (cr4.union CodeReq.empty) := by
+    rw [hunion_empty]; exact hd34
+  have n3 := cpsBranch_cons_cpsNBranch (base + 16) cr3 (cr4.union CodeReq.empty)
+    hd3_rest _ e3 _ (base + 24) _ _ cs3 n4
+  have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
+    rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
+  have n2 := cpsBranch_cons_cpsNBranch (base + 8) cr2
+    (cr3.union (cr4.union CodeReq.empty)) hd2_rest
+    _ e2 _ (base + 16) _ _ cs2 n3
+  have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
+    rw [hunion_empty]
+    exact CodeReq.Disjoint.union_right hd12 (CodeReq.Disjoint.union_right hd13 hd14)
+  have n1 := cpsBranch_cons_cpsNBranch base cr1
+    (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
+    _ e1 _ (base + 8) _ _ cs1 n2
+  have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
+      rlp_phase1_classifier_code off1 off2 off3 off4 base := by
+    simp only [hunion_empty]; rfl
+  -- n1's exits already match the goal's exit list structurally; just unfold
+  -- the `@[irreducible]` exit-post def and rewrite the code requirement.
+  simp only [rlp_phase1_exit_post_acc_unfold]
+  exact hcr_eq ▸ n1
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1288,6 +1288,40 @@ theorem sepConj_extract_pure_end3 (A B C : Assertion) (P : Prop) :
     obtain ⟨_, _, _, _, _, h3⟩ := h2
     exact ((sepConj_pure_right _ _ _).1 h3).2
 
+/-- Push the outer atom of a 4-chain left-associated `(3-chain) ** D`
+    into the right-associated 4-chain — the inverse of the tree shape
+    `cpsBranch_frame_left` produces when framing a 3-atom pre with a
+    single-atom frame:
+    `A ** B ** C ** D → (A ** B ** C) ** D`.
+
+    Useful to reconcile `cpsBranch_frame_left` output with a theorem
+    statement written in right-associated form. -/
+theorem sepConj_chain_push_outer (A B C D : Assertion) :
+    ∀ h, (A ** B ** C ** D) h → ((A ** B ** C) ** D) h := by
+  intro h hp
+  refine (sepConj_assoc _ _ _ _).mpr ?_
+  refine sepConj_mono_right ?_ _ hp
+  intro h' hp'
+  exact (sepConj_assoc _ _ _ _).mpr hp'
+
+/-- Merge a trailing framed pure fact into the existing pure fact at depth 3,
+    swapping the order:
+    `(A ** B ** C ** ⌜P⌝) ** ⌜Q⌝ → A ** B ** C ** ⌜Q ∧ P⌝`.
+
+    The outer left-associated shape is what `cpsBranch_frame_left` produces
+    when framed with `⌜Q⌝`; the right-associated output is what downstream
+    consumers with a single accumulated pure fact expect. -/
+theorem sepConj_merge_pure_and_end3 (A B C : Assertion) (P Q : Prop) :
+    ∀ h, ((A ** B ** C ** ⌜P⌝) ** ⌜Q⌝) h → (A ** B ** C ** ⌜Q ∧ P⌝) h := by
+  intro h hp
+  obtain ⟨hL, hR, _hdLR, huLR, hL_prop, ⟨eR, hQ⟩⟩ := hp
+  subst eR
+  rw [PartialState.union_empty_right] at huLR
+  subst huLR
+  refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right ?_)) _ hL_prop
+  intro h' ⟨eh, hP⟩
+  exact ⟨eh, hQ, hP⟩
+
 -- ============================================================================
 -- CompatibleWith decomposition through unions
 -- ============================================================================

--- a/PLAN.md
+++ b/PLAN.md
@@ -580,16 +580,18 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
 
 ### EL.3 RLP RISC-V Decoder (in progress)
 - **Files**: `EvmAsm/Rv64/RLP/`
-- Phase 1: Prefix classifier (cascade BLTUs, 5 exits) — ✅ both variants landed
+- Phase 1: Prefix classifier (cascade BLTUs, 5 exits) — ✅ all three variants landed
   - `rlp_phase1_step_spec` (per-step with pure ult fact),
-    `rlp_phase1_step_spec_plain` (strips pure facts).
+    `rlp_phase1_step_spec_plain` (strips pure facts),
+    `rlp_phase1_step_spec_acc` (frames with accumulator, merges into single `⌜Acc ∧ …⌝`).
   - `rlp_phase1_classifier_spec` — plain 5-exit `cpsNBranch` at boundaries
     0x80, 0xB8, 0xC0, 0xF8 (no dispatch facts).
   - `rlp_phase1_classifier_spec_pure` — per-step dispatch facts at each
-    exit (`⌜ult v5 k_i⌝` for taken exits, `⌜¬ ult v5 k4⌝` for fall-through).
-  - Optional accumulated-chain variant (each exit carries *all* prior
-    negations plus the current taken fact) not yet implemented; downstream
-    phases that only need the current-step fact can use `_pure` as-is.
+    exit (`⌜ult v5 k_i⌝` for taken, `⌜¬ ult v5 k4⌝` for fall-through).
+  - `rlp_phase1_classifier_spec_acc` — full accumulated-chain variant:
+    each exit carries the complete conjunction of prior `¬ult` facts plus
+    (for taken exits) the current `ult` fact. Enables downstream range
+    proofs like `0x80 ≤ p < 0xB8` at exit `e2`.
 - Phase 2: Length extraction — ⏳ short form landed
   - `rlp_phase2_short_length_spec` (`EvmAsm/Rv64/RLP/Phase2Short.lean`):
     one-instruction `ADDI x11, x5, -k` extractor for short byte strings


### PR DESCRIPTION
## Summary

Third and final Phase 1 variant: **accumulated-chain** — each exit post carries the **full** conjunction of prior `¬ ult` facts plus (for taken exits) the current `ult` fact, enabling downstream range proofs like `0x80 ≤ p < 0xB8` at exit `e2` without re-reading the prefix byte.

| Exit | Accumulated pure fact at the exit post              | Range              |
|------|----------------------------------------------------|--------------------|
| `e1` | `⌜ult v5 k1⌝`                                      | `p < 0x80`         |
| `e2` | `⌜¬ ult v5 k1 ∧ ult v5 k2⌝`                        | `0x80 ≤ p < 0xB8`  |
| `e3` | `⌜(¬ ult v5 k1 ∧ ¬ ult v5 k2) ∧ ult v5 k3⌝`        | `0xB8 ≤ p < 0xC0`  |
| `e4` | `⌜((¬k1 ∧ ¬k2) ∧ ¬k3) ∧ ult v5 k4⌝`                | `0xC0 ≤ p < 0xF8`  |
| `e5` | `⌜((¬k1 ∧ ¬k2) ∧ ¬k3) ∧ ¬ ult v5 k4⌝`              | `0xF8 ≤ p`         |

## Building blocks

- **`sepConj_chain_push_outer (A B C D)`** — right-assoc 4-chain → left-assoc `(3-chain) ** D`, i.e., the tree shape produced by `cpsBranch_frame_left`.
- **`sepConj_merge_pure_and_end3 (A B C P Q)`** — merges a trailing framed pure fact into the existing pure fact with order swapped:
  `(A ** B ** C ** ⌜P⌝) ** ⌜Q⌝ → A ** B ** C ** ⌜Q ∧ P⌝`.
- **`rlp_phase1_step_spec_acc (Acc : Prop)`** — step spec parameterised by a pure accumulator; produces a single `⌜Acc ∧ ult⌝` / `⌜Acc ∧ ¬ult⌝` at each branch. Built by framing `rlp_phase1_step_spec` with `⌜Acc⌝` and collapsing via the two helpers above.
- **`rlp_phase1_exit_post_acc v5 k Acc`** — `@[irreducible]` bundled exit post (AGENTS.md "Bundling Postconditions with `let` Bindings").
- **`rlp_phase1_classifier_spec_acc`** — full 5-exit `cpsNBranch`. Uses the plain `rlp_phase1_step_spec` for step 1 (no prior accumulator) and the acc variant for steps 2–4; each chain transition matches shapes directly — no `hperm` callbacks needed.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (697 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

Independent of #327 (Phase 2 short-form); both add net-new content on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)