### PR TITLE
refactor(DivMod): dedupe signExtend13/21 constant-eval lemmas across Compose/

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -512,6 +512,26 @@ theorem phB_off_20 (base : Word) : (base + phaseBOff : Word) + 20 = base + 52 :=
 theorem phB_off_24 (base : Word) : (base + phaseBOff : Word) + 24 = base + 56 := by bv_addr
 theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
 
+-- ============================================================================
+-- Shared concrete-offset `signExtend13` / `signExtend21` evaluations.
+-- Previously scattered as `private theorem signExtend13_N` across PhaseAB /
+-- Epilogue / Norm / NormA plus `mod_signExtend13_N` / `mod_signExtend21_N`
+-- duplicates across ModPhaseB / ModNorm / ModNormA — every copy was
+-- verbatim `by decide`. Consolidate to a single shared set so the MOD-side
+-- `mod_` prefix disappears and adding a new concrete offset is a one-line
+-- edit in this file. Naming mirrors `EvmAsm/Rv64/AddrNorm.lean`'s `se13_N`
+-- pattern but keeps the original `signExtend13_N` form used by every
+-- existing call-site.
+-- ============================================================================
+
+theorem signExtend13_8    : signExtend13 (8    : BitVec 13) = (8    : Word) := by decide
+theorem signExtend13_16   : signExtend13 (16   : BitVec 13) = (16   : Word) := by decide
+theorem signExtend13_24   : signExtend13 (24   : BitVec 13) = (24   : Word) := by decide
+theorem signExtend13_172  : signExtend13 (172  : BitVec 13) = (172  : Word) := by decide
+theorem signExtend13_464  : signExtend13 (464  : BitVec 13) = (464  : Word) := by decide
+theorem signExtend13_1020 : signExtend13 (1020 : BitVec 13) = (1020 : Word) := by decide
+theorem signExtend21_40   : signExtend21 (40   : BitVec 21) = (40   : Word) := by decide
+
 /-- When b ≠ 0, 0 < b in unsigned ordering (BitVec.ult). -/
 theorem ult_zero_of_ne {b : Word} (h : b ≠ 0) : BitVec.ult 0 b := by
   unfold BitVec.ult; simp

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -305,9 +305,7 @@ private theorem beq_singleton_sub_modCode (base : Word) :
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
       (by decide) (by decide)) a i h)
 
--- signExtend13 normalization needed for BEQ offset in MOD specs
-private theorem signExtend13_1020 : signExtend13 (1020 : BitVec 13) = (1020 : Word) := by
-  decide
+-- `signExtend13_1020` moved to `Compose/Base.lean` (shared).
 
 -- ============================================================================
 -- Section 13: MOD zero path composition (b = 0)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -38,7 +38,7 @@ private theorem beq_shift_sub_modCode (base : Word) :
   exact divK_phaseC2_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
-private theorem mod_signExtend13_172 : signExtend13 (172 : BitVec 13) = (172 : Word) := by decide
+-- `signExtend13_172` → use `signExtend13_172` from `Compose/Base.lean`.
 
 /-- Phase C2 body (base+212 -> base+224): store shift, compute anti_shift.
     Extends to modCode. Uses first 3 instructions of phaseC2. -/
@@ -64,7 +64,7 @@ theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
   have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
-        rw [mod_signExtend13_172]; bv_addr,
+        rw [signExtend13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQt => by
@@ -94,7 +94,7 @@ theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
   have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
-        rw [mod_signExtend13_172]; bv_addr,
+        rw [signExtend13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
     (fun hp hQf => by

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -42,7 +42,7 @@ private theorem mod_se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by 
 private theorem mod_se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
 private theorem mod_se12_8 : signExtend12 (8 : BitVec 12) = (8 : Word) := by decide
 private theorem mod_se12_0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-private theorem mod_signExtend21_40 : signExtend21 (40 : BitVec 21) = (40 : Word) := by decide
+-- `signExtend21_40` → use `signExtend21_40` from `Compose/Base.lean`.
 
 /-- Full NormA for modCode: normalize dividend a[0..3] -> u[0..4] and jump to loopSetup.
     base+312 -> base+432 (21 instructions including JAL).
@@ -158,7 +158,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   -- JAL x0 40 at base+392 -> base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
   rw [show (base + 392 : Word) + signExtend21 40 = base + loopSetupOff from by
-        rw [mod_signExtend21_40]; bv_addr] at hjal
+        rw [signExtend21_40]; bv_addr] at hjal
   have hjale := cpsTriple_extend_code (hmono := by
     intro a i h
     exact divK_normA_code_sub_modCode base a i
@@ -247,7 +247,7 @@ private theorem blt_loopSetup_sub_modCode (base : Word) :
   exact divK_loopSetup_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
-private theorem mod_signExtend13_464 : signExtend13 (464 : BitVec 13) = (464 : Word) := by decide
+-- `signExtend13_464` → use `signExtend13_464` from `Compose/Base.lean`.
 
 /-- LoopSetup when m >= 0 (n <= 4): falls through to loop body at base+448.
     MOD mirror of divK_loopSetup_ntaken_spec. -/
@@ -265,7 +265,7 @@ theorem mod_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_modCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
-        rw [mod_signExtend13_464]; bv_addr,
+        rw [signExtend13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQt => by
@@ -298,7 +298,7 @@ theorem mod_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   have hbodye := cpsTriple_extend_code (divK_loopSetup_code_sub_modCode base) hbody
   have hblt_raw := blt_spec_gen .x1 .x0 464 m (0 : Word) (base + 444)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
-        rw [mod_signExtend13_464]; bv_addr,
+        rw [signExtend13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
   have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
     (fun hp hQf => by

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -95,8 +95,7 @@ theorem mod_phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv
 theorem mod_phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
 theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
-theorem mod_signExtend13_24 : signExtend13 (24 : BitVec 13) = (24 : Word) := by
-  decide
+-- `mod_signExtend13_24` → use `signExtend13_24` from `Compose/Base.lean`.
 theorem mod_phB_sp24_32 (sp : Word) :
     sp + ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat +
       signExtend12 (32 : BitVec 12) = sp + 56 := by
@@ -153,7 +152,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [mod_signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne_raw
+        rw [signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -244,10 +243,8 @@ theorem addi_x5_1_sub_modCode (base : Word) :
 -- MOD Phase B cascade constants and address lemmas
 -- ============================================================================
 
--- signExtend13 constants for cascade branches (se12_* come from AddrNorm)
-theorem mod_signExtend13_16 : signExtend13 (16 : BitVec 13) = (16 : Word) := by
-  decide
-theorem mod_signExtend13_8 : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
+-- signExtend13 constants for cascade branches: `signExtend13_{8,16}` now live
+-- in `Compose/Base.lean` (shared with PhaseAB). `se12_*` come from AddrNorm.
 
 -- nm1_x8 = (n + signExtend12 4095) <<< 3 for each n value
 theorem mod_divK_phaseB_n3_nm1_x8 :

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -81,7 +81,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [mod_signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -116,7 +116,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [mod_signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -151,7 +151,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [mod_signExtend13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
+        rw [signExtend13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -261,7 +261,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [mod_signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -296,7 +296,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [mod_signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -331,7 +331,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [mod_signExtend13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
+        rw [signExtend13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -80,7 +80,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [mod_signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+        rw [signExtend13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -115,7 +115,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [mod_signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+        rw [signExtend13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -32,7 +32,7 @@ private theorem beq_shift_sub_divCode (base : Word) :
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
-private theorem signExtend13_172 : signExtend13 (172 : BitVec 13) = (172 : Word) := by decide
+-- `signExtend13_172` moved to `Compose/Base.lean` (shared with ModNorm).
 
 /-- Phase C2 body (base+212 → base+224): store shift, compute anti_shift.
     Extends to divCode. Uses first 3 instructions of phaseC2. -/

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -39,7 +39,7 @@ private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
 
-private theorem signExtend21_40 : signExtend21 (40 : BitVec 21) = (40 : Word) := by decide
+-- `signExtend21_40` moved to `Compose/Base.lean` (shared with ModNormA).
 
 /-- Full NormA: normalize dividend a[0..3] → u[0..4] and jump to loopSetup.
     base+312 → base+432 (21 instructions including JAL).
@@ -246,7 +246,7 @@ private theorem blt_loopSetup_sub_divCode (base : Word) :
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)
 
-private theorem signExtend13_464 : signExtend13 (464 : BitVec 13) = (464 : Word) := by decide
+-- `signExtend13_464` moved to `Compose/Base.lean` (shared with ModNormA).
 
 /-- LoopSetup when m ≥ 0 (n ≤ 4): falls through to loop body at base+448.
     Loads n from scratch, computes m = 4-n, BLT not taken. -/

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -120,13 +120,11 @@ private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
 
 -- ============================================================================
 -- Section 6: signExtend13 normalization
+--
+-- `signExtend13_{8,16,24,1020}` now live in `Compose/Base.lean` and are shared
+-- with the MOD-side files (ModPhaseB / ModNorm / ModNormA) — the identical
+-- `mod_signExtend13_*` duplicates on the MOD side are gone.
 -- ============================================================================
-
-private theorem signExtend13_1020 : signExtend13 (1020 : BitVec 13) = (1020 : Word) := by
-  decide
-
-private theorem signExtend13_24 : signExtend13 (24 : BitVec 13) = (24 : Word) := by
-  decide
 
 -- Phase B n=4: signExtend12 4 = 4 (result of ADDI x5 x0 4 via addi_x0_spec_gen)
 private theorem divK_se12_4 : signExtend12 (4 : BitVec 12) = (4 : Word) := by decide
@@ -486,8 +484,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
 private theorem divK_se12_3 : signExtend12 (3 : BitVec 12) = (3 : Word) := by decide
 private theorem divK_se12_2 : signExtend12 (2 : BitVec 12) = (2 : Word) := by decide
 private theorem divK_se12_1 : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
-private theorem signExtend13_16 : signExtend13 (16 : BitVec 13) = (16 : Word) := by decide
-private theorem signExtend13_8 : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
+-- `signExtend13_{8,16}` moved to `Compose/Base.lean` (shared with MOD side).
 
 -- nm1_x8 = (n + signExtend12 4095) <<< 3 for each n value
 private theorem divK_phaseB_n3_nm1_x8 :


### PR DESCRIPTION
## Summary

Seven \`signExtend13\` / \`signExtend21\` evaluation lemmas were duplicated across the DIV and MOD sides of \`Compose/\` as \`private theorem signExtend1?_N\` + \`private theorem mod_signExtend1?_N\` pairs — every copy identical, proved by \`by decide\`. The \`private\` scoping kept each file's version unreachable from its sibling, so the MOD-side copies existed purely as same-name re-proofs.

Consolidate into **\`Compose/Base.lean\`** (shared, non-private) — same pattern as PR #374 (\`phB_off_*\` dedupe) and the existing \`se12_{32,40,48,56}\` block.

### Before

| Lemma | DIV-side file (\`private\`) | MOD-side file (\`private mod_*\`) |
|---|---|---|
| \`signExtend13_1020\` | PhaseAB.lean, Epilogue.lean | — |
| \`signExtend13_24\`   | PhaseAB.lean | ModPhaseB.lean |
| \`signExtend13_16\`   | PhaseAB.lean | ModPhaseB.lean |
| \`signExtend13_8\`    | PhaseAB.lean | ModPhaseB.lean |
| \`signExtend13_172\`  | Norm.lean    | ModNorm.lean |
| \`signExtend13_464\`  | NormA.lean   | ModNormA.lean |
| \`signExtend21_40\`   | NormA.lean   | ModNormA.lean |

### After

- Single non-private copy of each in \`Compose/Base.lean\`, imported transitively by all 10 consumer files.
- Call-sites in the MOD files renamed from \`mod_signExtend1?_N\` to \`signExtend1?_N\` (4 rename sites across \`ModPhaseB\`, \`ModPhaseBn3\`, \`ModPhaseBn21\`, \`ModNorm\`, \`ModNormA\`).
- No proof-body changes; \`by decide\` still closes every lemma.

Moves the codebase closer to the end-state sketched by **GRIND.md §8.2 Phase 3** (\`rv64_addr\`): a single shared set of \`signExtend13\`/\`signExtend21\` atomic facts. When Phase 3 (tracked by my #373) eventually lands, these seven theorems in Base.lean are the natural migration target to \`EvmAsm/Rv64/AddrNorm.lean\`'s \`se13_*\` / \`se21_*\` grindset.

## Test plan

- [x] \`lake build\` — full repo green (3511 jobs).
- [x] \`grep -rn 'private theorem \\(signExtend\\|mod_signExtend\\)' EvmAsm/Evm64/DivMod/Compose/\` → zero matches.

Refs #301 (named-offset / dedupe spirit) and GRIND.md §8.2 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)