### PR TITLE
feat(divmod): add divN4StackPre_unfold_atoms full-depth unfold

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -369,6 +369,31 @@ theorem modN4MaxSkipStackPost_unfold (sp : Word) (a b : EvmWord) :
      divScratchOwn sp) := by
   delta modN4MaxSkipStackPost; rfl
 
+/-- Full-depth unfold of `modN4MaxSkipStackPost`: expands the bundle, its
+    inner `evmWordIs` atoms, and `divScratchOwn` all at once. Mirror of
+    `divN4MaxSkipStackPost_unfold_atoms`. -/
+theorem modN4MaxSkipStackPost_unfold_atoms (sp : Word) (a b : EvmWord) :
+    modN4MaxSkipStackPost sp a b =
+    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
+     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
+     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
+     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
+     (((sp + 32) ↦ₘ (EvmWord.mod a b).getLimbN 0) **
+      ((sp + 40) ↦ₘ (EvmWord.mod a b).getLimbN 1) **
+      ((sp + 48) ↦ₘ (EvmWord.mod a b).getLimbN 2) **
+      ((sp + 56) ↦ₘ (EvmWord.mod a b).getLimbN 3)) **
+     (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
+      memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
+      memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
+      memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
+      memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
+      memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
+      memOwn (sp + signExtend12 3992) ** memOwn (sp + signExtend12 3984) **
+      memOwn (sp + signExtend12 3976))) := by
+  rw [modN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
+      divScratchOwn_unfold]
+
 theorem pcFree_modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
     (modN4MaxSkipStackPost sp a b).pcFree := by
   rw [modN4MaxSkipStackPost_unfold]; pcFree

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -211,6 +211,38 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
        shift_mem n_mem j_mem) := by
   delta divN4StackPre; rfl
 
+/-- Full-depth unfold of `divN4StackPre`: expands the bundle, both `evmWordIs`
+    atoms, and `divScratchValues` into primitive `regIs` / `memIs` atoms.
+    Parallel to `divN4MaxSkipStackPost_unfold_atoms` — useful when proving
+    the stack spec by unfolding the target and matching position-by-position
+    against a concrete unfolded hypothesis. -/
+theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shift_mem n_mem j_mem : Word) :
+    divN4StackPre sp a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x11 ↦ᵣ v11) **
+     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
+     (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+      ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
+     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+      ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+      ((sp + signExtend12 3984) ↦ₘ n_mem) **
+      ((sp + signExtend12 3976) ↦ₘ j_mem))) := by
+  rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
+      divScratchValues_unfold]
+
 /-- MOD-side parallel of `divN4StackPre`. Identical content — same registers,
     same operands, same scratch bundle. The name is kept distinct so the
     forthcoming MOD stack spec reads symmetrically with its DIV counterpart.


### PR DESCRIPTION
Parallel to `divN4MaxSkipStackPost_unfold_atoms` (#399): expands the stack-pre bundle + both `evmWordIs` + `divScratchValues` down to primitive `regIs`/`memIs` atoms in one rewrite.

Useful for the full stack-spec composition: unfold target pre and post into flat atom chains, then match position-by-position against the limb-level spec.

## Test plan
- [x] `lake build` succeeds (3513 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)