### PR TITLE
refactor(divmod): add evmWordIs_{sp,sp32}_limbs_eq bridge helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -47,6 +47,27 @@ theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
     ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
      ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
 
+/-- Rewrite `evmWordIs (sp+32) v` to four limb atoms given explicit getLimbN
+    equalities. Caller-friendly alternative to `evmWordIs_sp32_unfold` when the
+    target limb values are already known concretely — avoids the
+    match-expression unification issues that arise when `v = fromLimbs …`. -/
+theorem evmWordIs_sp32_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    evmWordIs (sp + 32) v =
+    (((sp + 32) ↦ₘ w0) ** ((sp + 40) ↦ₘ w1) **
+     ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3)) := by
+  rw [evmWordIs_sp32_unfold, h0, h1, h2, h3]
+
+/-- Same as `evmWordIs_sp32_limbs_eq` but for `evmWordIs sp v`. -/
+theorem evmWordIs_sp_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    evmWordIs sp v =
+    ((sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+     ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)) := by
+  rw [evmWordIs_sp_unfold, h0, h1, h2, h3]
+
 -- ============================================================================
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)
 -- ============================================================================
@@ -82,12 +103,10 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
   have hr3 : (EvmWord.div a 0).getLimbN 3 = 0 := EvmWord.div_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      rw [evmWordIs_sp32_unfold] at hp
-      simp only [hg0, hg1, hg2, hg3] at hp
+      rw [evmWordIs_sp32_limbs_eq sp 0 0 0 0 0 hg0 hg1 hg2 hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
-      rw [evmWordIs_sp32_unfold]
-      simp only [hr0, hr1, hr2, hr3]
+      rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
@@ -135,12 +154,10 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
   have hr3 : (EvmWord.mod a 0).getLimbN 3 = 0 := EvmWord.mod_getLimb_zero_right a 3
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
-      rw [evmWordIs_sp32_unfold] at hp
-      simp only [hg0, hg1, hg2, hg3] at hp
+      rw [evmWordIs_sp32_limbs_eq sp 0 0 0 0 0 hg0 hg1 hg2 hg3] at hp
       xperm_hyp hp)
     (fun h hq => by
-      rw [evmWordIs_sp32_unfold]
-      simp only [hr0, hr1, hr2, hr3]
+      rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -18,57 +18,6 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 -- ============================================================================
--- Shared helpers for stack-level DIV/MOD specs
--- ============================================================================
-
-/-- Weaken concrete register to existential ownership. -/
-private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
-
-/-- Unfold `evmWordIs (sp+32) v` into four limb-level memory atoms at the
-    absolute stack addresses `sp+32, sp+40, sp+48, sp+56`. Used by both the
-    b=0 and (forthcoming) b≠0 stack specs to bridge between the separation-logic
-    `evmWordIs` predicate and the raw limb atoms that the limb-level specs
-    produce. -/
-theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
-    evmWordIs (sp + 32) v =
-    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
-     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
-  unfold evmWordIs
-  rw [show (sp + 32 : Word) + 8 = sp + 40 from by bv_addr,
-      show (sp + 32 : Word) + 16 = sp + 48 from by bv_addr,
-      show (sp + 32 : Word) + 24 = sp + 56 from by bv_addr]
-
-/-- Unfold `evmWordIs sp v` into four limb-level memory atoms at
-    `sp, sp+8, sp+16, sp+24`. Trivial rewrite of the definition; provided as a
-    companion to `evmWordIs_sp32_unfold` for readability at call sites. -/
-theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
-    evmWordIs sp v =
-    ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
-     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
-
-/-- Rewrite `evmWordIs (sp+32) v` to four limb atoms given explicit getLimbN
-    equalities. Caller-friendly alternative to `evmWordIs_sp32_unfold` when the
-    target limb values are already known concretely — avoids the
-    match-expression unification issues that arise when `v = fromLimbs …`. -/
-theorem evmWordIs_sp32_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
-    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
-    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
-    evmWordIs (sp + 32) v =
-    (((sp + 32) ↦ₘ w0) ** ((sp + 40) ↦ₘ w1) **
-     ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3)) := by
-  rw [evmWordIs_sp32_unfold, h0, h1, h2, h3]
-
-/-- Same as `evmWordIs_sp32_limbs_eq` but for `evmWordIs sp v`. -/
-theorem evmWordIs_sp_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
-    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
-    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
-    evmWordIs sp v =
-    ((sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
-     ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)) := by
-  rw [evmWordIs_sp_unfold, h0, h1, h2, h3]
-
--- ============================================================================
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)
 -- ============================================================================
 
@@ -107,14 +56,14 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
-      have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
+      have w0 := sepConj_mono_left (regIs_implies_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
            ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
           from by xperm) h).mp hq)
-      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h w0
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x10 _)) h w0
       exact (congrFun (show _ =
         ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
          ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
@@ -158,14 +107,14 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
       xperm_hyp hp)
     (fun h hq => by
       rw [evmWordIs_sp32_limbs_eq sp _ 0 0 0 0 hr0 hr1 hr2 hr3]
-      have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
+      have w0 := sepConj_mono_left (regIs_implies_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
            ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
           from by xperm) h).mp hq)
-      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h w0
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_implies_regOwn .x10 _)) h w0
       exact (congrFun (show _ =
         ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
          ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -51,6 +51,53 @@ theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 
 -- ============================================================================
+-- evmWordIs unfold and limb-equality bridges
+-- ============================================================================
+
+/-- Unfold `evmWordIs sp v` into four limb-level memory atoms at
+    `sp, sp+8, sp+16, sp+24`. Trivial rewrite of the definition; provided as a
+    named lemma for readability at call sites in stack-level specs. -/
+theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
+    evmWordIs sp v =
+    ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
+     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
+
+/-- Unfold `evmWordIs (sp+32) v` into four limb-level memory atoms at the
+    absolute stack addresses `sp+32, sp+40, sp+48, sp+56`. Bridges the
+    separation-logic `evmWordIs` predicate and the raw limb atoms that the
+    limb-level specs produce for the `b`-operand on the EVM stack. -/
+theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
+    evmWordIs (sp + 32) v =
+    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
+     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
+  unfold evmWordIs
+  rw [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
+      show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
+      show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+
+/-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
+    equalities. Decouples the caller's representation of `v` from the limb
+    form — works uniformly whether the equalities come from
+    `getLimbN_fromLimbs_*`, per-op bridge lemmas, or `by decide` facts. -/
+theorem evmWordIs_sp_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    evmWordIs sp v =
+    ((sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+     ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3)) := by
+  rw [evmWordIs_sp_unfold, h0, h1, h2, h3]
+
+/-- Rewrite `evmWordIs (sp+32) v` to four limb atoms given explicit getLimbN
+    equalities. Companion to `evmWordIs_sp_limbs_eq` for the `b`-operand slot. -/
+theorem evmWordIs_sp32_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    evmWordIs (sp + 32) v =
+    (((sp + 32) ↦ₘ w0) ** ((sp + 40) ↦ₘ w1) **
+     ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3)) := by
+  rw [evmWordIs_sp32_unfold, h0, h1, h2, h3]
+
+-- ============================================================================
 -- Shared infrastructure for stack operation specs
 -- ============================================================================
 


### PR DESCRIPTION
## Summary
- Add `evmWordIs_sp32_limbs_eq` / `evmWordIs_sp_limbs_eq`: given an `EvmWord v` and explicit equalities `v.getLimbN k = w_k`, rewrite `evmWordIs (sp[+32]) v` to the four limb memory atoms carrying `w0..w3`.
- This is the caller-friendly form that avoids the match-expression unification issues that arise when `v` has the form `EvmWord.fromLimbs (fun i => match i …)` — the getLimbN hypotheses decouple the caller's representation of `v` from the limb form we rewrite to.
- Refactor the existing b=0 stack specs (`evm_div_bzero_stack_spec`, `evm_mod_bzero_stack_spec`) to use the new helper in place of the inline `rw [evmWordIs_sp32_unfold]; simp only [h_i]` pattern.

Builds on the helpers added in #351 and continues progress toward #61 (b≠0 stack spec).

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)