### PR TITLE
refactor(shift): migrate inline signExtend13/21 rewrites to rv64_addr grindset

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -15,6 +15,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252)
 
 -- ============================================================================
 -- Section 1: shrCode definition and helpers
@@ -207,26 +208,26 @@ private theorem shr_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 :=
 private theorem shr_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
 private theorem shr_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
 private theorem shr_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
-  rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by decide]; bv_omega
+  rw [se13_320]; bv_omega
 private theorem shr_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
-  rw [show signExtend13 (308 : BitVec 13) = (308 : Word) from by decide]; bv_omega
+  rw [se13_308]; bv_omega
 -- Phase C exit addresses
 private theorem shr_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by
-  rw [show signExtend13 (176 : BitVec 13) = (176 : Word) from by decide]; bv_omega
+  rw [se13_176]; bv_omega
 private theorem shr_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 92 = base + 164 := by
-  rw [show signExtend13 (92 : BitVec 13) = (92 : Word) from by decide]; bv_omega
+  rw [se13_92]; bv_omega
 private theorem shr_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 32 = base + 112 := by
-  rw [show signExtend13 (32 : BitVec 13) = (32 : Word) from by decide]; bv_omega
+  rw [se13_32]; bv_omega
 private theorem shr_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets)
 private theorem shr_body3_exit (base : Word) : ((base + 84 : Word) + 24) + signExtend21 252 = base + 360 := by
-  rw [show signExtend21 (252 : BitVec 21) = (252 : Word) from by decide]; bv_omega
+  rw [se21_252]; bv_omega
 private theorem shr_body2_exit (base : Word) : ((base + 112 : Word) + 48) + signExtend21 200 = base + 360 := by
-  rw [show signExtend21 (200 : BitVec 21) = (200 : Word) from by decide]; bv_omega
+  rw [se21_200]; bv_omega
 private theorem shr_body1_exit (base : Word) : ((base + 164 : Word) + 72) + signExtend21 124 = base + 360 := by
-  rw [show signExtend21 (124 : BitVec 21) = (124 : Word) from by decide]; bv_omega
+  rw [se21_124]; bv_omega
 private theorem shr_body0_exit (base : Word) : ((base + 240 : Word) + 96) + signExtend21 24 = base + 360 := by
-  rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_omega
+  rw [se21_24]; bv_omega
 
 -- ============================================================================
 -- Section 4: Zero path composition

--- a/EvmAsm/Evm64/Shift/ComposeBase.lean
+++ b/EvmAsm/Evm64/Shift/ComposeBase.lean
@@ -16,6 +16,7 @@
 -/
 
 import EvmAsm.Evm64.Shift.LimbSpec
+import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -18,6 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268)
 
 -- ============================================================================
 -- Section 1: sarCode definition and helpers
@@ -242,26 +243,26 @@ private theorem sar_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 :=
 private theorem sar_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
 private theorem sar_off_352_28 (base : Word) : (base + 352 : Word) + 28 = base + 380 := by bv_omega
 private theorem sar_bne_target (base : Word) : (base + 20 : Word) + signExtend13 332 = base + 352 := by
-  rw [show signExtend13 (332 : BitVec 13) = (332 : Word) from by decide]; bv_omega
+  rw [se13_332]; bv_omega
 private theorem sar_beq_target (base : Word) : (base + 32 : Word) + signExtend13 320 = base + 352 := by
-  rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by decide]; bv_omega
+  rw [se13_320]; bv_omega
 -- Phase C exit addresses
 private theorem sar_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 188 = base + 252 := by
-  rw [show signExtend13 (188 : BitVec 13) = (188 : Word) from by decide]; bv_omega
+  rw [se13_188]; bv_omega
 private theorem sar_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 100 = base + 172 := by
-  rw [show signExtend13 (100 : BitVec 13) = (100 : Word) from by decide]; bv_omega
+  rw [se13_100]; bv_omega
 private theorem sar_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 36 = base + 116 := by
-  rw [show signExtend13 (36 : BitVec 13) = (36 : Word) from by decide]; bv_omega
+  rw [se13_36]; bv_omega
 private theorem sar_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets → base+380)
 private theorem sar_body3_exit (base : Word) : ((base + 84 : Word) + 28) + signExtend21 268 = base + 380 := by
-  rw [show signExtend21 (268 : BitVec 21) = (268 : Word) from by decide]; bv_omega
+  rw [se21_268]; bv_omega
 private theorem sar_body2_exit (base : Word) : ((base + 116 : Word) + 52) + signExtend21 212 = base + 380 := by
-  rw [show signExtend21 (212 : BitVec 21) = (212 : Word) from by decide]; bv_omega
+  rw [se21_212]; bv_omega
 private theorem sar_body1_exit (base : Word) : ((base + 172 : Word) + 76) + signExtend21 132 = base + 380 := by
-  rw [show signExtend21 (132 : BitVec 21) = (132 : Word) from by decide]; bv_omega
+  rw [se21_132]; bv_omega
 private theorem sar_body0_exit (base : Word) : ((base + 252 : Word) + 96) + signExtend21 32 = base + 380 := by
-  rw [show signExtend21 (32 : BitVec 21) = (32 : Word) from by decide]; bv_omega
+  rw [se21_32]; bv_omega
 
 private theorem sar_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
   simp only [signExtend12_32]

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -18,6 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252)
 
 -- ============================================================================
 -- Section 1: shlCode definition and helpers
@@ -197,26 +198,26 @@ private theorem shl_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 :=
 private theorem shl_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
 private theorem shl_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
 private theorem shl_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
-  rw [show signExtend13 (320 : BitVec 13) = (320 : Word) from by decide]; bv_omega
+  rw [se13_320]; bv_omega
 private theorem shl_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
-  rw [show signExtend13 (308 : BitVec 13) = (308 : Word) from by decide]; bv_omega
+  rw [se13_308]; bv_omega
 -- Phase C exit addresses
 private theorem shl_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by
-  rw [show signExtend13 (176 : BitVec 13) = (176 : Word) from by decide]; bv_omega
+  rw [se13_176]; bv_omega
 private theorem shl_c_e1 (base : Word) : ((base + 64 : Word) + 8) + signExtend13 92 = base + 164 := by
-  rw [show signExtend13 (92 : BitVec 13) = (92 : Word) from by decide]; bv_omega
+  rw [se13_92]; bv_omega
 private theorem shl_c_e2 (base : Word) : ((base + 64 : Word) + 16) + signExtend13 32 = base + 112 := by
-  rw [show signExtend13 (32 : BitVec 13) = (32 : Word) from by decide]; bv_omega
+  rw [se13_32]; bv_omega
 private theorem shl_c_e3 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 -- Body exit addresses (JAL targets)
 private theorem shl_body3_exit (base : Word) : ((base + 84 : Word) + 24) + signExtend21 252 = base + 360 := by
-  rw [show signExtend21 (252 : BitVec 21) = (252 : Word) from by decide]; bv_omega
+  rw [se21_252]; bv_omega
 private theorem shl_body2_exit (base : Word) : ((base + 112 : Word) + 48) + signExtend21 200 = base + 360 := by
-  rw [show signExtend21 (200 : BitVec 21) = (200 : Word) from by decide]; bv_omega
+  rw [se21_200]; bv_omega
 private theorem shl_body1_exit (base : Word) : ((base + 164 : Word) + 72) + signExtend21 124 = base + 360 := by
-  rw [show signExtend21 (124 : BitVec 21) = (124 : Word) from by decide]; bv_omega
+  rw [se21_124]; bv_omega
 private theorem shl_body0_exit (base : Word) : ((base + 240 : Word) + 96) + signExtend21 24 = base + 360 := by
-  rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_omega
+  rw [se21_24]; bv_omega
 
 -- ============================================================================
 -- Section 4: Zero path composition


### PR DESCRIPTION
## Summary

**GRIND.md §8.2 Phase 3 follow-up.** After #385 / #388 / #390 migrated the DivMod and SignExtend subtrees, 27 inline \`rw [show signExtend1? N = <const> from by decide]; bv_omega\` sites remain in three Shift composition files. Every offset they use is already registered as \`@[rv64_addr, grind =] theorem se13_N\` / \`se21_N\` in \`EvmAsm/Rv64/AddrNorm.lean\` (landed in #373).

## Changes

- \`Shift/ComposeBase.lean\` gains \`import EvmAsm.Rv64.AddrNorm\` so all three consumers (\`Compose.lean\`, \`ShlCompose.lean\`, \`SarCompose.lean\`) reach the grindset through the shared umbrella.
- Each of the three consumer files adds one \`open EvmAsm.Rv64.AddrNorm (se13_... se21_...)\` line listing only the specific offsets it uses.
- 27 \`rw [show signExtend1? N = <const> from by decide]; bv_omega\` sites become \`rw [seNN_N]; bv_omega\`.

## Per-file coverage

| File | Opened from AddrNorm | Call-sites |
|---|---|---|
| \`Shift/Compose.lean\`    (SHR) | \`se13_{32, 92, 176, 308, 320}, se21_{24, 124, 200, 252}\` | 9 |
| \`Shift/ShlCompose.lean\` (SHL) | same offset set as SHR (SHL/SHR mirror) | 9 |
| \`Shift/SarCompose.lean\` (SAR) | \`se13_{36, 100, 188, 320, 332}, se21_{32, 132, 212, 268}\` | 9 |

## Why this is safe

No proof-body changes beyond the rewrite-target swap; the lemmas still close by \`bv_omega\` after rewriting. Identical behaviour, simpler proofs, and adding a new concrete signExtend offset to any Shift Compose file is now a one-line \`@[rv64_addr, grind =]\` edit in \`Rv64/AddrNorm.lean\` — not a new \`rw [show …]\` block scattered across three mirror files.

Matches the pattern established by #385 / #388 / #390.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep -rn 'rw \\[show signExtend1[23]\\|rw \\[show signExtend21' EvmAsm/Evm64/Shift/\` returns no hits.

Refs GRIND.md §8.2 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)