### PR TITLE
feat(divmod): add pcFree instances for denormModPost and normBPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -267,6 +267,24 @@ instance (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
   ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
 
+/-- `denormModPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_denormModPost (sp shift u0 u1 u2 u3 : Word) :
+    (denormModPost sp shift u0 u1 u2 u3).pcFree := by
+  rw [denormModPost_unfold]; pcFree
+
+instance (sp shift u0 u1 u2 u3 : Word) :
+    Assertion.PCFree (denormModPost sp shift u0 u1 u2 u3) :=
+  ⟨pcFree_denormModPost sp shift u0 u1 u2 u3⟩
+
+/-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
+    (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by
+  rw [normBPost_unfold]; pcFree
+
+instance (sp n_val shift b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (normBPost sp n_val shift b0 b1 b2 b3) :=
+  ⟨pcFree_normBPost sp n_val shift b0 b1 b2 b3⟩
+
 /-- MOD counterpart of `div_n4_max_skip_stack_weaken`. Same pattern, same
     register/memory weakenings — only the result-slot `evmWordIs` holds
     `EvmWord.mod a b` instead of `EvmWord.div a b`. -/


### PR DESCRIPTION
## Summary
Add `pcFree_denormModPost` and `pcFree_normBPost` + `Assertion.PCFree` instances. Parallel to the pcFree lemmas for the other post bundles (`divN4MaxSkipStackPost` — #362, `denormDivPost` — #383, `loopSetupPost` — #384). Each post bundle is already `@[irreducible]`, so the pcFree proofs go through `rw [_unfold]; pcFree`.

Completes the pcFree coverage for the four DivMod post bundles defined in `Compose/Base.lean` — downstream `cpsTriple_frame_*` applications against any of them will now resolve the `PCFree` typeclass obligation without manual intervention.

Stacks on #384. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3513 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)