### PR TITLE
feat(divmod): add pcFree instance for fullDivN4MaxSkipPost

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -285,6 +285,19 @@ instance (sp n_val shift b0 b1 b2 b3 : Word) :
     Assertion.PCFree (normBPost sp n_val shift b0 b1 b2 b3) :=
   ⟨pcFree_normBPost sp n_val shift b0 b1 b2 b3⟩
 
+/-- `fullDivN4MaxSkipPost` is pc-free: all its atoms (inside the
+    `denormDivPost` sub-bundle plus the top-level wrapper atoms) are
+    `regIs` / `memIs`. Proof goes through `delta` since the bundle is
+    `@[irreducible]` and has no dedicated `_unfold` theorem. -/
+theorem pcFree_fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
+  delta fullDivN4MaxSkipPost
+  pcFree
+
+instance (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
+  ⟨pcFree_fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3⟩
+
 /-- MOD counterpart of `div_n4_max_skip_stack_weaken`. Same pattern, same
     register/memory weakenings — only the result-slot `evmWordIs` holds
     `EvmWord.mod a b` instead of `EvmWord.div a b`. -/


### PR DESCRIPTION
## Summary
Add `pcFree_fullDivN4MaxSkipPost` + `Assertion.PCFree` instance. Parallel to the other DivMod post-bundle pcFree lemmas (#362/#383/#384/#386): all atoms inside the bundle + its inner `denormDivPost` are `regIs`/`memIs`, so the bundle is pc-free.

Since `fullDivN4MaxSkipPost` lives in `FullPathN4.lean` which has a file-size exception, the pcFree lemma lives in `Spec.lean` alongside the other stack-spec infrastructure. Proof goes through `delta` (there's no dedicated `_unfold` theorem on this bundle).

Needed for downstream `cpsTriple_frame_*` applications that frame `fullDivN4MaxSkipPost`.

Stacks on #386. Continues progress toward #61.

## Test plan
- [x] `lake build` succeeds (3513 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)