### PR TITLE
feat(divmod): add divScratchValues_unfold_right mid-tree variant

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -268,6 +268,28 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
      ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
 
+/-- Mid-tree variant of `divScratchValues_unfold`: threads a `Q` through the
+    equality so `rw ←` can fold the 15 atoms into a `divScratchValues` bundle
+    **even when they sit in the middle of a longer sepConj chain**. Counterpart
+    to `evmWordIs_sp{_,32}_limbs_eq_right`. Used by the DIV/MOD stack-spec
+    composition where scratch atoms are scattered across the unfolded
+    `fullDivN4MaxSkipPost` post. -/
+theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem : Word) (Q : Assertion) :
+    (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+     ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+     ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+     ((sp + signExtend12 3984) ↦ₘ n_mem) **
+     ((sp + signExtend12 3976) ↦ₘ j_mem) ** Q) =
+    (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shift_mem n_mem j_mem ** Q) := by
+  rw [divScratchValues_unfold]
+  iterate 14 rw [sepConj_assoc']
+
 /-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
     with ownership only (no commitment to specific values). Suitable for the
     postcondition of a stack-level DIV/MOD spec that doesn't want to expose

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -97,6 +97,38 @@ theorem evmWordIs_sp32_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
      ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3)) := by
   rw [evmWordIs_sp32_unfold, h0, h1, h2, h3]
 
+/-- Mid-tree variant of `evmWordIs_sp_limbs_eq`: fold four limb atoms into
+    `evmWordIs sp v` **even when they sit in the middle of a sepConj chain**,
+    by explicitly threading the rest of the chain (`Q`) through the equality.
+
+    The plain `evmWordIs_sp_limbs_eq`'s RHS is a four-atom right-terminal
+    sub-tree; `rw ←` finds it only when the last of those four atoms has no
+    right neighbor. When the four atoms live mid-chain (e.g. in the unfolded
+    `fullDivN4MaxSkipPost`'s post), Lean's syntactic matcher can't find that
+    sub-tree — folding fails. This variant makes the "rest of chain" explicit
+    so the pattern `atoms ** Q` matches wherever the atoms appear. -/
+theorem evmWordIs_sp_limbs_eq_right (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (Q : Assertion)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    ((sp ↦ₘ w0) ** ((sp + 8) ↦ₘ w1) **
+     ((sp + 16) ↦ₘ w2) ** ((sp + 24) ↦ₘ w3) ** Q) =
+    (evmWordIs sp v ** Q) := by
+  rw [evmWordIs_sp_limbs_eq sp v w0 w1 w2 w3 h0 h1 h2 h3]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `evmWordIs_sp32_limbs_eq`. Same purpose as
+    `evmWordIs_sp_limbs_eq_right` but for the `b`-operand slot at `sp+32`. -/
+theorem evmWordIs_sp32_limbs_eq_right (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (Q : Assertion)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    (((sp + 32) ↦ₘ w0) ** ((sp + 40) ↦ₘ w1) **
+     ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3) ** Q) =
+    (evmWordIs (sp + 32) v ** Q) := by
+  rw [evmWordIs_sp32_limbs_eq sp v w0 w1 w2 w3 h0 h1 h2 h3]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 -- ============================================================================
 -- Shared infrastructure for stack operation specs
 -- ============================================================================


### PR DESCRIPTION
## Summary
Add `divScratchValues_unfold_right` to complete the mid-tree fold helpers (counterpart of `evmWordIs_sp{_,32}_limbs_eq_right` landed in #376). Threads a `Q` through the equality so `rw ←` can fold the 15 scratch atoms into a `divScratchValues` bundle **even when they sit in the middle of a longer sepConj chain** — as they do in the unfolded `fullDivN4MaxSkipPost` post.

Proof: apply the plain `divScratchValues_unfold` in the forward direction, then re-associate via `sepConj_assoc'` 14 times to move the trailing `Q` out to the top-level right.

No call sites updated here — this helper (together with #376) is the plumbing the final n=4 max+skip stack spec composition needs. Attempting that composition next revealed that `rw`/`simp only` still struggle to infer the `Q` metavariable in practice; a subsequent PR will either invoke a lower-level fold primitive or restructure hq via explicit `sepConj_assoc` steps before invoking the fold.

Stacks on #376. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3511 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)