### PR TITLE
refactor(DivMod,Byte): dedupe x1_val_n4 + drop private signExtend12_255 shadow

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -265,8 +265,8 @@ private theorem cpsTriple_strip_pure_and_convert
 -- Bridge lemma: connect per-limb body output to EvmWord.byte result
 -- ============================================================================
 
-/-- signExtend12 (255 : BitVec 12) = (255 : Word). -/
-private theorem signExtend12_255 : signExtend12 (255 : BitVec 12) = (255 : Word) := by decide
+-- `signExtend12_255` is the `@[simp]` theorem in `EvmAsm/Rv64/Instructions.lean`
+-- (reachable via `open EvmAsm.Rv64` at the file header).
 
 /-- Bridge from per-limb SRL+ANDI to natural number div+mod.
     `(limb >>> (n % 64)) &&& 255 = BitVec.ofNat 64 ((limb.toNat / 2^n) % 256)` for n < 64. -/

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -554,6 +554,11 @@ theorem phB_off_20 (base : Word) : (base + phaseBOff : Word) + 20 = base + 52 :=
 theorem phB_off_24 (base : Word) : (base + phaseBOff : Word) + 24 = base + 56 := by bv_addr
 theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
 
+-- n=4 special: x1 = signExtend12 4 - 4 = 0, used by the shift-0 fast path
+-- and the main `FullPathN4` path. Shared here so the two consumer files
+-- (`FullPathN4.lean`, `FullPathN4Shift0.lean`) don't re-declare it privately.
+theorem x1_val_n4 : signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) := by decide
+
 -- Shared `signExtend13`/`signExtend21` evaluations for these seven concrete
 -- offsets (8, 16, 24, 172, 464, 1020 and 21_40) used to live here as
 -- `theorem signExtend13_N`. They have been migrated to the repo-wide

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -22,8 +22,7 @@ open EvmAsm.Rv64
 
 -- se12_32, se12_40, se12_48, se12_56 are in Base.lean
 
-/-- signExtend12(4) - 4 = 0, used for x1 register in loopSetupPost at n=4. -/
-private theorem x1_val_n4 : signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) := by decide
+-- `x1_val_n4` now lives in `Compose/Base.lean` (shared with FullPathN4Shift0).
 
 -- ============================================================================
 -- Postcondition and condition functions for n=4 composition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
 
 -- se12_32, se12_40, se12_48, se12_56, ult_zero_of_ne are in Base.lean
 
-private theorem x1_val_n4 : signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) := by decide
+-- `x1_val_n4` now lives in `Compose/Base.lean` (shared with FullPathN4).
 
 -- ============================================================================
 -- Condition definitions for shift=0 call path

--- a/EvmAsm/Rv64/Instructions.lean
+++ b/EvmAsm/Rv64/Instructions.lean
@@ -76,6 +76,7 @@ def signExtend21 (imm : BitVec 21) : Word :=
 @[simp] theorem signExtend12_5  : signExtend12 (5  : BitVec 12) = (5  : Word) := by decide
 @[simp] theorem signExtend12_6  : signExtend12 (6  : BitVec 12) = (6  : Word) := by decide
 @[simp] theorem signExtend12_63 : signExtend12 (63 : BitVec 12) = (63 : Word) := by decide
+@[simp] theorem signExtend12_255 : signExtend12 (255 : BitVec 12) = (255 : Word) := by decide
 
 -- Negative offsets used by DivMod scratch memory (signExtend12 of values >= 2048)
 @[simp] theorem signExtend12_4095 : signExtend12 (4095 : BitVec 12) = (18446744073709551615 : Word) := by decide  -- -1


### PR DESCRIPTION
## Summary

Two small shadow-dedup cleanups mirroring the pattern of #374 / #380 / #382:

### 1. \`x1_val_n4\` — private dup across two files

\`x1_val_n4\` (proves \`signExtend12 4 - 4 = 0\`, used to fold the \`x1\` register in \`loopSetupPost\` at n=4) was declared **privately** in both \`Compose/FullPathN4.lean\` and \`Compose/FullPathN4Shift0.lean\` as verbatim \`by decide\` copies.

- Move to \`Compose/Base.lean\` as a shared non-private theorem.
- Drop both file-local \`private\` shadows (replaced by one-line pointer comments).

### 2. \`Byte/Spec.lean\` file-private \`signExtend12_255\`

\`Byte/Spec.lean\` carried a file-private \`signExtend12_255 : signExtend12 (255 : BitVec 12) = (255 : Word) := by decide\`. The same lemma can now be \`@[simp]\`-tagged in \`Rv64/Instructions.lean\` alongside its small-offset siblings (\`_63\`, \`_31\`, \`_6\`, \`_5\`, \`_3\`, \`_2\`, \`_1\`, …).

- Add \`@[simp] signExtend12_255\` to \`Rv64/Instructions.lean\`.
- Drop the private shadow. The lone \`rw [signExtend12_255]\` call-site now resolves to the Rv64-level lemma via the file's existing \`open EvmAsm.Rv64\`.

## Net

- **−3 private duplicate theorem lines** (2× \`x1_val_n4\` + 1× \`signExtend12_255\`).
- **+1 shared theorem** in \`Compose/Base.lean\`.
- **+1 \`@[simp]\` entry** in \`Rv64/Instructions.lean\`.
- **3 pointer comments** explaining where the replacements live.
- **No proof body changes**.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep -rn '^private theorem .*: signExtend12\` EvmAsm/\` and \`grep -rn 'x1_val_n4' EvmAsm/\` confirm no further duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)