### PR TITLE
feat(divmod): add pcFree instance for loopSetupPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -258,6 +258,15 @@ instance (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
     Assertion.PCFree (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
   ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
 
+/-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
+  rw [loopSetupPost_unfold]; pcFree
+
+instance (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
+  ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
+
 /-- MOD counterpart of `div_n4_max_skip_stack_weaken`. Same pattern, same
     register/memory weakenings — only the result-slot `evmWordIs` holds
     `EvmWord.mod a b` instead of `EvmWord.div a b`. -/


### PR DESCRIPTION
## Summary
Add `pcFree_loopSetupPost` + `Assertion.PCFree` instance. Parallel to `pcFree_denormDivPost` (#383): `loopSetupPost` is `@[irreducible]` so the pcFree proof goes through `rw [loopSetupPost_unfold]; pcFree`.

Needed for any downstream `cpsTriple_frame_*` application that frames `loopSetupPost` around an inner spec — the framing tactics require `PCFree` typeclass resolution on every framed assertion.

Stacks on #379 → #383. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3513 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)