### PR TITLE
feat(rlp): add Phase 2 long-form big-endian accumulation step

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -15,3 +15,4 @@
 
 import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
+import EvmAsm.Rv64.RLP.Phase2LongAcc

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -1,0 +1,123 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongAcc
+
+  EL.3 Phase 2 (long form) — big-endian accumulation step.
+
+  For a long-form RLP prefix (`0xB8..0xBF` byte string or `0xF8..0xFF` list),
+  the payload length is encoded as the next `lenLen` bytes in big-endian.
+  Decoding loops over those bytes, accumulating:
+
+      length = length * 256 + next_byte
+
+  This file defines the two-instruction arithmetic core of that loop:
+
+      SLLI x11, x11, 8        ; length <<= 8      (i.e. length *= 256)
+      ADD  x11, x11, x12      ; length += byte
+
+  The surrounding loop (byte load, counter decrement, branch-back) is
+  layered on top in a follow-up. Keeping the arithmetic step as a
+  self-contained spec makes the loop proof's invariant step a direct
+  application of this lemma.
+
+  Register usage:
+    x11 — accumulated length (mutated)
+    x12 — input byte, assumed zero-extended (low 8 bits) (preserved)
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.Program
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- Two-instruction big-endian accumulation step:
+    `SLLI x11, x11, 8 ; ADD x11, x11, x12`. -/
+def rlp_phase2_long_acc_prog : Program :=
+  [.SLLI .x11 .x11 8, .ADD .x11 .x11 .x12]
+
+example : rlp_phase2_long_acc_prog.length = 2 := rfl
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled postcondition for the accumulation step: `x11` now holds
+    `(length <<< 8) + byte`; `x12` is unchanged. -/
+@[irreducible]
+def rlp_phase2_long_acc_post (len byte : Word) : Assertion :=
+  let length' := (len <<< 8) + byte
+  (.x11 ↦ᵣ length') ** (.x12 ↦ᵣ byte)
+
+theorem rlp_phase2_long_acc_post_unfold (len byte : Word) :
+    rlp_phase2_long_acc_post len byte =
+    ((.x11 ↦ᵣ ((len <<< 8) + byte)) ** (.x12 ↦ᵣ byte)) := by
+  delta rlp_phase2_long_acc_post; rfl
+
+/-- `cpsTriple` spec for the big-endian accumulation step. Composes SLLI
+    (mutates x11 in place) with ADD rd=rs1 (folds x12 into x11).
+
+    The caller must supply a `byte` value whose high 56 bits are zero (the
+    natural result of an `LBU` load); this spec does not enforce that
+    constraint, so the post `(len <<< 8) + byte` is exact BitVec arithmetic
+    even if the high bits are set — only the low 8 bits are "meaningful"
+    for RLP length decoding. -/
+theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
+    cpsTriple base (base + 8)
+      (CodeReq.ofProg base rlp_phase2_long_acc_prog)
+      ((.x11 ↦ᵣ len) ** (.x12 ↦ᵣ byte))
+      (rlp_phase2_long_acc_post len byte) := by
+  simp only [rlp_phase2_long_acc_post_unfold]
+  -- Reshape the code requirement: a 2-instruction `ofProg` is the disjoint
+  -- union of two singletons.
+  have hcr_eq : CodeReq.ofProg base rlp_phase2_long_acc_prog =
+      (CodeReq.singleton base (.SLLI .x11 .x11 8)).union
+      (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) := by
+    funext a
+    simp only [rlp_phase2_long_acc_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+      CodeReq.union, CodeReq.empty]
+    cases (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) a <;> rfl
+  rw [hcr_eq]
+  -- Disjointness of the two singletons (distinct PCs).
+  have hd : CodeReq.Disjoint
+      (CodeReq.singleton base (.SLLI .x11 .x11 8))
+      (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) :=
+    CodeReq.Disjoint.singleton (by bv_omega) _ _
+  -- Step 1: SLLI x11, x11, 8 — use `slli_spec_gen_same` (rd = rs1),
+  -- then frame with x12 to bring it into scope.
+  have s1_base := slli_spec_gen_same .x11 len 8 base (by nofun)
+  have s1 : cpsTriple base (base + 4)
+      (CodeReq.singleton base (.SLLI .x11 .x11 8))
+      ((.x11 ↦ᵣ len) ** (.x12 ↦ᵣ byte))
+      ((.x11 ↦ᵣ (len <<< (8 : BitVec 6).toNat)) ** (.x12 ↦ᵣ byte)) :=
+    cpsTriple_frame_left _ _ _ _ _ (.x12 ↦ᵣ byte) (by pcFree) s1_base
+  -- Step 2: ADD x11, x11, x12 — `add_spec_gen_rd_eq_rs1` (rd = rs1 = x11,
+  -- rs2 = x12). No framing needed.
+  have s2 := add_spec_gen_rd_eq_rs1 .x11 .x12
+    (len <<< (8 : BitVec 6).toNat) byte (base + 4) (by nofun)
+  rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at s2
+  -- Compose. `(8 : BitVec 6).toNat = 8` so the result matches.
+  have heq : (8 : BitVec 6).toNat = 8 := by decide
+  rw [heq] at s1
+  exact cpsTriple_seq _ _ _ _ _ hd _ _ _ s1 s2
+
+/-! ## Concrete sanity checks -/
+
+-- One accumulation step starting from 0: length = 0 * 256 + byte = byte.
+example : (((0 : Word) <<< 8) + (0x42 : Word)) = (0x42 : Word) := by decide
+
+-- Accumulating 2 bytes (0x01, 0x00) gives 0x100 = 256.
+example : ((((0 : Word) <<< 8) + (0x01 : Word)) <<< 8) + (0x00 : Word) =
+    (0x100 : Word) := by decide
+
+-- Accumulating 3 bytes (0x01, 0x02, 0x03) gives 0x010203 = 66051.
+example : (((((0 : Word) <<< 8) + (0x01 : Word)) <<< 8) + (0x02 : Word)) <<< 8 +
+    (0x03 : Word) = (0x010203 : Word) := by decide
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -592,13 +592,17 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     each exit carries the complete conjunction of prior `¬ult` facts plus
     (for taken exits) the current `ult` fact. Enables downstream range
     proofs like `0x80 ≤ p < 0xB8` at exit `e2`.
-- Phase 2: Length extraction — ⏳ short form landed
+- Phase 2: Length extraction — ⏳ short form + long-form accumulation step
   - `rlp_phase2_short_length_spec` (`EvmAsm/Rv64/RLP/Phase2Short.lean`):
     one-instruction `ADDI x11, x5, -k` extractor for short byte strings
     (k = 0x80) and short lists (k = 0xC0). Concrete tests verify
     0x85 → 5, 0xB7 → 55, 0xC3 → 3, 0x80 → 0 via `decide`.
-  - Long form (length-of-length big-endian loop for 0xB8..0xBF /
-    0xF8..0xFF prefixes) still pending.
+  - `rlp_phase2_long_acc_spec` (`EvmAsm/Rv64/RLP/Phase2LongAcc.lean`):
+    two-instruction `SLLI x11, x11, 8 ; ADD x11, x11, x12` big-endian
+    accumulation core of the long-form length-of-length loop. Post:
+    `x11 ← (len <<< 8) + byte`.
+  - Full long-form loop (byte load, counter decrement, branch-back,
+    invariant) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)
 - Phase 5: Recursive list decode (iterative with explicit stack)


### PR DESCRIPTION
## Summary

Two-instruction arithmetic core of Phase 2's long-form length-of-length loop:

```
SLLI x11, x11, 8       ; length <<= 8    (length *= 256)
ADD  x11, x11, x12     ; length += byte
```

Given `(x11 ↦ᵣ len) ** (x12 ↦ᵣ byte)`, writes `(len <<< 8) + byte` into `x11` and preserves `x12`.

## What's in this PR

- **`rlp_phase2_long_acc_prog`** — the two-instruction program.
- **`rlp_phase2_long_acc_post len byte`** — `@[irreducible]` bundled post (AGENTS.md "Bundling Postconditions with `let` Bindings") wrapping `let length' := (len <<< 8) + byte`.
- **`rlp_phase2_long_acc_spec`** — `cpsTriple` proved by composing `slli_spec_gen_same` (framed with `x12 ↦ᵣ byte`) and `add_spec_gen_rd_eq_rs1` via `cpsTriple_seq`. The `(8 : BitVec 6).toNat = 8` literal reduction bridges the SLLI post into the ADD pre.
- Concrete `decide` tests for 1-, 2-, and 3-byte big-endian sequences (`[0x42] → 0x42`, `[0x01, 0x00] → 0x100`, `[0x01, 0x02, 0x03] → 0x010203`).

## Scope

This is the **arithmetic core only**. The surrounding loop infrastructure — byte load (`LBU`), pointer advance (`ADDI x_ptr, x_ptr, 1`), counter decrement (`ADDI x_cnt, x_cnt, -1`), and branch-back (`BNE x_cnt, x0, ...`) with a loop invariant — is deferred to a follow-up PR.

Keeping the arithmetic step as a self-contained spec makes the loop proof's invariant step a direct application of this lemma.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (123 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)