### PR TITLE
refactor: remove underscore-prefixed unused parameters

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
@@ -83,7 +83,7 @@ def byte (i x : EvmWord) : EvmWord :=
     BitVec.ofNat 256 ((x.toNat / 2 ^ ((31 - i.toNat) * 8)) % 256)
   else 0
 
-private theorem getLimb_0_ofNat_small (n : Nat) (_hn : n < 2 ^ 64) :
+private theorem getLimb_0_ofNat_small (n : Nat) :
     getLimb (BitVec.ofNat 256 n) 0 = BitVec.ofNat 64 n := by
   simp only [getLimb]
   simp only [Fin.val_zero, Nat.zero_mul]
@@ -109,10 +109,7 @@ theorem byte_getLimb_0 (idx x : EvmWord) (hi : idx.toNat < 32) :
     BitVec.ofNat 64 ((x.toNat / 2 ^ ((31 - idx.toNat) * 8)) % 256) := by
   unfold byte
   rw [if_pos hi]
-  have : (x.toNat / 2 ^ ((31 - idx.toNat) * 8)) % 256 < 2 ^ 64 := by
-    have := Nat.mod_lt (x.toNat / 2 ^ ((31 - idx.toNat) * 8)) (by norm_num : 0 < 256)
-    linarith [show (256 : Nat) ≤ 2 ^ 64 from by norm_num]
-  exact getLimb_0_ofNat_small _ this
+  exact getLimb_0_ofNat_small _
 
 theorem byte_getLimb_high (idx x : EvmWord) (j : Fin 4) (hj : j.val ≠ 0) :
     (byte idx x).getLimb j = 0 := by

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -69,7 +69,7 @@ theorem ult_iff {n : Nat} (x y : BitVec n) : BitVec.ult x y ↔ x.toNat < y.toNa
 -- M is the positional multiplier (2^64 at step 1, 2^128 at step 2, 2^192 at step 3).
 -- aH, bH are single limbs (< 2^64). aLo, bLo are partial sums (< M).
 theorem borrow_step_iff (M : Nat)
-    {aH bH : Nat} (_haH : aH < 2^64) (_hbH : bH < 2^64)
+    {aH bH : Nat} (haH : aH < 2^64) (hbH : bH < 2^64)
     {aLo bLo : Nat} (haLo : aLo < M) (hbLo : bLo < M) :
     (aH < bH ∨ (aH + 2^64 - bH) % 2^64 < (if aLo < bLo then 1 else 0)) ↔
     (aLo + aH * M < bLo + bH * M) := by

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -76,7 +76,6 @@ theorem generic_lbu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -122,7 +121,6 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -166,7 +164,6 @@ SB writes a byte to memory at an arbitrary byte address. -/
 theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_old : Word)
-    (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -63,7 +63,6 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -108,7 +107,6 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -152,7 +150,6 @@ SH writes a halfword to memory at a 2-byte aligned address. -/
 theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_old : Word)
-    (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -137,7 +137,7 @@ theorem rlp_phase2_long_iter_spec
   have hvalid0 : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
     rw [h_se0]; simpa using hvalid
   have lbu_raw := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr word_val
-    (by nofun) (by nofun) halign0 hvalid0
+    (by nofun) halign0 hvalid0
   rw [show ptr + signExtend12 (0 : BitVec 12) = ptr from by
         rw [h_se0]; bv_omega] at lbu_raw
   -- Step 2: SLLI x11, x11, 8.

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -105,7 +105,7 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word
   have hvalid' : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
     rw [hptr_eq]; exact hvalid
   have lbu := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr word_val
-    (by nofun) (by nofun) halign' hvalid'
+    (by nofun) halign' hvalid'
   rw [hptr_eq] at lbu
   -- Frame LBU with `x11 ↦ᵣ len` and permute to match the sequence shape.
   let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -691,7 +691,6 @@ namespace EvmAsm.Rv64
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -701,13 +700,12 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lbu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lb_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -717,12 +715,11 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lb_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sb_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_old : Word)
-    (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -731,7 +728,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) **
        (dwordAddr ↦ₘ replaceByte word_old (byteOffset (v_addr + signExtend12 offset)) (v_data.truncate 8))) :=
   generic_sb_spec rs1 rs2 v_addr v_data offset addr dwordAddr word_old
-    hne halign hvalid
+    halign hvalid
 
 -- ============================================================================
 -- Phase 3: M-extension (MULH, MULHSU, DIV, REM)
@@ -817,7 +814,6 @@ namespace EvmAsm.Rv64
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -827,13 +823,12 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lhu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lh_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -843,12 +838,11 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lh_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sh_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_old : Word)
-    (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -857,7 +851,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) **
        (dwordAddr ↦ₘ replaceHalfword word_old ((byteOffset (v_addr + signExtend12 offset)) / 2) (v_data.truncate 16))) :=
   generic_sh_spec rs1 rs2 v_addr v_data offset addr dwordAddr word_old
-    hne halign hvalid
+    halign hvalid
 
 -- ============================================================================
 -- Phase 6: Word32 memory specs (LW, LWU, SW)
@@ -867,7 +861,6 @@ namespace EvmAsm.Rv64
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -877,13 +870,12 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lwu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lw_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -893,12 +885,11 @@ namespace EvmAsm.Rv64
        (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64) **
        (dwordAddr ↦ₘ word_val)) :=
   generic_lw_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
-    hrd_ne_x0 hrd_ne_rs1 halign hvalid
+    hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sw_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (addr : Word)
     (dwordAddr : Word) (word_old : Word)
-    (hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
@@ -907,6 +898,6 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) **
        (dwordAddr ↦ₘ replaceWord32 word_old ((byteOffset (v_addr + signExtend12 offset)) / 4) (v_data.truncate 32))) :=
   generic_sw_spec rs1 rs2 v_addr v_data offset addr dwordAddr word_old
-    hne halign hvalid
+    halign hvalid
 
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -48,7 +48,6 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -93,7 +92,6 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_val : Word)
     (hrd_ne_x0 : rd ≠ .x0)
-    (_hrd_ne_rs1 : rd ≠ rs1)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
@@ -137,7 +135,6 @@ SW writes the lower 32 bits of a register to memory at a 4-byte aligned address.
 theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     (offset : BitVec 12) (base : Word)
     (dwordAddr : Word) (word_old : Word)
-    (_hne : rs1 ≠ rs2)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)


### PR DESCRIPTION
## Summary
- Remove `_`-prefixed parameters in RV64 generic memory specs (`generic_{lwu,lw,sw,lhu,lh,sh,lbu,lb,sb}_spec`) and the matching now-unused `hrd_ne_rs1` / `hne` in the `_spec_gen` wrappers in `SyscallSpecs.lean`.
- Drop unused `_hn` in `ByteOps.getLimb_0_ofNat_small`.
- In `borrow_step_iff`, `_haH`/`_hbH` were actually load-bearing for `omega` — renamed to `haH`/`hbH` rather than removed.
- Adjust call sites in `RLP/Phase2Long{Load,Iter}.lean`.

## Test plan
- [x] `lake build` succeeds (3504/3504)

🤖 Generated with [Claude Code](https://claude.com/claude-code)