### PR TITLE
feat(rlp): add Phase 2 long-form load-and-accumulate step

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -16,3 +16,4 @@
 import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
 import EvmAsm.Rv64.RLP.Phase2LongAcc
+import EvmAsm.Rv64.RLP.Phase2LongLoad

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -1,0 +1,139 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLoad
+
+  EL.3 Phase 2 (long form) — load-and-accumulate step.
+
+  Composes the byte load (`LBU`) with the two-instruction arithmetic
+  accumulator `rlp_phase2_long_acc_prog` into a 3-instruction body that
+  reads one byte from memory and folds it into the running length:
+
+      LBU  x12, x13, 0        ; byte = mem[x13]
+      SLLI x11, x11, 8        ; length <<= 8
+      ADD  x11, x11, x12      ; length += byte
+
+  This is one tick of the long-form length-of-length loop, minus the
+  pointer / counter advance and the branch back. Layered on top of the
+  arithmetic-only spec in `Phase2LongAcc.lean`.
+
+  Register usage:
+    x11 — accumulated length (mutated)
+    x12 — scratch byte slot (mutated to hold the loaded byte)
+    x13 — byte pointer (preserved; the caller advances it separately)
+-/
+
+import EvmAsm.Rv64.ByteOps
+import EvmAsm.Rv64.RLP.Phase2LongAcc
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- Three-instruction load-and-accumulate step:
+    `LBU x12, x13, 0 ; SLLI x11, x11, 8 ; ADD x11, x11, x12`. -/
+def rlp_phase2_long_load_acc_prog : Program :=
+  (.LBU .x12 .x13 0) :: rlp_phase2_long_acc_prog
+
+example : rlp_phase2_long_load_acc_prog.length = 3 := rfl
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled post: `x11` holds `(len <<< 8) + byte_zext`, `x12` holds the
+    loaded byte (zero-extended to 64 bits), `x13` and memory are unchanged.
+
+    `byte_zext` is parametric — the caller supplies the concrete byte
+    value extracted from the containing doubleword. Wrapped
+    `@[irreducible]` to keep the let-bindings out of the theorem statement. -/
+@[irreducible]
+def rlp_phase2_long_load_acc_post
+    (len ptr byte_zext word_val dwordAddr : Word) : Assertion :=
+  let length' := (len <<< 8) + byte_zext
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+    (dwordAddr ↦ₘ word_val)
+
+theorem rlp_phase2_long_load_acc_post_unfold
+    (len ptr byte_zext word_val dwordAddr : Word) :
+    rlp_phase2_long_load_acc_post len ptr byte_zext word_val dwordAddr =
+    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
+     (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) := by
+  delta rlp_phase2_long_load_acc_post; rfl
+
+/-- `cpsTriple` spec for the load-and-accumulate step.
+
+    The caller owns the doubleword at `dwordAddr` containing the byte at
+    `ptr` (established via `halign`, `hvalid`). After execution, `x11`
+    holds `len * 256 + byte` (as BitVec arithmetic) and `x12` holds the
+    zero-extended byte. `x13` and memory are preserved. -/
+theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word)
+    (base : Word)
+    (halign : alignToDword ptr = dwordAddr)
+    (hvalid : isValidByteAccess ptr = true) :
+    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    cpsTriple base (base + 12)
+      (CodeReq.ofProg base rlp_phase2_long_load_acc_prog)
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
+       (dwordAddr ↦ₘ word_val))
+      (rlp_phase2_long_load_acc_post len ptr byte_zext word_val dwordAddr) := by
+  simp only [rlp_phase2_long_load_acc_post_unfold]
+  -- Reshape the top-level CodeReq: `ofProg base (LBU :: acc_prog)` unfolds
+  -- to `singleton base LBU ∪ ofProg (base + 4) acc_prog`.
+  have hcr_eq : CodeReq.ofProg base rlp_phase2_long_load_acc_prog =
+      (CodeReq.singleton base (.LBU .x12 .x13 0)).union
+      (CodeReq.ofProg (base + 4) rlp_phase2_long_acc_prog) := by
+    simp only [rlp_phase2_long_load_acc_prog, CodeReq.ofProg_cons]
+  rw [hcr_eq]
+  -- Disjointness: the singleton at `base` is outside the acc program's
+  -- 8-byte range `[base + 4, base + 12)`.
+  have hd : CodeReq.Disjoint
+      (CodeReq.singleton base (.LBU .x12 .x13 0))
+      (CodeReq.ofProg (base + 4) rlp_phase2_long_acc_prog) := by
+    apply CodeReq.Disjoint.singleton_ofProg
+    apply CodeReq.ofProg_none_range
+    intro k hk
+    simp only [rlp_phase2_long_acc_prog, List.length_cons, List.length_nil] at hk
+    interval_cases k <;> bv_omega
+  -- Step 1: LBU x12, x13, 0. `signExtend12 0 = 0`, so `ptr + 0 = ptr`.
+  have hptr_eq : ptr + signExtend12 (0 : BitVec 12) = ptr := by
+    show ptr + (0 : Word) = ptr; bv_omega
+  have halign' : alignToDword (ptr + signExtend12 (0 : BitVec 12)) = dwordAddr := by
+    rw [hptr_eq]; exact halign
+  have hvalid' : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
+    rw [hptr_eq]; exact hvalid
+  have lbu := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr word_val
+    (by nofun) (by nofun) halign' hvalid'
+  rw [hptr_eq] at lbu
+  -- Frame LBU with `x11 ↦ᵣ len` and permute to match the sequence shape.
+  let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  have lbu_framed : cpsTriple base (base + 4)
+      (CodeReq.singleton base (.LBU .x12 .x13 0))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
+       (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+       (dwordAddr ↦ₘ word_val)) :=
+    cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTriple_frame_left _ _ _ _ _ (.x11 ↦ᵣ len) (by pcFree) lbu)
+  -- Step 2: accumulation step at `base + 4`. Frame with `x13` and memory.
+  have acc := rlp_phase2_long_acc_spec len byte_zext (base + 4)
+  simp only [rlp_phase2_long_acc_post_unfold] at acc
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at acc
+  have acc_framed : cpsTriple (base + 4) (base + 12)
+      (CodeReq.ofProg (base + 4) rlp_phase2_long_acc_prog)
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+       (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
+       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) :=
+    cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTriple_frame_left _ _ _ _ _
+        ((.x13 ↦ᵣ ptr) ** (dwordAddr ↦ₘ word_val)) (by pcFree) acc)
+  exact cpsTriple_seq _ _ _ _ _ hd _ _ _ lbu_framed acc_framed
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -601,7 +601,10 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     two-instruction `SLLI x11, x11, 8 ; ADD x11, x11, x12` big-endian
     accumulation core of the long-form length-of-length loop. Post:
     `x11 ← (len <<< 8) + byte`.
-  - Full long-form loop (byte load, counter decrement, branch-back,
+  - `rlp_phase2_long_load_acc_spec` (`EvmAsm/Rv64/RLP/Phase2LongLoad.lean`):
+    three-instruction `LBU x12, x13, 0` prefix over the accumulation
+    step. Reads one byte from `mem[x13]` and folds it into `x11`.
+  - Full long-form loop (pointer/counter advance, branch-back,
     invariant) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)


### PR DESCRIPTION
## Summary

Three-instruction loop body for the Phase 2 long-form length-of-length loop:

```
LBU  x12, x13, 0        ; byte = mem[x13]
SLLI x11, x11, 8        ; length <<= 8
ADD  x11, x11, x12      ; length += byte
```

Composes `rlp_phase2_long_acc_spec` (#329) with `generic_lbu_spec` from `ByteOps.lean` — first place in the RLP pipeline that brings byte-addressable memory ownership together with the arithmetic loop core.

## What's in this PR

- **`rlp_phase2_long_load_acc_prog`** — the 3-instruction program (`LBU` prefix + `rlp_phase2_long_acc_prog`).
- **`rlp_phase2_long_load_acc_post len ptr byte_zext word_val dwordAddr`** — `@[irreducible]` bundled post (AGENTS.md pattern) wrapping the 3-register + memory state.
- **`rlp_phase2_long_load_acc_spec`** — `cpsTriple` composing LBU + acc via `cpsTriple_seq`. The caller owns the doubleword containing the byte at `ptr`, supplies the usual byte-access preconditions (`alignToDword`, `isValidByteAccess`), and gets back the zero-extended byte in `x12` plus the folded length in `x11`.

## Scope

Pointer advance (`ADDI x13, x13, 1`), counter decrement + back-branch (`ADDI x14, x14, -1 ; BNE x14, x0, -N`), and the loop invariant are the natural next slice.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (139 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

Independent of PR #329 (which this builds on); since #329 hasn't landed yet, PR targets `main` but the changes live on top of #329's branch via the file it defines. Mergeable after #329.

🤖 Generated with [Claude Code](https://claude.com/claude-code)