### PR TITLE
feat(rlp): add Phase 2 long-form two-iteration loop closure

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -20,3 +20,4 @@ import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongIter
 import EvmAsm.Rv64.RLP.Phase2LongLoopBody
 import EvmAsm.Rv64.RLP.Phase2LongLoopOne
+import EvmAsm.Rv64.RLP.Phase2LongLoopTwo

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLoopTwo
+
+  EL.3 Phase 2 (long form) — two-iteration closure of the loop body.
+
+  Specializes `rlp_phase2_long_loop_body_spec` (#333) at `x14 = 2`,
+  composed with `rlp_phase2_long_loop_one_byte_spec` (#335) for the
+  second iteration. The overall execution:
+
+      iter 1 @ base → state at base (taken back via BNE, cnt 2→1)
+      iter 2 @ base → state at base + 24 (fall-through, cnt 1→0)
+
+  Produces a `cpsTriple` from `base` to `base + 24` that decodes two
+  big-endian bytes. Corresponds to RLP prefixes `0xB9` and `0xF9`
+  (`lenLen = 2`).
+
+  Memory model: both bytes (`mem[ptr]`, `mem[ptr + 1]`) are assumed to
+  live in the same doubleword at `dwordAddr`. This is captured by two
+  `alignToDword` hypotheses. Spans of more than one doubleword would
+  require carrying a second memory atom.
+
+  Further closures — arbitrary `n` via induction — are future work.
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongLoopOne
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled post for the two-iteration loop closure: registers in the
+    "two iterations done" state, `x14` now `0`, both bytes folded into
+    `x11` in big-endian order. -/
+@[irreducible]
+def rlp_phase2_long_loop_two_byte_post
+    (len ptr byte1 byte2 word_val dwordAddr : Word) : Assertion :=
+  let length' := ((len <<< 8) + byte1) <<< 8 + byte2
+  let ptr'    := ptr + 2
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
+    (.x12 ↦ᵣ byte2) ** (.x0 ↦ᵣ (0 : Word)) **
+    (dwordAddr ↦ₘ word_val)
+
+theorem rlp_phase2_long_loop_two_byte_post_unfold
+    (len ptr byte1 byte2 word_val dwordAddr : Word) :
+    rlp_phase2_long_loop_two_byte_post len ptr byte1 byte2 word_val dwordAddr =
+    ((.x11 ↦ᵣ (((len <<< 8) + byte1) <<< 8 + byte2)) **
+     (.x13 ↦ᵣ (ptr + 2)) **
+     (.x14 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ byte2) ** (.x0 ↦ᵣ (0 : Word)) **
+     (dwordAddr ↦ₘ word_val)) := by
+  delta rlp_phase2_long_loop_two_byte_post; rfl
+
+/-- `cpsTriple` spec for the two-iteration (lenLen = 2) closure of
+    the long-form length loop.
+
+    The first iteration runs the loop body with `cnt = 2`; the
+    BNE is taken (`cnt' = 1 ≠ 0`), PC returns to `base`. The second
+    iteration then runs with `cnt = 1`, falls through, and lands at
+    `base + 24`. -/
+theorem rlp_phase2_long_loop_two_byte_spec
+    (len ptr v12_old word_val dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (halign1 : alignToDword ptr = dwordAddr)
+    (halign2 : alignToDword (ptr + 1) = dwordAddr)
+    (hvalid1 : isValidByteAccess ptr = true)
+    (hvalid2 : isValidByteAccess (ptr + 1) = true)
+    (hback : (base + 20) + signExtend13 back = base) :
+    let byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byte2 := (extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64
+    cpsTriple base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (2 : Word)) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      (rlp_phase2_long_loop_two_byte_post len ptr
+        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
+        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
+        word_val dwordAddr) := by
+  simp only [rlp_phase2_long_loop_two_byte_post_unfold]
+  -- Iter 1: loop-body spec at cnt = 2.
+  have body := rlp_phase2_long_loop_body_spec len ptr (2 : Word) v12_old
+    word_val dwordAddr base back halign1 hvalid1
+  -- cnt' = 2 + signExtend12 (-1) = 1. Rewrite.
+  have hcnt' : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by
+    decide
+  rw [hcnt'] at body
+  -- The fall-through carries `⌜(1 : Word) = 0⌝`, which is False.
+  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  have h_absurd : ∀ hp,
+      rlp_phase2_long_loop_body_post len ptr (2 : Word) byte1 word_val
+         dwordAddr ((1 : Word) = 0) hp → False := by
+    intro hp hpost
+    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x11
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x13
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x14
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x12
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
+    exact absurd hpost.2 (by decide)
+  -- `cpsBranch_elim_taken` drops fall-through. Keeps taken exit (loops back).
+  have tri1 := cpsBranch_elim_taken _ _ _ _ _ _ _ body h_absurd
+  -- Taken exit is `(base + 20) + signExtend13 back = base` by hback.
+  rw [hback] at tri1
+  -- Weaken post: unfold wrapper, strip trailing `⌜(1 : Word) ≠ 0⌝` pure fact,
+  -- matching the one-byte spec's precondition at `base`.
+  have tri1' : cpsTriple base base
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (2 : Word)) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
+       (.x14 ↦ᵣ (1 : Word)) ** (.x12 ↦ᵣ byte1) **
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+    cpsTriple_consequence _ _ _ _ _ _ _
+      (fun _ hp => hp)
+      (fun h hp => by
+        simp only [rlp_phase2_long_loop_body_post_unfold] at hp
+        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
+        intro h' hp'
+        exact ((sepConj_pure_right _ _ _).1 hp').1)
+      tri1
+  -- Iter 2: one-byte spec at base, using state from tri1's post.
+  -- Permute post to match one-byte spec's pre shape (put x13, x14 first).
+  have one_byte := rlp_phase2_long_loop_one_byte_spec ((len <<< 8) + byte1)
+    (ptr + 1) byte1 word_val dwordAddr base back halign2 hvalid2
+  simp only [rlp_phase2_long_loop_one_byte_post_unfold] at one_byte
+  -- Both CRs are the same (loop body prog at base), so use `_seq_same_cr`.
+  -- Need to convert tri1''s post into one_byte's pre shape via consequence.
+  have composed :=
+    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+      (fun h hp => by xperm_hyp hp) tri1' one_byte
+  -- Final post: rewrite `ptr + 1 + 1 = ptr + 2` and reshape.
+  have h_ptr_2 : (ptr + 1 : Word) + 1 = ptr + 2 := by bv_omega
+  rw [h_ptr_2] at composed
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun _ hp => hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -618,6 +618,12 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     closure (lenLen = 1). When `x14 = 1` at entry, the taken branch is
     unreachable (`cnt' = 0`), so the `cpsBranch` collapses to a plain
     `cpsTriple` exiting at `base + 24`.
+  - `rlp_phase2_long_loop_two_byte_spec`
+    (`EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean`): two-iteration closure
+    (lenLen = 2). Composes the body spec (iter 1, BNE taken) with the
+    one-byte closure (iter 2, fall-through) via
+    `cpsTriple_seq_with_perm_same_cr`. Assumes both bytes live in the
+    same doubleword.
   - General `n`-iteration closure (induction over `cnt`) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)


### PR DESCRIPTION
## Summary

Second concrete closure of the long-form length loop: two iterations, corresponding to RLP prefixes `0xB9` and `0xF9` (lenLen = 2).

Execution:
- **iter 1 @ base** — body runs with `cnt = 2`; `cnt' = 1 ≠ 0`, BNE taken, PC returns to `base` (via `hback`).
- **iter 2 @ base** — reuses the one-byte closure (#335) with `cnt = 1`; fall-through to `base + 24`.

## What's in this PR

- **`rlp_phase2_long_loop_two_byte_post len ptr byte1 byte2 word_val dwordAddr`** — `@[irreducible]` bundled post. Final state: `x11 = ((len <<< 8) + byte1) <<< 8 + byte2`, `x13 = ptr + 2`, `x14 = 0`, `x12 = byte2`.
- **`rlp_phase2_long_loop_two_byte_spec`** — the `cpsTriple` itself, composed from the body spec + one-byte closure.

Proof sketch:
1. Instantiate the body spec at `cnt = 2`; rewrite `2 + signExtend12 (-1) = 1`.
2. Fall-through post carries `⌜(1 : Word) = 0⌝ = False` → use `cpsBranch_elim_taken` to drop fall-through, keep taken branch.
3. `hback : (base + 20) + signExtend13 back = base` substitutes the taken exit to `base`, giving `cpsTriple base base ...`.
4. Weaken its post to strip the trailing `⌜cnt' ≠ 0⌝ = ⌜True⌝`.
5. Chain with `rlp_phase2_long_loop_one_byte_spec` at `base` (state has `cnt = 1`) via `cpsTriple_seq_with_perm_same_cr`.

## Memory model

Both bytes (`mem[ptr]`, `mem[ptr + 1]`) are assumed to live in the **same doubleword** at `dwordAddr` (two `alignToDword` hypotheses). Cross-doubleword reads are a future refinement.

## Scope

General `n`-iteration closure via induction on the counter is the natural next slice.

## PR stacking

Base branch: `el3-phase2-long-loop-one-byte` (#335). Will retarget to `main` once #335 lands.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (146 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)