### PR TITLE
feat(divmod): add EvmWord-level n=4 max runtime condition wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -268,6 +268,32 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
      ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
 
+/-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
+    with ownership only (no commitment to specific values). Suitable for the
+    postcondition of a stack-level DIV/MOD spec that doesn't want to expose
+    the algorithm's internal scratch state to callers. -/
+def divScratchOwn (sp : Word) : Assertion :=
+  memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
+  memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
+  memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
+  memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
+  memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
+  memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
+  memOwn (sp + signExtend12 3992) **
+  memOwn (sp + signExtend12 3984) **
+  memOwn (sp + signExtend12 3976)
+
+/-- Weakening: any concrete scratch state implies ownership of the same 15
+    cells. This lets a stack spec hide the scratch values on exit. -/
+theorem divScratchValues_implies_divScratchOwn
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    ∀ h, divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shift_mem n_mem j_mem h → divScratchOwn sp h := by
+  unfold divScratchValues divScratchOwn
+  -- Weaken each of the 15 memIs cells to memOwn, left to right.
+  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
+  exact memIs_implies_memOwn _ _
+
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/anti_shift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -9,6 +9,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4
 import EvmAsm.Evm64.EvmWordArith
 
 open EvmAsm.Rv64.Tactics
@@ -16,6 +17,38 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+-- ============================================================================
+-- EvmWord-level runtime condition predicates for the n=4 max path
+-- ============================================================================
+
+-- The full-path DIV spec `evm_div_n4_full_max_skip_spec` takes runtime
+-- conditions (`isMaxTrialN4`, `isSkipBorrowN4Max`) keyed off eight Word
+-- limbs. For the EvmWord-level stack spec, it's more natural to express
+-- these on `a b : EvmWord` directly — the wrappers below defer to the
+-- Word-level predicates via `a.getLimbN k` / `b.getLimbN k`.
+
+/-- Max trial quotient condition at n=4 in EvmWord form: `u4 ≥ b3'` after
+    normalization, i.e., the algorithm uses the maximum trial quotient
+    (`signExtend12 4095 = 2^64 - 1`). -/
+def isMaxTrialN4Evm (a b : EvmWord) : Prop :=
+  isMaxTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+
+/-- Skip-addback condition at n=4 max in EvmWord form: the runtime borrow
+    check `u4 < mulsubN4_c3` does not fire, so the algorithm skips the
+    addback step and uses `q_hat` as the quotient digit. -/
+def isSkipBorrowN4MaxEvm (a b : EvmWord) : Prop :=
+  isSkipBorrowN4Max (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem isMaxTrialN4Evm_def (a b : EvmWord) :
+    isMaxTrialN4Evm a b =
+    isMaxTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3) := rfl
+
+theorem isSkipBorrowN4MaxEvm_def (a b : EvmWord) :
+    isSkipBorrowN4MaxEvm a b =
+    isSkipBorrowN4Max (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
 -- ============================================================================
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)


### PR DESCRIPTION
## Summary
- Add `isMaxTrialN4Evm` and `isSkipBorrowN4MaxEvm` in `DivMod/Spec.lean` — EvmWord-level wrappers for the Word-level `isMaxTrialN4` / `isSkipBorrowN4Max` runtime conditions from `FullPathN4.lean`. They defer to the underlying predicates via `a.getLimbN k` / `b.getLimbN k`, plus `rfl` unfold lemmas (`_def` suffix).
- Purpose: the forthcoming n=4 max-path stack spec takes `a b : EvmWord` as operands, not eight Word limbs. Having the runtime conditions exposed at the EvmWord level keeps the spec signature readable.
- Also: add a direct `import EvmAsm.Evm64.DivMod.Compose.FullPathN4` to `Spec.lean` since `FullPathN4` is not reachable via the `Compose.lean` index (Compose only imports `FullPathN1..3` and the full-path composers).

Stacks on #355 + #356. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)