### PR TITLE
feat(rlp): add Phase 2 long-form loop body with back-branch

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -18,3 +18,4 @@ import EvmAsm.Rv64.RLP.Phase2Short
 import EvmAsm.Rv64.RLP.Phase2LongAcc
 import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongIter
+import EvmAsm.Rv64.RLP.Phase2LongLoopBody

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -1,0 +1,205 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLoopBody
+
+  EL.3 Phase 2 (long form) — full loop body with back-branch.
+
+  Extends the 5-instruction iteration body with a `BNE x14, x0, back`
+  tail:
+
+      LBU  x12, x13, 0        ; byte = mem[x13]
+      SLLI x11, x11, 8        ; length <<= 8
+      ADD  x11, x11, x12      ; length += byte
+      ADDI x13, x13, 1        ; ptr += 1
+      ADDI x14, x14, -1       ; counter -= 1
+      BNE  x14, x0, back      ; if counter != 0, loop back
+
+  The `back` offset is a parameter; the caller chooses it so the taken
+  branch lands at the loop header.
+
+  The spec is a `cpsBranch` at the loop-body entry:
+    * taken      → PC = `(base + 20) + signExtend13 back`,  ⌜cnt' ≠ 0⌝
+    * not taken  → PC = `base + 24`,                        ⌜cnt' = 0⌝
+  where `cnt' = cnt + signExtend12 (-1 : BitVec 12)`.
+
+  Full loop closure (invariant over iterations) is a follow-up; this
+  file provides the per-iteration `cpsBranch` that that closure will
+  unfold.
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongIter
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- Six-instruction loop body: the iteration body of `Phase2LongIter`
+    followed by `BNE x14, x0, back`. -/
+def rlp_phase2_long_loop_body_prog (back : BitVec 13) : Program :=
+  [.LBU .x12 .x13 0, .SLLI .x11 .x11 8, .ADD .x11 .x11 .x12,
+   .ADDI .x13 .x13 1, .ADDI .x14 .x14 (-1), .BNE .x14 .x0 back]
+
+example (back : BitVec 13) :
+    (rlp_phase2_long_loop_body_prog back).length = 6 := rfl
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled post for either exit of the loop body: registers updated as
+    per one iteration, plus a caller-supplied pure dispatch fact `P`
+    (typically `cnt' ≠ 0` for the loop-back exit or `cnt' = 0` for the
+    fall-through exit). -/
+@[irreducible]
+def rlp_phase2_long_loop_body_post
+    (len ptr cnt byte_zext word_val dwordAddr : Word) (P : Prop) : Assertion :=
+  let length' := (len <<< 8) + byte_zext
+  let ptr'    := ptr + 1
+  let cnt'    := cnt + signExtend12 (-1 : BitVec 12)
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ cnt') **
+    (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+    (dwordAddr ↦ₘ word_val) ** ⌜P⌝
+
+theorem rlp_phase2_long_loop_body_post_unfold
+    (len ptr cnt byte_zext word_val dwordAddr : Word) (P : Prop) :
+    rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val dwordAddr P =
+    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+     (.x13 ↦ᵣ (ptr + 1)) **
+     (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
+     (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+     (dwordAddr ↦ₘ word_val) ** ⌜P⌝) := by
+  delta rlp_phase2_long_loop_body_post; rfl
+
+/-- `cpsBranch` spec for one pass through the long-form length-loop body.
+
+    Composes `rlp_phase2_long_iter_spec` (the 5-instruction iteration
+    body) with `bne_spec_gen` at `base + 20`. The pure dispatch fact
+    (`cnt' ≠ 0` on taken, `cnt' = 0` on fall-through) flows directly from
+    BNE's postcondition. -/
+theorem rlp_phase2_long_loop_body_spec
+    (len ptr cnt v12_old word_val dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (halign : alignToDword ptr = dwordAddr)
+    (hvalid : isValidByteAccess ptr = true) :
+    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let cnt'      := cnt + signExtend12 (-1 : BitVec 12)
+    cpsBranch base (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      ((base + 20) + signExtend13 back)
+        (rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val
+           dwordAddr (cnt' ≠ 0))
+      (base + 24)
+        (rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val
+           dwordAddr (cnt' = 0)) := by
+  -- The loop-body `ofProg` splits as `ofProg base iter_prog ∪ ofProg (base+20) [BNE]`
+  -- via `ofProg_append`; the tail is one singleton plus an `empty`.
+  -- The loop-body CodeReq equals the iter CodeReq unioned with the BNE
+  -- singleton (plus a trailing `empty` to match `cpsTriple_seq_cpsBranch`'s
+  -- output shape). Proved pointwise via funext + case analysis on whether
+  -- `a` matches each singleton address.
+  have hcr_eq : CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back) =
+      (CodeReq.ofProg base rlp_phase2_long_iter_prog).union
+      ((CodeReq.singleton (base + 20) (.BNE .x14 .x0 back)).union
+        CodeReq.empty) := by
+    funext a
+    have e2 : (base + 4 + 4 : Word) = base + 8 := by bv_omega
+    have e3 : (base + 8 + 4 : Word) = base + 12 := by bv_omega
+    have e4 : (base + 12 + 4 : Word) = base + 16 := by bv_omega
+    have e5 : (base + 16 + 4 : Word) = base + 20 := by bv_omega
+    simp only [rlp_phase2_long_loop_body_prog, rlp_phase2_long_iter_prog,
+      CodeReq.ofProg_cons, CodeReq.ofProg_nil, CodeReq.union, CodeReq.empty,
+      e2, e3, e4, e5, CodeReq.singleton]
+    simp only [beq_iff_eq]
+    by_cases h0 : a = base
+    · simp [h0]
+    by_cases h1 : a = base + 4#64
+    · simp [h0, h1]
+    by_cases h2 : a = base + 8#64
+    · simp [h0, h1, h2]
+    by_cases h3 : a = base + 12#64
+    · simp [h0, h1, h2, h3]
+    by_cases h4 : a = base + 16#64
+    · simp [h0, h1, h2, h3, h4]
+    by_cases h5 : a = base + 20#64
+    · simp [h0, h1, h2, h3, h4, h5]
+    simp [h0, h1, h2, h3, h4]
+  rw [hcr_eq]
+  simp only [rlp_phase2_long_loop_body_post_unfold]
+  -- Get iter_spec (5 instructions base → base+20).
+  have iter := rlp_phase2_long_iter_spec len ptr cnt v12_old word_val dwordAddr
+    base halign hvalid
+  simp only [rlp_phase2_long_iter_post_unfold] at iter
+  set byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set cnt' := cnt + signExtend12 (-1 : BitVec 12)
+  -- Frame iter with (.x0 ↦ᵣ 0) so the composition state matches bne's.
+  have iter' : cpsTriple base (base + 20)
+      (CodeReq.ofProg base rlp_phase2_long_iter_prog)
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+       (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
+       (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val)) :=
+    cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTriple_frame_left _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) iter)
+  -- BNE x14, x0, back at (base + 20). Taken when x14 ≠ 0, not taken when x14 = 0.
+  have bne_raw := bne_spec_gen .x14 .x0 back cnt' (0 : Word) (base + 20)
+  -- Frame BNE with all the other state (x11, x13, x12, dwordAddr) and
+  -- permute to the shape produced by `iter'`'s post.
+  have bne_framed : cpsBranch (base + 20)
+      (CodeReq.singleton (base + 20) (.BNE .x14 .x0 back))
+      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+       (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
+       (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      ((base + 20) + signExtend13 back)
+        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+         (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
+         (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+         (dwordAddr ↦ₘ word_val) ** ⌜cnt' ≠ 0⌝)
+      (base + 24)
+        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+         (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
+         (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+         (dwordAddr ↦ₘ word_val) ** ⌜cnt' = 0⌝) := by
+    have h_eq_20_4 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+    rw [h_eq_20_4] at bne_raw
+    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsBranch_frame_left _ _ _ _ _ _ _
+        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+         (.x13 ↦ᵣ (ptr + 1)) ** (.x12 ↦ᵣ byte_zext) **
+         (dwordAddr ↦ₘ word_val)) (by pcFree) bne_raw)
+  -- Disjointness between iter CR and BNE-singleton-union-empty CR.
+  have hd_iter_bne : (CodeReq.ofProg base rlp_phase2_long_iter_prog).Disjoint
+      ((CodeReq.singleton (base + 20) (.BNE .x14 .x0 back)).union
+        CodeReq.empty) := by
+    refine CodeReq.Disjoint.union_right ?_ (CodeReq.Disjoint.empty_right _)
+    apply CodeReq.Disjoint.ofProg_singleton
+    apply CodeReq.ofProg_none_range
+    intro k hk
+    simp only [rlp_phase2_long_iter_prog, List.length_cons, List.length_nil] at hk
+    interval_cases k <;> bv_omega
+  -- Extend bne_framed's CR with trailing empty.
+  have bne_ext : cpsBranch (base + 20)
+      ((CodeReq.singleton (base + 20) (.BNE .x14 .x0 back)).union CodeReq.empty)
+      _ _ _ _ _ :=
+    cpsBranch_extend_code
+      (fun a _ hcr => by
+        show (CodeReq.singleton (base + 20) (.BNE .x14 .x0 back)).union
+            CodeReq.empty a = _
+        simp only [CodeReq.union, hcr])
+      bne_framed
+  exact cpsTriple_seq_cpsBranch _ _ _ _ hd_iter_bne _ _ _ _ _ _ iter' bne_ext
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -608,7 +608,12 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     five-instruction full loop body (no back-branch) adding pointer
     advance (`ADDI x13, x13, 1`) and counter decrement
     (`ADDI x14, x14, -1`) on top of load-accumulate.
-  - Full long-form loop (BNE back-branch + loop invariant) still pending.
+  - `rlp_phase2_long_loop_body_spec`
+    (`EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean`): six-instruction loop
+    body as a `cpsBranch` — iteration body + `BNE x14, x0, back`.
+    Taken at `(base+20) + signExtend13 back` with `⌜cnt' ≠ 0⌝`; fall-
+    through at `base + 24` with `⌜cnt' = 0⌝`.
+  - Full loop closure (iteration invariant over `cnt`) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)
 - Phase 5: Recursive list decode (iterative with explicit stack)


### PR DESCRIPTION
## Summary

Six-instruction loop body for the Phase 2 long-form length-of-length loop. Extends the iteration body (#332) with the `BNE x14, x0, back` that closes the loop:

```
LBU  x12, x13, 0      ; byte = mem[x13]
SLLI x11, x11, 8      ; length <<= 8
ADD  x11, x11, x12    ; length += byte
ADDI x13, x13, 1      ; ptr += 1
ADDI x14, x14, -1     ; counter -= 1
BNE  x14, x0, back    ; if counter != 0, loop back
```

The spec is a `cpsBranch` at the loop-body entry:

| Branch    | PC                                      | Pure fact    |
|-----------|-----------------------------------------|--------------|
| taken     | `(base + 20) + signExtend13 back`       | `⌜cnt' ≠ 0⌝` |
| not taken | `base + 24`                             | `⌜cnt' = 0⌝` |

where `cnt' = cnt + signExtend12 (-1 : BitVec 12)`.

## What's in this PR

- **`rlp_phase2_long_loop_body_prog back`** — the 6-instruction program, parameterised by the back-branch offset.
- **`rlp_phase2_long_loop_body_post … P`** — `@[irreducible]` bundled post (AGENTS.md pattern) carrying a caller-supplied dispatch fact `⌜P⌝`.
- **`rlp_phase2_long_loop_body_spec`** — composed via `cpsTriple_seq_cpsBranch` from `rlp_phase2_long_iter_spec` (5-instruction prefix) and `bne_spec_gen` framed with the untouched state.

## Scope

Full loop closure — wrapping this `cpsBranch` with an induction on `cnt` to prove the loop correctly decodes a big-endian length across all iterations — is the natural next slice.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (205 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

Depends on #332 (iteration body) for the spec composition. Since #332 hasn't landed yet, this PR includes its file; merge after #332.

🤖 Generated with [Claude Code](https://claude.com/claude-code)