### PR TITLE
refactor(divmod): migrate remaining block offsets to named constants (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -21,7 +21,7 @@ open EvmAsm.Rv64
 
 /-- CLZ code (block 2) is subsumed by divCode. -/
 private theorem divK_clz_code_sub_divCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 116) divK_clz) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
@@ -35,11 +35,11 @@ private theorem clz_stage_sub (base : Word)
     (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
       divK_clz_stage_prog K M_s M_a)
     (hbound : 4 * divK_clz.length < 2 ^ 64) :
-    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + 116) + BitVec.ofNat 64 (4 * k))) a = some i →
+    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + 116) _ divK_clz _ k
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
 /-- Helper: CLZ last stage at instruction index k is subsumed by divCode.
@@ -48,22 +48,22 @@ private theorem clz_last_sub (base : Word) (k : Nat)
     (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
     (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
     (hbound : 4 * divK_clz.length < 2 ^ 64) :
-    ∀ a i, (divK_clz_last_code ((base + 116) + BitVec.ofNat 64 (4 * k))) a = some i →
+    ∀ a i, (divK_clz_last_code ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + 116) _ divK_clz _ k
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
 /-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by divCode. -/
 private theorem clz_init_sub (base : Word) :
-    ∀ a i, (CodeReq.singleton (base + 116) (.ADDI .x6 .x0 0)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_divCode base a i
-    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + 116) divK_clz 0
-      (by decide) (by decide)) a i (by rwa [show (base + 116 : Word) =
-        base + 116 + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
+      (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
+        base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
 
 -- CLZ stage parameters: (SRLI_K, SLLI_M_s, ADDI_M_a, instruction_index)
 -- Stage 0: K=32, M_s=32, M_a=32, index 1 (after init at index 0)
@@ -96,13 +96,13 @@ noncomputable def clzResult (val : Word) : Word × Word :=
   (c5, v4)
 
 -- Address lemmas for CLZ stages
-private theorem clz_addr0 (base : Word) : (base + 116 : Word) + 4 = base + 120 := by bv_addr
+private theorem clz_addr0 (base : Word) : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
 private theorem clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_addr
 private theorem clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_addr
 private theorem clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_addr
 private theorem clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_addr
 private theorem clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_addr
-private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + 212 := by bv_addr
+private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     After stage: val' = if (val>>>K≠0) then val else val<<<M_s,
@@ -153,13 +153,13 @@ set_option maxHeartbeats 6400000 in
     Entry: base+116 with x5=val, x6=v6_old, x7=v7_old, x0=0.
     Exit: base+212 with x5=(clzResult val).2, x6=(clzResult val).1, x0=0. -/
 theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
-    cpsTriple (base + 116) (base + 212) (divCode base)
+    cpsTriple (base + clzOff) (base + phaseC2Off) (divCode base)
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
        (.x7 ↦ᵣ (clzResult val).2 >>> (63 : Nat)) ** (.x0 ↦ᵣ (0 : Word))) := by
   unfold clzResult
   -- 0. Init: ADDI x6 x0 0 (base+116 → base+120)
-  have I := divK_clz_init_spec v6_old (base + 116)
+  have I := divK_clz_init_spec v6_old (base + clzOff)
   have Ie := cpsTriple_extend_code (hmono := clz_init_sub base) I
   rw [clz_addr0] at Ie
   -- Frame init with x5, x7
@@ -167,11 +167,11 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
     ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ v7_old)) (by pcFree) Ie
   -- Stage 0: K=32, M_s=32, M_a=32 (base+120 → base+136)
   have S0 := divK_clz_stage_combined 32 32 32 val (signExtend12 0) v7_old
-    ((base + 116) + BitVec.ofNat 64 (4 * 1))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 1))
   dsimp only [] at S0
   have S0e := cpsTriple_extend_code (hmono := clz_stage_sub base 32 32 32 1
     (by decide) (by decide) (by decide)) S0
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_addr] at S0e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_addr] at S0e
   rw [clz_addr1] at S0e
   seqFrame Ief S0e
   -- Abbreviations for stage 0 results
@@ -180,55 +180,55 @@ theorem divK_clz_spec (val v6_old v7_old : Word) (base : Word) :
     else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
   -- Stage 1: K=48, M_s=16, M_a=16 (base+136 → base+152)
   have S1 := divK_clz_stage_combined 48 16 16 v0 c0 (val >>> (32 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 5))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 5))
   dsimp only [] at S1
   have S1e := cpsTriple_extend_code (hmono := clz_stage_sub base 48 16 16 5
     (by decide) (by decide) (by decide)) S1
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_addr] at S1e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_addr] at S1e
   rw [clz_addr2] at S1e
   seqFrame IefS0e S1e
   -- Stage 2: K=56, M_s=8, M_a=8 (base+152 → base+168)
   let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
   let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
   have S2 := divK_clz_stage_combined 56 8 8 v1 c1 (v0 >>> (48 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 9))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 9))
   dsimp only [] at S2
   have S2e := cpsTriple_extend_code (hmono := clz_stage_sub base 56 8 8 9
     (by decide) (by decide) (by decide)) S2
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_addr] at S2e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_addr] at S2e
   rw [clz_addr3] at S2e
   seqFrame IefS0eS1e S2e
   -- Stage 3: K=60, M_s=4, M_a=4 (base+168 → base+184)
   let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
   let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
   have S3 := divK_clz_stage_combined 60 4 4 v2 c2 (v1 >>> (56 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 13))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 13))
   dsimp only [] at S3
   have S3e := cpsTriple_extend_code (hmono := clz_stage_sub base 60 4 4 13
     (by decide) (by decide) (by decide)) S3
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_addr] at S3e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_addr] at S3e
   rw [clz_addr4] at S3e
   seqFrame IefS0eS1eS2e S3e
   -- Stage 4: K=62, M_s=2, M_a=2 (base+184 → base+200)
   let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
   let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
   have S4 := divK_clz_stage_combined 62 2 2 v3 c3 (v2 >>> (60 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 17))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 17))
   dsimp only [] at S4
   have S4e := cpsTriple_extend_code (hmono := clz_stage_sub base 62 2 2 17
     (by decide) (by decide) (by decide)) S4
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_addr] at S4e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_addr] at S4e
   rw [clz_addr5] at S4e
   seqFrame IefS0eS1eS2eS3e S4e
   -- Stage 5 (last): K=63 (base+200 → base+212)
   let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
   let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
   have S5 := divK_clz_last_combined v4 c4 (v3 >>> (62 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 21))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 21))
   dsimp only [] at S5
   have S5e := cpsTriple_extend_code (hmono := clz_last_sub base 21
     (by decide) (by decide) (by decide)) S5
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_addr] at S5e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_addr] at S5e
   rw [clz_addr6] at S5e
   seqFrame IefS0eS1eS2eS3eS4e S5e
   -- Final permutation

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -22,7 +22,7 @@ open EvmAsm.Rv64
 -- Master subsumption: ofProg (base+1072) divK_div128 ⊆ sharedDivModCode base
 -- Block 12 in sharedDivModCode's unionAll; skip blocks 0-11.
 private theorem divK_div128_ofProg_sub_sharedCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 1072) divK_div128) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
       (sharedDivModCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -44,23 +44,23 @@ private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
 -- Used to prove each singleton in a block's cr is subsumed by sharedDivModCode.
 private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < divK_div128.length)
-    (h_addr : addr = (base + 1072) + BitVec.ofNat 64 (4 * k))
+    (h_addr : addr = (base + div128Off) + BitVec.ofNat 64 (4 * k))
     (h_instr : divK_div128.get ⟨k, hk⟩ = instr) :
     ∀ a i, CodeReq.singleton addr instr a = some i →
       (sharedDivModCode base) a = some i := by
   subst h_addr; subst h_instr
   exact fun a i h => divK_div128_ofProg_sub_sharedCode base a i
     (CodeReq.singleton_mono
-      (CodeReq.ofProg_lookup (base + 1072) divK_div128 k hk (by decide)) a i h)
+      (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
 -- Abbreviation for repeated `by decide` / `by bv_addr` calls
 -- Each block's subsumption uses: CodeReq_union_sub (d128_sub ...) (CodeReq_union_sub ...)
 
--- Address normalization: block entry offsets relative to (base + 1072)
-private theorem d128_off_40 (base : Word) : (base + 1072 : Word) + 40 = base + 1112 := by bv_addr
-private theorem d128_off_100 (base : Word) : (base + 1072 : Word) + 100 = base + 1172 := by bv_addr
-private theorem d128_off_120 (base : Word) : (base + 1072 : Word) + 120 = base + 1192 := by bv_addr
-private theorem d128_off_180 (base : Word) : (base + 1072 : Word) + 180 = base + 1252 := by bv_addr
+-- Address normalization: block entry offsets relative to (base + div128Off)
+private theorem d128_off_40 (base : Word) : (base + div128Off : Word) + 40 = base + 1112 := by bv_addr
+private theorem d128_off_100 (base : Word) : (base + div128Off : Word) + 100 = base + 1172 := by bv_addr
+private theorem d128_off_120 (base : Word) : (base + div128Off : Word) + 120 = base + 1192 := by bv_addr
+private theorem d128_off_180 (base : Word) : (base + div128Off : Word) + 180 = base + 1252 := by bv_addr
 
 -- ============================================================================
 -- div128_spec: compose 5 block specs into single subroutine theorem.
@@ -103,7 +103,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + 1072) ret_addr (sharedDivModCode base)
+    cpsTriple (base + div128Off) ret_addr (sharedDivModCode base)
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
@@ -129,8 +129,8 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Saves ret/d, splits d and u_lo into halves.
   -- ================================================================
   have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-    ret_mem d_mem dlo_mem un0_mem (base + 1072)
-  rw [show (base + 1072 : Word) + 40 = base + 1112 from by bv_addr] at hph1
+    ret_mem d_mem dlo_mem un0_mem (base + div128Off)
+  rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
   -- Extend phase1 cr to sharedDivModCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -20,7 +20,7 @@ open EvmAsm.Rv64
 
 /-- Denorm code (block 9) is subsumed by divCode. -/
 private theorem divK_denorm_code_sub_divCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 908) divK_denorm) a = some i → (divCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
@@ -31,11 +31,11 @@ private theorem denorm_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ divK_denorm.length)
     (hslice : (divK_denorm.drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * divK_denorm.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + 908) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
+    ∀ a i, (CodeReq.ofProg ((base + denormOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_denorm_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + 908) _ divK_denorm _ k rfl hslice hk hbound a i h)
+    (CodeReq.ofProg_mono_sub (base + denormOff) _ divK_denorm _ k rfl hslice hk hbound a i h)
 
 -- signExtend12 for u[] offsets
 private theorem se12_4032' : signExtend12 (4032 : BitVec 12) = signExtend12 4032 := rfl
@@ -49,7 +49,7 @@ set_option maxHeartbeats 3200000 in
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
 theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 908) (base + 916) (divCode base)
+    cpsTriple (base + denormOff) (base + 916) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -57,23 +57,23 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + 908) (by nofun)
-  rw [show (base + 908 : Word) + 4 = base + 912 from by bv_addr] at hld
+  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
+  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 908) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + 1008 from by
+  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
         rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
   have hbeq_exit := cpsBranch_elim_ntaken _ _ _ _ _ _ _ hbeqe
@@ -113,7 +113,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTriple (base + 916) (base + 1008) (divCode base)
+    cpsTriple (base + 916) (base + epilogueOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -128,7 +128,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 916) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 916) divK_denorm
         [.ADDI .x2 .x0 0] 2
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) haddi
   -- Frame ADDI with x12, x5, x7, x6, and all memory
@@ -143,10 +143,10 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   have hsube := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
       (CodeReq.singleton_mono (by
-        have hlookup := CodeReq.ofProg_lookup (base + 908) divK_denorm 3
+        have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
         rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-            show (base + 908 : Word) + 12 = base + 920 from by bv_addr] at hlookup
+            show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTriple_frame_left _ _ _ _ _
@@ -161,7 +161,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 924) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 924) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm0
   have hm0ef := cpsTriple_frame_left _ _ _ _ _
@@ -176,7 +176,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 948) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 948) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   have hm1ef := cpsTriple_frame_left _ _ _ _ _
@@ -191,7 +191,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 972) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 972) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
@@ -202,10 +202,10 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 996)
-  rw [show (base + 996 : Word) + 12 = base + 1008 from by bv_addr] at hl
+  rw [show (base + 996 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 996) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 996) divK_denorm
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _
@@ -227,7 +227,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
 
 /-- DIV epilogue code (block 10) is subsumed by divCode. -/
 private theorem divK_divEpilogue_code_sub_divCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 1008) (divK_div_epilogue 24)) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + epilogueOff) (divK_div_epilogue 24)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -240,7 +240,7 @@ set_option maxRecDepth 4096 in
     base+1008 → base+1068 (10 instructions). -/
 theorem divK_div_epilogue_spec (sp : Word) (base : Word)
     (q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24 : Word) :
-    cpsTriple (base + 1008) (base + 1068) (divCode base)
+    cpsTriple (base + epilogueOff) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
@@ -253,21 +253,21 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
        ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) := by
   -- Load phase (base+1008 → base+1024)
   have hload := divK_epilogue_load_spec 4088 4080 4072 4064 sp q0 q1 q2 q3 v5 v6 v7 v10
-    (base + 1008)
-  rw [show (base + 1008 : Word) + 16 = base + 1024 from by bv_addr] at hload
+    (base + epilogueOff)
+  rw [show (base + epilogueOff : Word) + 16 = base + 1024 from by bv_addr] at hload
   have hloade := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 1008) (base + 1008) (divK_div_epilogue 24)
+      (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + epilogueOff) (divK_div_epilogue 24)
         (divK_epilogue_load_prog 4088 4080 4072 4064) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hload
   -- Store phase (base+1024 → base+1068 via JAL)
   have hstore := divK_epilogue_store_spec sp (base + 1024) q0 q1 q2 q3 m0 m8 m16 m24 24
-  rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + 1068 from by
+  rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + nopOff from by
         rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_addr]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 1008) (base + 1024) (divK_div_epilogue 24)
+      (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + 1024) (divK_div_epilogue 24)
         (divK_epilogue_store_prog 24) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hstore
   -- Frame load with output memory
@@ -302,7 +302,7 @@ private theorem divK_phaseA_code_sub_modCode (base : Word) :
   exact CodeReq.union_mono_left _ _
 
 private theorem divK_zeroPath_code_sub_modCode (base : Word) :
-    ∀ a i, (divK_zeroPath_code (base + 1048)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_zeroPath_code (base + zeroPathOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -332,7 +332,7 @@ set_option maxRecDepth 2048 in
 theorem evm_mod_bzero_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbz : b0 ||| b1 ||| b2 ||| b3 = 0) :
-    cpsTriple base (base + 1068) (modCode base)
+    cpsTriple base (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
@@ -344,7 +344,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + 1048 from by
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [signExtend13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
@@ -363,8 +363,8 @@ theorem evm_mod_bzero_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hbody hbeq_framed
   -- Step 5: ZeroPath (base+1048 → base+1068)
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_modCode base)
-    (divK_zeroPath_spec sp (base + 1048) b0 b1 b2 b3)
-  rw [show (base + 1048 : Word) + 20 = base + 1068 from by bv_addr] at hzp
+    (divK_zeroPath_spec sp (base + zeroPathOff) b0 b1 b2 b3)
+  rw [show (base + zeroPathOff : Word) + 20 = base + nopOff from by bv_addr] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -400,7 +400,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + 1048 from by
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [signExtend13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
@@ -429,7 +429,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
 -- ============================================================================
 
 private theorem divK_modEpilogue_code_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 1008) (divK_mod_epilogue 24)) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + epilogueOff) (divK_mod_epilogue 24)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -442,7 +442,7 @@ set_option maxRecDepth 4096 in
     base+1008 → base+1068 (10 instructions). -/
 theorem divK_mod_epilogue_spec (sp : Word) (base : Word)
     (u0 u1 u2 u3 v5 v6 v7 v10 m0 m8 m16 m24 : Word) :
-    cpsTriple (base + 1008) (base + 1068) (modCode base)
+    cpsTriple (base + epilogueOff) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -455,21 +455,21 @@ theorem divK_mod_epilogue_spec (sp : Word) (base : Word)
        ((sp + 48) ↦ₘ u2) ** ((sp + 56) ↦ₘ u3)) := by
   -- Load phase (base+1008 → base+1024): load u[0..3] from scratch memory
   have hload := divK_epilogue_load_spec 4056 4048 4040 4032 sp u0 u1 u2 u3 v5 v6 v7 v10
-    (base + 1008)
-  rw [show (base + 1008 : Word) + 16 = base + 1024 from by bv_addr] at hload
+    (base + epilogueOff)
+  rw [show (base + epilogueOff : Word) + 16 = base + 1024 from by bv_addr] at hload
   have hloade := cpsTriple_extend_code (hmono := fun a i h =>
     divK_modEpilogue_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 1008) (base + 1008) (divK_mod_epilogue 24)
+      (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + epilogueOff) (divK_mod_epilogue 24)
         (divK_epilogue_load_prog 4056 4048 4040 4032) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hload
   -- Store phase (base+1024 → base+1068 via JAL): advance sp, store u[0..3] to output
   have hstore := divK_epilogue_store_spec sp (base + 1024) u0 u1 u2 u3 m0 m8 m16 m24 24
-  rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + 1068 from by
+  rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + nopOff from by
         rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_addr]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
     divK_modEpilogue_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 1008) (base + 1024) (divK_mod_epilogue 24)
+      (CodeReq.ofProg_mono_sub (base + epilogueOff) (base + 1024) (divK_mod_epilogue 24)
         (divK_epilogue_store_prog 24) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hstore
   -- Frame load with output memory

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -31,7 +31,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple base (base + 212) (divCode base)
+    cpsTriple base (base + phaseC2Off) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -83,7 +83,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
-    cpsTriple base (base + 312) (divCode base)
+    cpsTriple base (base + normAOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -157,7 +157,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -262,7 +262,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -397,7 +397,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
 theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word) :
-    cpsTriple (base + 916) (base + 1068) (divCode base)
+    cpsTriple (base + 916) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -453,7 +453,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
 theorem evm_mod_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (m0 m8 m16 m24 : Word) :
-    cpsTriple (base + 916) (base + 1068) (modCode base)
+    cpsTriple (base + 916) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -505,7 +505,7 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 908) (base + 1068) (divCode base)
+    cpsTriple (base + denormOff) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift) **
@@ -551,7 +551,7 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
 /-- Denorm code (block 9) is subsumed by modCode.
     Re-proved here because the version in ModEpilogue.lean is private. -/
 private theorem divK_denorm_code_sub_modCode' (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 908) divK_denorm) a = some i → (modCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
@@ -563,7 +563,7 @@ set_option maxHeartbeats 3200000 in
     base+908 → base+916. -/
 theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 908) (base + 916) (modCode base)
+    cpsTriple (base + denormOff) (base + 916) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -571,23 +571,23 @@ theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + 908) (by nofun)
-  rw [show (base + 908 : Word) + 4 = base + 912 from by bv_addr] at hld
+  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
+  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 908) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + 1008 from by
+  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
         rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
   have hbeq_exit := cpsBranch_elim_ntaken _ _ _ _ _ _ _ hbeqe
@@ -627,7 +627,7 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
     (m0 m8 m16 m24 : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 908) (base + 1068) (modCode base)
+    cpsTriple (base + denormOff) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift) **
@@ -668,7 +668,7 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
 /-- Denorm code (block 9) is subsumed by divCode.
     Re-proved here because the version in Epilogue.lean is private. -/
 private theorem divK_denorm_code_sub_divCode' (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 908) divK_denorm) a = some i → (divCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
@@ -687,7 +687,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
     (_u0 _u1 _u2 _u3 shift v2 v5 v6 v7 v10 : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word)
     (hshift_z : shift = 0) :
-    cpsTriple (base + 908) (base + 1068) (divCode base)
+    cpsTriple (base + denormOff) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift) **
@@ -703,23 +703,23 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
        ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
        ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + 908) (by nofun)
-  rw [show (base + 908 : Word) + 4 = base + 912 from by bv_addr] at hld
+  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
+  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 908) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + 1008 from by
+  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
         rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
@@ -776,7 +776,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 shift v2 v5 v6 v7 v10 : Word)
     (m0 m8 m16 m24 : Word)
     (hshift_z : shift = 0) :
-    cpsTriple (base + 908) (base + 1068) (modCode base)
+    cpsTriple (base + denormOff) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift) **
@@ -792,23 +792,23 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
        ((sp + 32) ↦ₘ u0) ** ((sp + 40) ↦ₘ u1) **
        ((sp + 48) ↦ₘ u2) ** ((sp + 56) ↦ₘ u3)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + 908) (by nofun)
-  rw [show (base + 908 : Word) + 4 = base + 912 from by bv_addr] at hld
+  have hld := ld_spec_gen .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
+  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 908) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + 1008 from by
+  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
         rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -27,7 +27,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
-    cpsTriple base (base + 212) (divCode base)
+    cpsTriple base (base + phaseC2Off) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -89,7 +89,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -230,7 +230,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -176,7 +176,7 @@ theorem divK_loop_n1_unified_divCode (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
         (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
         (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -160,7 +160,7 @@ private theorem evm_div_n1_loop_unified_inst
           (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.2.2.1).2.1
       v0')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN1PreWithScratch sp j_mem (1 : Word) shift u0_s v10_val v11_old anti_shift
         v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
         u2_s u1_s u0_s (0 : Word) (0 : Word) (0 : Word) (0 : Word)
@@ -205,7 +205,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
       ((b1 <<< (((clzResult b0).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
       ((b2 <<< (((clzResult b0).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
       ((b3 <<< (((clzResult b0).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -27,7 +27,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
-    cpsTriple base (base + 212) (divCode base)
+    cpsTriple base (base + phaseC2Off) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -92,7 +92,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -233,7 +233,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -76,7 +76,7 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -209,7 +209,7 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -342,7 +342,7 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -475,7 +475,7 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -608,7 +608,7 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -741,7 +741,7 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -874,7 +874,7 @@ theorem evm_div_n2_full_TTT_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -81,7 +81,7 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -268,7 +268,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -145,7 +145,7 @@ theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
       (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
       (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -122,7 +122,7 @@ private theorem evm_div_n2_loop_unified_inst
         (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
       v1')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN2PreWithScratch sp j_mem (2 : Word) shift u0_s v10_val v11_old anti_shift
         v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
         u1_s u0_s (0 : Word) (0 : Word) (0 : Word)
@@ -165,7 +165,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
       ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
       ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -27,7 +27,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
-    cpsTriple base (base + 212) (divCode base)
+    cpsTriple base (base + phaseC2Off) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -92,7 +92,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -233,7 +233,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
-    cpsTriple base (base + 448) (divCode base)
+    cpsTriple base (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -90,7 +90,7 @@ theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
     (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -94,7 +94,7 @@ private theorem evm_div_n3_loop_unified_inst
     (hbltu_0 : bltu_0 = BitVec.ult
       (iterN3 bltu_1 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
     (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN3PreWithScratch sp j_mem (3 : Word) shift u0 v10_old v11_old anti_shift
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
         ret_mem d_mem dlo_mem scratch_un0)
@@ -129,7 +129,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
       ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -93,7 +93,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
     let q_hat : Word := signExtend12 4095
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -129,7 +129,7 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
     (hshift_nz : (clzResult b3).1 ≠ 0)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hborrow : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -284,7 +284,7 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
     (hshift_nz : (clzResult b3).1 ≠ 0)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hborrow : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -413,7 +413,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -535,7 +535,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -655,7 +655,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -43,7 +43,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
     let q_hat : Word := signExtend12 4095
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -103,7 +103,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -213,7 +213,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -373,7 +373,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11_old) **
@@ -573,7 +573,7 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -789,7 +789,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -85,7 +85,7 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -144,7 +144,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -189,7 +189,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -245,7 +245,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (divCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -77,7 +77,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     (hshift_z : (clzResult b3).1 = 0)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hborrow : isSkipBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 908) (divCode base)
+    cpsTriple base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -234,7 +234,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
     (hshift_z : (clzResult b3).1 = 0)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hborrow : isSkipBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
@@ -20,7 +20,7 @@ open EvmAsm.Rv64
 
 /-- CLZ code (block 2) is subsumed by modCode. -/
 private theorem divK_clz_code_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 116) divK_clz) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + clzOff) divK_clz) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
@@ -33,11 +33,11 @@ private theorem clz_stage_sub_mod (base : Word)
     (hslice : (divK_clz.drop k).take (divK_clz_stage_prog K M_s M_a).length =
       divK_clz_stage_prog K M_s M_a)
     (hbound : 4 * divK_clz.length < 2 ^ 64) :
-    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + 116) + BitVec.ofNat 64 (4 * k))) a = some i →
+    ∀ a i, (divK_clz_stage_code K M_s M_a ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
       (modCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + 116) _ divK_clz _ k
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
 /-- Helper: CLZ last stage at instruction index k is subsumed by modCode. -/
@@ -45,31 +45,31 @@ private theorem clz_last_sub_mod (base : Word) (k : Nat)
     (hk : k + divK_clz_last_prog.length ≤ divK_clz.length)
     (hslice : (divK_clz.drop k).take divK_clz_last_prog.length = divK_clz_last_prog)
     (hbound : 4 * divK_clz.length < 2 ^ 64) :
-    ∀ a i, (divK_clz_last_code ((base + 116) + BitVec.ofNat 64 (4 * k))) a = some i →
+    ∀ a i, (divK_clz_last_code ((base + clzOff) + BitVec.ofNat 64 (4 * k))) a = some i →
       (modCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + 116) _ divK_clz _ k
+    (CodeReq.ofProg_mono_sub (base + clzOff) _ divK_clz _ k
       rfl hslice hk hbound a i h)
 
 /-- Helper: CLZ init singleton (ADDI x6 x0 0 at base+116) is subsumed by modCode. -/
 private theorem clz_init_sub_mod (base : Word) :
-    ∀ a i, (CodeReq.singleton (base + 116) (.ADDI .x6 .x0 0)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + clzOff) (.ADDI .x6 .x0 0)) a = some i →
       (modCode base) a = some i := by
   intro a i h
   exact divK_clz_code_sub_modCode base a i
-    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + 116) divK_clz 0
-      (by decide) (by decide)) a i (by rwa [show (base + 116 : Word) =
-        base + 116 + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
+    (CodeReq.singleton_mono (CodeReq.ofProg_lookup (base + clzOff) divK_clz 0
+      (by decide) (by decide)) a i (by rwa [show (base + clzOff : Word) =
+        base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
 
 -- Address lemmas for CLZ stages (reused from CLZ.lean, but those are private so we redefine)
-private theorem mod_clz_addr0 (base : Word) : (base + 116 : Word) + 4 = base + 120 := by bv_addr
+private theorem mod_clz_addr0 (base : Word) : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
 private theorem mod_clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_addr
 private theorem mod_clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_addr
 private theorem mod_clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_addr
 private theorem mod_clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_addr
 private theorem mod_clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_addr
-private theorem mod_clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + 212 := by bv_addr
+private theorem mod_clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     (Reused from CLZ.lean — the stage specs are code-generic, only subsumption differs.) -/
@@ -117,13 +117,13 @@ set_option maxHeartbeats 6400000 in
 /-- Full CLZ composition for modCode: 24 instructions at base+116 -> base+212.
     Mirror of divK_clz_spec with modCode instead of divCode. -/
 theorem mod_clz_spec (val v6_old v7_old : Word) (base : Word) :
-    cpsTriple (base + 116) (base + 212) (modCode base)
+    cpsTriple (base + clzOff) (base + phaseC2Off) (modCode base)
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ v6_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ (clzResult val).2) ** (.x6 ↦ᵣ (clzResult val).1) **
        (.x7 ↦ᵣ (clzResult val).2 >>> (63 : Nat)) ** (.x0 ↦ᵣ (0 : Word))) := by
   unfold clzResult
   -- 0. Init: ADDI x6 x0 0 (base+116 -> base+120)
-  have I := divK_clz_init_spec v6_old (base + 116)
+  have I := divK_clz_init_spec v6_old (base + clzOff)
   have Ie := cpsTriple_extend_code (hmono := clz_init_sub_mod base) I
   rw [mod_clz_addr0] at Ie
   -- Frame init with x5, x7
@@ -131,11 +131,11 @@ theorem mod_clz_spec (val v6_old v7_old : Word) (base : Word) :
     ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ v7_old)) (by pcFree) Ie
   -- Stage 0: K=32, M_s=32, M_a=32 (base+120 -> base+136)
   have S0 := mod_clz_stage_combined 32 32 32 val (signExtend12 0) v7_old
-    ((base + 116) + BitVec.ofNat 64 (4 * 1))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 1))
   dsimp only [] at S0
   have S0e := cpsTriple_extend_code (hmono := clz_stage_sub_mod base 32 32 32 1
     (by decide) (by decide) (by decide)) S0
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_addr] at S0e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 1) = base + 120 from by bv_addr] at S0e
   rw [mod_clz_addr1] at S0e
   seqFrame Ief S0e
   -- Abbreviations for stage 0 results
@@ -144,55 +144,55 @@ theorem mod_clz_spec (val v6_old v7_old : Word) (base : Word) :
     else signExtend12 (0 : BitVec 12) + signExtend12 (32 : BitVec 12)
   -- Stage 1: K=48, M_s=16, M_a=16 (base+136 -> base+152)
   have S1 := mod_clz_stage_combined 48 16 16 v0 c0 (val >>> (32 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 5))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 5))
   dsimp only [] at S1
   have S1e := cpsTriple_extend_code (hmono := clz_stage_sub_mod base 48 16 16 5
     (by decide) (by decide) (by decide)) S1
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_addr] at S1e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 5) = base + 136 from by bv_addr] at S1e
   rw [mod_clz_addr2] at S1e
   seqFrame IefS0e S1e
   -- Stage 2: K=56, M_s=8, M_a=8 (base+152 -> base+168)
   let v1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then v0 else v0 <<< (16 : BitVec 6).toNat
   let c1 := if v0 >>> (48 : BitVec 6).toNat ≠ 0 then c0 else c0 + signExtend12 (16 : BitVec 12)
   have S2 := mod_clz_stage_combined 56 8 8 v1 c1 (v0 >>> (48 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 9))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 9))
   dsimp only [] at S2
   have S2e := cpsTriple_extend_code (hmono := clz_stage_sub_mod base 56 8 8 9
     (by decide) (by decide) (by decide)) S2
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_addr] at S2e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 9) = base + 152 from by bv_addr] at S2e
   rw [mod_clz_addr3] at S2e
   seqFrame IefS0eS1e S2e
   -- Stage 3: K=60, M_s=4, M_a=4 (base+168 -> base+184)
   let v2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then v1 else v1 <<< (8 : BitVec 6).toNat
   let c2 := if v1 >>> (56 : BitVec 6).toNat ≠ 0 then c1 else c1 + signExtend12 (8 : BitVec 12)
   have S3 := mod_clz_stage_combined 60 4 4 v2 c2 (v1 >>> (56 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 13))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 13))
   dsimp only [] at S3
   have S3e := cpsTriple_extend_code (hmono := clz_stage_sub_mod base 60 4 4 13
     (by decide) (by decide) (by decide)) S3
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_addr] at S3e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 13) = base + 168 from by bv_addr] at S3e
   rw [mod_clz_addr4] at S3e
   seqFrame IefS0eS1eS2e S3e
   -- Stage 4: K=62, M_s=2, M_a=2 (base+184 -> base+200)
   let v3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then v2 else v2 <<< (4 : BitVec 6).toNat
   let c3 := if v2 >>> (60 : BitVec 6).toNat ≠ 0 then c2 else c2 + signExtend12 (4 : BitVec 12)
   have S4 := mod_clz_stage_combined 62 2 2 v3 c3 (v2 >>> (60 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 17))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 17))
   dsimp only [] at S4
   have S4e := cpsTriple_extend_code (hmono := clz_stage_sub_mod base 62 2 2 17
     (by decide) (by decide) (by decide)) S4
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_addr] at S4e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 17) = base + 184 from by bv_addr] at S4e
   rw [mod_clz_addr5] at S4e
   seqFrame IefS0eS1eS2eS3e S4e
   -- Stage 5 (last): K=63 (base+200 -> base+212)
   let v4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then v3 else v3 <<< (2 : BitVec 6).toNat
   let c4 := if v3 >>> (62 : BitVec 6).toNat ≠ 0 then c3 else c3 + signExtend12 (2 : BitVec 12)
   have S5 := mod_clz_last_combined v4 c4 (v3 >>> (62 : BitVec 6).toNat)
-    ((base + 116) + BitVec.ofNat 64 (4 * 21))
+    ((base + clzOff) + BitVec.ofNat 64 (4 * 21))
   dsimp only [] at S5
   have S5e := cpsTriple_extend_code (hmono := clz_last_sub_mod base 21
     (by decide) (by decide) (by decide)) S5
-  rw [show (base + 116 : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_addr] at S5e
+  rw [show (base + clzOff : Word) + BitVec.ofNat 64 (4 * 21) = base + 200 from by bv_addr] at S5e
   rw [mod_clz_addr6] at S5e
   seqFrame IefS0eS1eS2eS3eS4e S5e
   -- Final permutation

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -23,7 +23,7 @@ open EvmAsm.Rv64
 -- Master subsumption: ofProg (base+1072) divK_div128 ⊆ modCode base
 -- Block 13 in modCode's unionAll; skip blocks 0-12.
 private theorem divK_div128_ofProg_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 1072) divK_div128) a = some i →
+    ∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -46,20 +46,20 @@ private theorem CodeReq_union_sub_mod {cr1 cr2 target : CodeReq}
 -- Used to prove each singleton in a block's cr is subsumed by modCode.
 private theorem d128_sub_mod (base : Word) (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < divK_div128.length)
-    (h_addr : addr = (base + 1072) + BitVec.ofNat 64 (4 * k))
+    (h_addr : addr = (base + div128Off) + BitVec.ofNat 64 (4 * k))
     (h_instr : divK_div128.get ⟨k, hk⟩ = instr) :
     ∀ a i, CodeReq.singleton addr instr a = some i →
       (modCode base) a = some i := by
   subst h_addr; subst h_instr
   exact fun a i h => divK_div128_ofProg_sub_modCode base a i
     (CodeReq.singleton_mono
-      (CodeReq.ofProg_lookup (base + 1072) divK_div128 k hk (by decide)) a i h)
+      (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
--- Address normalization: block entry offsets relative to (base + 1072)
-private theorem d128_off_40_mod (base : Word) : (base + 1072 : Word) + 40 = base + 1112 := by bv_addr
-private theorem d128_off_100_mod (base : Word) : (base + 1072 : Word) + 100 = base + 1172 := by bv_addr
-private theorem d128_off_120_mod (base : Word) : (base + 1072 : Word) + 120 = base + 1192 := by bv_addr
-private theorem d128_off_180_mod (base : Word) : (base + 1072 : Word) + 180 = base + 1252 := by bv_addr
+-- Address normalization: block entry offsets relative to (base + div128Off)
+private theorem d128_off_40_mod (base : Word) : (base + div128Off : Word) + 40 = base + 1112 := by bv_addr
+private theorem d128_off_100_mod (base : Word) : (base + div128Off : Word) + 100 = base + 1172 := by bv_addr
+private theorem d128_off_120_mod (base : Word) : (base + div128Off : Word) + 120 = base + 1192 := by bv_addr
+private theorem d128_off_180_mod (base : Word) : (base + div128Off : Word) + 180 = base + 1252 := by bv_addr
 
 -- ============================================================================
 -- mod_div128_spec: compose 5 block specs into single subroutine theorem.
@@ -106,7 +106,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + 1072) ret_addr (modCode base)
+    cpsTriple (base + div128Off) ret_addr (modCode base)
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
@@ -132,8 +132,8 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Saves ret/d, splits d and u_lo into halves.
   -- ================================================================
   have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-    ret_mem d_mem dlo_mem un0_mem (base + 1072)
-  rw [show (base + 1072 : Word) + 40 = base + 1112 from by bv_addr] at hph1
+    ret_mem d_mem dlo_mem un0_mem (base + div128Off)
+  rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
   -- Extend phase1 cr to modCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -20,7 +20,7 @@ open EvmAsm.Rv64
 
 /-- Denorm code (block 9) is subsumed by modCode. -/
 private theorem divK_denorm_code_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 908) divK_denorm) a = some i → (modCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + denormOff) divK_denorm) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
@@ -31,11 +31,11 @@ private theorem denorm_sub_mod (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ divK_denorm.length)
     (hslice : (divK_denorm.drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * divK_denorm.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + 908) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
+    ∀ a i, (CodeReq.ofProg ((base + denormOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
       (modCode base) a = some i := by
   intro a i h
   exact divK_denorm_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + 908) _ divK_denorm _ k rfl hslice hk hbound a i h)
+    (CodeReq.ofProg_mono_sub (base + denormOff) _ divK_denorm _ k rfl hslice hk hbound a i h)
 
 set_option maxHeartbeats 12800000 in
 set_option maxRecDepth 4096 in
@@ -49,7 +49,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTriple (base + 916) (base + 1008) (modCode base)
+    cpsTriple (base + 916) (base + epilogueOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -64,7 +64,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 916) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 916) divK_denorm
         [.ADDI .x2 .x0 0] 2
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) haddi
   -- Frame ADDI with x12, x5, x7, x6, and all memory
@@ -79,10 +79,10 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   have hsube := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
       (CodeReq.singleton_mono (by
-        have hlookup := CodeReq.ofProg_lookup (base + 908) divK_denorm 3
+        have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
         rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-            show (base + 908 : Word) + 12 = base + 920 from by bv_addr] at hlookup
+            show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTriple_frame_left _ _ _ _ _
@@ -97,7 +97,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 924) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 924) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm0
   have hm0ef := cpsTriple_frame_left _ _ _ _ _
@@ -112,7 +112,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 948) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 948) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   have hm1ef := cpsTriple_frame_left _ _ _ _ _
@@ -127,7 +127,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 972) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 972) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
@@ -138,10 +138,10 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 996)
-  rw [show (base + 996 : Word) + 12 = base + 1008 from by bv_addr] at hl
+  rw [show (base + 996 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 908) (base + 996) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 996) divK_denorm
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -29,7 +29,7 @@ theorem evm_mod_phaseAB_n4_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple base (base + 116) (modCode base)
+    cpsTriple base (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -78,7 +78,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple base (base + 212) (modCode base)
+    cpsTriple base (base + phaseC2Off) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -126,7 +126,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
-    cpsTriple base (base + 312) (modCode base)
+    cpsTriple base (base + normAOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -192,7 +192,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -289,7 +289,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -29,7 +29,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
-    cpsTriple base (base + 212) (modCode base)
+    cpsTriple base (base + phaseC2Off) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -91,7 +91,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -232,7 +232,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -29,7 +29,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
-    cpsTriple base (base + 212) (modCode base)
+    cpsTriple base (base + phaseC2Off) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -94,7 +94,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -235,7 +235,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -29,7 +29,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
-    cpsTriple base (base + 212) (modCode base)
+    cpsTriple base (base + phaseC2Off) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -94,7 +94,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -235,7 +235,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
-    cpsTriple base (base + 448) (modCode base)
+    cpsTriple base (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -21,7 +21,7 @@ open EvmAsm.Rv64
 
 /-- Phase C2 code (block 3) is subsumed by modCode. -/
 private theorem divK_phaseC2_code_sub_modCode (base : Word) :
-    ∀ a i, (divK_phaseC2_code 172 (base + 212)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -31,10 +31,10 @@ private theorem beq_shift_sub_modCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 224) (.BEQ .x6 .x0 172)) a = some i →
       (modCode base) a = some i := by
   intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + 212) (divK_phaseC2 172) 3
+  have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-      show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hlookup
+      show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -43,13 +43,13 @@ private theorem mod_signExtend13_172 : signExtend13 (172 : BitVec 13) = (172 : W
 /-- Phase C2 body (base+212 -> base+224): store shift, compute anti_shift.
     Extends to modCode. Uses first 3 instructions of phaseC2. -/
 private theorem mod_phaseC2_body_modCode (sp shift v2 shift_mem : Word) (base : Word) :
-    cpsTriple (base + 212) (base + 224) (modCode base)
+    cpsTriple (base + phaseC2Off) (base + 224) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + 212)
-  rw [show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hbody
+  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + phaseC2Off)
+  rw [show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_modCode base) hbody
 
 set_option maxRecDepth 2048 in
@@ -57,16 +57,16 @@ set_option maxRecDepth 2048 in
     MOD mirror of divK_phaseC2_ntaken_spec. -/
 theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 212) (base + 228) (modCode base)
+    cpsTriple (base + phaseC2Off) (base + normBOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [mod_signExtend13_172]; bv_addr,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -88,16 +88,16 @@ set_option maxRecDepth 2048 in
     MOD mirror of divK_phaseC2_taken_spec. -/
 theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hshift_z : shift = 0) :
-    cpsTriple (base + 212) (base + 396) (modCode base)
+    cpsTriple (base + phaseC2Off) (base + copyAUOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [mod_signExtend13_172]; bv_addr,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -121,7 +121,7 @@ theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
 
 /-- NormB code (block 4) is subsumed by modCode. -/
 private theorem divK_normB_code_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 228) divK_normB) a = some i → (modCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -139,7 +139,7 @@ set_option maxRecDepth 4096 in
 private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    cpsTriple (base + 228) (base + 276) (modCode base)
+    cpsTriple (base + normBOff) (base + 276) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -150,12 +150,12 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2'
   -- Merge 1: b[3] with b[2] (base+228 -> base+252)
-  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + 228)
+  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + normBOff)
   simp only [mod_se12_56, mod_se12_48] at hm1
-  rw [show (base + 228 : Word) + 24 = base + 252 from by bv_addr] at hm1
+  rw [show (base + normBOff : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 228) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff) divK_normB
         (divK_normB_merge_prog 56 48) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   -- Frame merge1 with b[0], b[1] (not touched by merge1)
@@ -169,7 +169,7 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
   rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 252) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 252) divK_normB
         (divK_normB_merge_prog 48 40) 6
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
@@ -189,7 +189,7 @@ set_option maxRecDepth 4096 in
 private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base : Word) :
     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    cpsTriple (base + 276) (base + 312) (modCode base)
+    cpsTriple (base + 276) (base + normAOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -206,7 +206,7 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
   rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 276) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 276) divK_normB
         (divK_normB_merge_prog 40 32) 12
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm3
   have hm3ef := cpsTriple_frame_left _ _ _ _ _
@@ -215,10 +215,10 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
   -- Last: b[0] alone (base+300 -> base+312)
   have hl := divK_normB_last_spec 32 sp b0 b1' shift (base + 300)
   simp only [mod_se12_32] at hl
-  rw [show (base + 300 : Word) + 12 = base + 312 from by bv_addr] at hl
+  rw [show (base + 300 : Word) + 12 = base + normAOff from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 300) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 300) divK_normB
         (divK_normB_last_prog 32) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _
@@ -242,7 +242,7 @@ theorem mod_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base
     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    cpsTriple (base + 228) (base + 312) (modCode base)
+    cpsTriple (base + normBOff) (base + normAOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -21,7 +21,7 @@ open EvmAsm.Rv64
 
 /-- NormA code (block 5) is subsumed by modCode. -/
 private theorem divK_normA_code_sub_modCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 312) (divK_normA 40)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -31,11 +31,11 @@ private theorem normA_sub_mod (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ (divK_normA 40).length)
     (hslice : ((divK_normA 40).drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * (divK_normA 40).length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + 312) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
+    ∀ a i, (CodeReq.ofProg ((base + normAOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
       (modCode base) a = some i := by
   intro a i h
   exact divK_normA_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + 312) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
+    (CodeReq.ofProg_mono_sub (base + normAOff) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
 
 -- signExtend12 for src/dst offsets used by normA specs
 private theorem mod_se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
@@ -56,7 +56,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    cpsTriple (base + 312) (base + 432) (modCode base)
+    cpsTriple (base + normAOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -73,12 +73,12 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
        ((sp + signExtend12 4056) ↦ₘ u0)) := by
   intro u4 u3 u2 u1 u0
   -- Top: LD a[3], SRL->u[4], SD u[4] (base+312 -> base+324)
-  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + 312)
+  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + normAOff)
   simp only [mod_se12_24] at htop
-  rw [show (base + 312 : Word) + 12 = base + 324 from by bv_addr] at htop
+  rw [show (base + normAOff : Word) + 12 = base + 324 from by bv_addr] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 312) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff) (divK_normA 40)
         (divK_normA_top_prog 24 4024) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) htop
   -- Frame top with x6, x10, a[0..2], u[0..3]
@@ -95,7 +95,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 324 : Word) + 20 = base + 344 from by bv_addr] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 324) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 324) (divK_normA 40)
         (divK_normA_mergeA_prog 16 4032) 3
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma1
   have hma1ef := cpsTriple_frame_left _ _ _ _ _
@@ -113,7 +113,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 344 : Word) + 20 = base + 364 from by bv_addr] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 344) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 344) (divK_normA 40)
         (divK_normA_mergeB_prog 8 4040) 8
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hmb
   have hmbef := cpsTriple_frame_left _ _ _ _ _
@@ -130,7 +130,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 364 : Word) + 20 = base + 384 from by bv_addr] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 364) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 364) (divK_normA 40)
         (divK_normA_mergeA_prog 0 4048) 13
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma2
   have hma2ef := cpsTriple_frame_left _ _ _ _ _
@@ -145,7 +145,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 384 : Word) + 8 = base + 392 from by bv_addr] at hlast
   have hlaste := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_modCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 384) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 384) (divK_normA 40)
         (divK_normA_last_prog 4056) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
   have hlastef := cpsTriple_frame_left _ _ _ _ _
@@ -159,15 +159,15 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     (fun h hp => by xperm_hyp hp) h1234 hlastef
   -- JAL x0 40 at base+392 -> base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
-  rw [show (base + 392 : Word) + signExtend21 40 = base + 432 from by
+  rw [show (base + 392 : Word) + signExtend21 40 = base + loopSetupOff from by
         rw [mod_signExtend21_40]; bv_addr] at hjal
   have hjale := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_normA_code_sub_modCode base a i
       (CodeReq.singleton_mono (by
-        have hlookup := CodeReq.ofProg_lookup (base + 312) (divK_normA 40) 20
+        have hlookup := CodeReq.ofProg_lookup (base + normAOff) (divK_normA 40) 20
           (by decide) (by decide)
-        rw [show (base + 312 : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_addr]
+        rw [show (base + normAOff : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_addr]
           at hlookup
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
@@ -179,7 +179,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
     ((sp + signExtend12 4056) ↦ₘ u0)
   have hjalef := cpsTriple_frame_left _ _ _ _ _ postAll (by pcFree) hjale
-  have hjal_clean : cpsTriple (base + 392) (base + 432) (modCode base) postAll postAll :=
+  have hjal_clean : cpsTriple (base + 392) (base + loopSetupOff) (modCode base) postAll postAll :=
     cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
       (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
@@ -198,7 +198,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
 
 /-- CopyAU code (block 6) is subsumed by modCode. -/
 private theorem divK_copyAU_code_sub_modCode (base : Word) :
-    ∀ a i, (divK_copyAU_code (base + 396)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -208,7 +208,7 @@ private theorem divK_copyAU_code_sub_modCode (base : Word) :
     MOD mirror of divK_copyAU_full_spec. -/
 theorem mod_copyAU_full_spec (sp : Word)
     (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTriple (base + 396) (base + 432) (modCode base)
+    cpsTriple (base + copyAUOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
        ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -221,8 +221,8 @@ theorem mod_copyAU_full_spec (sp : Word)
        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
-  have hcopy := divK_copyAU_spec sp (base + 396) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
-  rw [show (base + 396 : Word) + 36 = base + 432 from by bv_addr] at hcopy
+  have hcopy := divK_copyAU_spec sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTriple_extend_code (divK_copyAU_code_sub_modCode base) hcopy
 
 -- ============================================================================
@@ -232,7 +232,7 @@ theorem mod_copyAU_full_spec (sp : Word)
 
 /-- LoopSetup code (block 7) is subsumed by modCode. -/
 private theorem divK_loopSetup_code_sub_modCode (base : Word) :
-    ∀ a i, (divK_loopSetup_code 464 (base + 432)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -242,10 +242,10 @@ private theorem blt_loopSetup_sub_modCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 444) (.BLT .x1 .x0 464)) a = some i →
       (modCode base) a = some i := by
   intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + 432) (divK_loopSetup 464) 3
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-      show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hlookup
+      show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -257,19 +257,19 @@ set_option maxRecDepth 2048 in
 theorem mod_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
-    cpsTriple (base + 432) (base + 448) (modCode base)
+    cpsTriple (base + loopSetupOff) (base + loopBodyOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
-  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + 432)
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
+  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + loopSetupOff)
+  rw [show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_modCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Word) + signExtend13 464 = base + 908 from by
+  rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [mod_signExtend13_464]; bv_addr,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
+      show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -291,19 +291,19 @@ set_option maxRecDepth 2048 in
 theorem mod_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
     (hm_lt : BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
-    cpsTriple (base + 432) (base + 908) (modCode base)
+    cpsTriple (base + loopSetupOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
-  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + 432)
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
+  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + loopSetupOff)
+  rw [show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_modCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Word) + signExtend13 464 = base + 908 from by
+  rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [mod_signExtend13_464]; bv_addr,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
+      show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -91,7 +91,7 @@ theorem mod_phB_off_28 (base : Word) : (base + 32 : Word) + 28 = base + 60 := by
 theorem mod_phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_addr
 theorem mod_phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
-theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + 116 := by bv_addr
+theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
 theorem mod_signExtend13_24 : signExtend13 (24 : BitVec 13) = (24 : Word) := by
   decide
 theorem mod_divK_se12_4 : signExtend12 (4 : BitVec 12) = (4 : Word) := by decide
@@ -118,7 +118,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (modCode base)
+    cpsTriple (base + 32) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -23,7 +23,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (modCode base)
+    cpsTriple (base + 32) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -205,7 +205,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
-    cpsTriple (base + 32) (base + 116) (modCode base)
+    cpsTriple (base + 32) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -22,7 +22,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (modCode base)
+    cpsTriple (base + 32) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -15,7 +15,7 @@ open EvmAsm.Rv64
 
 /-- Phase C2 code (block 3) is subsumed by divCode. -/
 private theorem divK_phaseC2_code_sub_divCode (base : Word) :
-    ∀ a i, (divK_phaseC2_code 172 (base + 212)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -25,10 +25,10 @@ private theorem beq_shift_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 224) (.BEQ .x6 .x0 172)) a = some i →
       (divCode base) a = some i := by
   intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + 212) (divK_phaseC2 172) 3
+  have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-      show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hlookup
+      show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -37,13 +37,13 @@ private theorem signExtend13_172 : signExtend13 (172 : BitVec 13) = (172 : Word)
 /-- Phase C2 body (base+212 → base+224): store shift, compute anti_shift.
     Extends to divCode. Uses first 3 instructions of phaseC2. -/
 private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base : Word) :
-    cpsTriple (base + 212) (base + 224) (divCode base)
+    cpsTriple (base + phaseC2Off) (base + 224) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + 212)
-  rw [show (base + 212 : Word) + 12 = base + 224 from by bv_addr] at hbody
+  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + phaseC2Off)
+  rw [show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_divCode base) hbody
 
 set_option maxRecDepth 2048 in
@@ -51,16 +51,16 @@ set_option maxRecDepth 2048 in
     Stores shift to scratch, computes anti_shift = -shift. -/
 theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTriple (base + 212) (base + 228) (divCode base)
+    cpsTriple (base + phaseC2Off) (base + normBOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [signExtend13_172]; bv_addr,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -82,16 +82,16 @@ set_option maxRecDepth 2048 in
     Stores shift (=0) to scratch, computes anti_shift = 0. -/
 theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
     (hshift_z : shift = 0) :
-    cpsTriple (base + 212) (base + 396) (divCode base)
+    cpsTriple (base + phaseC2Off) (base + copyAUOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift_mem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
-  rw [show (base + 224 : Word) + signExtend13 172 = base + 396 from by
+  rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [signExtend13_172]; bv_addr,
-      show (base + 224 : Word) + 4 = base + 228 from by bv_addr] at hbeq_raw
+      show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -115,7 +115,7 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
 
 /-- NormB code (block 4) is subsumed by divCode. -/
 private theorem divK_normB_code_sub_divCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 228) divK_normB) a = some i → (divCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -125,11 +125,11 @@ private theorem normB_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ divK_normB.length)
     (hslice : (divK_normB.drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * divK_normB.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + 228) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
+    ∀ a i, (CodeReq.ofProg ((base + normBOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_normB_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + 228) _ divK_normB _ k rfl hslice hk hbound a i h)
+    (CodeReq.ofProg_mono_sub (base + normBOff) _ divK_normB _ k rfl hslice hk hbound a i h)
 
 -- se12_32, se12_40, se12_48, se12_56 are in Base.lean
 
@@ -140,7 +140,7 @@ set_option maxRecDepth 4096 in
 private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    cpsTriple (base + 228) (base + 276) (divCode base)
+    cpsTriple (base + normBOff) (base + 276) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -151,12 +151,12 @@ private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) 
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2'
   -- Merge 1: b[3] with b[2] (base+228 → base+252)
-  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + 228)
+  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + normBOff)
   simp only [se12_56, se12_48] at hm1
-  rw [show (base + 228 : Word) + 24 = base + 252 from by bv_addr] at hm1
+  rw [show (base + normBOff : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 228) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + normBOff) divK_normB
         (divK_normB_merge_prog 56 48) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   -- Frame merge1 with b[0], b[1] (not touched by merge1)
@@ -170,7 +170,7 @@ private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) 
   rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 252) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 252) divK_normB
         (divK_normB_merge_prog 48 40) 6
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
@@ -190,7 +190,7 @@ set_option maxRecDepth 4096 in
 private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base : Word) :
     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    cpsTriple (base + 276) (base + 312) (divCode base)
+    cpsTriple (base + 276) (base + normAOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -207,7 +207,7 @@ private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (bas
   rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 276) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 276) divK_normB
         (divK_normB_merge_prog 40 32) 12
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm3
   have hm3ef := cpsTriple_frame_left _ _ _ _ _
@@ -216,10 +216,10 @@ private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (bas
   -- Last: b[0] alone (base+300 → base+312)
   have hl := divK_normB_last_spec 32 sp b0 b1' shift (base + 300)
   simp only [se12_32] at hl
-  rw [show (base + 300 : Word) + 12 = base + 312 from by bv_addr] at hl
+  rw [show (base + 300 : Word) + 12 = base + normAOff from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 228) (base + 300) divK_normB
+      (CodeReq.ofProg_mono_sub (base + normBOff) (base + 300) divK_normB
         (divK_normB_last_prog 32) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frame_left _ _ _ _ _
@@ -244,7 +244,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    cpsTriple (base + 228) (base + 312) (divCode base)
+    cpsTriple (base + normBOff) (base + normAOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -20,7 +20,7 @@ open EvmAsm.Rv64
 
 /-- NormA code (block 5) is subsumed by divCode. -/
 private theorem divK_normA_code_sub_divCode (base : Word) :
-    ∀ a i, (CodeReq.ofProg (base + 312) (divK_normA 40)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -30,11 +30,11 @@ private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
     (hk : k + sub_prog.length ≤ (divK_normA 40).length)
     (hslice : ((divK_normA 40).drop k).take sub_prog.length = sub_prog)
     (hbound : 4 * (divK_normA 40).length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + 312) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
+    ∀ a i, (CodeReq.ofProg ((base + normAOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
       (divCode base) a = some i := by
   intro a i h
   exact divK_normA_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + 312) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
+    (CodeReq.ofProg_mono_sub (base + normAOff) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
 
 -- signExtend12 for src/dst offsets used by normA specs
 private theorem se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
@@ -60,7 +60,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    cpsTriple (base + 312) (base + 432) (divCode base)
+    cpsTriple (base + normAOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -77,12 +77,12 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
        ((sp + signExtend12 4056) ↦ₘ u0)) := by
   intro u4 u3 u2 u1 u0
   -- Top: LD a[3], SRL→u[4], SD u[4] (base+312 → base+324)
-  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + 312)
+  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + normAOff)
   simp only [se12_24] at htop
-  rw [show (base + 312 : Word) + 12 = base + 324 from by bv_addr] at htop
+  rw [show (base + normAOff : Word) + 12 = base + 324 from by bv_addr] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 312) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + normAOff) (divK_normA 40)
         (divK_normA_top_prog 24 4024) 0
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) htop
   -- Frame top with x6, x10, a[0..2], u[0..3]
@@ -99,7 +99,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 324 : Word) + 20 = base + 344 from by bv_addr] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 324) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 324) (divK_normA 40)
         (divK_normA_mergeA_prog 16 4032) 3
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma1
   have hma1ef := cpsTriple_frame_left _ _ _ _ _
@@ -117,7 +117,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 344 : Word) + 20 = base + 364 from by bv_addr] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 344) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 344) (divK_normA 40)
         (divK_normA_mergeB_prog 8 4040) 8
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hmb
   have hmbef := cpsTriple_frame_left _ _ _ _ _
@@ -134,7 +134,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 364 : Word) + 20 = base + 384 from by bv_addr] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 364) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 364) (divK_normA 40)
         (divK_normA_mergeA_prog 0 4048) 13
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hma2
   have hma2ef := cpsTriple_frame_left _ _ _ _ _
@@ -149,7 +149,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   rw [show (base + 384 : Word) + 8 = base + 392 from by bv_addr] at hlast
   have hlaste := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normA_code_sub_divCode base a i
-      (CodeReq.ofProg_mono_sub (base + 312) (base + 384) (divK_normA 40)
+      (CodeReq.ofProg_mono_sub (base + normAOff) (base + 384) (divK_normA 40)
         (divK_normA_last_prog 4056) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
   have hlastef := cpsTriple_frame_left _ _ _ _ _
@@ -163,15 +163,15 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
     (fun h hp => by xperm_hyp hp) h1234 hlastef
   -- JAL x0 40 at base+392 → base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
-  rw [show (base + 392 : Word) + signExtend21 40 = base + 432 from by
+  rw [show (base + 392 : Word) + signExtend21 40 = base + loopSetupOff from by
         rw [signExtend21_40]; bv_addr] at hjal
   have hjale := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_normA_code_sub_divCode base a i
       (CodeReq.singleton_mono (by
-        have hlookup := CodeReq.ofProg_lookup (base + 312) (divK_normA 40) 20
+        have hlookup := CodeReq.ofProg_lookup (base + normAOff) (divK_normA 40) 20
           (by decide) (by decide)
-        rw [show (base + 312 : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_addr]
+        rw [show (base + normAOff : Word) + BitVec.ofNat 64 (4 * 20) = base + 392 from by bv_addr]
           at hlookup
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
@@ -186,7 +186,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   -- Compose h12345 with JAL by consequence (empAssertion → postAll → postAll)
   -- Since JAL has empAssertion pre/post and frame is postAll, the result is (empAssertion ** postAll).
   -- Use consequence to strip empAssertion from both sides.
-  have hjal_clean : cpsTriple (base + 392) (base + 432) (divCode base) postAll postAll :=
+  have hjal_clean : cpsTriple (base + 392) (base + loopSetupOff) (divCode base) postAll postAll :=
     cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
       (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
@@ -205,7 +205,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
 
 /-- CopyAU code (block 6) is subsumed by divCode. -/
 private theorem divK_copyAU_code_sub_divCode (base : Word) :
-    ∀ a i, (divK_copyAU_code (base + 396)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -214,7 +214,7 @@ private theorem divK_copyAU_code_sub_divCode (base : Word) :
     base+396 → base+432 (9 instructions). -/
 theorem divK_copyAU_full_spec (sp : Word)
     (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTriple (base + 396) (base + 432) (divCode base)
+    cpsTriple (base + copyAUOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
        ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -227,8 +227,8 @@ theorem divK_copyAU_full_spec (sp : Word)
        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) := by
-  have hcopy := divK_copyAU_spec sp (base + 396) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
-  rw [show (base + 396 : Word) + 36 = base + 432 from by bv_addr] at hcopy
+  have hcopy := divK_copyAU_spec sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
+  rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTriple_extend_code (divK_copyAU_code_sub_divCode base) hcopy
 
 -- ============================================================================
@@ -238,7 +238,7 @@ theorem divK_copyAU_full_spec (sp : Word)
 
 /-- LoopSetup code (block 7) is subsumed by divCode. -/
 private theorem divK_loopSetup_code_sub_divCode (base : Word) :
-    ∀ a i, (divK_loopSetup_code 464 (base + 432)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
@@ -248,10 +248,10 @@ private theorem blt_loopSetup_sub_divCode (base : Word) :
     ∀ a i, (CodeReq.singleton (base + 444) (.BLT .x1 .x0 464)) a = some i →
       (divCode base) a = some i := by
   intro a i h
-  have hlookup := CodeReq.ofProg_lookup (base + 432) (divK_loopSetup 464) 3
+  have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
   rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
-      show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hlookup
+      show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
@@ -263,19 +263,19 @@ set_option maxRecDepth 2048 in
 theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
     (hm_ge : ¬BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
-    cpsTriple (base + 432) (base + 448) (divCode base)
+    cpsTriple (base + loopSetupOff) (base + loopBodyOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
-  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + 432)
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
+  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + loopSetupOff)
+  rw [show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Word) + signExtend13 464 = base + 908 from by
+  rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [signExtend13_464]; bv_addr,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
+      show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -296,19 +296,19 @@ set_option maxRecDepth 2048 in
 theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
     (hm_lt : BitVec.slt (signExtend12 (4 : BitVec 12) - n) (0 : Word)) :
     let m := signExtend12 (4 : BitVec 12) - n
-    cpsTriple (base + 432) (base + 908) (divCode base)
+    cpsTriple (base + loopSetupOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n)) := by
   intro m
-  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + 432)
-  rw [show (base + 432 : Word) + 12 = base + 444 from by bv_addr] at hbody
+  have hbody := divK_loopSetup_body_spec sp n v1 v5 464 (base + loopSetupOff)
+  rw [show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hbody
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_divCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
-  rw [show (base + 444 : Word) + signExtend13 464 = base + 908 from by
+  rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [signExtend13_464]; bv_addr,
-      show (base + 444 : Word) + 4 = base + 448 from by bv_addr] at hblt_raw
+      show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -23,12 +23,12 @@
     [normAOff     = 312] divK_normA         (84 bytes)
     [copyAUOff    = 396] divK_copyAU        (36 bytes)
     [loopSetupOff = 432] divK_loopSetup     (16 bytes)
-    [loopBodyOff  = 448] divK_loopBody     (456 bytes)
-    [denormOff    = 904] divK_denorm       (100 bytes)
-    [epilogueOff  =1004] divK_{div,mod}_epilogue (40 bytes)
-    [zeroPathOff  =1044] divK_zeroPath      (20 bytes)
-    [nopOff       =1064] ADDI x0, x0, 0      (4 bytes)
-    [div128Off    =1068] divK_div128       (196 bytes)
+    [loopBodyOff  = 448] divK_loopBody     (460 bytes)
+    [denormOff    = 908] divK_denorm       (100 bytes)
+    [epilogueOff  =1008] divK_{div,mod}_epilogue (40 bytes)
+    [zeroPathOff  =1048] divK_zeroPath      (20 bytes)
+    [nopOff       =1068] ADDI x0, x0, 0      (4 bytes)
+    [div128Off    =1072] divK_div128       (196 bytes)
 -/
 
 import EvmAsm.Evm64.DivMod.Program

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -43,7 +43,7 @@ private theorem divK_phaseA_code_sub_divCode (base : Word) :
 
 /-- Zero path code (5 instructions, block 11) is subsumed by divCode. -/
 private theorem divK_zeroPath_code_sub_divCode (base : Word) :
-    ∀ a i, (divK_zeroPath_code (base + 1048)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_zeroPath_code (base + zeroPathOff)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
   -- Skip blocks 0-10, then match block 11
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -155,7 +155,7 @@ private theorem phB_t_4 (base : Word) : (base + 96 : Word) + 4 = base + 100 := b
 private theorem phB_t_8 (base : Word) : (base + 96 : Word) + 8 = base + 104 := by bv_addr
 private theorem phB_t_12 (base : Word) : (base + 96 : Word) + 12 = base + 108 := by bv_addr
 private theorem phB_t_16 (base : Word) : (base + 96 : Word) + 16 = base + 112 := by bv_addr
-private theorem phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + 116 := by bv_addr
+private theorem phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
 private theorem phB_sp24_32 (sp : Word) : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_addr
 
 -- ============================================================================
@@ -201,7 +201,7 @@ set_option maxRecDepth 2048 in
 theorem evm_div_bzero_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbz : b0 ||| b1 ||| b2 ||| b3 = 0) :
-    cpsTriple base (base + 1068) (divCode base)
+    cpsTriple base (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
@@ -214,7 +214,7 @@ theorem evm_div_bzero_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + 1048 from by
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [signExtend13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
@@ -235,8 +235,8 @@ theorem evm_div_bzero_spec (sp base : Word)
   -- Step 5: ZeroPath (base+1048 → base+1068)
   -- Extend to divCode CodeReq
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_divCode base)
-    (divK_zeroPath_spec sp (base + 1048) b0 b1 b2 b3)
-  rw [show (base + 1048 : Word) + 20 = base + 1068 from by bv_addr] at hzp
+    (divK_zeroPath_spec sp (base + zeroPathOff) b0 b1 b2 b3)
+  rw [show (base + zeroPathOff : Word) + 20 = base + nopOff from by bv_addr] at hzp
   -- Frame ZP with x5 + x10 + x0
   have hzp_framed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
@@ -273,7 +273,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + 1048 from by
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [signExtend13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + 32 from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
@@ -311,7 +311,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (divCode base)
+    cpsTriple (base + 32) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -383,7 +383,7 @@ theorem evm_div_phaseAB_n4_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
-    cpsTriple base (base + 116) (divCode base)
+    cpsTriple base (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -538,7 +538,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (divCode base)
+    cpsTriple (base + 32) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -683,7 +683,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
-    cpsTriple (base + 32) (base + 116) (divCode base)
+    cpsTriple (base + 32) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -864,7 +864,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
     (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
     (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
-    cpsTriple (base + 32) (base + 116) (divCode base)
+    cpsTriple (base + 32) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -789,7 +789,7 @@ private theorem lb_bltu_taken (base : Word) : (base + 500 : Word) + signExtend13
   rw [this]; bv_addr
 private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_addr
 private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_addr
-private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (560 : BitVec 21) = base + 1072 := by
+private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (560 : BitVec 21) = base + div128Off := by
   have : signExtend21 (560 : BitVec 21) = (560 : Word) := by decide
   rw [this]; bv_addr
 private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_addr
@@ -914,7 +914,7 @@ private theorem lb_lc_taken (base : Word) :
     (base + 900 : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
   have : signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) := by decide
   rw [this]; bv_addr
-private theorem lb_lc_exit (base : Word) : (base + 900 : Word) + 8 = base + 908 := by bv_addr
+private theorem lb_lc_exit (base : Word) : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
 
 private theorem lb_beq_back_ntaken (base : Word) : (base + 880 : Word) + 4 = base + 884 := by bv_addr
 
@@ -1099,7 +1099,7 @@ theorem divK_store_loop_spec
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_hat))
-      (base + 908)
+      (base + denormOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_hat)) := by
@@ -1137,7 +1137,7 @@ theorem divK_store_loop_spec
       (base + loopBodyOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) ** (q_addr ↦ₘ q_hat))
-      (base + 908)
+      (base + denormOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) ** (q_addr ↦ₘ q_hat)) :=
     cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
@@ -1169,7 +1169,7 @@ theorem divK_store_loop_j0_spec
     (base : Word) :
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     let j' := (0 : Word) + signExtend12 4095
-    cpsTriple (base + 884) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + 884) (base + denormOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_old))
@@ -1196,7 +1196,7 @@ theorem divK_store_loop_j0_spec
   rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
         rw [show signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) from by decide]
         bv_addr,
-      show (base + 904 : Word) + 4 = base + 908 from by bv_addr] at hbge_raw
+      show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by
     exact lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
   -- 4. Eliminate taken branch: j' = -1 < 0, so BGE is not taken
@@ -1255,7 +1255,7 @@ theorem divK_store_loop_jgt0_spec
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - j_x8
     let j' := j + signExtend12 4095
-    cpsTriple (base + 884) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + 884) (base + loopBodyOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (q_addr ↦ₘ q_old))
@@ -1279,10 +1279,10 @@ theorem divK_store_loop_jgt0_spec
     exact lb_sub base 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
   have hbge_raw := bge_spec_gen .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
-  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + 448 from by
+  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
         rw [show signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) from by decide]
         bv_addr,
-      show (base + 904 : Word) + 4 = base + 908 from by bv_addr] at hbge_raw
+      show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by
     exact lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
   -- 4. Eliminate not-taken branch: j' = j-1 ≥ 0, so BGE is taken

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -58,7 +58,7 @@ theorem divK_trial_max_full_spec_n1
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 516) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -115,7 +115,7 @@ theorem divK_trial_call_full_spec_n1
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + 448) (base + 516) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -169,7 +169,7 @@ theorem divK_loop_body_n1_max_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -181,8 +181,8 @@ theorem divK_loop_body_n1_max_skip_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -282,7 +282,7 @@ theorem divK_loop_body_n1_max_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -294,8 +294,8 @@ theorem divK_loop_body_n1_max_addback_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -400,7 +400,7 @@ theorem divK_loop_body_n1_call_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -416,13 +416,13 @@ theorem divK_loop_body_n1_call_skip_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
@@ -559,7 +559,7 @@ theorem divK_loop_body_n1_call_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -575,13 +575,13 @@ theorem divK_loop_body_n1_call_addback_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -67,7 +67,7 @@ theorem divK_loop_body_n2_max_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -79,8 +79,8 @@ theorem divK_loop_body_n2_max_skip_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -187,7 +187,7 @@ theorem divK_loop_body_n2_max_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -199,8 +199,8 @@ theorem divK_loop_body_n2_max_addback_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -309,7 +309,7 @@ theorem divK_loop_body_n2_call_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -325,13 +325,13 @@ theorem divK_loop_body_n2_call_skip_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
@@ -471,7 +471,7 @@ theorem divK_loop_body_n2_call_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -487,13 +487,13 @@ theorem divK_loop_body_n2_call_addback_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -67,7 +67,7 @@ theorem divK_loop_body_n3_max_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -79,8 +79,8 @@ theorem divK_loop_body_n3_max_skip_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -186,7 +186,7 @@ theorem divK_loop_body_n3_max_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -198,8 +198,8 @@ theorem divK_loop_body_n3_max_addback_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -309,7 +309,7 @@ theorem divK_loop_body_n3_call_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -325,13 +325,13 @@ theorem divK_loop_body_n3_call_skip_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
@@ -471,7 +471,7 @@ theorem divK_loop_body_n3_call_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -487,13 +487,13 @@ theorem divK_loop_body_n3_call_addback_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -67,7 +67,7 @@ theorem divK_loop_body_n4_max_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -79,8 +79,8 @@ theorem divK_loop_body_n4_max_skip_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -188,7 +188,7 @@ theorem divK_loop_body_n4_max_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -200,8 +200,8 @@ theorem divK_loop_body_n4_max_addback_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
        ((u_base + signExtend12 4064) ↦ₘ u_top) **
        (q_addr ↦ₘ q_old))
-      (base + 448) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + 908) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (base + denormOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -311,7 +311,7 @@ theorem divK_loop_body_n4_call_skip_spec
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -327,13 +327,13 @@ theorem divK_loop_body_n4_call_skip_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
@@ -473,7 +473,7 @@ theorem divK_loop_body_n4_call_addback_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsBranch (base + 448) (sharedDivModCode base)
+    cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -489,13 +489,13 @@ theorem divK_loop_body_n4_call_addback_spec
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (base + 448)
+      (base + loopBodyOff)
       (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
-      (base + 908)
+      (base + denormOff)
       (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **

--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -139,7 +139,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -189,7 +189,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -239,7 +239,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -292,7 +292,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -350,7 +350,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -409,7 +409,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -468,7 +468,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -528,7 +528,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -70,7 +70,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -119,7 +119,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -169,7 +169,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -226,7 +226,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -283,7 +283,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -341,7 +341,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -398,7 +398,7 @@ theorem divK_loop_n2_max_max_spec
     (hbltu_1 : ¬BitVec.ult u2 v1)
     (hbltu_0 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
       (loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
@@ -475,7 +475,7 @@ theorem divK_loop_n2_call_call_spec
     (hbltu_1 : BitVec.ult u2 v1)
     (hbltu_0 : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -559,7 +559,7 @@ theorem divK_loop_n2_max_call_spec
     (hbltu_1 : ¬BitVec.ult u2 v1)
     (hbltu_0 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -647,7 +647,7 @@ theorem divK_loop_n2_call_max_spec
     (hbltu_1 : BitVec.ult u2 v1)
     (hbltu_0 : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -68,7 +68,7 @@ theorem divK_loop_n3_max_skip_skip_spec
     -- Branch conditions (j=0, depend on j=1 mulsub output)
     (hbltu_0 : isMaxBltuN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3)
     (hborrow_0 : isSkipBorrowN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3 u0_orig) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
       (loopN3MaxSkipSkipPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
@@ -137,7 +137,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -188,7 +188,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -241,7 +241,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -300,7 +300,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -362,7 +362,7 @@ theorem divK_loop_n3_max_max_spec
     (hbltu_1 : ¬BitVec.ult u3 v2)
     (hbltu_0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
       (loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
@@ -444,7 +444,7 @@ theorem divK_loop_n3_call_call_spec
     (hbltu_1 : BitVec.ult u3 v2)
     (hbltu_0 : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -531,7 +531,7 @@ theorem divK_loop_n3_max_call_spec
     (hbltu_1 : ¬BitVec.ult u3 v2)
     (hbltu_0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
@@ -619,7 +619,7 @@ theorem divK_loop_n3_call_max_spec
     (hbltu_1 : BitVec.ult u3 v2)
     (hbltu_0 : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -31,7 +31,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -155,7 +155,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -280,7 +280,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -405,7 +405,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -32,7 +32,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -151,7 +151,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -271,7 +271,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -391,7 +391,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -30,7 +30,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -134,7 +134,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -224,7 +224,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -314,7 +314,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -31,7 +31,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -114,7 +114,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -198,7 +198,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -282,7 +282,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -40,7 +40,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -145,7 +145,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -278,7 +278,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -369,7 +369,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -495,7 +495,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -586,7 +586,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -715,7 +715,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -801,7 +801,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -930,7 +930,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -1017,7 +1017,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -1138,7 +1138,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -1225,7 +1225,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -35,7 +35,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -140,7 +140,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
     (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -273,7 +273,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -379,7 +379,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
     (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -514,7 +514,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -606,7 +606,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -738,7 +738,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -831,7 +831,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + 448) (base + 448) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -33,7 +33,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -167,7 +167,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -283,7 +283,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
@@ -409,7 +409,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + 448) (base + 908) (sharedDivModCode base)
+    cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **


### PR DESCRIPTION
## Summary

Completes the block-offset migration from issue #301 (previous phases: #306, #308). Replaces remaining `base + N` literal offsets with the named `*Off` abbreviations from `EvmAsm.Evm64.DivMod.Compose.Offsets` across 49 DivMod files.

Offsets migrated: `448 → loopBodyOff`, `908 → denormOff`, `1008 → epilogueOff`, `1048 → zeroPathOff`, `1068 → nopOff`, `1072 → div128Off`, `396 → copyAUOff`, `432 → loopSetupOff`, `312 → normAOff`, `228 → normBOff`, `212 → phaseC2Off`, `116 → clzOff`.

Also refreshes the header layout comment in `Offsets.lean` which had stale 904/1004/1044/1064/1068 values left over from PR #300 (the `abbrev` declarations themselves were already correct, so drift checks had been passing).

## Test plan

- [x] `lake build EvmAsm.Evm64.DivMod` succeeds (3399 jobs, no errors)
- [x] `Offsets.lean` drift-check `example`s continue to pass
- [ ] No behavioral changes — all edits are `abbrev` substitutions that reduce to the same numerals

🤖 Generated with [Claude Code](https://claude.com/claude-code)