### PR TITLE
feat(divmod): add modN4MaxSkipStackPost + pcFree instance

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -134,6 +134,25 @@ instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
   ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
 
+/-- MOD counterpart of `divN4MaxSkipStackPost`: same structure, same register
+    and scratch handling, but the second operand slot holds `EvmWord.mod a b`
+    instead of `EvmWord.div a b`. Target shape for the forthcoming MOD stack
+    spec on the n=4 max+skip sub-path. -/
+def modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+  divScratchOwn sp
+
+theorem pcFree_modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+    (modN4MaxSkipStackPost sp a b).pcFree := by
+  unfold modN4MaxSkipStackPost; pcFree
+
+instance (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (modN4MaxSkipStackPost sp a b) :=
+  ⟨pcFree_modN4MaxSkipStackPost sp a b⟩
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -76,6 +76,29 @@ theorem n4MaxSkipSemanticHolds_def (a b : EvmWord) :
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0) :=
   rfl
 
+/-- Semantic-correctness precondition for the n=4 max+addback sub-path: on
+    **un-normalized** `a`, `b` limbs with the maximum trial quotient, the
+    mulsub carry is `1` *and* the addback carry is `1`. Together these two
+    facts feed `n4_max_addback_div_mod_getLimbN` to conclude the per-limb
+    `EvmWord.div` / `EvmWord.mod` equalities. -/
+def n4MaxAddbackSemanticHolds (a b : EvmWord) : Prop :=
+  let ms := mulsubN4 (signExtend12 4095)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+  ms.2.2.2.2 = 1 ∧
+  addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1
+
+theorem n4MaxAddbackSemanticHolds_def (a b : EvmWord) :
+    n4MaxAddbackSemanticHolds a b =
+    (let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+     ms.2.2.2.2 = 1 ∧
+     addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1) :=
+  rfl
+
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.
 
     * `.x12 ↦ᵣ (sp+32)` — EVM stack pointer advanced past the popped second operand.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -120,6 +120,20 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
   divScratchOwn sp
 
+theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+  unfold divScratchOwn; pcFree
+
+instance (sp : Word) : Assertion.PCFree (divScratchOwn sp) :=
+  ⟨pcFree_divScratchOwn sp⟩
+
+theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+    (divN4MaxSkipStackPost sp a b).pcFree := by
+  unfold divN4MaxSkipStackPost; pcFree
+
+instance (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
+  ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /


### PR DESCRIPTION
## Summary
Add the MOD counterpart of `divN4MaxSkipStackPost` (#358 → #362): same register/scratch handling, but the second operand slot holds `EvmWord.mod a b` instead of `EvmWord.div a b`. Plus `pcFree_modN4MaxSkipStackPost` + the `Assertion.PCFree` instance.

Parallel scaffolding for the eventual MOD stack spec on the n=4 max+skip sub-path. The underlying `n4_max_skip_div_mod_getLimbN` (#354) already produces per-limb equalities for both `EvmWord.div a b` and `EvmWord.mod a b`, so once the DIV stack spec lands, the only extra missing piece on the MOD side is the analogous `evm_mod_n4_full_max_skip_spec` + stack wrapper — MOD full-path composers don't yet exist in the codebase.

Stacks on #355 → … → #362. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)