### PR TITLE
Remove unused hvalid params exposed by memIs→valid cascade (#338)

### DIFF
--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -25,8 +25,7 @@ abbrev evm_add_code (base : Word) : CodeReq :=
     Carry propagates through limbs via x5. -/
 theorem evm_add_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     let sum0 := a0 + b0
     let carry0 := if BitVec.ult sum0 b0 then (1 : Word) else 0
     let psum1 := a1 + b1
@@ -68,8 +67,7 @@ theorem evm_add_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM ADD: operates on two EvmWords via evmWordIs. -/
 theorem evm_add_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
     let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
     let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
@@ -104,7 +102,7 @@ theorem evm_add_stack_spec (sp base : Word)
   have h_main := evm_add_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   -- Get the carry chain correctness
   have ⟨h0, h1, h2, h3⟩ := EvmWord.add_carry_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -23,8 +23,7 @@ abbrev evm_and_code (base : Word) : CodeReq :=
     17 instructions total. Pops 2 stack words (A at sp, B at sp+32),
     writes A &&& B to sp+32..sp+56, advances sp by 32. -/
 theorem evm_and_spec (sp base : Word)
-    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word) :
     let code := evm_and_code base
     cpsTriple base (base + 68) code
       (-- Registers + memory
@@ -48,8 +47,7 @@ theorem evm_and_spec (sp base : Word)
 
 /-- Stack-level 256-bit EVM AND: operates on two EvmWords via evmWordIs. -/
 theorem evm_and_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 : Word) :
     let code := evm_and_code base
     cpsTriple base (base + 68) code
       (-- Registers + memory
@@ -61,7 +59,7 @@ theorem evm_and_stack_spec (sp base : Word)
   have h_main := evm_and_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 hvalid
+    v7 v6
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -71,10 +71,6 @@ set_option maxRecDepth 4096 in
 theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (v1_old v6_old v11_old : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
-    (hv_ret : isValidDwordAccess (sp + signExtend12 3968) = true)
-    (hv_d   : isValidDwordAccess (sp + signExtend12 3960) = true)
-    (hv_dlo : isValidDwordAccess (sp + signExtend12 3952) = true)
-    (hv_un0 : isValidDwordAccess (sp + signExtend12 3944) = true)
     (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
     -- Phase 1 intermediates
     let d_hi := d >>> (32 : BitVec 6).toNat

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -26,8 +26,7 @@ abbrev evm_eq_code (base : Word) : CodeReq :=
     21 instructions = 84 bytes total. -/
 theorem evm_eq_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     -- XOR-OR accumulation chain
     let acc0 := a0 ^^^ b0
     let acc1 := acc0 ||| (a1 ^^^ b1)
@@ -73,8 +72,7 @@ theorem evm_eq_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM EQ: operates on two EvmWords via evmWordIs. -/
 theorem evm_eq_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     -- XOR-OR accumulation chain
     let acc0 := a.getLimbN 0 ^^^ b.getLimbN 0
     let acc1 := acc0 ||| (a.getLimbN 1 ^^^ b.getLimbN 1)
@@ -95,7 +93,7 @@ theorem evm_eq_stack_spec (sp base : Word)
   have h_main := evm_eq_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -28,8 +28,7 @@ abbrev evm_gt_code (base : Word) : CodeReq :=
     26 instructions = 104 bytes total. -/
 theorem evm_gt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     -- Borrow chain: b - a (GT direction)
     let borrow0 := if BitVec.ult b0 a0 then (1 : Word) else 0
     let borrow1a := if BitVec.ult b1 a1 then (1 : Word) else 0
@@ -77,8 +76,7 @@ theorem evm_gt_spec (sp : Word) (base : Word)
 /-- Stack-level 256-bit EVM GT: operates on two EvmWords via evmWordIs.
     GT(a, b) = LT(b, a), using the borrow chain in b-a direction. -/
 theorem evm_gt_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     -- Borrow chain: b - a (GT direction)
     let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
     let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
@@ -106,7 +104,7 @@ theorem evm_gt_stack_spec (sp base : Word)
   have h_main := evm_gt_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -24,8 +24,7 @@ abbrev evm_iszero_code (base : Word) : CodeReq :=
     12 instructions = 48 bytes. -/
 theorem evm_iszero_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 : Word)
-    (v7 v6 : Word)
-    (hvalid : ValidMemRange sp 4) :
+    (v7 v6 : Word) :
     let or_all := a0 ||| a1 ||| a2 ||| a3
     let result := if BitVec.ult or_all (1 : Word) then (1 : Word) else 0
     let code := evm_iszero_code base
@@ -61,8 +60,7 @@ theorem evm_iszero_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM ISZERO: operates on an EvmWord via evmWordIs. -/
 theorem evm_iszero_stack_spec (sp base : Word)
-    (a : EvmWord) (v7 v6 : Word)
-    (hvalid : ValidMemRange sp 4) :
+    (a : EvmWord) (v7 v6 : Word) :
     let or_all := a.getLimbN 0 ||| a.getLimbN 1 ||| a.getLimbN 2 ||| a.getLimbN 3
     let result := if BitVec.ult or_all 1 then (1 : Word) else 0
     let code := evm_iszero_code base
@@ -76,7 +74,7 @@ theorem evm_iszero_stack_spec (sp base : Word)
   intro or_all result
   have h_main := evm_iszero_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    v7 v6 hvalid
+    v7 v6
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -27,8 +27,7 @@ abbrev evm_lt_code (base : Word) : CodeReq :=
     26 instructions = 104 bytes total. -/
 theorem evm_lt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
     let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
     let temp1 := a1 - b1
@@ -74,8 +73,7 @@ theorem evm_lt_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM LT: operates on two EvmWords via evmWordIs. -/
 theorem evm_lt_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
     let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
     let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
@@ -106,7 +104,7 @@ theorem evm_lt_stack_spec (sp base : Word)
   have h_main := evm_lt_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Multiply/LimbSpec.lean
+++ b/EvmAsm/Evm64/Multiply/LimbSpec.lean
@@ -416,8 +416,7 @@ abbrev evm_mul_code (base : Word) : CodeReq :=
     writes (A * B) mod 2^256 to sp+32..sp+56, advances sp by 32. -/
 theorem evm_mul_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v5 v6 v7 v10 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v5 v6 v7 v10 v11 : Word) :
     -- Col0 intermediates
     let c0_r0 := a0 * b0
     let c0_hi_a0b0 := rv64_mulhu a0 b0

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -25,8 +25,7 @@ abbrev evm_not_code (base : Word) : CodeReq :=
     12 instructions total. Unary: complements each limb in-place, sp unchanged. -/
 theorem evm_not_spec (sp base : Word)
     (a0 a1 a2 a3 : Word)
-    (v7 : Word)
-    (hvalid : ValidMemRange sp 4) :
+    (v7 : Word) :
     let c := signExtend12 (-1 : BitVec 12)
     let code := evm_not_code base
     cpsTriple base (base + 48) code
@@ -52,8 +51,7 @@ theorem signExtend12_neg1_eq_allOnes : signExtend12 (-1 : BitVec 12) = BitVec.al
 
 /-- Stack-level 256-bit EVM NOT: complements an EvmWord in-place. -/
 theorem evm_not_stack_spec (sp base : Word)
-    (a : EvmWord) (v7 : Word)
-    (hvalid : ValidMemRange sp 4) :
+    (a : EvmWord) (v7 : Word) :
     let c := signExtend12 (-1 : BitVec 12)
     let code := evm_not_code base
     cpsTriple base (base + 48) code
@@ -69,7 +67,7 @@ theorem evm_not_stack_spec (sp base : Word)
   -- Apply evm_not_spec with individual limbs
   have h_main := evm_not_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    v7 hvalid
+    v7
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -17,8 +17,7 @@ abbrev evm_or_code (base : Word) : CodeReq :=
 
 /-- Full 256-bit EVM OR: composes 4 per-limb OR specs + sp adjustment. -/
 theorem evm_or_spec (sp base : Word)
-    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word) :
     let code := evm_or_code base
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
@@ -36,8 +35,7 @@ theorem evm_or_spec (sp base : Word)
 
 /-- Stack-level 256-bit EVM OR. -/
 theorem evm_or_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 : Word) :
     let code := evm_or_code base
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
@@ -47,7 +45,7 @@ theorem evm_or_stack_spec (sp base : Word)
   have h_main := evm_or_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 hvalid
+    v7 v6
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -33,8 +33,7 @@ abbrev evm_sgt_code (base : Word) : CodeReq :=
     25 instructions = 100 bytes total. -/
 theorem evm_sgt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     -- Lower 3 limbs borrow chain: b - a direction (used when MSB limbs equal)
     let borrow0 := if BitVec.ult b0 a0 then (1 : Word) else 0
     let borrow1a := if BitVec.ult b1 a1 then (1 : Word) else 0
@@ -115,8 +114,7 @@ theorem evm_sgt_spec (sp : Word) (base : Word)
 /-- Stack-level 256-bit EVM SGT: operates on two EvmWords via evmWordIs.
     SGT(a, b) = SLT(b, a), using signed comparison with swapped operands. -/
 theorem evm_sgt_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     -- Lower 3 limbs borrow chain: b - a direction (used when MSB limbs equal)
     let borrow0 := if BitVec.ult (b.getLimbN 0) (a.getLimbN 0) then (1 : Word) else 0
     let borrow1a := if BitVec.ult (b.getLimbN 1) (a.getLimbN 1) then (1 : Word) else 0
@@ -146,7 +144,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
   have h_main := evm_sgt_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -874,16 +874,16 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   -- Body specs extended to shrCode
   have hbody3 := cpsTriple_extend_code (body_3_sub_shrCode base)
     (shr_body_3_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 84) (base + 360) 252 (shr_body3_exit base) hv32)
+      v0 v1 v2 v3 (base + 84) (base + 360) 252 (shr_body3_exit base))
   have hbody2 := cpsTriple_extend_code (body_2_sub_shrCode base)
     (shr_body_2_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 112) (base + 360) 200 (shr_body2_exit base) hv32)
+      v0 v1 v2 v3 (base + 112) (base + 360) 200 (shr_body2_exit base))
   have hbody1 := cpsTriple_extend_code (body_1_sub_shrCode base)
     (shr_body_1_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 1) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 164) (base + 360) 124 (shr_body1_exit base) hv32)
+      v0 v1 v2 v3 (base + 164) (base + 360) 124 (shr_body1_exit base))
   have hbody0 := cpsTriple_extend_code (body_0_sub_shrCode base)
     (shr_body_0_spec (sp + 32) limb_shift sltiu_val bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 240) (base + 360) 24 (shr_body0_exit base) hv32)
+      v0 v1 v2 v3 (base + 240) (base + 360) 24 (shr_body0_exit base))
   -- Frame each body with (x0=0 ** shift_mem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -215,8 +215,7 @@ theorem shr_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 24) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 24) + signExtend21 jal_off = exit) :
     let result0 := v3 >>> (bit_shift.toNat % 64)
     let code := shr_body_3_code jal_off base
     cpsTriple base exit code
@@ -244,8 +243,7 @@ theorem shr_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 48) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 48) + signExtend21 jal_off = exit) :
     let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := v3 >>> (bit_shift.toNat % 64)
     let code := shr_body_2_code jal_off base
@@ -276,8 +274,7 @@ theorem shr_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 72) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 72) + signExtend21 jal_off = exit) :
     let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
     let result2 := v3 >>> (bit_shift.toNat % 64)
@@ -312,8 +309,7 @@ theorem shr_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 96) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 96) + signExtend21 jal_off = exit) :
     let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
     let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -1034,16 +1034,16 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   -- Body specs extended to sarCode
   have hbody3 := cpsTriple_extend_code (sar_body_3_sub_sarCode base)
     (sar_body_3_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 84) (base + 380) 268 (sar_body3_exit base) hv32)
+      v0 v1 v2 v3 (base + 84) (base + 380) 268 (sar_body3_exit base))
   have hbody2 := cpsTriple_extend_code (sar_body_2_sub_sarCode base)
     (sar_body_2_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 116) (base + 380) 212 (sar_body2_exit base) hv32)
+      v0 v1 v2 v3 (base + 116) (base + 380) 212 (sar_body2_exit base))
   have hbody1 := cpsTriple_extend_code (sar_body_1_sub_sarCode base)
     (sar_body_1_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 1) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 172) (base + 380) 132 (sar_body1_exit base) hv32)
+      v0 v1 v2 v3 (base + 172) (base + 380) 132 (sar_body1_exit base))
   have hbody0 := cpsTriple_extend_code (sar_body_0_sub_sarCode base)
     (sar_body_0_spec (sp + 32) limb_shift sltiu_val bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 252) (base + 380) 32 (sar_body0_exit base) hv32)
+      v0 v1 v2 v3 (base + 252) (base + 380) 32 (sar_body0_exit base))
   -- Frame each body with (x0=0 ** shift_mem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 380) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -87,8 +87,7 @@ theorem sar_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 28) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 28) + signExtend21 jal_off = exit) :
     let result0 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
     let sign_ext := BitVec.sshiftRight result0 63
     let cr := sar_body_3_code base jal_off
@@ -122,8 +121,7 @@ theorem sar_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 52) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 52) + signExtend21 jal_off = exit) :
     let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
     let sign_ext := BitVec.sshiftRight result1 63
@@ -164,8 +162,7 @@ theorem sar_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 76) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 76) + signExtend21 jal_off = exit) :
     let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
     let result2 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
@@ -210,8 +207,7 @@ theorem sar_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 96) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 96) + signExtend21 jal_off = exit) :
     let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
     let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
     let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -847,16 +847,16 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   -- Body specs extended to shlCode
   have hbody3 := cpsTriple_extend_code (shl_body_3_sub_shlCode base)
     (shl_body_3_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 84) (base + 360) 252 (shl_body3_exit base) hv32)
+      v0 v1 v2 v3 (base + 84) (base + 360) 252 (shl_body3_exit base))
   have hbody2 := cpsTriple_extend_code (shl_body_2_sub_shlCode base)
     (shl_body_2_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 112) (base + 360) 200 (shl_body2_exit base) hv32)
+      v0 v1 v2 v3 (base + 112) (base + 360) 200 (shl_body2_exit base))
   have hbody1 := cpsTriple_extend_code (shl_body_1_sub_shlCode base)
     (shl_body_1_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 1) bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 164) (base + 360) 124 (shl_body1_exit base) hv32)
+      v0 v1 v2 v3 (base + 164) (base + 360) 124 (shl_body1_exit base))
   have hbody0 := cpsTriple_extend_code (shl_body_0_sub_shlCode base)
     (shl_body_0_spec (sp + 32) limb_shift sltiu_val bit_shift anti_shift mask
-      v0 v1 v2 v3 (base + 240) (base + 360) 24 (shl_body0_exit base) hv32)
+      v0 v1 v2 v3 (base + 240) (base + 360) 24 (shl_body0_exit base))
   -- Frame each body with (x0=0 ** shift_mem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -170,8 +170,7 @@ theorem shl_body_3_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 24) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 24) + signExtend21 jal_off = exit) :
     let result3 := v0 <<< (bit_shift.toNat % 64)
     let cr := shl_body_3_code base jal_off
     cpsTriple base exit cr
@@ -202,8 +201,7 @@ theorem shl_body_2_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 48) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 48) + signExtend21 jal_off = exit) :
     let result3 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
     let result2 := v0 <<< (bit_shift.toNat % 64)
     let cr := shl_body_2_code base jal_off
@@ -239,8 +237,7 @@ theorem shl_body_1_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 72) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 72) + signExtend21 jal_off = exit) :
     let result3 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
     let result2 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
     let result1 := v0 <<< (bit_shift.toNat % 64)
@@ -278,8 +275,7 @@ theorem shl_body_0_spec (sp : Word)
     (v5 v10 bit_shift anti_shift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 96) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 4) :
+    (hexit : (base + 96) + signExtend21 jal_off = exit) :
     let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (anti_shift.toNat % 64)) &&& mask)
     let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
     let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -647,13 +647,13 @@ theorem signext_body_spec (sp base : Word)
   have hphaseC := cpsNBranch_extend_code (phase_c_sub_signextCode base) hphaseC_raw
   -- Body specs + done, extended to signextCode
   have hbody3 := cpsTriple_extend_code (body_3_sub_signextCode base)
-    (signext_body_3_spec sp limb_idx shift_amount v3 (base + 76) (base + 188) 96 (se_body3_exit base) hvalid)
+    (signext_body_3_spec sp limb_idx shift_amount v3 (base + 76) (base + 188) 96 (se_body3_exit base))
   have hbody2 := cpsTriple_extend_code (body_2_sub_signextCode base)
-    (signext_body_2_spec sp limb_idx ((0 : Word) + signExtend12 2) shift_amount v2 v3 (base + 96) (base + 188) 68 (se_body2_exit base) hvalid)
+    (signext_body_2_spec sp limb_idx ((0 : Word) + signExtend12 2) shift_amount v2 v3 (base + 96) (base + 188) 68 (se_body2_exit base))
   have hbody1 := cpsTriple_extend_code (body_1_sub_signextCode base)
-    (signext_body_1_spec sp limb_idx ((0 : Word) + signExtend12 1) shift_amount v1 v2 v3 (base + 124) (base + 188) 36 (se_body1_exit base) hvalid)
+    (signext_body_1_spec sp limb_idx ((0 : Word) + signExtend12 1) shift_amount v1 v2 v3 (base + 124) (base + 188) 36 (se_body1_exit base))
   have hbody0 := cpsTriple_extend_code (body_0_sub_signextCode base)
-    (signext_body_0_spec sp limb_idx byte_shift shift_amount v0 v1 v2 v3 (base + 156) hvalid)
+    (signext_body_0_spec sp limb_idx byte_shift shift_amount v0 v1 v2 v3 (base + 156))
   rw [show (base + 156 : Word) + 32 = base + 188 from by bv_omega] at hbody0
   have hdone := cpsTriple_extend_code (done_sub_signextCode base) (signext_done_spec sp (base + 188))
   rw [se_done_exit] at hdone

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -65,8 +65,7 @@ abbrev signext_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
 theorem signext_body_3_spec (sp : Word)
     (v5 shift_amount : Word) (v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 16) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 8) :
+    (hexit : (base + 16) + signExtend21 jal_off = exit) :
     let result := BitVec.sshiftRight (v3 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let code := signext_body_3_code base jal_off
     cpsTriple base exit code
@@ -89,8 +88,7 @@ abbrev signext_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
 theorem signext_body_2_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 24) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 8) :
+    (hexit : (base + 24) + signExtend21 jal_off = exit) :
     let result := BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let sign_fill := BitVec.sshiftRight result 63
     let code := signext_body_2_code base jal_off
@@ -122,8 +120,7 @@ abbrev signext_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
 theorem signext_body_1_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
-    (hexit : (base + 28) + signExtend21 jal_off = exit)
-    (hvalid : ValidMemRange sp 8) :
+    (hexit : (base + 28) + signExtend21 jal_off = exit) :
     let result := BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let sign_fill := BitVec.sshiftRight result 63
     let code := signext_body_1_code base jal_off
@@ -158,8 +155,7 @@ abbrev signext_body_0_code (base : Word) : CodeReq :=
     LD + SLL + SRA + SD + SRAI + SD + SD + SD. Falls through to done. -/
 theorem signext_body_0_spec (sp : Word)
     (v5 v10 shift_amount : Word) (v0 v1 v2 v3 : Word)
-    (base : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (base : Word) :
     let result := BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
     let sign_fill := BitVec.sshiftRight result 63
     let code := signext_body_0_code base

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -32,8 +32,7 @@ abbrev evm_slt_code (base : Word) : CodeReq :=
     25 instructions = 100 bytes total. -/
 theorem evm_slt_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     -- Lower 3 limbs borrow chain (used when MSB limbs equal)
     let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
     let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
@@ -113,8 +112,7 @@ theorem evm_slt_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM SLT: operates on two EvmWords via evmWordIs. -/
 theorem evm_slt_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     -- Lower 3 limbs borrow chain (used when MSB limbs equal)
     let borrow0 := if BitVec.ult (a.getLimbN 0) (b.getLimbN 0) then (1 : Word) else 0
     let borrow1a := if BitVec.ult (a.getLimbN 1) (b.getLimbN 1) then (1 : Word) else 0
@@ -144,7 +142,7 @@ theorem evm_slt_stack_spec (sp base : Word)
   have h_main := evm_slt_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -25,8 +25,7 @@ abbrev evm_sub_code (base : Word) : CodeReq :=
     Borrow propagates through limbs via x5. -/
 theorem evm_sub_spec (sp : Word) (base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (v7 v6 v5 v11 : Word) :
     let borrow0 := if BitVec.ult a0 b0 then (1 : Word) else 0
     let diff0 := a0 - b0
     let borrow1a := if BitVec.ult a1 b1 then (1 : Word) else 0
@@ -68,8 +67,7 @@ theorem evm_sub_spec (sp : Word) (base : Word)
 
 /-- Stack-level 256-bit EVM SUB: operates on two EvmWords via evmWordIs. -/
 theorem evm_sub_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 v5 v11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 v5 v11 : Word) :
     let a0 := a.getLimbN 0; let b0 := b.getLimbN 0
     let a1 := a.getLimbN 1; let b1 := b.getLimbN 1
     let a2 := a.getLimbN 2; let b2 := b.getLimbN 2
@@ -104,7 +102,7 @@ theorem evm_sub_stack_spec (sp base : Word)
   have h_main := evm_sub_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 v5 v11 hvalid
+    v7 v6 v5 v11
   -- Get the borrow chain correctness
   have ⟨h0, h1, h2, h3⟩ := EvmWord.sub_borrow_chain_correct a b
   exact cpsTriple_consequence _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -17,8 +17,7 @@ abbrev evm_xor_code (base : Word) : CodeReq :=
 
 /-- Full 256-bit EVM XOR: composes 4 per-limb XOR specs + sp adjustment. -/
 theorem evm_xor_spec (sp base : Word)
-    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a0 a1 a2 a3 b0 b1 b2 b3 v7 v6 : Word) :
     let code := evm_xor_code base
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
@@ -36,8 +35,7 @@ theorem evm_xor_spec (sp base : Word)
 
 /-- Stack-level 256-bit EVM XOR. -/
 theorem evm_xor_stack_spec (sp base : Word)
-    (a b : EvmWord) (v7 v6 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (a b : EvmWord) (v7 v6 : Word) :
     let code := evm_xor_code base
     cpsTriple base (base + 68) code
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
@@ -47,7 +45,7 @@ theorem evm_xor_stack_spec (sp base : Word)
   have h_main := evm_xor_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    v7 v6 hvalid
+    v7 v6
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -68,9 +68,6 @@ theorem rlp_phase2_long_loop_three_byte_spec
     (hvalid2 : isValidByteAccess (ptr + 1) = true)
     (hvalid3 : isValidByteAccess (ptr + 2) = true)
     (hback : (base + 20) + signExtend13 back = base) :
-    let byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
-    let byte2 := (extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64
-    let byte3 := (extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64
     cpsTriple base (base + 24)
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (3 : Word)) **

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -69,8 +69,6 @@ theorem rlp_phase2_long_loop_two_byte_spec
     (hvalid1 : isValidByteAccess ptr = true)
     (hvalid2 : isValidByteAccess (ptr + 1) = true)
     (hback : (base + 20) + signExtend13 back = base) :
-    let byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
-    let byte2 := (extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64
     cpsTriple base (base + 24)
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (2 : Word)) **


### PR DESCRIPTION
## Summary
- Follow-up to #341 (`el3-memIs-imply-dword-access`): now that `|->m` implies valid addresses, the `ValidMemRange` / `isValidDwordAccess` side-conditions on many specs are genuinely unused.
- Per CONTRIBUTING.md's no-underscored-params rule, drop `hvalid` / `hv_*` parameters (and their call-site arguments) rather than renaming to `_hvalid`.
- Also removes dead \`let byte_i := …\` bindings in \`Phase2LongLoop{Two,Three}.lean\`.

Covered files:
- 12 \`evm_*_spec\` pairs in \`Evm64/{Add,And,Eq,Gt,IsZero,Lt,Not,Or,Sgt,Slt,Sub,Xor}/Spec.lean\`
- Shift body specs (SHR/SHL/SAR LimbSpec + their Compose call sites)
- SignExtend body specs + Compose call sites
- \`evm_mul_spec\` in \`Multiply/LimbSpec.lean\`
- \`mod_div128_spec\` in \`DivMod/Compose/ModDiv128.lean\` (4 \`hv_*\` params)

Resolves all \`unused variable hvalid\` / \`hv_*\` / \`byte_i\` warnings from \`lake build\`. Remaining warnings (\`push_neg\` deprecation, unused simp args in \`Phase2LongLoopBody\`) are a different category and out of scope.

## Test plan
- [x] \`lake build\` succeeds with no unused-variable warnings
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)