### PR TITLE
feat(divmod): add n4MaxSkipSemanticHolds semantic precondition predicate

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -75,9 +75,53 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
   divScratchOwn sp
 
--- ============================================================================
--- DIV: Zero divisor stack spec (b = 0 → result = 0)
--- ============================================================================
+/-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
+    guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
+    sub-path), but with the operands bundled as `evmWordIs sp a` /
+    `evmWordIs (sp+32) b` and the 15 scratch cells bundled as `divScratchValues`.
+    The postcondition is still the concrete `fullDivN4MaxSkipPost` — turning
+    that into `divN4MaxSkipStackPost` requires the semantic-correctness bridge
+    (`hc3_zero`) which is threaded separately in the final stack spec. -/
+theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
+     n_mem shift_mem j_mem : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hbltu : isMaxTrialN4Evm a b)
+    (hborrow : isSkipBorrowN4MaxEvm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValues sp q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old
+         u5 u6 u7 shift_mem n_mem j_mem)
+      (fullDivN4MaxSkipPost sp
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+  have hraw := evm_div_n4_full_max_skip_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
+    n_mem shift_mem j_mem
+    hbnz' hb3nz hshift_nz hbltu hborrow
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValues_unfold] at hp
+      -- Normalize `sp + 0 ↦ₘ _` in the target side to `sp ↦ₘ _` so xperm finds it.
+      rw [show (sp + 0 : Word) = sp from by bv_omega]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
 
 /-- Stack-level DIV spec for the zero divisor path: when b = 0, result is 0.
     Uses evmWordIs for the b-operand at sp+32. The a-operand at sp is untouched. -/

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -54,6 +54,28 @@ theorem isSkipBorrowN4MaxEvm_def (a b : EvmWord) :
 -- Stack-level post state for n=4 max-skip DIV
 -- ============================================================================
 
+/-- Semantic-correctness precondition for the n=4 max+skip sub-path: the
+    mulsub carry on **un-normalized** `a`, `b` limbs with the maximum trial
+    quotient (`signExtend12 4095 = 2^64 - 1`) is zero.
+
+    This is what `n4_max_skip_div_mod_getLimbN` consumes to conclude
+    `(EvmWord.div a b).getLimbN k` values. It is distinct from the runtime
+    borrow check `isSkipBorrowN4MaxEvm` (which inspects the **normalized**
+    mulsub carry), so the forthcoming stack spec takes both as separate
+    hypotheses. Packaging the long equality behind a named predicate keeps
+    the stack-spec signature readable. -/
+def n4MaxSkipSemanticHolds (a b : EvmWord) : Prop :=
+  (mulsubN4 (signExtend12 4095)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0
+
+theorem n4MaxSkipSemanticHolds_def (a b : EvmWord) :
+    n4MaxSkipSemanticHolds a b =
+    ((mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0) :=
+  rfl
+
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.
 
     * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.


### PR DESCRIPTION
## Summary
- Add `n4MaxSkipSemanticHolds a b : Prop` — the semantic-correctness precondition for the n=4 max+skip sub-path: the mulsub carry on **un-normalized** `a`, `b` limbs with the maximum trial quotient (`signExtend12 4095`) is zero.
- This is what `n4_max_skip_div_mod_getLimbN` consumes to conclude per-limb `EvmWord.div` equalities.
- Distinct from the runtime borrow check `isSkipBorrowN4MaxEvm` (which inspects the **normalized** mulsub carry), so the forthcoming stack spec takes both as separate hypotheses. Packaging the long equality behind a named predicate keeps the stack-spec signature readable — without this wrapper the hypothesis fills eight lines of `mulsubN4` / `getLimbN`.
- Plus a trivial `_def` `rfl` lemma for unfolding at call sites.

Stacks on #355 → #356 → #357 → #358 → #359. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)