### PR TITLE
feat(divmod): add n4MaxAddbackSemanticHolds predicate

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -76,6 +76,29 @@ theorem n4MaxSkipSemanticHolds_def (a b : EvmWord) :
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0) :=
   rfl
 
+/-- Semantic-correctness precondition for the n=4 max+addback sub-path: on
+    **un-normalized** `a`, `b` limbs with the maximum trial quotient, the
+    mulsub carry is `1` *and* the addback carry is `1`. Together these two
+    facts feed `n4_max_addback_div_mod_getLimbN` to conclude the per-limb
+    `EvmWord.div` / `EvmWord.mod` equalities. -/
+def n4MaxAddbackSemanticHolds (a b : EvmWord) : Prop :=
+  let ms := mulsubN4 (signExtend12 4095)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+  ms.2.2.2.2 = 1 ∧
+  addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1
+
+theorem n4MaxAddbackSemanticHolds_def (a b : EvmWord) :
+    n4MaxAddbackSemanticHolds a b =
+    (let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+     ms.2.2.2.2 = 1 ∧
+     addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1) :=
+  rfl
+
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.
 
     * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -54,6 +54,28 @@ theorem isSkipBorrowN4MaxEvm_def (a b : EvmWord) :
 -- Stack-level post state for n=4 max-skip DIV
 -- ============================================================================
 
+/-- Semantic-correctness precondition for the n=4 max+skip sub-path: the
+    mulsub carry on **un-normalized** `a`, `b` limbs with the maximum trial
+    quotient (`signExtend12 4095 = 2^64 - 1`) is zero.
+
+    This is what `n4_max_skip_div_mod_getLimbN` consumes to conclude
+    `(EvmWord.div a b).getLimbN k` values. It is distinct from the runtime
+    borrow check `isSkipBorrowN4MaxEvm` (which inspects the **normalized**
+    mulsub carry), so the forthcoming stack spec takes both as separate
+    hypotheses. Packaging the long equality behind a named predicate keeps
+    the stack-spec signature readable. -/
+def n4MaxSkipSemanticHolds (a b : EvmWord) : Prop :=
+  (mulsubN4 (signExtend12 4095)
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0
+
+theorem n4MaxSkipSemanticHolds_def (a b : EvmWord) :
+    n4MaxSkipSemanticHolds a b =
+    ((mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0) :=
+  rfl
+
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.
 
     * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.


### PR DESCRIPTION
## Summary
Add the n=4 max+addback counterpart of `n4MaxSkipSemanticHolds` (#360): bundles the two hypotheses that `n4_max_addback_div_mod_getLimbN` consumes —
- mulsub carry `c3 = 1` on un-normalized limbs
- addback carry on the post-mulsub state = `1`

into a single readable `Prop`.

With both `n4MaxSkipSemanticHolds` and `n4MaxAddbackSemanticHolds` in place, the two per-sub-path stack specs (skip and addback variants of the n=4 max-trial DIV/MOD) can be stated with compact, parallel signatures.

Plus a `_def` `rfl` lemma.

Stacks on #355 → … → #360. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)