### PR TITLE
docs(PLAN): cross-reference OPCODE_TEMPLATE.md from Phase 4 opcodes

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -503,8 +503,21 @@ All phases below target **Evm64** primarily. Files are under `EvmAsm/Evm64/`.
   6. Stack-level spec: case-split b=0/≠0, then on n, compose full-path + semantic bridge
   7. Factor shared DIV/MOD loop (Issue #266) to derive MOD specs from DIV proofs
 
+Before starting **any** of the remaining arithmetic opcodes below (SDIV,
+SMOD, ADDMOD, MULMOD, EXP), read
+[`EvmAsm/Evm64/OPCODE_TEMPLATE.md`](EvmAsm/Evm64/OPCODE_TEMPLATE.md) —
+it codifies the day-one conventions distilled from the DivMod retrofit
+experience (parallel `LimbSpec/` / `LoopDefs/` / `Compose/` layout,
+unified Bool/Fin dispatch from day one, sibling-opcode factoring,
+`@[irreducible]` bundling thresholds, named `Compose/Offsets.lean`,
+per-opcode `AddrNorm` grindset, `structure <Opcode>Valid` validity
+bundle). Tracked by issue #313.
+
 #### 4.3 SDIV and SMOD (Signed)
 - **Approach**: Check signs, compute unsigned div/mod, apply sign correction.
+- **Per OPCODE_TEMPLATE.md**: SMOD is a sign-sibling of SDIV; layout the
+  files with a shared body + per-sibling epilogue split from the first PR
+  (do not copy DIV's retrofit-style parallel MOD clone).
 
 #### 4.4 ADDMOD and MULMOD
 - **Approach**: ADDMOD needs 257-bit intermediate (carry). MULMOD needs


### PR DESCRIPTION
## Summary

PLAN.md §4.3 (SDIV / SMOD), §4.4 (ADDMOD / MULMOD), §4.5 (EXP) are exactly the scheduled-next opcodes that issue #313 + the resulting [\`EvmAsm/Evm64/OPCODE_TEMPLATE.md\`](../blob/main/EvmAsm/Evm64/OPCODE_TEMPLATE.md) (landed as #370) were written for. The template was missing from the roadmap, so a future agent picking up one of those opcodes would not necessarily know to read it.

## Changes

- Add a short prelude before §4.3 pointing at \`OPCODE_TEMPLATE.md\` and summarising what it codifies (parallel directory layout, unified Bool/Fin dispatch from day one, sibling-opcode factoring, \`@[irreducible]\` bundling thresholds, named \`Compose/Offsets.lean\`, per-opcode \`AddrNorm\` grindset, \`structure <Opcode>Valid\` validity bundle).

- Strengthen §4.3 (SDIV/SMOD) with an explicit \"SMOD-as-sign-sibling\" reminder — the template's \"sibling opcodes factor as post-rewrite\" rule directly applies here and is the tax #266 is cleaning up for the existing MOD clone.

Doc-only change; no Lean sources touched.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).

Refs #313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)