### PR TITLE
feat(divmod): add divN4MaxSkipStackPost target predicate

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -268,6 +268,32 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
      ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
 
+/-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
+    with ownership only (no commitment to specific values). Suitable for the
+    postcondition of a stack-level DIV/MOD spec that doesn't want to expose
+    the algorithm's internal scratch state to callers. -/
+def divScratchOwn (sp : Word) : Assertion :=
+  memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
+  memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
+  memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
+  memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
+  memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
+  memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
+  memOwn (sp + signExtend12 3992) **
+  memOwn (sp + signExtend12 3984) **
+  memOwn (sp + signExtend12 3976)
+
+/-- Weakening: any concrete scratch state implies ownership of the same 15
+    cells. This lets a stack spec hide the scratch values on exit. -/
+theorem divScratchValues_implies_divScratchOwn
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    ∀ h, divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shift_mem n_mem j_mem h → divScratchOwn sp h := by
+  unfold divScratchValues divScratchOwn
+  -- Weaken each of the 15 memIs cells to memOwn, left to right.
+  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
+  exact memIs_implies_memOwn _ _
+
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/anti_shift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -79,10 +79,6 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)
 -- ============================================================================
 
--- ============================================================================
--- DIV: Zero divisor stack spec (b = 0 → result = 0)
--- ============================================================================
-
 /-- Stack-level DIV spec for the zero divisor path: when b = 0, result is 0.
     Uses evmWordIs for the b-operand at sp+32. The a-operand at sp is untouched. -/
 theorem evm_div_bzero_stack_spec (sp base : Word)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -9,6 +9,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4
 import EvmAsm.Evm64.EvmWordArith
 
 open EvmAsm.Rv64.Tactics
@@ -16,6 +17,38 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+-- ============================================================================
+-- EvmWord-level runtime condition predicates for the n=4 max path
+-- ============================================================================
+
+-- The full-path DIV spec `evm_div_n4_full_max_skip_spec` takes runtime
+-- conditions (`isMaxTrialN4`, `isSkipBorrowN4Max`) keyed off eight Word
+-- limbs. For the EvmWord-level stack spec, it's more natural to express
+-- these on `a b : EvmWord` directly — the wrappers below defer to the
+-- Word-level predicates via `a.getLimbN k` / `b.getLimbN k`.
+
+/-- Max trial quotient condition at n=4 in EvmWord form: `u4 ≥ b3'` after
+    normalization, i.e., the algorithm uses the maximum trial quotient
+    (`signExtend12 4095 = 2^64 - 1`). -/
+def isMaxTrialN4Evm (a b : EvmWord) : Prop :=
+  isMaxTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+
+/-- Skip-addback condition at n=4 max in EvmWord form: the runtime borrow
+    check `u4 < mulsubN4_c3` does not fire, so the algorithm skips the
+    addback step and uses `q_hat` as the quotient digit. -/
+def isSkipBorrowN4MaxEvm (a b : EvmWord) : Prop :=
+  isSkipBorrowN4Max (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem isMaxTrialN4Evm_def (a b : EvmWord) :
+    isMaxTrialN4Evm a b =
+    isMaxTrialN4 (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3) := rfl
+
+theorem isSkipBorrowN4MaxEvm_def (a b : EvmWord) :
+    isSkipBorrowN4MaxEvm a b =
+    isSkipBorrowN4Max (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
 -- ============================================================================
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -51,6 +51,35 @@ theorem isSkipBorrowN4MaxEvm_def (a b : EvmWord) :
                       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
 -- ============================================================================
+-- Stack-level post state for n=4 max-skip DIV
+-- ============================================================================
+
+/-- Stack-level postcondition shape for the n=4 DIV max+skip path.
+
+    * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.
+    * `regOwn` for every scratch register the program touches (`x1, x2, x5, x6,
+      x7, x10, x11`). Caller has ownership but no knowledge of the final values.
+    * `.x0 ↦ᵣ 0` — the zero register is preserved.
+    * `evmWordIs sp a` — first operand preserved at its original location.
+    * `evmWordIs (sp+32) (EvmWord.div a b)` — DIV result written over the second
+      operand slot.
+    * `divScratchOwn sp` — ownership of all 15 scratch cells, values unspecified.
+
+    Paired with the forthcoming `evm_div_n4_max_skip_stack_spec` and derived
+    from the concrete `fullDivN4MaxSkipPost` via the `n4_max_skip_div_mod_getLimbN`
+    semantic bridge + `divScratchValues_implies_divScratchOwn` weakener. -/
+def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+  divScratchOwn sp
+
+-- ============================================================================
+-- DIV: Zero divisor stack spec (b = 0 → result = 0)
+-- ============================================================================
+
+-- ============================================================================
 -- DIV: Zero divisor stack spec (b = 0 → result = 0)
 -- ============================================================================
 


### PR DESCRIPTION
## Summary
- Add `divN4MaxSkipStackPost sp a b : Assertion` — the shape of the postcondition that the forthcoming `evm_div_n4_max_skip_stack_spec` will establish.
- Contents:
  - `.x12 ↦ᵣ (sp+32)`, `.x0 ↦ᵣ 0`
  - `regOwn` for every scratch register (`x1, x2, x5, x6, x7, x10, x11`)
  - `evmWordIs sp a` (first operand preserved)
  - `evmWordIs (sp+32) (EvmWord.div a b)` (DIV result written over the second operand slot)
  - `divScratchOwn sp` (15 scratch cells, values hidden)
- Pure definition in this PR. The weakening from the concrete `fullDivN4MaxSkipPost` will follow once the post-implication lemma and the stack spec itself are composed. This locks in the target shape so future work can reference it.

Stacks on #355 → #356 → #357. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)