### PR TITLE
refactor(divmod): drop private mod_divK_se12_* shadows in ModPhaseB files

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -13,6 +13,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4 se12_4095)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for blocks 0 and 1
@@ -94,15 +95,10 @@ theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by b
 theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
 theorem mod_signExtend13_24 : signExtend13 (24 : BitVec 13) = (24 : Word) := by
   decide
-theorem mod_divK_se12_4 : signExtend12 (4 : BitVec 12) = (4 : Word) := by decide
-theorem mod_divK_phaseB_n4_nm1_x8 :
-    signExtend12 (8 : BitVec 12) = (8 : Word) := by decide
-theorem mod_divK_se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
 theorem mod_phB_sp24_32 (sp : Word) :
     sp + ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat +
       signExtend12 (32 : BitVec 12) = sp + 56 := by
-  simp only [show signExtend12 (4095 : BitVec 12) = (18446744073709551615 : Word) from by decide,
-             show signExtend12 (32 : BitVec 12) = (32 : Word) from by decide]
+  simp only [se12_4095, se12_32]
   bv_addr
 
 -- ============================================================================
@@ -149,7 +145,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   seqFrame hinit1f hinit2
   -- ---- Step 3: ADDI x5 x0 4 at base+68 → base+72
   have haddi_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
-  simp only [mod_phB_addi_4, mod_divK_se12_4] at haddi_raw
+  simp only [mod_phB_addi_4, se12_4] at haddi_raw
   have haddi := cpsTriple_extend_code (addi_x5_singleton_sub_modCode base) haddi_raw
   seqFrame hinit1fhinit2 haddi
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
@@ -246,10 +242,7 @@ theorem addi_x5_1_sub_modCode (base : Word) :
 -- MOD Phase B cascade constants and address lemmas
 -- ============================================================================
 
--- signExtend constants for cascade steps
-theorem mod_divK_se12_3 : signExtend12 (3 : BitVec 12) = (3 : Word) := by decide
-theorem mod_divK_se12_2 : signExtend12 (2 : BitVec 12) = (2 : Word) := by decide
-theorem mod_divK_se12_1 : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+-- signExtend13 constants for cascade branches (se12_* come from AddrNorm)
 theorem mod_signExtend13_16 : signExtend13 (16 : BitVec 13) = (16 : Word) := by
   decide
 theorem mod_signExtend13_8 : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -7,6 +7,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4)
 
 -- ============================================================================
 -- MOD Phase B n=2 (b[3]=b[2]=0, b[1]≠0)
@@ -64,7 +65,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
-  simp only [mod_phB_addi_4, mod_divK_se12_4] at haddi0_raw
+  simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTriple_extend_code (addi_x5_singleton_sub_modCode base) haddi0_raw
   have haddi0f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -99,7 +100,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
-  simp only [mod_phB_step1_4, mod_divK_se12_3] at haddi1_raw
+  simp only [mod_phB_step1_4, se12_3] at haddi1_raw
   have haddi1 := cpsTriple_extend_code (addi_x5_3_sub_modCode base) haddi1_raw
   have haddi1f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -134,7 +135,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
-  simp only [mod_phB_step2_4, mod_divK_se12_2] at haddi2_raw
+  simp only [mod_phB_step2_4, se12_2] at haddi2_raw
   have haddi2 := cpsTriple_extend_code (addi_x5_2_sub_modCode base) haddi2_raw
   have haddi2f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
@@ -169,7 +170,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 n_mem (base + 96)
-  simp only [mod_phB_t_20, mod_divK_phaseB_n2_nm1_x8, mod_divK_se12_32,
+  simp only [mod_phB_t_20, mod_divK_phaseB_n2_nm1_x8, se12_32,
     mod_phB_sp8_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw
   have htailf := cpsTriple_frame_left _ _ _ _ _
@@ -244,7 +245,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
-  simp only [mod_phB_addi_4, mod_divK_se12_4] at haddi0_raw
+  simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTriple_extend_code (addi_x5_singleton_sub_modCode base) haddi0_raw
   have haddi0f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -279,7 +280,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
-  simp only [mod_phB_step1_4, mod_divK_se12_3] at haddi1_raw
+  simp only [mod_phB_step1_4, se12_3] at haddi1_raw
   have haddi1 := cpsTriple_extend_code (addi_x5_3_sub_modCode base) haddi1_raw
   have haddi1f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -314,7 +315,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
-  simp only [mod_phB_step2_4, mod_divK_se12_2] at haddi2_raw
+  simp only [mod_phB_step2_4, se12_2] at haddi2_raw
   have haddi2 := cpsTriple_extend_code (addi_x5_2_sub_modCode base) haddi2_raw
   have haddi2f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) ** (.x6 ↦ᵣ b1) **
@@ -349,7 +350,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Fallthrough: ADDI x5=1 (base+92 → base+96)
   have haddi3_raw := addi_x0_spec_gen .x5 (2 : Word) 1 (base + 92) (by nofun)
-  simp only [mod_phB_fall_4, mod_divK_se12_1] at haddi3_raw
+  simp only [mod_phB_fall_4, se12_1] at haddi3_raw
   have haddi3 := cpsTriple_extend_code (addi_x5_1_sub_modCode base) haddi3_raw
   have haddi3f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -364,7 +365,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 n_mem (base + 96)
-  simp only [mod_phB_t_20, mod_divK_phaseB_n1_nm1_x8, mod_divK_se12_32,
+  simp only [mod_phB_t_20, mod_divK_phaseB_n1_nm1_x8, se12_32,
     mod_phB_sp0_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw
   have htailf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -7,6 +7,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_3 se12_4)
 
 -- ============================================================================
 -- MOD Phase B n=3 (b[3]=0, b[2]≠0)
@@ -63,7 +64,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
-  simp only [mod_phB_addi_4, mod_divK_se12_4] at haddi0_raw
+  simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTriple_extend_code (addi_x5_singleton_sub_modCode base) haddi0_raw
   have haddi0f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -98,7 +99,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
-  simp only [mod_phB_step1_4, mod_divK_se12_3] at haddi1_raw
+  simp only [mod_phB_step1_4, se12_3] at haddi1_raw
   have haddi1 := cpsTriple_extend_code (addi_x5_3_sub_modCode base) haddi1_raw
   have haddi1f := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -133,7 +134,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 n_mem (base + 96)
-  simp only [mod_phB_t_20, mod_divK_phaseB_n3_nm1_x8, mod_divK_se12_32,
+  simp only [mod_phB_t_20, mod_divK_phaseB_n3_nm1_x8, se12_32,
     mod_phB_sp16_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw
   have htailf := cpsTriple_frame_left _ _ _ _ _

--- a/GRIND.md
+++ b/GRIND.md
@@ -201,7 +201,7 @@ Every phase follows the same seven-step shape. Deviate only with a documented re
   1. `LoopComposeN1.lean` (12) + `LoopComposeN2.lean` (4)
   2. `FullPathN1Loop.lean` (15) — **blocked on PR #300 merge**
   3. `FullPathN2Loop.lean` (13) + `FullPathN3Loop.lean` (13) — **blocked on PR #300 merge**
-  4. `ModPhaseB.lean` (15) + `Compose/ModPhaseBn21.lean` + `Compose/ModPhaseBn3.lean`
+  4. `ModPhaseB.lean` (15) + `Compose/ModPhaseBn21.lean` + `Compose/ModPhaseBn3.lean` — file-private `mod_divK_se12_*` shadows dropped (use `AddrNorm.se12_1..4` / Base.lean `se12_32`); one-off address lemmas remain.
   5. `Compose/NormA.lean` + `Compose/Norm.lean` + `Compose/Epilogue.lean` — also delete their file-private `se12_*` shadows, which collide-by-name with `AddrNorm.lean`'s globals. (Partial: NormA/Epilogue/ModNorm shadows removed — Norm.lean already uses Base.lean's public `se12_32..56` directly.)
   6. Sweep: grep for any remaining `simp only [show signExtend12 .* by decide]` in `EvmAsm/Evm64/DivMod/` and clean up.
 - **Dependencies:** PR #300 (double-addback) for sub-PRs 2–3. Sub-PRs 1, 4, 5, 6 are unblocked today.


### PR DESCRIPTION
## Summary

Continues GRIND.md **Phase 2, sub-PR 4** (issue #263): delete the file-local `signExtend12` shadows in the ModPhaseB cascade files that duplicate the public `divmod_addr` set in `AddrNorm.lean`.

- **ModPhaseB.lean**: drop `mod_divK_se12_1/2/3/4` and `mod_divK_se12_32`; active callsites now pull `se12_1..4` via `open EvmAsm.Evm64.DivMod.AddrNorm (...)`, and `se12_32` comes from `Compose/Base.lean`'s existing copy. Also drops the unused `mod_divK_phaseB_n4_nm1_x8` (a misnamed `signExtend12 8` shadow with zero call sites). Simplifies `mod_phB_sp24_32` to `simp only [se12_4095, se12_32]` instead of two inline `show … by decide` rewrites.
- **ModPhaseBn21.lean, ModPhaseBn3.lean**: rewrite the `simp only` references from `mod_divK_se12_*` to `se12_*` after selectively opening `AddrNorm`.

`signExtend13` shadows (`mod_signExtend13_*`) are left untouched — they are outside `divmod_addr`'s scope (which currently covers `signExtend12`) and untangling them is a separate follow-up.

Net: +19 / −24 lines.

## Test plan

- [x] `lake build` — 3504 jobs, no regressions