### PR TITLE
feat(divmod): add divScratchOwn_unfold named unfold theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -268,6 +268,28 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
      ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
 
+/-- Mid-tree variant of `divScratchValues_unfold`: threads a `Q` through the
+    equality so `rw ←` can fold the 15 atoms into a `divScratchValues` bundle
+    **even when they sit in the middle of a longer sepConj chain**. Counterpart
+    to `evmWordIs_sp{_,32}_limbs_eq_right`. Used by the DIV/MOD stack-spec
+    composition where scratch atoms are scattered across the unfolded
+    `fullDivN4MaxSkipPost` post. -/
+theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shift_mem n_mem j_mem : Word) (Q : Assertion) :
+    (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+     ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+     ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+     ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+     ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+     ((sp + signExtend12 3984) ↦ₘ n_mem) **
+     ((sp + signExtend12 3976) ↦ₘ j_mem) ** Q) =
+    (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shift_mem n_mem j_mem ** Q) := by
+  rw [divScratchValues_unfold]
+  iterate 14 rw [sepConj_assoc']
+
 /-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
     with ownership only (no commitment to specific values). Suitable for the
     postcondition of a stack-level DIV/MOD spec that doesn't want to expose

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -239,6 +239,7 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
     The full-path specs universally-quantify over these values since the program
     overwrites them; the predicate packages them so stack specs aren't littered
     with fifteen `↦ₘ` lines at every call site. -/
+@[irreducible]
 def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem : Word) : Assertion :=
   ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -266,7 +267,8 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
      ((sp + signExtend12 3992) ↦ₘ shift_mem) **
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
-     ((sp + signExtend12 3976) ↦ₘ j_mem)) := rfl
+     ((sp + signExtend12 3976) ↦ₘ j_mem)) := by
+  delta divScratchValues; rfl
 
 /-- Mid-tree variant of `divScratchValues_unfold`: threads a `Q` through the
     equality so `rw ←` can fold the 15 atoms into a `divScratchValues` bundle
@@ -294,6 +296,7 @@ theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     with ownership only (no commitment to specific values). Suitable for the
     postcondition of a stack-level DIV/MOD spec that doesn't want to expose
     the algorithm's internal scratch state to callers. -/
+@[irreducible]
 def divScratchOwn (sp : Word) : Assertion :=
   memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
   memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -308,6 +308,22 @@ def divScratchOwn (sp : Word) : Assertion :=
   memOwn (sp + signExtend12 3984) **
   memOwn (sp + signExtend12 3976)
 
+/-- Named unfold for `divScratchOwn`. Restores access to the underlying
+    definition once the `@[irreducible]` attribute has made `delta` the only
+    way in at call sites. Parallel to `divScratchValues_unfold`. -/
+theorem divScratchOwn_unfold (sp : Word) :
+    divScratchOwn sp =
+    (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
+     memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
+     memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
+     memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
+     memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
+     memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
+     memOwn (sp + signExtend12 3992) **
+     memOwn (sp + signExtend12 3984) **
+     memOwn (sp + signExtend12 3976)) := by
+  delta divScratchOwn; rfl
+
 theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem : Word) :
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7


### PR DESCRIPTION
## Summary
Add `divScratchOwn_unfold` — the named rewrite counterpart of the `@[irreducible]` attribute on `divScratchOwn` landed in #379. Parallel to the existing `divScratchValues_unfold`: gives call sites a clean handle for breaking the irreducibility via `rw [divScratchOwn_unfold]` when they need to see the 15 `memOwn` atoms directly, rather than relying on `delta`/`unfold` inside tactic blocks.

Also addressed pirapira's comment on #378 (build failure was transient — elan infrastructure issue, not a code issue). Rerun of #378 CI was triggered.

Stacks on #379. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3511 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)