### PR TITLE
feat(rlp): add Phase 2 long-form three-iteration loop closure

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -21,3 +21,4 @@ import EvmAsm.Rv64.RLP.Phase2LongIter
 import EvmAsm.Rv64.RLP.Phase2LongLoopBody
 import EvmAsm.Rv64.RLP.Phase2LongLoopOne
 import EvmAsm.Rv64.RLP.Phase2LongLoopTwo
+import EvmAsm.Rv64.RLP.Phase2LongLoopThree

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -1,0 +1,146 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2LongLoopThree
+
+  EL.3 Phase 2 (long form) — three-iteration closure of the loop body.
+
+  Specializes `rlp_phase2_long_loop_body_spec` (#333) at `x14 = 3`,
+  composed with `rlp_phase2_long_loop_two_byte_spec` (#336) for the
+  remaining two iterations. Execution:
+
+      iter 1 @ base → state at base (BNE taken, cnt 3→2)
+      iter 2+3 @ base (via two-byte closure) → state at base + 24
+
+  Produces a `cpsTriple` from `base` to `base + 24` that decodes three
+  big-endian bytes. Corresponds to RLP prefixes `0xBA` and `0xFA`
+  (`lenLen = 3`).
+
+  Memory model: all three bytes (`mem[ptr]`, `mem[ptr + 1]`,
+  `mem[ptr + 2]`) are assumed to live in the same doubleword at
+  `dwordAddr`. Cross-doubleword reads are a future refinement.
+-/
+
+import EvmAsm.Rv64.RLP.Phase2LongLoopTwo
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- Bundled post for the three-iteration loop closure: registers in the
+    "three iterations done" state, `x14 = 0`, three bytes folded into
+    `x11` in big-endian order. -/
+@[irreducible]
+def rlp_phase2_long_loop_three_byte_post
+    (len ptr byte1 byte2 byte3 word_val dwordAddr : Word) : Assertion :=
+  let length' := ((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8) + byte3
+  let ptr'    := ptr + 3
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
+    (.x12 ↦ᵣ byte3) ** (.x0 ↦ᵣ (0 : Word)) **
+    (dwordAddr ↦ₘ word_val)
+
+theorem rlp_phase2_long_loop_three_byte_post_unfold
+    (len ptr byte1 byte2 byte3 word_val dwordAddr : Word) :
+    rlp_phase2_long_loop_three_byte_post len ptr byte1 byte2 byte3 word_val
+        dwordAddr =
+    ((.x11 ↦ᵣ ((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8 + byte3)) **
+     (.x13 ↦ᵣ (ptr + 3)) **
+     (.x14 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ byte3) ** (.x0 ↦ᵣ (0 : Word)) **
+     (dwordAddr ↦ₘ word_val)) := by
+  delta rlp_phase2_long_loop_three_byte_post; rfl
+
+/-- `cpsTriple` spec for the three-iteration (lenLen = 3) closure of
+    the long-form length loop.
+
+    The first iteration runs at `cnt = 3` (BNE taken back to `base` with
+    `cnt' = 2 ≠ 0`); the remaining two iterations are folded into
+    `rlp_phase2_long_loop_two_byte_spec` (#336). -/
+theorem rlp_phase2_long_loop_three_byte_spec
+    (len ptr v12_old word_val dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (halign1 : alignToDword ptr = dwordAddr)
+    (halign2 : alignToDword (ptr + 1) = dwordAddr)
+    (halign3 : alignToDword (ptr + 2) = dwordAddr)
+    (hvalid1 : isValidByteAccess ptr = true)
+    (hvalid2 : isValidByteAccess (ptr + 1) = true)
+    (hvalid3 : isValidByteAccess (ptr + 2) = true)
+    (hback : (base + 20) + signExtend13 back = base) :
+    let byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byte2 := (extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64
+    let byte3 := (extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64
+    cpsTriple base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (3 : Word)) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      (rlp_phase2_long_loop_three_byte_post len ptr
+        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
+        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64)
+        word_val dwordAddr) := by
+  simp only [rlp_phase2_long_loop_three_byte_post_unfold]
+  -- Iter 1: body spec at cnt = 3. cnt' = 2.
+  have body := rlp_phase2_long_loop_body_spec len ptr (3 : Word) v12_old
+    word_val dwordAddr base back halign1 hvalid1
+  have hcnt' : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by
+    decide
+  rw [hcnt'] at body
+  -- The fall-through carries `⌜(2 : Word) = 0⌝`, which is False.
+  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  have h_absurd : ∀ hp,
+      rlp_phase2_long_loop_body_post len ptr (3 : Word) byte1 word_val
+         dwordAddr ((2 : Word) = 0) hp → False := by
+    intro hp hpost
+    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+    exact absurd hpost.2 (by decide)
+  have tri1 := cpsBranch_elim_taken _ _ _ _ _ _ _ body h_absurd
+  rw [hback] at tri1
+  -- Weaken: unfold @[irreducible] + strip trailing `⌜(2 : Word) ≠ 0⌝`.
+  have tri1' : cpsTriple base base
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (3 : Word)) **
+       (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
+       (.x14 ↦ᵣ (2 : Word)) ** (.x12 ↦ᵣ byte1) **
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+    cpsTriple_consequence _ _ _ _ _ _ _
+      (fun _ hp => hp)
+      (fun h hp => by
+        simp only [rlp_phase2_long_loop_body_post_unfold] at hp
+        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
+        intro h' hp'
+        exact ((sepConj_pure_right _ _ _).1 hp').1)
+      tri1
+  -- Iter 2+3: two-byte closure starting at base with ptr+1, cnt = 2.
+  have two_byte := rlp_phase2_long_loop_two_byte_spec ((len <<< 8) + byte1)
+    (ptr + 1) byte1 word_val dwordAddr base back
+    halign2
+    (by rw [show (ptr + 1 : Word) + 1 = ptr + 2 from by bv_omega]; exact halign3)
+    hvalid2
+    (by rw [show (ptr + 1 : Word) + 1 = ptr + 2 from by bv_omega]; exact hvalid3)
+    hback
+  simp only [rlp_phase2_long_loop_two_byte_post_unfold] at two_byte
+  -- Address normalisation inside two_byte: `(ptr + 1) + 1 = ptr + 2`, etc.
+  have h_ptr_2 : (ptr + 1 : Word) + 1 = ptr + 2 := by bv_omega
+  have h_ptr_3 : (ptr + 1 : Word) + 2 = ptr + 3 := by bv_omega
+  rw [h_ptr_2, h_ptr_3] at two_byte
+  have composed :=
+    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+      (fun h hp => by xperm_hyp hp) tri1' two_byte
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun _ hp => hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -624,6 +624,10 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     one-byte closure (iter 2, fall-through) via
     `cpsTriple_seq_with_perm_same_cr`. Assumes both bytes live in the
     same doubleword.
+  - `rlp_phase2_long_loop_three_byte_spec`
+    (`EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean`): three-iteration
+    closure (lenLen = 3). Composes body spec (iter 1) with two-byte
+    closure (iters 2–3). All three bytes assumed in same doubleword.
   - General `n`-iteration closure (induction over `cnt`) still pending.
 - Phase 3: Single-item flat decode (byte strings only)
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)


### PR DESCRIPTION
## Summary

Third concrete closure of the long-form length loop: three iterations, corresponding to RLP prefixes `0xBA` and `0xFA` (lenLen = 3).

Execution:
- **iter 1 @ base** — body runs with `cnt = 3`; `cnt' = 2 ≠ 0`, BNE taken, PC returns to `base` (via `hback`).
- **iters 2-3 @ base** — reuses the two-byte closure (#336) with `cnt = 2` for the remaining two iterations, fall-through to `base + 24`.

## What's in this PR

- **`rlp_phase2_long_loop_three_byte_post len ptr byte1 byte2 byte3 word_val dwordAddr`** — `@[irreducible]` bundled post. Final state: `x11 = ((len <<< 8 + byte1) <<< 8 + byte2) <<< 8 + byte3`, `x13 = ptr + 3`, `x14 = 0`, `x12 = byte3`.
- **`rlp_phase2_long_loop_three_byte_spec`** — the `cpsTriple` itself.

Proof mirrors the two-byte composition exactly:
1. Instantiate body spec at `cnt = 3`; rewrite `3 + signExtend12 (-1) = 2`.
2. Eliminate fall-through via `cpsBranch_elim_taken` (post has `⌜(2 : Word) = 0⌝ = False`).
3. Rewrite taken exit to `base` via `hback`; strip trailing `⌜cnt' ≠ 0⌝` from post.
4. Chain with `rlp_phase2_long_loop_two_byte_spec` (#336) via `cpsTriple_seq_with_perm_same_cr`.

## Memory model

All three bytes (`mem[ptr]`, `mem[ptr + 1]`, `mem[ptr + 2]`) assumed in the same doubleword at `dwordAddr`. Cross-doubleword reads deferred.

## Pattern observation

The pattern `N-byte = 1 iter + (N-1)-byte` is now well-established across #335 → #336 → this PR. The natural next slice is either continuing to unroll (4..8 bytes — RLP's lenLen bound) or committing to a single induction-based closure that subsumes all `lenLen ∈ [1, 8]` cases.

## PR stacking

Base branch: `el3-phase2-long-loop-two` (#336). Will retarget to `main` once #336 lands.

## Test plan

- [x] `lake build` succeeds, 0 errors / 0 sorries
- [x] `scripts/check-file-size.sh` passes (146 / 1500 lines)
- [x] No `native_decide` / `bv_decide` introduced
- [x] No `set_option maxHeartbeats` override

🤖 Generated with [Claude Code](https://claude.com/claude-code)