### PR TITLE
fix: remove build warnings

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -514,7 +514,7 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hqv_gt_u : q.toNat * val256 v0 v1 v2 v3 > val256 u0 u1 u2 u3 := by nlinarith
   -- q ≥ 1
   have hq_ge_1 : q.toNat ≥ 1 := by
-    by_contra h; push_neg at h
+    by_contra h
     have : q.toNat = 0 := by omega
     simp [this] at hqv_gt_u
   -- (q-1) * val256(v) ≤ val256(u) (from hq_over: q ≤ ⌊u/v⌋ + 1)
@@ -540,7 +540,7 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   -- carry * 2^256 ≥ 1, so carry ≥ 1
   -- Also val256(un) + val256(v) < 2 * 2^256, so carry < 2
   have hc_ge : carry ≥ 1 := by
-    by_contra h; push_neg at h
+    by_contra h
     have : carry = 0 := by omega
     rw [this] at hab
     linarith

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -118,15 +118,15 @@ theorem rlp_phase2_long_loop_body_spec
     by_cases h0 : a = base
     · simp [h0]
     by_cases h1 : a = base + 4#64
-    · simp [h0, h1]
+    · simp [h1]
     by_cases h2 : a = base + 8#64
-    · simp [h0, h1, h2]
+    · simp [h2]
     by_cases h3 : a = base + 12#64
-    · simp [h0, h1, h2, h3]
+    · simp [h3]
     by_cases h4 : a = base + 16#64
-    · simp [h0, h1, h2, h3, h4]
+    · simp [h4]
     by_cases h5 : a = base + 20#64
-    · simp [h0, h1, h2, h3, h4, h5]
+    · simp [h5]
     simp [h0, h1, h2, h3, h4]
   rw [hcr_eq]
   simp only [rlp_phase2_long_loop_body_post_unfold]


### PR DESCRIPTION
## Summary
- Drop unused simp arguments in `Phase2LongLoopBody.lean` (progressive `simp [h0, h1, ...]` lists where only the latest hypothesis was needed)
- Replace deprecated `push_neg` with plain `by_contra` in `DivN4Overestimate.lean` (omega handles the negated hypothesis directly)

## Test plan
- [x] `lake build` completes with zero warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)