### PR TITLE
refactor(byte): migrate inline signExtend13/21 rewrites to rv64_addr grindset

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -15,6 +15,7 @@
 
 import EvmAsm.Evm64.Byte.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Rv64.AddrNorm
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics
@@ -22,6 +23,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se21_24 se21_32 se21_48)
 
 -- ============================================================================
 -- Full program CodeReq
@@ -172,35 +174,35 @@ private theorem byte_off_160_20 (base : Word) : (base + 160 : Word) + 20 = base 
 
 -- BNE/BEQ branch targets
 private theorem byte_bne_target (base : Word) : (base + 20 : Word) + signExtend13 140 = base + 160 := by
-  rw [show signExtend13 (140 : BitVec 13) = (140 : Word) from by decide]; bv_omega
+  rw [se13_140]; bv_omega
 private theorem byte_beq_target (base : Word) : (base + 32 : Word) + signExtend13 128 = base + 160 := by
-  rw [show signExtend13 (128 : BitVec 13) = (128 : Word) from by decide]; bv_omega
+  rw [se13_128]; bv_omega
 
 -- Phase C exit addresses
 private theorem byte_c_e0 (base : Word) : (base + 56 : Word) + signExtend13 68 = base + 124 := by
-  rw [show signExtend13 (68 : BitVec 13) = (68 : Word) from by decide]; bv_omega
+  rw [se13_68]; bv_omega
 private theorem byte_c_e1 (base : Word) : ((base + 56 : Word) + 8) + signExtend13 44 = base + 108 := by
-  rw [show signExtend13 (44 : BitVec 13) = (44 : Word) from by decide]; bv_omega
+  rw [se13_44]; bv_omega
 private theorem byte_c_e2 (base : Word) : ((base + 56 : Word) + 16) + signExtend13 20 = base + 92 := by
-  rw [show signExtend13 (20 : BitVec 13) = (20 : Word) from by decide]; bv_omega
+  rw [se13_20]; bv_omega
 private theorem byte_c_e3 (base : Word) : (base + 56 : Word) + 20 = base + 76 := by bv_omega
 
 -- Body exit addresses (JAL targets → store at base+136)
 private theorem byte_body_3_exit_eq (base : Word) :
     (base + 76 + 12) + signExtend21 (48 : BitVec 21) = base + 136 := by
-  rw [show signExtend21 (48 : BitVec 21) = (48 : Word) from by decide]; bv_omega
+  rw [se21_48]; bv_omega
 private theorem byte_body_2_exit_eq (base : Word) :
     (base + 92 + 12) + signExtend21 (32 : BitVec 21) = base + 136 := by
-  rw [show signExtend21 (32 : BitVec 21) = (32 : Word) from by decide]; bv_omega
+  rw [se21_32]; bv_omega
 private theorem byte_body_1_exit_eq (base : Word) :
     (base + 108 + 12) + signExtend21 (16 : BitVec 21) = base + 136 := by
-  rw [show signExtend21 (16 : BitVec 21) = (16 : Word) from by decide]; bv_omega
+  rw [se21_16]; bv_omega
 -- body_0 is fallthrough: exits at base+124+12 = base+136 (no JAL)
 
 -- Store exit address
 private theorem byte_store_exit_eq (base : Word) :
     (base + 136 + 20) + signExtend21 (24 : BitVec 21) = base + 180 := by
-  rw [show signExtend21 (24 : BitVec 21) = (24 : Word) from by decide]; bv_omega
+  rw [se21_24]; bv_omega
 
 -- sp address normalization
 private theorem byte_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by


### PR DESCRIPTION
## Summary

**GRIND.md §8.2 Phase 3 follow-up.** After #385 / #388 / #390 / #392 migrated the DivMod / SignExtend / Shift subtrees, 9 inline \`rw [show signExtend1? N = <const> from by decide]; bv_omega\` sites remain in \`EvmAsm/Evm64/Byte/Spec.lean\`. Every offset is already \`@[rv64_addr, grind =]\` in \`EvmAsm/Rv64/AddrNorm.lean\` (landed in #373).

## Changes

- Add \`import EvmAsm.Rv64.AddrNorm\` to \`Byte/Spec.lean\`.
- Add \`open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se21_24 se21_32 se21_48)\` at the file header.
- 9 \`rw [show signExtend1? N = <const> from by decide]; bv_omega\` sites become \`rw [seNN_N]; bv_omega\`.

| Helper | New rewrite target |
|---|---|
| \`byte_bne_target\`         | \`se13_140\` |
| \`byte_beq_target\`         | \`se13_128\` |
| \`byte_c_e0\`               | \`se13_68\` |
| \`byte_c_e1\`               | \`se13_44\` |
| \`byte_c_e2\`               | \`se13_20\` |
| \`byte_body_3_exit_eq\`     | \`se21_48\` |
| \`byte_body_2_exit_eq\`     | \`se21_32\` |
| \`byte_body_1_exit_eq\`     | \`se21_16\` |
| \`byte_store_exit_eq\`      | \`se21_24\` |

## Why this is safe

No proof-body changes beyond the rewrite-target swap. The lemmas still close by \`bv_omega\` after rewriting; identical behaviour, simpler proofs.

Matches the pattern established by #385 / #388 / #390 / #392.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep -n 'rw \\[show signExtend1[23]\\|rw \\[show signExtend21' EvmAsm/Evm64/Byte/Spec.lean\` returns no hits.

Refs GRIND.md §8.2 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)