### PR TITLE
feat(divmod): add mod_n4_max_skip_stack_weaken (MOD parallel)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -220,6 +220,36 @@ instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (modN4MaxSkipStackPost sp a b) :=
   ⟨pcFree_modN4MaxSkipStackPost sp a b⟩
 
+/-- MOD counterpart of `div_n4_max_skip_stack_weaken`. Same pattern, same
+    register/memory weakenings — only the result-slot `evmWordIs` holds
+    `EvmWord.mod a b` instead of `EvmWord.div a b`. -/
+theorem mod_n4_max_skip_stack_weaken
+    (sp : Word) (a b : EvmWord)
+    (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
+    (q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+     shift_p n_p j_p : Word) :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
+       (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+       divScratchValues sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p
+         u5_p u6_p u7_p shift_p n_p j_p) h →
+      modN4MaxSkipStackPost sp a b h := by
+  intro h hp
+  rw [divScratchValues_unfold] at hp
+  delta modN4MaxSkipStackPost
+  unfold divScratchOwn
+  refine sepConj_mono_right ?_ h hp
+  iterate 7 apply sepConj_mono (regIs_implies_regOwn _ _)
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
+  exact memIs_implies_memOwn _ _
+
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip
     sub-path), but with the operands bundled as `evmWordIs sp a` /


### PR DESCRIPTION
## Summary
MOD counterpart of `div_n4_max_skip_stack_weaken` (#368). Same pattern, same register/memory weakenings — only the result-slot `evmWordIs` holds `EvmWord.mod a b` instead of `EvmWord.div a b`.

Will slot in alongside the DIV weakener once the MOD full-path spec variants (`evm_mod_n4_full_*`) are built out in the codebase.

Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3509 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)