### PR TITLE
refactor(divmod): factor evmWordIs (sp+32) unfold helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -18,12 +18,38 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 -- ============================================================================
--- DIV: Zero divisor stack spec (b = 0 → result = 0)
+-- Shared helpers for stack-level DIV/MOD specs
 -- ============================================================================
 
 /-- Weaken concrete register to existential ownership. -/
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
   fun _ hp => ⟨v, hp⟩
+
+/-- Unfold `evmWordIs (sp+32) v` into four limb-level memory atoms at the
+    absolute stack addresses `sp+32, sp+40, sp+48, sp+56`. Used by both the
+    b=0 and (forthcoming) b≠0 stack specs to bridge between the separation-logic
+    `evmWordIs` predicate and the raw limb atoms that the limb-level specs
+    produce. -/
+theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
+    evmWordIs (sp + 32) v =
+    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
+     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
+  unfold evmWordIs
+  rw [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
+      show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
+      show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr]
+
+/-- Unfold `evmWordIs sp v` into four limb-level memory atoms at
+    `sp, sp+8, sp+16, sp+24`. Trivial rewrite of the definition; provided as a
+    companion to `evmWordIs_sp32_unfold` for readability at call sites. -/
+theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
+    evmWordIs sp v =
+    ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
+     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
+
+-- ============================================================================
+-- DIV: Zero divisor stack spec (b = 0 → result = 0)
+-- ============================================================================
 
 /-- Stack-level DIV spec for the zero divisor path: when b = 0, result is 0.
     Uses evmWordIs for the b-operand at sp+32. The a-operand at sp is untouched. -/
@@ -56,18 +82,12 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
   have hr3 : (EvmWord.div a 0).getLimbN 3 = 0 := EvmWord.div_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      unfold evmWordIs at hp
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
-                 hg0, hg1, hg2, hg3] at hp
+      rw [evmWordIs_sp32_unfold] at hp
+      simp only [hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
-      unfold evmWordIs
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
-                 hr0, hr1, hr2, hr3]
+      rw [evmWordIs_sp32_unfold]
+      simp only [hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
@@ -115,18 +135,12 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
   have hr3 : (EvmWord.mod a 0).getLimbN 3 = 0 := EvmWord.mod_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      unfold evmWordIs at hp
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
-                 hg0, hg1, hg2, hg3] at hp
+      rw [evmWordIs_sp32_unfold] at hp
+      simp only [hg0, hg1, hg2, hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
-      unfold evmWordIs
-      simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
-                 show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
-                 show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr,
-                 hr0, hr1, hr2, hr3]
+      rw [evmWordIs_sp32_unfold]
+      simp only [hr0, hr1, hr2, hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **


### PR DESCRIPTION
## Summary
- Extract the inline `evmWordIs (sp+32) v` address-expansion blocks used by the existing b=0 stack specs (`evm_div_bzero_stack_spec` / `evm_mod_bzero_stack_spec`) into reusable lemmas `evmWordIs_sp32_unfold` and `evmWordIs_sp_unfold` in `EvmAsm/Evm64/DivMod/Spec.lean`.
- No behaviour change: both existing stack specs now use the helpers; the full-path and zero-divisor proofs are unchanged.
- Foundational step toward #61 — the forthcoming b≠0 stack specs (blocked on the semantic correctness bridge in `DivN4Overestimate.lean`) will reuse the same helper to bridge between `evmWordIs` and the raw limb memory atoms produced by limb-level specs.

Refs #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)
- [x] `EvmAsm.Evm64.DivMod.Spec` rebuilds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)