### PR TITLE
refactor(divmod): drop private se12_* shadows in NormA/Epilogue/ModNorm

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -37,12 +37,6 @@ private theorem denorm_sub (base : Word) (sub_prog : List Instr) (k : Nat)
   exact divK_denorm_code_sub_divCode base a i
     (CodeReq.ofProg_mono_sub (base + denormOff) _ divK_denorm _ k rfl hslice hk hbound a i h)
 
--- signExtend12 for u[] offsets
-private theorem se12_4032' : signExtend12 (4032 : BitVec 12) = signExtend12 4032 := rfl
-private theorem se12_4040' : signExtend12 (4040 : BitVec 12) = signExtend12 4040 := rfl
-private theorem se12_4048' : signExtend12 (4048 : BitVec 12) = signExtend12 4048 := rfl
-private theorem se12_4056' : signExtend12 (4056 : BitVec 12) = signExtend12 4056 := rfl
-
 /-- Denorm preamble for shift≠0: LD shift from memory + BEQ not taken.
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
 theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -124,11 +124,7 @@ private theorem divK_normB_code_sub_modCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
--- signExtend12 for offsets used by normB merge spec
-private theorem mod_se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
-private theorem mod_se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
-private theorem mod_se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
-private theorem mod_se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
+-- Reuse se12_32/40/48/56 from Compose.Base (no private shadows needed).
 
 /-- NormB first half: merge1 (b[3] with b[2]) + merge2 (b[2] with b[1]).
     base+228 -> base+276 (12 instructions). MOD mirror. -/
@@ -147,7 +143,7 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
   intro b3' b2'
   -- Merge 1: b[3] with b[2] (base+228 -> base+252)
   have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + normBOff)
-  simp only [mod_se12_56, mod_se12_48] at hm1
+  simp only [se12_56, se12_48] at hm1
   rw [show (base + normBOff : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
@@ -161,7 +157,7 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
   -- Merge 2: b[2] with b[1] (base+252 -> base+276)
   have hm2 := divK_normB_merge_spec 48 40 sp b2 b1 b3' (b2 >>> (anti_shift.toNat % 64))
     shift anti_shift (base + 252)
-  simp only [mod_se12_48, mod_se12_40] at hm2
+  simp only [se12_48, se12_40] at hm2
   rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
@@ -196,7 +192,7 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
   -- Merge 3: b[1] with b[0] (base+276 -> base+300)
   have hm3 := divK_normB_merge_spec 40 32 sp b1 b0
     b2' (b1 >>> (anti_shift.toNat % 64)) shift anti_shift (base + 276)
-  simp only [mod_se12_40, mod_se12_32] at hm3
+  simp only [se12_40, se12_32] at hm3
   rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i
@@ -208,7 +204,7 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
     (by pcFree) hm3e
   -- Last: b[0] alone (base+300 -> base+312)
   have hl := divK_normB_last_spec 32 sp b0 b1' shift (base + 300)
-  simp only [mod_se12_32] at hl
+  simp only [se12_32] at hl
   rw [show (base + 300 : Word) + 12 = base + normAOff from by bv_addr] at hl
   have hle := cpsTriple_extend_code (hmono := fun a i h =>
     divK_normB_code_sub_modCode base a i

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -36,16 +36,9 @@ private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
   exact divK_normA_code_sub_divCode base a i
     (CodeReq.ofProg_mono_sub (base + normAOff) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
 
--- signExtend12 for src/dst offsets used by normA specs
-private theorem se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
-private theorem se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
-private theorem se12_8 : signExtend12 (8 : BitVec 12) = (8 : Word) := by decide
-private theorem se12_0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-private theorem se12_4024 : signExtend12 (4024 : BitVec 12) = signExtend12 4024 := rfl
-private theorem se12_4032 : signExtend12 (4032 : BitVec 12) = signExtend12 4032 := rfl
-private theorem se12_4040 : signExtend12 (4040 : BitVec 12) = signExtend12 4040 := rfl
-private theorem se12_4048 : signExtend12 (4048 : BitVec 12) = signExtend12 4048 := rfl
-private theorem se12_4056 : signExtend12 (4056 : BitVec 12) = signExtend12 4056 := rfl
+-- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
+
 private theorem signExtend21_40 : signExtend21 (40 : BitVec 21) = (40 : Word) := by decide
 
 /-- Full NormA: normalize dividend a[0..3] → u[0..4] and jump to loopSetup.

--- a/GRIND.md
+++ b/GRIND.md
@@ -202,7 +202,7 @@ Every phase follows the same seven-step shape. Deviate only with a documented re
   2. `FullPathN1Loop.lean` (15) — **blocked on PR #300 merge**
   3. `FullPathN2Loop.lean` (13) + `FullPathN3Loop.lean` (13) — **blocked on PR #300 merge**
   4. `ModPhaseB.lean` (15) + `Compose/ModPhaseBn21.lean` + `Compose/ModPhaseBn3.lean`
-  5. `Compose/NormA.lean` + `Compose/Norm.lean` + `Compose/Epilogue.lean` — also delete their file-private `se12_*` shadows, which collide-by-name with `AddrNorm.lean`'s globals.
+  5. `Compose/NormA.lean` + `Compose/Norm.lean` + `Compose/Epilogue.lean` — also delete their file-private `se12_*` shadows, which collide-by-name with `AddrNorm.lean`'s globals. (Partial: NormA/Epilogue/ModNorm shadows removed — Norm.lean already uses Base.lean's public `se12_32..56` directly.)
   6. Sweep: grep for any remaining `simp only [show signExtend12 .* by decide]` in `EvmAsm/Evm64/DivMod/` and clean up.
 - **Dependencies:** PR #300 (double-addback) for sub-PRs 2–3. Sub-PRs 1, 4, 5, 6 are unblocked today.
 - **Stop criterion:** `grep -r "simp only \[show signExtend12" EvmAsm/Evm64/DivMod/` returns zero matches.


### PR DESCRIPTION
## Summary

Continues GRIND.md **Phase 2, sub-PR 5** (issue #263): delete the file-private `signExtend12` lemmas that shadow the global `divmod_addr` set in `EvmAsm/Evm64/DivMod/AddrNorm.lean`.

- **NormA.lean**: drop private `se12_0/8/16/24` plus the dead `rfl` shadows `se12_4024..4056` (never referenced). The active callsites now pull `se12_0/8/16/24` in via `open EvmAsm.Evm64.DivMod.AddrNorm`.
- **Epilogue.lean**: drop dead `rfl` shadows `se12_4032'..4056'` (zero call sites — pure noise).
- **ModNorm.lean**: drop private `mod_se12_32/40/48/56`; the four `simp only [mod_se12_*]` rewrites now reference Base.lean's public `se12_32..56` (ModNorm already imports Base).

No proof changes. Updates GRIND.md §8.2 to mark sub-PR 5 partially landed (Norm.lean has no file-private shadows to remove — it already uses Base.lean's public `se12_*`).

Net: +9 / −26 lines.

## Test plan
- [x] `lake build` — 3504 jobs, success, no regressions in downstream DivMod modules.