### PR TITLE
refactor(DivMod): dedupe `phB_off_*` address rewrites across DIV/MOD

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -492,6 +492,26 @@ theorem se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
 theorem se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
 theorem se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
 
+-- ============================================================================
+-- Shared `phB_off_*` address rewrites.
+-- `base + phaseBOff` is the entry PC of `divK_phaseB` (and the structurally
+-- identical block in `modCode`). `phB_off_k` rewrites `(base + phaseBOff) + k`
+-- to `base + (phaseBOff + k)` with the constant folded on the RHS, so that
+-- `simp only [phB_off_k]` closes the address-matching goal that appears when
+-- a `divK_phaseB_*` sub-spec is embedded in `divCode base` / `modCode base`.
+-- Consumers: PhaseAB.lean (DIV side), ModPhaseB.lean, ModPhaseBn3.lean,
+-- ModPhaseBn21.lean (MOD side). Previously duplicated as `private phB_off_*`
+-- in PhaseAB.lean and `mod_phB_off_28` in ModPhaseB.lean.
+-- ============================================================================
+
+theorem phB_off_4  (base : Word) : (base + phaseBOff : Word) + 4  = base + 36 := by bv_addr
+theorem phB_off_8  (base : Word) : (base + phaseBOff : Word) + 8  = base + 40 := by bv_addr
+theorem phB_off_12 (base : Word) : (base + phaseBOff : Word) + 12 = base + 44 := by bv_addr
+theorem phB_off_16 (base : Word) : (base + phaseBOff : Word) + 16 = base + 48 := by bv_addr
+theorem phB_off_20 (base : Word) : (base + phaseBOff : Word) + 20 = base + 52 := by bv_addr
+theorem phB_off_24 (base : Word) : (base + phaseBOff : Word) + 24 = base + 56 := by bv_addr
+theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
+
 /-- When b ≠ 0, 0 < b in unsigned ordering (BitVec.ult). -/
 theorem ult_zero_of_ne {b : Word} (h : b ≠ 0) : BitVec.ult 0 b := by
   unfold BitVec.ult; simp

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -88,7 +88,9 @@ theorem divK_phaseB_tail_code_sub_modCode (base : Word) :
   exact sub_modCode_of_phaseB_left base _ a i h1
 
 -- Address normalization helpers
-theorem mod_phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
+-- The former `mod_phB_off_28` (identical to PhaseAB's private `phB_off_28`)
+-- now lives in `Compose/Base.lean` as the shared `phB_off_28` and is used
+-- directly from both the DIV and MOD sides.
 theorem mod_phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_addr
 theorem mod_phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
@@ -131,7 +133,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
        ((sp + signExtend12 3984) ↦ₘ (4 : Word))) := by
   -- ---- Step 1: init1 (base+32 → base+60) — zero q[0..3] and u[5..7]
   have hinit1_raw := divK_phaseB_init1_spec sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
-  simp only [mod_phB_off_28] at hinit1_raw
+  simp only [phB_off_28] at hinit1_raw
   have hinit1 := cpsTriple_extend_code (divK_phaseB_init1_code_sub_modCode base) hinit1_raw
   have hinit1f := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -41,7 +41,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
        ((sp + signExtend12 3984) ↦ₘ (2 : Word))) := by
   -- ---- init1 (base+32 → base+60)
   have hinit1_raw := divK_phaseB_init1_spec sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
-  simp only [mod_phB_off_28] at hinit1_raw
+  simp only [phB_off_28] at hinit1_raw
   have hinit1 := cpsTriple_extend_code (divK_phaseB_init1_code_sub_modCode base) hinit1_raw
   have hinit1f := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -221,7 +221,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
        ((sp + signExtend12 3984) ↦ₘ (1 : Word))) := by
   -- ---- init1 (base+32 → base+60)
   have hinit1_raw := divK_phaseB_init1_spec sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
-  simp only [mod_phB_off_28] at hinit1_raw
+  simp only [phB_off_28] at hinit1_raw
   have hinit1 := cpsTriple_extend_code (divK_phaseB_init1_code_sub_modCode base) hinit1_raw
   have hinit1f := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -40,7 +40,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
        ((sp + signExtend12 3984) ↦ₘ (3 : Word))) := by
   -- ---- init1 (base+32 → base+60)
   have hinit1_raw := divK_phaseB_init1_spec sp (base + phaseBOff) q0 q1 q2 q3 u5 u6 u7
-  simp only [mod_phB_off_28] at hinit1_raw
+  simp only [phB_off_28] at hinit1_raw
   have hinit1 := cpsTriple_extend_code (divK_phaseB_init1_code_sub_modCode base) hinit1_raw
   have hinit1f := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -139,14 +139,8 @@ private theorem divK_phaseB_n4_nm1_x8 :
 -- signExtend12 32 = 32 (for tail load address: sp + 24 + signExtend12 32 = sp + 56)
 private theorem divK_se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
 
--- Address normalization lemmas for phaseB composition (separate theorems for heartbeat budget)
-private theorem phB_off_4 (base : Word) : (base + phaseBOff : Word) + 4 = base + 36 := by bv_addr
-private theorem phB_off_8 (base : Word) : (base + phaseBOff : Word) + 8 = base + 40 := by bv_addr
-private theorem phB_off_12 (base : Word) : (base + phaseBOff : Word) + 12 = base + 44 := by bv_addr
-private theorem phB_off_16 (base : Word) : (base + phaseBOff : Word) + 16 = base + 48 := by bv_addr
-private theorem phB_off_20 (base : Word) : (base + phaseBOff : Word) + 20 = base + 52 := by bv_addr
-private theorem phB_off_24 (base : Word) : (base + phaseBOff : Word) + 24 = base + 56 := by bv_addr
-private theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
+-- Address normalization lemmas `phB_off_{4..28}` now live in `Compose/Base.lean`
+-- and are shared with the MOD-side files (ModPhaseB / ModPhaseBn3 / ModPhaseBn21).
 private theorem phB_i2_4 (base : Word) : (base + 60 : Word) + 4 = base + 64 := by bv_addr
 private theorem phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_addr
 private theorem phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr


### PR DESCRIPTION
## Summary

Previously \`Compose/PhaseAB.lean\` (DIV side) held seven \`private theorem phB_off_{4,8,12,16,20,24,28}\` address rewrites of shape \`(base + phaseBOff) + k = base + (phaseBOff + k)\`, while \`Compose/ModPhaseB.lean\` (MOD side) re-declared \`mod_phB_off_28\` as a verbatim duplicate — because \`private\` scope kept PhaseAB's version unreachable from the MOD files. \`mod_phB_off_28\` was then consumed by three MOD files (\`ModPhaseB\`, \`ModPhaseBn3\`, \`ModPhaseBn21\`).

This PR moves the seven lemmas into \`Compose/Base.lean\` (already imported by every DIV/MOD phase-B file), drops the \`private\` qualifier, and retires the MOD-side duplicate.

| File | Change |
|---|---|
| \`Compose/Base.lean\` | **Added** \`phB_off_{4,8,12,16,20,24,28}\` (after the existing \`se12_{32,40,48,56}\` block). |
| \`Compose/PhaseAB.lean\` | **Removed** 7× \`private theorem phB_off_*\` (replaced by a one-line pointer comment). |
| \`Compose/ModPhaseB.lean\` | **Removed** \`theorem mod_phB_off_28\`; renamed its one local call-site. |
| \`Compose/ModPhaseBn3.lean\` | **Renamed** 1× \`mod_phB_off_28\` → \`phB_off_28\`. |
| \`Compose/ModPhaseBn21.lean\` | **Renamed** 2× \`mod_phB_off_28\` → \`phB_off_28\`. |

No proof text changes; the lemmas still close by \`bv_addr\`. \`phB_off_28\`'s type is identical in both old locations (both keyed on \`phaseBOff\`, both produce \`base + 60\`), so the deduplicated lemma is interchangeable with every prior call.

## Why this is a net win

- One fewer verbatim-duplicated lemma to keep in sync when \`phaseBOff\` (or the block layout) changes.
- The DIV side's \`private phB_off_*\` block shrinks by 7 lines; the MOD side's \`mod_phB_off_28\` line goes away; the shared location grows by 7 lines → net **-5 lines**, but more importantly, **single source of truth**.
- Matches the broader #301 direction of localising block-layout knowledge to \`Compose/Base.lean\` + \`Compose/Offsets.lean\`.

Refs #301 (named offset constants) and #266 (MOD/DIV duplication) in spirit — small follow-on cleanup rather than either issue's headline work.

## Test plan

- [x] \`lake build\` — full repo green (3509 jobs). No proof edits beyond call-site renames, so if the rename is correct (it is, because \`mod_phB_off_28\` and \`phB_off_28\` had identical types), the build is guaranteed to pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)