### PR TITLE
refactor(specs): drop unused ValidMemRange hypotheses (#338)

### DIFF
--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -1,7 +1,7 @@
 /-
   EvmAsm.Evm64.And.Spec
 
-  Full 256-bit EVM AND spec with ValidMemRange abstractions.
+  Full 256-bit EVM AND spec.
 -/
 
 import EvmAsm.Evm64.And.LimbSpec

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -214,14 +214,6 @@ private theorem byte_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) =
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
   fun _ hp => ⟨v, hp⟩
 
-/-- Helper to derive ValidMemRange for the value portion (sp+32..sp+56). -/
-private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
-    ValidMemRange (sp + 32) 4 := by
-  intro i hi; have := hvalid.get (i := i + 4) (by omega)
-  have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-  rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-  exact this
-
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
 private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
     {P : Assertion} {exits : List (Word × Assertion)}
@@ -299,8 +291,7 @@ private theorem bv_srl_mask_eq (x : Word) (n : Nat) (hn : n < 64) :
     Execution: LD idx[1] → LD/OR idx[2] → LD/OR idx[3] → BNE(taken) → zero_path. -/
 theorem evm_byte_zero_high_spec (sp base : Word)
     (i0 i1 i2 i3 v0 v1 v2 v3 r5 r10 : Word)
-    (hhigh : i1 ||| i2 ||| i3 ≠ 0)
-    (hvalid : ValidMemRange sp 8) :
+    (hhigh : i1 ||| i2 ||| i3 ≠ 0) :
     cpsTriple base (base + 180) (evm_byte_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
@@ -308,14 +299,6 @@ theorem evm_byte_zero_high_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Step 1: OR-reduce (base → base+20) → extend to evm_byte_code
   have hOR := cpsTriple_extend_code (byte_phase_a_sub base)
     (byte_phase_a_or_reduce_spec sp r5 r10 i1 i2 i3 base)
@@ -386,8 +369,7 @@ theorem evm_byte_zero_high_spec (sp base : Word)
 theorem evm_byte_zero_geq32_spec (sp base : Word)
     (i0 i1 i2 i3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : i1 ||| i2 ||| i3 = 0)
-    (hlarge : BitVec.ult i0 (signExtend12 (32 : BitVec 12)) = false)
-    (hvalid : ValidMemRange sp 8) :
+    (hlarge : BitVec.ult i0 (signExtend12 (32 : BitVec 12)) = false) :
     cpsTriple base (base + 180) (evm_byte_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
@@ -395,16 +377,6 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Step 1: OR-reduce (base → base+20) → extend to evm_byte_code
   have hOR := cpsTriple_extend_code (byte_phase_a_sub base)
     (byte_phase_a_or_reduce_spec sp r5 r10 i1 i2 i3 base)
@@ -521,7 +493,6 @@ open EvmWord in
     and uses byte_correct to connect per-limb results to EvmWord.byte. -/
 theorem evm_byte_body_evmWord_spec (sp base : Word)
     (idx value : EvmWord) (r5 r6 r10 : Word)
-    (hvalid : ValidMemRange sp 8)
     (hhigh_zero : idx.getLimbN 1 ||| idx.getLimbN 2 ||| idx.getLimbN 3 = 0)
     (hlt_i0 : BitVec.ult (idx.getLimbN 0) (signExtend12 (32 : BitVec 12)) = true)
     (hlt : idx.toNat < 32) :
@@ -570,16 +541,6 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat memIs form
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
   have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
   have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
@@ -673,14 +634,6 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hphaseC := cpsNBranch_extend_code (byte_phase_c_sub base) hphaseC_raw
   -- Body specs extended to evm_byte_code, then composed with store
   -- body_3: base+76 → base+136 (via JAL 48), then store: base+136 → base+180
-  have hv32_single : isValidDwordAccess (sp + signExtend12 (32 : BitVec 12)) = true := by
-    simp only [signExtend12_32]; have := hvalid.get (i := 4) (by omega); simpa using this
-  have hv40_single : isValidDwordAccess (sp + signExtend12 (40 : BitVec 12)) = true := by
-    simp only [signExtend12_40]; have := hvalid.get (i := 5) (by omega); simpa using this
-  have hv48_single : isValidDwordAccess (sp + signExtend12 (48 : BitVec 12)) = true := by
-    simp only [signExtend12_48]; have := hvalid.get (i := 6) (by omega); simpa using this
-  have hv56_single : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true := by
-    simp only [signExtend12_56]; have := hvalid.get (i := 7) (by omega); simpa using this
   -- Body 3 spec (load from sp+32, i.e. limb 0 = v0)
   have hbody3_raw := byte_body_3_spec sp limb_from_msb shift_amount v0 (base + 76)
   rw [byte_body_3_exit_eq] at hbody3_raw
@@ -970,8 +923,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
 
 /-- Stack-level BYTE spec using evmWordIs and EvmWord.byte. -/
 theorem evm_byte_stack_spec (sp base : Word)
-    (idx val : EvmWord) (v5 v6 v10 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (idx val : EvmWord) (v5 v6 v10 : Word) :
     cpsTriple base (base + 180) (evm_byte_code base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) **
        (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
@@ -1012,7 +964,7 @@ theorem evm_byte_stack_spec (sp base : Word)
       rw [h1, h2, h3]; simp
     rw [hbyte_zero]
     -- Use evm_byte_zero_high_spec at the limb level, then wrap with evmWordIs
-    have h_raw := evm_byte_zero_high_spec sp base i0 i1 i2 i3 v0 v1 v2 v3 v5 v10 hhigh hvalid
+    have h_raw := evm_byte_zero_high_spec sp base i0 i1 i2 i3 v0 v1 v2 v3 v5 v10 hhigh
     -- Frame x6 (not used by zero_high path)
     have h_framed := cpsTriple_frame_left base (base + 180) _ _ _
       (.x6 ↦ᵣ v6) (by pcFree) h_raw
@@ -1044,7 +996,7 @@ theorem evm_byte_stack_spec (sp base : Word)
         have hidx_toNat : idx.toNat = i0.toNat :=
           EvmWord.toNat_eq_getLimb0_of_high_zero idx hhigh
         rw [decide_eq_true_eq]; omega
-      exact evm_byte_body_evmWord_spec sp base idx val v5 v6 v10 hvalid hhigh hlt_i0 hlt
+      exact evm_byte_body_evmWord_spec sp base idx val v5 v6 v10 hhigh hlt_i0 hlt
     · -- Case 2: idx.toNat >= 32, high limbs zero → zero result
       have hbyte_zero : EvmWord.byte idx val = 0 := EvmWord.byte_zero idx val hlt
       rw [hbyte_zero]
@@ -1055,7 +1007,7 @@ theorem evm_byte_stack_spec (sp base : Word)
         have hidx_toNat : idx.toNat = i0.toNat :=
           EvmWord.toNat_eq_getLimb0_of_high_zero idx hhigh
         rw [decide_eq_false_iff_not]; omega
-      have h_raw := evm_byte_zero_geq32_spec sp base i0 i1 i2 i3 v0 v1 v2 v3 v5 v10 hhigh hlarge hvalid
+      have h_raw := evm_byte_zero_geq32_spec sp base i0 i1 i2 i3 v0 v1 v2 v3 v5 v10 hhigh hlarge
       have h_framed := cpsTriple_frame_left base (base + 180) _ _ _
         (.x6 ↦ᵣ v6) (by pcFree) h_raw
       exact cpsTriple_consequence _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -42,8 +42,7 @@ theorem evm_dup_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (s0 s1 s2 s3 : Word)
     (d0 d1 d2 d3 : Word)
-    (v7 : Word)
-    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    (v7 : Word) :
     cpsTriple base (base + 36) (evm_dup_code base n)
       ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
        (nsp ↦ₘ d0) ** ((nsp+8) ↦ₘ d1) ** ((nsp+16) ↦ₘ d2) ** ((nsp+24) ↦ₘ d3) **
@@ -75,20 +74,6 @@ theorem evm_dup_spec (nsp base : Word)
     rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
   have hm24 : nsp + signExtend12 (BitVec.ofNat 12 24) = nsp + 24 := by
     rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
-  -- Memory validity from ValidMemRange for dst locations
-  have hv0  : isValidDwordAccess nsp       = true := by have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8  : isValidDwordAccess (nsp + 8)  = true := by have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (nsp + 16) = true := by have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (nsp + 24) = true := by have := hvalid.get (i := 3) (by omega); simpa using this
-  -- Memory validity from ValidMemRange for src locations
-  have hvs0 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32)) = true := by
-    have := hvalid.get (i := n*4) (by omega); rwa [show 8 * (n * 4) = n * 32 from by omega] at this
-  have hvs8 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+8)) = true := by
-    have := hvalid.get (i := n*4+1) (by omega); rwa [show 8 * (n * 4 + 1) = n * 32 + 8 from by omega] at this
-  have hvs16 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+16)) = true := by
-    have := hvalid.get (i := n*4+2) (by omega); rwa [show 8 * (n * 4 + 2) = n * 32 + 16 from by omega] at this
-  have hvs24 : isValidDwordAccess (nsp + BitVec.ofNat 64 (n*32+24)) = true := by
-    have := hvalid.get (i := n*4+3) (by omega); rwa [show 8 * (n * 4 + 3) = n * 32 + 24 from by omega] at this
   -- ADDI spec
   have sA := addi_spec_gen_same .x12 (nsp + 32) (-32) base (by nofun)
   simp only [signExtend12_neg32] at sA
@@ -115,8 +100,7 @@ theorem evm_dup_spec (nsp base : Word)
 /-- DUPn spec at evmWordIs level: copies the nth stack element to new top position. -/
 theorem evm_dup_evmword_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
-    (src dst : EvmWord) (v7 : Word)
-    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    (src dst : EvmWord) (v7 : Word) :
     cpsTriple base (base + 36) (evm_dup_code base n)
       ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
        evmWordIs nsp dst **
@@ -134,7 +118,7 @@ theorem evm_dup_evmword_spec (nsp base : Word)
   have h_main := evm_dup_spec nsp base n hn1 hn16
     (src.getLimbN 0) (src.getLimbN 1) (src.getLimbN 2) (src.getLimbN 3)
     (dst.getLimbN 0) (dst.getLimbN 1) (dst.getLimbN 2) (dst.getLimbN 3)
-    v7 hvalid
+    v7
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun _ hp => by
       simp only [evmWordIs, haddr8, haddr16, haddr24] at hp
@@ -153,8 +137,7 @@ theorem evm_dup_evmword_spec (nsp base : Word)
 theorem evm_dup_stack_spec (nsp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (stack : List EvmWord) (hlen : n ≤ stack.length)
-    (d : EvmWord) (v7 : Word)
-    (hvalid : ValidMemRange nsp ((n + 1) * 4)) :
+    (d : EvmWord) (v7 : Word) :
     let vn := stack[n - 1]'(by omega)
     cpsTriple base (base + 36) (evm_dup_code base n)
       ((.x12 ↦ᵣ (nsp + 32)) ** (.x7 ↦ᵣ v7) **
@@ -180,7 +163,7 @@ theorem evm_dup_stack_spec (nsp base : Word)
     (evmStackIs (nsp + 32) (stack.take (n - 1)) **
      evmStackIs (nsp + BitVec.ofNat 64 (n * 32 + 32)) (stack.drop n))
     (by pcFree)
-    (evm_dup_evmword_spec nsp base n hn1 hn16 vn d v7 hvalid)
+    (evm_dup_evmword_spec nsp base n hn1 hn16 vn d v7)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun _ hp => by rw [hsplit] at hp; xperm_hyp hp)
     (fun _ hq => by rw [hsplit]; xperm_hyp hq)

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -1,7 +1,7 @@
 /-
   EvmAsm.Evm64.Or.Spec
 
-  Full 256-bit EVM OR spec with ValidMemRange abstractions.
+  Full 256-bit EVM OR spec.
 -/
 
 import EvmAsm.Evm64.Or.LimbSpec

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -236,8 +236,7 @@ private theorem shr_body0_exit (base : Word) : ((base + 240 : Word) + 96) + sign
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → zero_path. -/
 theorem evm_shr_zero_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
-    (hhigh : s1 ||| s2 ||| s3 ≠ 0)
-    (hvalid : ValidMemRange sp 8) :
+    (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     cpsTriple base (base + 360) (shrCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -245,18 +244,6 @@ theorem evm_shr_zero_high_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
   -- Step 1: LD x5 x12 8 at base → extend to shrCode
   have h1 := cpsTriple_extend_code (ld_s1_sub_shrCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -359,8 +346,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
 theorem evm_shr_zero_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
-    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
-    (hvalid : ValidMemRange sp 8) :
+    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     cpsTriple base (base + 360) (shrCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -368,20 +354,6 @@ theorem evm_shr_zero_large_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
   -- Steps 1-3: Same linear chain as zero_high
   have h1 := cpsTriple_extend_code (ld_s1_sub_shrCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -563,14 +535,6 @@ private theorem shr_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = 
 -- Section 5b: Body path theorem (Phase A ntaken → B → C → body → exit)
 -- ============================================================================
 
--- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
-    ValidMemRange (sp + 32) 4 := by
-  intro i hi; have := hvalid.get (i := i + 4) (by omega)
-  have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-  rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-  exact this
-
 -- Note: evm_shr_body_spec (with memOwn postcondition) was removed because it
 -- hides the result. The useful spec is evm_shr_stack_spec in ShrSemantic.lean
 -- which states the concrete result `value >>> shift.toNat`.
@@ -693,7 +657,6 @@ open EvmWord in
     getLimb_ushiftRight to connect per-limb results to the 256-bit shift. -/
 theorem evm_shr_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
     (hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true)
     (hlt : shift.toNat < 256) :
@@ -744,16 +707,6 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
   have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
   have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -730,8 +730,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
     (s0 s1 s2 s3 : Word)
     (base zero_path : Word)
     (hzero : (base + 20) + signExtend13 320 = zero_path)
-    (hzero2 : (base + 32) + signExtend13 308 = zero_path)
-    (hvalid : ValidMemRange sp 8) :
+    (hzero2 : (base + 32) + signExtend13 308 = zero_path) :
     let code := shr_phase_a_code base
     cpsBranch base code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -742,15 +741,6 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       (base + 36)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
   -- Address arithmetic
   have ha48 : (base + 4 : Word) + 8 = base + 12 := by bv_omega
   have ha128 : (base + 12 : Word) + 8 = base + 20 := by bv_omega

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -274,8 +274,7 @@ private theorem sar_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = 
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → sign_fill_path. -/
 theorem evm_sar_sign_fill_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
-    (hhigh : s1 ||| s2 ||| s3 ≠ 0)
-    (hvalid : ValidMemRange sp 8) :
+    (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     let sign_ext := BitVec.sshiftRight v3 63
     cpsTriple base (base + 380) (sarCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -286,20 +285,6 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
        ((sp + 32) ↦ₘ sign_ext) ** ((sp + 40) ↦ₘ sign_ext) **
        ((sp + 48) ↦ₘ sign_ext) ** ((sp + 56) ↦ₘ sign_ext)) := by
   intro sign_ext
-  -- Memory validity
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
-  have hv56 : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true := by
-    have := hvalid.get (i := 7) (by omega); simp only [signExtend12_56] at this ⊢; simpa using this
   -- Step 1: LD x5 x12 8 at base → extend to sarCode
   have h1 := cpsTriple_extend_code (ld_s1_sub_sarCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -391,8 +376,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
 theorem evm_sar_sign_fill_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
-    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
-    (hvalid : ValidMemRange sp 8) :
+    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     let sign_ext := BitVec.sshiftRight v3 63
     cpsTriple base (base + 380) (sarCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -403,22 +387,6 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
        ((sp + 32) ↦ₘ sign_ext) ** ((sp + 40) ↦ₘ sign_ext) **
        ((sp + 48) ↦ₘ sign_ext) ** ((sp + 56) ↦ₘ sign_ext)) := by
   intro sign_ext
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
-  have hv56 : isValidDwordAccess (sp + signExtend12 (56 : BitVec 12)) = true := by
-    simp only [signExtend12_56]; have := hvalid.get (i := 7) (by omega); simpa using this
   -- Steps 1-3: Same linear chain as sign_fill_high (LD s1 → LD/OR s2 → LD/OR s3)
   have h1 := cpsTriple_extend_code (ld_s1_sub_sarCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -704,14 +672,6 @@ private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
 -- Address normalization for body path
 private theorem sar_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 
--- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
-    ValidMemRange (sp + 32) 4 := by
-  intro i hi; have := hvalid.get (i := i + 4) (by omega)
-  have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-  rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-  exact this
-
 /-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
@@ -852,7 +812,6 @@ open EvmWord in
     bridge lemmas to connect per-limb results to the 256-bit arithmetic shift. -/
 theorem evm_sar_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
     (hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true)
     (hlt : shift.toNat < 256) :
@@ -903,16 +862,6 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
   have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
   have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -146,8 +146,7 @@ private theorem sar_sign_fill_lift (sp base : Word)
     - `fromLimbs (fun _ => sshiftRight (value.getLimb 3) 63)` when shift ≥ 256
     - `sshiftRight value shift.toNat` when shift < 256 -/
 theorem evm_sar_stack_spec (sp base : Word)
-    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word) :
     let result := if shift.toNat ≥ 256
         then EvmWord.fromLimbs (fun _ => BitVec.sshiftRight (value.getLimb 3) 63)
         else BitVec.sshiftRight value shift.toNat
@@ -167,7 +166,7 @@ theorem evm_sar_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact sar_sign_fill_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_sar_sign_fill_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh hvalid)
+        (evm_sar_sign_fill_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -181,7 +180,7 @@ theorem evm_sar_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact sar_sign_fill_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_sar_sign_fill_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge hvalid)
+        (evm_sar_sign_fill_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = sshiftRight value shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge
@@ -200,6 +199,6 @@ theorem evm_sar_stack_spec (sp base : Word)
     rw [show result = BitVec.sshiftRight value shift.toNat from by
       simp [result, show ¬(shift.toNat ≥ 256) from hge]]
     exact evm_sar_body_evmWord_spec sp base shift value r5 r6 r7 r10 r11
-      hvalid hhigh_zero hlt_s0 hlt
+      hhigh_zero hlt_s0 hlt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -134,8 +134,7 @@ private theorem shr_zero_lift (sp base : Word)
     Given shift and value as EvmWords on the stack, produces
     `if shift.toNat ≥ 256 then 0 else value >>> shift.toNat`. -/
 theorem evm_shr_stack_spec (sp base : Word)
-    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word) :
     let result := if shift.toNat ≥ 256 then 0 else value >>> shift.toNat
     cpsTriple base (base + 360) (shrCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -152,7 +151,7 @@ theorem evm_shr_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact shr_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shr_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh hvalid)
+        (evm_shr_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -169,7 +168,7 @@ theorem evm_shr_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact shr_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shr_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge hvalid)
+        (evm_shr_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = value >>> shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge
@@ -191,6 +190,6 @@ theorem evm_shr_stack_spec (sp base : Word)
     -- We factor it into evm_shr_body_evmWord_spec (below) to keep this clean.
     rw [show result = value >>> shift.toNat from by simp [result, show ¬(shift.toNat ≥ 256) from hge]]
     exact evm_shr_body_evmWord_spec sp base shift value r5 r6 r7 r10 r11
-      hvalid hhigh_zero hlt_s0 hlt
+      hhigh_zero hlt_s0 hlt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -225,8 +225,7 @@ private theorem shl_body0_exit (base : Word) : ((base + 240 : Word) + 96) + sign
 /-- Zero path via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is zero. -/
 theorem evm_shl_zero_high_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
-    (hhigh : s1 ||| s2 ||| s3 ≠ 0)
-    (hvalid : ValidMemRange sp 8) :
+    (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     cpsTriple base (base + 360) (shlCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -234,18 +233,6 @@ theorem evm_shl_zero_high_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
   -- Step 1: LD x5 x12 8 at base → extend to shlCode
   have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -347,8 +334,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
 theorem evm_shl_zero_large_spec (sp base : Word)
     (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
-    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false)
-    (hvalid : ValidMemRange sp 8) :
+    (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     cpsTriple base (base + 360) (shlCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -356,20 +342,6 @@ theorem evm_shl_zero_large_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := by
-    intro i hi; have := hvalid.get (i := i + 4) (by omega)
-    have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-    rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-    exact this
   -- Steps 1-3: Same linear chain as zero_high
   have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
@@ -538,14 +510,6 @@ private theorem shl_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 8
 private theorem shl_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
   simp only [signExtend12_32]
 
--- Helper to derive ValidMemRange for the value portion (sp+32..sp+56)
-private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
-    ValidMemRange (sp + 32) 4 := by
-  intro i hi; have := hvalid.get (i := i + 4) (by omega)
-  have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-  rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-  exact this
-
 /-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
     to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert
@@ -666,7 +630,6 @@ open EvmWord in
     bridge lemmas to connect per-limb results to the 256-bit shift. -/
 theorem evm_shl_body_evmWord_spec (sp base : Word)
     (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8)
     (hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0)
     (hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true)
     (hlt : shift.toNat < 256) :
@@ -717,16 +680,6 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
-  have hv32 : ValidMemRange (sp + 32) 4 := validMem_value_portion hvalid
   -- Address normalization for sp+32 region
   have ha40 : sp + 40 = (sp + 32 : Word) + 8 := by bv_omega
   have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -134,8 +134,7 @@ private theorem shl_zero_lift (sp base : Word)
     Given shift and value as EvmWords on the stack, produces
     `if shift.toNat ≥ 256 then 0 else value <<< shift.toNat`. -/
 theorem evm_shl_stack_spec (sp base : Word)
-    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (shift value : EvmWord) (r5 r6 r7 r10 r11 : Word) :
     let result := if shift.toNat ≥ 256 then 0 else value <<< shift.toNat
     cpsTriple base (base + 360) (shlCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -152,7 +151,7 @@ theorem evm_shl_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact shl_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shl_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh hvalid)
+        (evm_shl_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -166,7 +165,7 @@ theorem evm_shl_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact shl_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shl_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge hvalid)
+        (evm_shl_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = value <<< shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge
@@ -184,6 +183,6 @@ theorem evm_shl_stack_spec (sp base : Word)
       · rfl
     rw [show result = value <<< shift.toNat from by simp [result, show ¬(shift.toNat ≥ 256) from hge]]
     exact evm_shl_body_evmWord_spec sp base shift value r5 r6 r7 r10 r11
-      hvalid hhigh_zero hlt_s0 hlt
+      hhigh_zero hlt_s0 hlt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -225,8 +225,7 @@ private theorem se_done_exit (base : Word) : (base + 188 : Word) + 4 = base + 19
     Execution: LD b1 → LD/OR b2 → LD/OR b3 → BNE(taken) → done. -/
 theorem signext_nochange_high_spec (sp base : Word)
     (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
-    (hhigh : b1 ||| b2 ||| b3 ≠ 0)
-    (hvalid : ValidMemRange sp 8) :
+    (hhigh : b1 ||| b2 ||| b3 ≠ 0) :
     cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -234,13 +233,6 @@ theorem signext_nochange_high_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) := by
-  -- Memory validity
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
   -- Step 1: LD x5 x12 8 at base → extend to signextCode
   have h1 := cpsTriple_extend_code (ld_b1_sub_signextCode base)
     (ld_spec_gen .x5 .x12 sp r5 b1 8 base (by nofun))
@@ -332,8 +324,7 @@ theorem signext_nochange_high_spec (sp base : Word)
 theorem signext_nochange_geq31_spec (sp base : Word)
     (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
     (hlow : b1 ||| b2 ||| b3 = 0)
-    (hlarge : BitVec.ult b0 (signExtend12 (31 : BitVec 12)) = false)
-    (hvalid : ValidMemRange sp 8) :
+    (hlarge : BitVec.ult b0 (signExtend12 (31 : BitVec 12)) = false) :
     cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -341,15 +332,6 @@ theorem signext_nochange_geq31_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
   -- Steps 1-3: Same linear chain
   have h1 := cpsTriple_extend_code (ld_b1_sub_signextCode base)
     (ld_spec_gen .x5 .x12 sp r5 b1 8 base (by nofun))
@@ -513,13 +495,6 @@ private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
   refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
-private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8) :
-    ValidMemRange (sp + 32) 4 := by
-  intro i hi; have := hvalid.get (i := i + 4) (by omega)
-  have : isValidDwordAccess (sp + BitVec.ofNat 64 (8 * (i + 4))) = true := this
-  rw [show sp + BitVec.ofNat 64 (8 * (i + 4)) = sp + 32 + BitVec.ofNat 64 (8 * i) from by bv_omega] at this
-  exact this
-
 -- ============================================================================
 -- Section 6: Body path composition (b < 31)
 -- ============================================================================
@@ -528,7 +503,6 @@ private theorem validMem_value_portion {sp : Word} (hvalid : ValidMemRange sp 8)
     Composes Phase A ntaken → B → C → body_L → done. -/
 theorem signext_body_spec (sp base : Word)
     (b x : EvmWord) (r5 r6 r10 : Word)
-    (hvalid : ValidMemRange sp 8)
     (hhigh : b.getLimb 1 ||| b.getLimb 2 ||| b.getLimb 3 = 0)
     (hsmall : BitVec.ult (b.getLimb 0) (signExtend12 (31 : BitVec 12)) = true) :
     cpsTriple base (base + 192) (signextCode base)
@@ -548,15 +522,6 @@ theorem signext_body_spec (sp base : Word)
   set b2 := b.getLimb 2; set b3 := b.getLimb 3
   set v0 := x.getLimb 0; set v1 := x.getLimb 1
   set v2 := x.getLimb 2; set v3 := x.getLimb 3
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
   -- Phase A: base → base+36 (same as no-change geq31 path but BEQ ntaken)
   have h1 := cpsTriple_extend_code (ld_b1_sub_signextCode base)
     (ld_spec_gen .x5 .x12 sp r5 b1 8 base (by nofun))

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -330,8 +330,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     (b0 b1 b2 b3 : Word)
     (base done_path : Word)
     (hdone1 : (base + 20) + signExtend13 168 = done_path)
-    (hdone2 : (base + 32) + signExtend13 156 = done_path)
-    (hvalid : ValidMemRange sp 4) :
+    (hdone2 : (base + 32) + signExtend13 156 = done_path) :
     let code := signext_phase_a_code base
     cpsBranch base code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -342,15 +341,6 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (base + 36)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) := by
-  -- Memory validity
-  have hv0 : isValidDwordAccess sp = true := by
-    have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8 : isValidDwordAccess (sp + 8) = true := by
-    have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by
-    have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by
-    have := hvalid.get (i := 3) (by omega); simpa using this
   -- Address arithmetic
   have ha48 : (base + 4 : Word) + 8 = base + 12 := by bv_omega
   have ha128 : (base + 12 : Word) + 8 = base + 20 := by bv_omega

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -70,8 +70,7 @@ private theorem signext_nochange_lift (sp base : Word)
 /-- **Main SIGNEXTEND theorem**: `evm_signextend` computes
     `EvmWord.signextend b x`. -/
 theorem evm_signextend_stack_spec (sp base : Word)
-    (b x : EvmWord) (r5 r6 r10 : Word)
-    (hvalid : ValidMemRange sp 8) :
+    (b x : EvmWord) (r5 r6 r10 : Word) :
     let result := EvmWord.signextend b x
     cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -84,7 +83,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
     have hresult : result = x := by simp [result, EvmWord.signextend_ge31 b x hge]
     by_cases hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0
     · exact signext_nochange_lift sp base b x r5 r6 r10
-        (signext_nochange_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh hvalid)
+        (signext_nochange_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
         result hresult
     · have hhigh' : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -98,7 +97,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact signext_nochange_lift sp base b x r5 r6 r10
-        (signext_nochange_geq31_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge hvalid)
+        (signext_nochange_geq31_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
         result hresult
   · -- b < 31: body path
     push Not at hge
@@ -113,7 +112,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
       · simp at h; omega
       · rfl
     -- Use the body path theorem from Compose, lifting to evmWordIs
-    have h_raw := signext_body_spec sp base b x r5 r6 r10 hvalid hhigh hsmall
+    have h_raw := signext_body_spec sp base b x r5 r6 r10 hhigh hsmall
     exact cpsTriple_consequence _ _ _ _ _ _ _
       (fun h hp => by
         simp only [evmWordIs] at hp

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -45,8 +45,7 @@ theorem evm_swap_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (a0 a1 a2 a3 : Word)
     (b0 b1 b2 b3 : Word)
-    (v7 v6 : Word)
-    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    (v7 v6 : Word) :
     cpsTriple base (base + 64) (evm_swap_code base n)
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        (sp ↦ₘ a0) ** ((sp+8) ↦ₘ a1) ** ((sp+16) ↦ₘ a2) ** ((sp+24) ↦ₘ a3) **
@@ -78,20 +77,6 @@ theorem evm_swap_spec (sp base : Word)
     rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
   have hm24 : sp + signExtend12 (BitVec.ofNat 12 24) = sp + 24 := by
     rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
-  -- Memory validity for destination locations (indices 0..3)
-  have hv0  : isValidDwordAccess sp       = true := by have := hvalid.get (i := 0) (by omega); simpa using this
-  have hv8  : isValidDwordAccess (sp + 8)  = true := by have := hvalid.get (i := 1) (by omega); simpa using this
-  have hv16 : isValidDwordAccess (sp + 16) = true := by have := hvalid.get (i := 2) (by omega); simpa using this
-  have hv24 : isValidDwordAccess (sp + 24) = true := by have := hvalid.get (i := 3) (by omega); simpa using this
-  -- Memory validity for source locations (indices n*4..n*4+3)
-  have hvs0 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32)) = true := by
-    have := hvalid.get (i := n*4) (by omega); rwa [show 8 * (n * 4) = n * 32 from by omega] at this
-  have hvs8 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+8)) = true := by
-    have := hvalid.get (i := n*4+1) (by omega); rwa [show 8 * (n * 4 + 1) = n * 32 + 8 from by omega] at this
-  have hvs16 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+16)) = true := by
-    have := hvalid.get (i := n*4+2) (by omega); rwa [show 8 * (n * 4 + 2) = n * 32 + 16 from by omega] at this
-  have hvs24 : isValidDwordAccess (sp + BitVec.ofNat 64 (n*32+24)) = true := by
-    have := hvalid.get (i := n*4+3) (by omega); rwa [show 8 * (n * 4 + 3) = n * 32 + 24 from by omega] at this
   -- Limb 0 swap
   have L0 := swap_limb_spec sp
     (BitVec.ofNat 12 0) (BitVec.ofNat 12 (n*32))
@@ -121,8 +106,7 @@ theorem evm_swap_spec (sp base : Word)
 /-- SWAPn spec at evmWordIs level: swaps the top and nth stack elements. -/
 theorem evm_swap_evmword_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
-    (top nth : EvmWord) (v7 v6 : Word)
-    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    (top nth : EvmWord) (v7 v6 : Word) :
     cpsTriple base (base + 64) (evm_swap_code base n)
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
        evmWordIs sp top **
@@ -147,7 +131,7 @@ theorem evm_swap_evmword_spec (sp base : Word)
     (evm_swap_spec sp base n hn1 hn16
       (top.getLimbN 0) (top.getLimbN 1) (top.getLimbN 2) (top.getLimbN 3)
       (nth.getLimbN 0) (nth.getLimbN 1) (nth.getLimbN 2) (nth.getLimbN 3)
-      v7 v6 hvalid)
+      v7 v6)
 
 -- ============================================================================
 -- Stack-level SWAP spec
@@ -157,8 +141,7 @@ theorem evm_swap_evmword_spec (sp base : Word)
 theorem evm_swap_stack_spec (sp base : Word)
     (n : Nat) (hn1 : 1 ≤ n) (hn16 : n ≤ 16)
     (stack : List EvmWord) (hlen : n + 1 ≤ stack.length)
-    (v7 v6 : Word)
-    (hvalid : ValidMemRange sp ((n + 1) * 4)) :
+    (v7 v6 : Word) :
     let top := stack[0]'(by omega)
     let nth := stack[n]'(by omega)
     cpsTriple base (base + 64) (evm_swap_code base n)
@@ -192,7 +175,7 @@ theorem evm_swap_stack_spec (sp base : Word)
     (evmStackIs (sp + 32) ((stack.drop 1).take (n - 1)) **
      evmStackIs (sp + BitVec.ofNat 64 ((n + 1) * 32)) ((stack.drop 1).drop n))
     (by pcFree)
-    (evm_swap_evmword_spec sp base n hn1 hn16 top nth v7 v6 hvalid)
+    (evm_swap_evmword_spec sp base n hn1 hn16 top nth v7 v6)
   have haddr32 : (sp + BitVec.ofNat 64 (1 * 32) : Word) = sp + 32 := by bv_omega
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -1,7 +1,7 @@
 /-
   EvmAsm.Evm64.Xor.Spec
 
-  Full 256-bit EVM XOR spec with ValidMemRange abstractions.
+  Full 256-bit EVM XOR spec.
 -/
 
 import EvmAsm.Evm64.Xor.LimbSpec


### PR DESCRIPTION
## Summary
- Since `↦ₘ` now implies `isValidDwordAccess` (PR #341), the `(hvalid : ValidMemRange sp N)` hypothesis on DUP/SWAP/BYTE/SHR/SHL/SAR/SIGNEXTEND stack-level and per-body specs is redundant.
- Its only downstream use was generating `have hv_* : isValidDwordAccess … = true` facts that no tactic ever consumed; drop the params, delete the dead `have` chains and the per-file `validMem_value_portion` helpers.
- Also drop "with ValidMemRange abstractions" from AND/OR/XOR header comments, which no longer matches what those specs take.

Net: 16 files, +45 / −331 lines. No kernel change.

## Test plan
- [x] `lake build` — 3504 jobs, success.

Advances #338.