### PR TITLE
docs(GRIND): cross-reference OPCODE_TEMPLATE.md from the header

### DIFF
--- a/GRIND.md
+++ b/GRIND.md
@@ -4,6 +4,8 @@ This document is the single source of truth for how this repo organizes `grind`-
 
 `CLAUDE.md` and `AGENTS.md` link here from their proof-conventions sections — do not duplicate this content elsewhere.
 
+**If you are starting a new opcode subtree** (SDIV, SMOD, ADDMOD, MULMOD, EXP, …): read [`EvmAsm/Evm64/OPCODE_TEMPLATE.md`](EvmAsm/Evm64/OPCODE_TEMPLATE.md) alongside this doc. The template's §2.5 "Opcode-specific address grindset" rule directs you to ship an `<Opcode>Addr` / `<Opcode>AddrAttr` pair on the first commit that introduces a non-trivial address computation — this is the canonical shape defined in §3 here.
+
 ---
 
 ## 1. Why we are doing this


### PR DESCRIPTION
## Summary

The new-opcode workflow has two canonical docs:

- **GRIND.md §3 / §4** — how to register a new opcode-specific grindset.
- **[\`EvmAsm/Evm64/OPCODE_TEMPLATE.md\`](../blob/main/EvmAsm/Evm64/OPCODE_TEMPLATE.md) §2.5** — directs implementors to ship one on the first commit that introduces a non-trivial address computation.

Each doc already points inward from its own corner of the repo — \`AGENTS.md\` links \`OPCODE_TEMPLATE.md\`, and \`CLAUDE.md\` + \`AGENTS.md\` link \`GRIND.md\` — but the two canonical docs didn't cross-reference each other.

Add a short one-paragraph pointer from GRIND.md's header to \`OPCODE_TEMPLATE.md\`, so:
- A contributor who starts with the proof-automation doc sees where the opcode-level layout rules live.
- A contributor starting from \`OPCODE_TEMPLATE.md\` is already routed to GRIND.md by §2.5.

Mirror of #405 (PLAN → OPCODE_TEMPLATE cross-ref).

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs). Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)