### PR TITLE
feat(divmod): add divScratchOwn value-agnostic scratch region

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -268,6 +268,32 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
      ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
 
+/-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
+    with ownership only (no commitment to specific values). Suitable for the
+    postcondition of a stack-level DIV/MOD spec that doesn't want to expose
+    the algorithm's internal scratch state to callers. -/
+def divScratchOwn (sp : Word) : Assertion :=
+  memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
+  memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
+  memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
+  memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
+  memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
+  memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
+  memOwn (sp + signExtend12 3992) **
+  memOwn (sp + signExtend12 3984) **
+  memOwn (sp + signExtend12 3976)
+
+/-- Weakening: any concrete scratch state implies ownership of the same 15
+    cells. This lets a stack spec hide the scratch values on exit. -/
+theorem divScratchValues_implies_divScratchOwn
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    ∀ h, divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shift_mem n_mem j_mem h → divScratchOwn sp h := by
+  unfold divScratchValues divScratchOwn
+  -- Weaken each of the 15 memIs cells to memOwn, left to right.
+  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
+  exact memIs_implies_memOwn _ _
+
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/anti_shift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -220,6 +220,54 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
 -- Used by all 8 _to_loopSetup_spec theorems (n=1..4, DIV and MOD).
 -- ============================================================================
 
+-- ============================================================================
+-- Scratch region bundle: 15 memory cells used by the 256-bit DIV/MOD program
+-- ============================================================================
+
+/-- The 15 scratch memory cells that the DIV/MOD program reads and writes
+    during execution. All live at negative offsets from the stack pointer
+    (`sp + signExtend12 …` with 12-bit values ≥ 2048 wrapping to negative).
+
+    Layout:
+    - `q0..q3` at `sp + signExtend12 4088/4080/4072/4064` — accumulated quotient digits
+    - `u0..u4` at `sp + signExtend12 4056/4048/4040/4032/4024` — normalized dividend
+    - `u5..u7` at `sp + signExtend12 4016/4008/4000` — overflow/scratch
+    - `shift_mem` at `sp + signExtend12 3992`, `n_mem` at `sp + signExtend12 3984`
+    - `j_mem` at `sp + signExtend12 3976`
+
+    This is the precondition shape — specific starting values for every cell.
+    The full-path specs universally-quantify over these values since the program
+    overwrites them; the predicate packages them so stack specs aren't littered
+    with fifteen `↦ₘ` lines at every call site. -/
+def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem : Word) : Assertion :=
+  ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+  ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+  ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+  ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+  ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+  ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+  ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+  ((sp + signExtend12 3984) ↦ₘ n_mem) **
+  ((sp + signExtend12 3976) ↦ₘ j_mem)
+
+/-- Unfold `divScratchValues` into its 15 underlying memory atoms. Since
+    `divScratchValues` is not `@[irreducible]` the `delta`/`unfold` tactics
+    reduce it directly, but this named rewrite is convenient at call sites. -/
+theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem : Word) :
+    divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shift_mem n_mem j_mem =
+    (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+     ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+     ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+     ((sp + signExtend12 3984) ↦ₘ n_mem) **
+     ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
+
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/anti_shift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.


### PR DESCRIPTION
## Summary
- Add `divScratchOwn sp : Assertion` — the value-agnostic counterpart to `divScratchValues` (#355). Bundles the same 15 scratch cells but as `memOwn` atoms (ownership only, no commitment to specific values), suitable for the postcondition of a stack-level DIV/MOD spec that shouldn't expose the algorithm's internal scratch state to callers.
- Add `divScratchValues_implies_divScratchOwn`: the weakening lemma that turns a concrete scratch state into `divScratchOwn sp`, via 14 nested `sepConj_mono` applications + a leaf `memIs_implies_memOwn`. The stack spec will thread this through `cpsTriple_consequence`'s postcondition weakener.

Stacks on #355 (still open). Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)