### PR TITLE
docs: document the new-file-import rule in AGENTS.md Common Pitfalls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,12 @@ When adding or modifying proofs:
 3. **List operations**: Be careful with `execProgram` and list append - may need explicit `execProgram_append`
 4. **Register inequality**: Use `decide` tactic for concrete register inequality proofs
 5. **Program type**: `Program = List Instr` is a `def`, not `abbrev` — use `simp only [..., Program]` to unfold before `List.length_append` etc.
+6. **New `.lean` files must be imported by the umbrella module**: `lake build` will compile every file it can reach from `EvmAsm.lean` via the transitive `import` graph, which goes `EvmAsm.lean → Rv64.lean / Evm64.lean / EL.lean → individual modules`. Leaf files that are **not** imported still get built by `lake build` (Lake discovers them via the directory-scoped library), but they are **invisible to downstream consumers** — proofs in other files cannot `open` or reference their declarations. When you add a file, register it in the corresponding umbrella:
+   - `EvmAsm/Rv64/Foo.lean` → add `import EvmAsm.Rv64.Foo` to `EvmAsm/Rv64.lean`.
+   - `EvmAsm/Evm64/Foo/Bar.lean` → add `import EvmAsm.Evm64.Foo.Bar` to `EvmAsm/Evm64.lean` (or to an intermediate umbrella like `EvmAsm/Evm64/Foo.lean` if one exists).
+   - `EvmAsm/EL/Foo.lean` → add `import EvmAsm.EL.Foo` to `EvmAsm/EL.lean`.
+
+   If your new file declares an attribute via `register_simp_attr`, place the attribute-declaration file **before** any consumer file in the umbrella's import list so the attribute exists when the consumer is elaborated. Typical pattern: split into `FooAttr.lean` (declares the attribute) + `Foo.lean` (uses the attribute, imports `FooAttr`), then import both from the umbrella, attr first. See `Rv64/RegOpsAttr.lean` + `Rv64/RegOps.lean` or `Evm64/DivMod/AddrNormAttr.lean` + `Evm64/DivMod/AddrNorm.lean` for the canonical shape.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Both #372 (\`reg_ops\`) and #373 (\`rv64_addr\`) needed a follow-up fix-up commit after reviewer feedback — the new files built fine via \`lake build\` as leaf modules but were not imported by the \`EvmAsm.Rv64\` umbrella, so downstream consumers could not reference them. This lesson is worth recording so future contributors (human or AI) don't repeat it.

Adds pitfall #6 to \`AGENTS.md\` \"Common Pitfalls\":

- The shape of the transitive import graph (\`EvmAsm.lean → Rv64.lean / Evm64.lean / EL.lean → modules\`).
- The rule: every new \`.lean\` file must be added to its umbrella (\`Rv64.lean\` / \`Evm64.lean\` / \`EL.lean\`, or the nearest intermediate like \`Evm64/Foo.lean\`).
- The attribute-file ordering requirement: a \`register_simp_attr\` file must be imported **before** any consumer file in the umbrella's import list.
- The canonical \`<Name>Attr.lean\` + \`<Name>.lean\` split pattern, with pointers to \`RegOps\` and \`AddrNorm\` as reference implementations.

## Why in \"Common Pitfalls\" specifically

The existing five bullets are exactly this shape — one-line \"watch out for X, here's the fix\" rules that a drive-by contributor would not discover from the code alone. The new-file-import rule fits the same mold.

## Test plan

- [x] \`lake build\` — full repo green (3511 jobs). Doc-only change; no Lean source is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)