### PR TITLE
feat(rlp): add Phase 2 long-form single-iteration loop closure

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -19,3 +19,4 @@ import EvmAsm.Rv64.RLP.Phase2LongAcc
 import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongIter
 import EvmAsm.Rv64.RLP.Phase2LongLoopBody
+import EvmAsm.Rv64.RLP.Phase2LongLoopOne

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -1,0 +1,113 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLoopOne
+
+  EL.3 Phase 2 (long form) — one-iteration closure of the loop body.
+
+  Specializes `rlp_phase2_long_loop_body_spec` to the case where the
+  initial counter `x14` is `1`. After the single iteration the counter
+  decrements to `0`, the `BNE x14, x0, back` falls through, and control
+  reaches the exit at `base + 24`. The "loop-back" branch is
+  unreachable (its pure fact `cnt' ≠ 0` is `0 ≠ 0`, which is false),
+  so the resulting spec is a plain `cpsTriple`.
+
+  This is the simplest concrete closure of the long-form loop: it
+  corresponds to RLP long-form prefixes `0xB8` or `0xF8`, where
+  `lenLen = 1` and exactly one big-endian byte encodes the payload
+  length.
+
+  Further closures — arbitrary `n`-iteration loops via induction on the
+  counter — are future work.
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongLoopBody
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled post for the single-iteration loop closure: the registers are
+    in the "one iteration done" state, `x14` is now `0`, and no dispatch
+    fact is needed (the caller knows we exited via fall-through). -/
+@[irreducible]
+def rlp_phase2_long_loop_one_byte_post
+    (len ptr byte_zext word_val dwordAddr : Word) : Assertion :=
+  let length' := (len <<< 8) + byte_zext
+  let ptr'    := ptr + 1
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
+    (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+    (dwordAddr ↦ₘ word_val)
+
+theorem rlp_phase2_long_loop_one_byte_post_unfold
+    (len ptr byte_zext word_val dwordAddr : Word) :
+    rlp_phase2_long_loop_one_byte_post len ptr byte_zext word_val dwordAddr =
+    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+     (.x13 ↦ᵣ (ptr + 1)) **
+     (.x14 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+     (dwordAddr ↦ₘ word_val)) := by
+  delta rlp_phase2_long_loop_one_byte_post; rfl
+
+/-- `cpsTriple` spec for the single-iteration (lenLen = 1) closure of
+    the long-form length loop.
+
+    Derived from `rlp_phase2_long_loop_body_spec` by observing that when
+    `cnt = 1`, `cnt' = 1 + signExtend12 (-1) = 0`, so the taken-branch
+    post `⌜cnt' ≠ 0⌝` collapses to `⌜(0 : Word) ≠ 0⌝ = False`. The
+    `cpsBranch_elim_ntaken` rule then turns the two-exit branch into a
+    single-exit triple at the fall-through. -/
+theorem rlp_phase2_long_loop_one_byte_spec
+    (len ptr v12_old word_val dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (halign : alignToDword ptr = dwordAddr)
+    (hvalid : isValidByteAccess ptr = true) :
+    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    cpsTriple base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (1 : Word)) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      (rlp_phase2_long_loop_one_byte_post len ptr byte_zext word_val
+         dwordAddr) := by
+  simp only [rlp_phase2_long_loop_one_byte_post_unfold]
+  -- Body spec instantiated at cnt = 1.
+  have body := rlp_phase2_long_loop_body_spec len ptr (1 : Word) v12_old
+    word_val dwordAddr base back halign hvalid
+  -- For cnt = 1, `cnt' = (1 : Word) + signExtend12 (-1 : BitVec 12) = 0`.
+  have hcnt' : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by
+    decide
+  rw [hcnt'] at body
+  -- The taken post carries `⌜(0 : Word) ≠ 0⌝`, which is False. Extract it
+  -- via six layers of destructuring and derive the contradiction.
+  set byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  have h_absurd : ∀ hp,
+      rlp_phase2_long_loop_body_post len ptr (1 : Word) byte_zext word_val
+         dwordAddr ((0 : Word) ≠ 0) hp → False := by
+    intro hp hpost
+    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x11
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x13
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x14
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x12
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
+    exact hpost.2 rfl
+  -- `cpsBranch_elim_ntaken` drops the taken branch.
+  have tri := cpsBranch_elim_ntaken _ _ _ _ _ _ _ body h_absurd
+  -- Weaken the post: unfold the `@[irreducible]` wrapper and strip the
+  -- trailing `⌜(0 : Word) = 0⌝ = True` pure fact (via 5 `mono_right` wraps
+  -- reaching the innermost `F ** ⌜P⌝`).
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun _ hp => hp)
+    (fun h hp => by
+      simp only [rlp_phase2_long_loop_body_post_unfold] at hp
+      refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
+      intro h' hp'
+      exact ((sepConj_pure_right _ _ _).1 hp').1)
+    tri
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -613,7 +613,12 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     body as a `cpsBranch` — iteration body + `BNE x14, x0, back`.
     Taken at `(base+20) + signExtend13 back` with `⌜cnt' ≠ 0⌝`; fall-
     through at `base + 24` with `⌜cnt' = 0⌝`.
-  - Full loop closure (iteration invariant over `cnt`) still pending.
+  - `rlp_phase2_long_loop_one_byte_spec`
+    (`EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean`): single-iteration
+    closure (lenLen = 1). When `x14 = 1` at entry, the taken branch is
+    unreachable (`cnt' = 0`), so the `cpsBranch` collapses to a plain
+    `cpsTriple` exiting at `base + 24`.
+  - General `n`-iteration closure (induction over `cnt`) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)
 - Phase 5: Recursive list decode (iterative with explicit stack)


### PR DESCRIPTION
## Summary

First concrete closure of the long-form length loop: specializes the `cpsBranch` body spec from #333 to the case `x14 = 1` at entry. After one iteration the counter decrements to `0`, the `BNE x14, x0, back` falls through, and control reaches the exit. The taken branch becomes unreachable, so `cpsBranch_elim_ntaken` turns the two-exit `cpsBranch` into a plain `cpsTriple`.

Corresponds to the RLP prefixes `0xB8` and `0xF8` where `lenLen = 1` and exactly one big-endian byte encodes the payload length.

## What's in this PR

- **`rlp_phase2_long_loop_one_byte_post len ptr byte_zext word_val dwordAddr`** — `@[irreducible]` bundled post for the single-iteration state (`x11 = len <<< 8 + byte`, `x13 = ptr + 1`, `x14 = 0`, byte in `x12`).
- **`rlp_phase2_long_loop_one_byte_spec`** — the `cpsTriple` itself.

Proof sketch:
1. Instantiate the body spec at `cnt = 1`; rewrite `1 + signExtend12 (-1 : BitVec 12) = 0` via `decide`.
2. Build the `h_absurd` hypothesis for `cpsBranch_elim_ntaken` by destructuring six layers of `sepConj` down to `⌜(0:Word) ≠ 0⌝` and applying it to `rfl`.
3. Weaken the post through an `@[irreducible]` def unfold, then strip the trivially-true trailing `⌜(0:Word) = 0⌝` pure fact via five `sepConj_mono_right` wraps.

## Scope

General `n`-iteration closure (induction on the counter value, proving that the loop correctly decodes a big-endian length across all iterations for `n ∈ [1, 8]`) is the natural next slice.

## PR stacking

Base branch: `el3-phase2-long-loop-body` (#333). Will retarget to `main` once #333 lands.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (113 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)