### PR TITLE
feat(divmod): add pcFree instances for divScratchOwn and divN4MaxSkipStackPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -76,6 +76,29 @@ theorem n4MaxSkipSemanticHolds_def (a b : EvmWord) :
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0) :=
   rfl
 
+/-- Semantic-correctness precondition for the n=4 max+addback sub-path: on
+    **un-normalized** `a`, `b` limbs with the maximum trial quotient, the
+    mulsub carry is `1` *and* the addback carry is `1`. Together these two
+    facts feed `n4_max_addback_div_mod_getLimbN` to conclude the per-limb
+    `EvmWord.div` / `EvmWord.mod` equalities. -/
+def n4MaxAddbackSemanticHolds (a b : EvmWord) : Prop :=
+  let ms := mulsubN4 (signExtend12 4095)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+  ms.2.2.2.2 = 1 ∧
+  addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1
+
+theorem n4MaxAddbackSemanticHolds_def (a b : EvmWord) :
+    n4MaxAddbackSemanticHolds a b =
+    (let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+     ms.2.2.2.2 = 1 ∧
+     addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1) :=
+  rfl
+
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.
 
     * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -120,6 +120,20 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
   divScratchOwn sp
 
+theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+  unfold divScratchOwn; pcFree
+
+instance (sp : Word) : Assertion.PCFree (divScratchOwn sp) :=
+  ⟨pcFree_divScratchOwn sp⟩
+
+theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+    (divN4MaxSkipStackPost sp a b).pcFree := by
+  unfold divN4MaxSkipStackPost; pcFree
+
+instance (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
+  ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /


### PR DESCRIPTION
## Summary
Add `pcFree_divScratchOwn` and `pcFree_divN4MaxSkipStackPost` lemmas plus the corresponding `Assertion.PCFree` instances. Required for composing these predicates into `cpsTriple` framing (`cpsTriple_frame_{left,right}`, `seqFrame`, `runBlock`) — all of those rely on the `PCFree` typeclass search to discharge the pc-free obligation on the framed atoms.

Without these, downstream work that frames the scratch region or the full stack post around an inner spec would trip over unresolved `PCFree` goals. Both predicates reduce to chains of primitive pcFree atoms (`memOwn`, `regOwn`, `regIs`, `memIs`, `evmWordIs`), so the `pcFree` tactic discharges them directly.

Stacks on #355 → … → #361. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)