### PR TITLE
refactor(signextend): migrate the last inline `signExtend12 31` rewrite

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -745,7 +745,7 @@ theorem signext_body_spec (sp base : Word)
   -- Key facts
   -- Key arithmetic facts
   have hb0_lt31 : b0.toNat < 31 := by
-    rw [show signExtend12 (31 : BitVec 12) = (31 : Word) from by decide] at hsmall
+    rw [signExtend12_31] at hsmall
     exact BitVec.lt_def.mp (of_decide_eq_true hsmall)
   -- High limbs of b are zero
   have hb12_b3 := BitVec.or_eq_zero_iff.mp hhigh

--- a/EvmAsm/Rv64/Instructions.lean
+++ b/EvmAsm/Rv64/Instructions.lean
@@ -75,6 +75,7 @@ def signExtend21 (imm : BitVec 21) : Word :=
 @[simp] theorem signExtend12_3  : signExtend12 (3  : BitVec 12) = (3  : Word) := by decide
 @[simp] theorem signExtend12_5  : signExtend12 (5  : BitVec 12) = (5  : Word) := by decide
 @[simp] theorem signExtend12_6  : signExtend12 (6  : BitVec 12) = (6  : Word) := by decide
+@[simp] theorem signExtend12_31 : signExtend12 (31 : BitVec 12) = (31 : Word) := by decide
 @[simp] theorem signExtend12_63 : signExtend12 (63 : BitVec 12) = (63 : Word) := by decide
 
 -- Negative offsets used by DivMod scratch memory (signExtend12 of values >= 2048)


### PR DESCRIPTION
## Summary

After #385 / #388 / #390 / #392 / #395, a single inline \`rw [show signExtend12 (31 : BitVec 12) = (31 : Word) from by decide]\` remained in \`EvmAsm/Evm64/SignExtend/Compose.lean:748\`. The value 31 wasn't covered by the existing \`@[simp]\` \`signExtend12_N\` family in \`EvmAsm/Rv64/Instructions.lean\`, so the site could not be migrated in the earlier sweeps.

## Changes

- \`EvmAsm/Rv64/Instructions.lean\`: add \`signExtend12_31 : signExtend12 (31 : BitVec 12) = (31 : Word) := by decide\` as \`@[simp]\`, adjacent to the other small-offset \`signExtend12_N\` siblings (\`_0\`, \`_4\`, ..., \`_63\`).
- \`EvmAsm/Evm64/SignExtend/Compose.lean:748\`: \`rw [show signExtend12 (31 : BitVec 12) = (31 : Word) from by decide]\` → \`rw [signExtend12_31]\`.

## Milestone

The inline-rewrite half of GRIND.md §8.2 Phase 3 is now complete for the entire repository:

\`\`\`
grep -rn 'rw \\[show signExtend1[23]\\|rw \\[show signExtend21\\|rw \\[show signExtend12\\|simp only \\[show signExtend1' EvmAsm/
→ 0 matches
\`\`\`

82 sites migrated by #385 / #388 / #390 / #392 / #395 + 1 final site here = 83 total inline signExtend \`show ... from by decide\` rewrites eliminated across 12 files.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep\` for the four inline-rewrite shapes across \`EvmAsm/\` returns zero hits.

Refs GRIND.md §8.2 Phase 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)