### PR TITLE
feat(byte_alg): add GRIND.md Phase 4 grindset for extractByte / replaceByte algebra

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -30,3 +30,5 @@ import EvmAsm.Rv64.RegOpsAttr
 import EvmAsm.Rv64.RegOps
 import EvmAsm.Rv64.AddrNormAttr
 import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Rv64.ByteAlgAttr
+import EvmAsm.Rv64.ByteAlg

--- a/EvmAsm/Rv64/ByteAlg.lean
+++ b/EvmAsm/Rv64/ByteAlg.lean
@@ -1,0 +1,61 @@
+/-
+  EvmAsm.Rv64.ByteAlg
+
+  `byte_alg` grindset for `extractByte` / `replaceByte` algebra on 64-bit
+  words (GRIND.md Phase 4).
+
+  Seeds the set with the single algebra identity that currently exists in
+  `Rv64/ByteOps.lean`:
+
+    extractByte_replaceByte_same
+      : extractByte (replaceByte w pos.val b) pos.val = b
+
+  Future siblings (`extractByte_replaceByte_diff` for `pos₁ ≠ pos₂`,
+  `replaceByte_replaceByte_same` idempotency, byte-index arithmetic,
+  `extractByte` of concrete word literals) land as one-line
+  `@[byte_alg, grind =]` facts in this file as they are proved.
+
+  The `byte_alg` tactic macro wraps `first | grind | simp only [byte_alg]`,
+  matching the `divmod_addr` / `rv64_addr` / `reg_ops` pattern.
+-/
+
+import EvmAsm.Rv64.ByteOps
+import EvmAsm.Rv64.ByteAlgAttr
+
+namespace EvmAsm.Rv64
+
+-- ============================================================================
+-- Existing byte algebra lemmas — register in the `byte_alg` simp / grind sets
+-- ============================================================================
+
+attribute [byte_alg, grind =] extractByte_replaceByte_same
+
+-- ============================================================================
+-- `byte_alg` tactic
+--
+-- Primary: `grind` (sees every `@[grind =]`-registered byte-algebra fact).
+-- Fallback: `simp only [byte_alg]` (matches the same vocabulary under the
+-- named attribute; useful when the consumer wants a tight rewrite without
+-- grind's congruence closure).
+-- ============================================================================
+
+/-- Close a byte-algebra equality (`extractByte`/`replaceByte` commute/cancel
+    identities). Tries `grind` first, falls back to
+    `simp only [byte_alg]`. -/
+macro "byte_alg" : tactic =>
+  `(tactic| first
+    | grind
+    | simp only [byte_alg])
+
+end EvmAsm.Rv64
+
+-- ============================================================================
+-- Sanity: the tactic closes the seeded identity.
+-- ============================================================================
+
+section Sanity
+open EvmAsm.Rv64
+
+example (w : Word) (pos : Fin 8) (b : BitVec 8) :
+    extractByte (replaceByte w pos.val b) pos.val = b := by byte_alg
+end Sanity

--- a/EvmAsm/Rv64/ByteAlgAttr.lean
+++ b/EvmAsm/Rv64/ByteAlgAttr.lean
@@ -1,0 +1,17 @@
+/-
+  EvmAsm.Rv64.ByteAlgAttr
+
+  Declares the `byte_alg` simp attribute used by `ByteAlg.lean`.
+
+  Split out from `ByteAlg.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code should
+  import `ByteAlg.lean` (which imports this file) — not this file directly.
+-/
+
+import Mathlib.Tactic.Attr.Register
+
+/-- Simp/grind set for `extractByte` / `replaceByte` algebra on 64-bit words.
+    Collects the commute / cancel identities (`extractByte (replaceByte w p b) p
+    = b`, future `..._diff` / `replaceByte_replaceByte_*` siblings) that drive
+    byte-level opcode proofs. GRIND.md Phase 4. -/
+register_simp_attr byte_alg

--- a/GRIND.md
+++ b/GRIND.md
@@ -167,6 +167,7 @@ When in doubt, write a short throwaway test demonstrating the duplication is rea
 | `divmod_addr` | `EvmAsm/Evm64/DivMod/AddrNorm.lean` (+ `AddrNormAttr.lean`) | landed (infrastructure + 1 file migrated) | #263 / #304 |
 | `reg_ops` | `EvmAsm/Rv64/RegOps.lean` (+ `RegOpsAttr.lean`) | infrastructure landed (sanity proofs only, migrations pending) | GRIND.md Phase 5 |
 | `rv64_addr` | `EvmAsm/Rv64/AddrNorm.lean` (+ `AddrNormAttr.lean`) | infrastructure landed (~47 signExtend13 / signExtend21 atomic facts + associativity, sanity proofs only, migrations pending) | GRIND.md Phase 3 |
+| `byte_alg` | `EvmAsm/Rv64/ByteAlg.lean` (+ `ByteAlgAttr.lean`) | infrastructure landed (seeded with `extractByte_replaceByte_same`; further algebra identities pending) | GRIND.md Phase 4 |
 
 Add new rows here as sets land. Each row should link the issue and the introducing PR.
 
@@ -219,11 +220,12 @@ Every phase follows the same seven-step shape. Deviate only with a documented re
   - Migration PRs collapsing `rw [show signExtend1? N = <const> from by decide]` to `rw [se13_N]` / `rw [se21_N]`: **#385** (DivMod/Compose/, 28 sites), **#388** (SignExtend/Compose, 9 sites), **#390** (DivMod/LoopBody + DivMod/Compose/{Epilogue, FullPath}, 9 sites), **#392** (Shift/{Compose, ShlCompose, SarCompose}, 27 sites), **#395** (Byte/Spec, 9 sites) — 82 sites total across 11 files. Remaining: a single `signExtend12 31` site in `SignExtend/Compose.lean:748` (value 31 is not in the grindset — leave it or backfill separately).
   - Bulk migration of the pure-associativity `bv_addr` call-sites (578 in DivMod alone) is the remaining follow-up and can happen incrementally: `rv64_addr` already subsumes `bv_addr` via the simp fallback, so any call-site can switch in place.
 
-#### Phase 4 ⏳ — `byte_alg`
+#### Phase 4 🚧 — `byte_alg`
 - **Goal:** close `extractByte`/`replaceByte` algebra goals with one tactic.
-- **Targets:** new `EvmAsm/Rv64/ByteAlg.lean`. Atomic facts: `extractByte_replaceByte_same`, `extractByte_replaceByte_diff`, `replaceByte_replaceByte_same`, byte-index arithmetic, `extractByte` of concrete word literals.
+- **Targets:** new `EvmAsm/Rv64/ByteAlg.lean` (+ `ByteAlgAttr.lean`). Atomic facts: `extractByte_replaceByte_same`, `extractByte_replaceByte_diff`, `replaceByte_replaceByte_same`, byte-index arithmetic, `extractByte` of concrete word literals.
 - **Proof-of-value:** one file in `EvmAsm/Evm64/Byte/` (e.g., `Byte/Spec.lean`).
 - **Dependencies:** none.
+- **Status:** Infrastructure landed. `EvmAsm/Rv64/ByteAlg.lean` + `ByteAlgAttr.lean` declare the `@[byte_alg]` attribute (Layout B) and the `byte_alg` tactic macro (`first | grind | simp only [byte_alg]`). Seeded with the single algebra identity currently proved in `Rv64/ByteOps.lean`: `extractByte_replaceByte_same`. One sanity `example` exercises the tactic. Further siblings (`extractByte_replaceByte_diff` for `pos₁ ≠ pos₂`, `replaceByte_replaceByte_same` idempotency, byte-index arithmetic, `extractByte` of concrete word literals) land as one-line `@[byte_alg, grind =]` additions once proved.
 
 #### Phase 5 🚧 — `reg_ops`
 - **Goal:** close register-read-after-write chains (`getReg (setReg s r v) r' = …`, `setReg_setReg` commute/idempotent) with one tactic.


### PR DESCRIPTION
## Summary

Lands the \`byte_alg\` simp/grind set infrastructure per **GRIND.md Phase 4**. Two new files under \`EvmAsm/Rv64/\`:

- **\`ByteAlgAttr.lean\`** declares the \`@[byte_alg]\` simp attribute (Layout B, separate-file split to allow same-target use).
- **\`ByteAlg.lean\`** imports \`ByteOps\`, registers the single existing byte-algebra identity (\`extractByte_replaceByte_same\`) as \`@[byte_alg, grind =]\` via \`attribute\` commands, and exposes a \`byte_alg\` tactic macro:

  \`\`\`lean
  macro "byte_alg" : tactic =>
    \`(tactic| first | grind | simp only [byte_alg])
  \`\`\`

One sanity \`example\` demonstrates the tactic closing the seeded identity.

## Scope boundary

Further algebra siblings called out in the Phase 4 plan — \`extractByte_replaceByte_diff\` (for \`pos₁ ≠ pos₂\`), \`replaceByte_replaceByte_same\` (idempotency), byte-index arithmetic, \`extractByte\` of concrete word literals — land as one-line \`@[byte_alg, grind =]\` additions in \`ByteAlg.lean\` once proved. This PR is the infrastructure seed; the Phase 4 stop criterion (proof-of-value migration in \`Evm64/Byte/Spec.lean\`) is the follow-up.

Matches the pattern established by:
- \`divmod_addr\` — #263 / #304
- \`reg_ops\` — #372 (GRIND.md Phase 5)
- \`rv64_addr\` — #373 (GRIND.md Phase 3)

## GRIND.md updates

- §7 (\"Sets currently in the repo\") gains a row for \`byte_alg\`.
- §8.2 Phase 4 is flipped from ⏳ pending to 🚧 in progress with a status note describing the landed scope and the pending sibling lemmas.

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs).
- [x] Sanity \`example\` in \`ByteAlg.lean\` closes via \`by byte_alg\`.

Refs GRIND.md Phase 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)