### PR TITLE
refactor(DivMod): migrate inline signExtend13/21 rewrites outside Compose/ to rv64_addr

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_1020)
+open EvmAsm.Rv64.AddrNorm (se13_96 se13_1020 se21_24)
 
 -- ============================================================================
 -- Section 10l: Denorm composition (25 instructions at base+904)
@@ -60,8 +60,7 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
   rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
-        rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
-        bv_addr,
+        rw [se13_96]; bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
     intro a i h
@@ -252,7 +251,7 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
   -- Store phase (base+1024 → base+1068 via JAL)
   have hstore := divK_epilogue_store_spec sp (base + 1024) q0 q1 q2 q3 m0 m8 m16 m24 24
   rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + nopOff from by
-        rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_addr]
+        rw [se21_24]; bv_addr]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
     divK_divEpilogue_code_sub_divCode base a i
@@ -448,7 +447,7 @@ theorem divK_mod_epilogue_spec (sp : Word) (base : Word)
   -- Store phase (base+1024 → base+1068 via JAL): advance sp, store u[0..3] to output
   have hstore := divK_epilogue_store_spec sp (base + 1024) u0 u1 u2 u3 m0 m8 m16 m24 24
   rw [show (base + 1024 : Word) + 20 + signExtend21 24 = base + nopOff from by
-        rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_addr]
+        rw [se21_24]; bv_addr]
     at hstore
   have hstoree := cpsTriple_extend_code (hmono := fun a i h =>
     divK_modEpilogue_code_sub_modCode base a i

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -19,6 +19,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_96)
 
 -- ============================================================================
 -- Phase AB(n=4) → CLZ composition: base → base+212
@@ -579,7 +580,7 @@ theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
   rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
-        rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
+        rw [se13_96]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
@@ -709,7 +710,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
   rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
-        rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
+        rw [se13_96]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by
@@ -796,7 +797,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
   have hbeq := beq_spec_gen .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
   rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by
-        rw [show signExtend13 (96 : BitVec 13) = (96 : Word) from by decide]
+        rw [se13_96]
         bv_addr,
       show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
   have hbeqe := cpsBranch_extend_code (hmono := by

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -18,6 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_7736 se13_8044)
 
 -- ============================================================================
 -- Section 1: CodeReq subsumption infrastructure for loop body instructions
@@ -931,7 +932,7 @@ theorem divK_beq_passthrough (carry : Word) (base : Word) (hne : carry ≠ 0) :
 -- Address normalization for BEQ taken (double-addback backward branch)
 private theorem lb_beq_back_taken (base : Word) :
     (base + 880 : Word) + signExtend13 (8044 : BitVec 13) = base + 732 := by
-  rw [show signExtend13 (8044 : BitVec 13) = (18446744073709551468 : Word) from by decide]
+  rw [se13_8044]
   bv_addr
 
 /-- Double-addback path at [108]: when first addback carry (x7) = 0, BEQ jumps back to [71]
@@ -1183,7 +1184,7 @@ theorem divK_store_loop_j0_spec
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
   have hbge_raw := bge_spec_gen .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
   rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
-        rw [show signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) from by decide]
+        rw [se13_7736]
         bv_addr,
       show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by
@@ -1269,7 +1270,7 @@ theorem divK_store_loop_jgt0_spec
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
   have hbge_raw := bge_spec_gen .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
   rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
-        rw [show signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) from by decide]
+        rw [se13_7736]
         bv_addr,
       show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by


### PR DESCRIPTION
## Summary

**GRIND.md §8.2 Phase 3 follow-up.** After #385 migrated the \`DivMod/Compose/\` subtree, 9 inline \`rw [show signExtend1? N = <const> from by decide]\` sites still remain in three DivMod files — either outside the \`Compose/\` subtree touched by #385, or inside files #385 didn't visit:

| File | Rewrite target | Sites |
|---|---|---|
| \`DivMod/LoopBody.lean\` | \`se13_7736\` | 2 |
| \`DivMod/LoopBody.lean\` | \`se13_8044\` | 1 |
| \`DivMod/Compose/Epilogue.lean\` | \`se13_96\` | 1 |
| \`DivMod/Compose/Epilogue.lean\` | \`se21_24\` | 2 |
| \`DivMod/Compose/FullPath.lean\` | \`se13_96\` | 3 |

Every value is already \`@[rv64_addr, grind =]\` in \`EvmAsm/Rv64/AddrNorm.lean\` (landed in #373). \`Compose/Base.lean\` already imports that file (since #385), and \`LoopBody.lean\` transitively reaches it via \`Compose\`.

## Changes

- Each consumer gains one \`open EvmAsm.Rv64.AddrNorm (se13_... se21_...)\` line listing only the specific offsets it uses.
- 9 \`rw [show signExtend1? N = <const> from by decide]; <closer>\` sites become \`rw [seNN_N]; <closer>\`.

## Why this is safe

No proof-body changes beyond the rewrite-target swap. The lemmas still close by \`bv_addr\` / \`bv_omega\` after rewriting, and the large-offset entries (\`se13_7736 = 2^64-456\`, \`se13_8044 = 2^64-148\`) carry the folded 64-bit constant on the RHS identically to the inline \`show\` proof — no implicit-reduction steps were papered over.

Matches the pattern established by #385. Moves the codebase closer to the §8.2 Phase 3 stop criterion (no scattered \`show signExtend1? N = … from by decide\` left in DivMod).

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep -rn 'rw \\[show signExtend1[23]' EvmAsm/Evm64/DivMod/\` returns no hits.

Refs GRIND.md §8.2 Phase 3 (follow-up to #373 / #385).

🤖 Generated with [Claude Code](https://claude.com/claude-code)