### PR TITLE
feat(divmod): add pcFree instance for divScratchValues

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -283,6 +283,18 @@ def divScratchOwn (sp : Word) : Assertion :=
   memOwn (sp + signExtend12 3984) **
   memOwn (sp + signExtend12 3976)
 
+theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem : Word) :
+    (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shift_mem n_mem j_mem).pcFree := by
+  unfold divScratchValues; pcFree
+
+instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    Assertion.PCFree (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shift_mem n_mem j_mem) :=
+  ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem⟩
+
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
 theorem divScratchValues_implies_divScratchOwn

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -134,6 +134,25 @@ instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
   ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
 
+/-- MOD counterpart of `divN4MaxSkipStackPost`: same structure, same register
+    and scratch handling, but the second operand slot holds `EvmWord.mod a b`
+    instead of `EvmWord.div a b`. Target shape for the forthcoming MOD stack
+    spec on the n=4 max+skip sub-path. -/
+def modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
+  (.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+  regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+  regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+  evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+  divScratchOwn sp
+
+theorem pcFree_modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+    (modN4MaxSkipStackPost sp a b).pcFree := by
+  unfold modN4MaxSkipStackPost; pcFree
+
+instance (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (modN4MaxSkipStackPost sp a b) :=
+  ⟨pcFree_modN4MaxSkipStackPost sp a b⟩
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -120,6 +120,20 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
   evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
   divScratchOwn sp
 
+theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+  unfold divScratchOwn; pcFree
+
+instance (sp : Word) : Assertion.PCFree (divScratchOwn sp) :=
+  ⟨pcFree_divScratchOwn sp⟩
+
+theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+    (divN4MaxSkipStackPost sp a b).pcFree := by
+  unfold divN4MaxSkipStackPost; pcFree
+
+instance (sp : Word) (a b : EvmWord) :
+    Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
+  ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /


### PR DESCRIPTION
## Summary
Add `pcFree_divScratchValues` + `Assertion.PCFree` instance for `divScratchValues`. Parallel to the `divScratchOwn` pcFree landed in #362, needed for when a stack spec frames the scratch region on the precondition side.

Stacks on #355 → … → #363. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3504 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)