### PR TITLE
refactor(Rv64,Evm64): share regIs_to_regOwn instead of 8 private duplicates

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -212,9 +212,7 @@ private theorem byte_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) =
 -- Helper lemmas
 -- ============================================================================
 
-/-- Weaken concrete register to existential ownership. -/
-private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
 private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -699,9 +699,7 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
 -- Section 8: Phase A (9 instructions, cpsBranch)
 -- ============================================================================
 
--- Helper: weaken concrete regs to regOwn
-private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Phase A code as explicit union of sub-CRs (matching disjoint composition structure).
     9 instructions: LD + LD/OR + LD/OR + BNE + LD + SLTIU + BEQ -/

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -21,8 +21,7 @@ open EvmAsm.Rv64
 -- Helpers
 -- ============================================================================
 
-private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: sign-fill result + frame regs → evmWordIs sign_fill + regOwn. -/
 private theorem sar_sign_fill_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 sign_ext : Word) :
@@ -44,12 +43,12 @@ private theorem sar_sign_fill_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 
      ((sp + 32) ↦ₘ sign_ext) ** ((sp + 40) ↦ₘ sign_ext) **
      ((sp + 48) ↦ₘ sign_ext) ** ((sp + 56) ↦ₘ sign_ext)) from by xperm) h).mp hp
   have w1 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _))))) h hp'
+    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _))))) h hp'
   have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x7 _)))))) h w1
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x7 _)))))) h w1
   have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-      (sepConj_mono_left (regIs_to_regOwn' .x11 _))))))) h w2
+      (sepConj_mono_left (regIs_to_regOwn .x11 _))))))) h w2
   exact w3
 
 -- ============================================================================

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -20,8 +20,7 @@ open EvmAsm.Rv64
 -- Helpers
 -- ============================================================================
 
-private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
 private theorem shr_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
@@ -43,12 +42,12 @@ private theorem shr_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Wor
      ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
      ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) from by xperm) h).mp hp
   have w1 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _))))) h hp'
+    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _))))) h hp'
   have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x7 _)))))) h w1
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x7 _)))))) h w1
   have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-      (sepConj_mono_left (regIs_to_regOwn' .x11 _))))))) h w2
+      (sepConj_mono_left (regIs_to_regOwn .x11 _))))))) h w2
   exact w3
 
 -- ============================================================================

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -20,8 +20,7 @@ open EvmAsm.Rv64
 -- Helpers
 -- ============================================================================
 
-private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
 private theorem shl_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
@@ -43,12 +42,12 @@ private theorem shl_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Wor
      ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
      ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) from by xperm) h).mp hp
   have w1 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _))))) h hp'
+    (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _))))) h hp'
   have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x7 _)))))) h w1
+    (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x7 _)))))) h w1
   have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-      (sepConj_mono_left (regIs_to_regOwn' .x11 _))))))) h w2
+      (sepConj_mono_left (regIs_to_regOwn .x11 _))))))) h w2
   exact w3
 
 -- ============================================================================

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -26,9 +26,8 @@ open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se
 /-- The full evm_signextend code as a single CodeReq.ofProg block (48 instructions). -/
 abbrev signextCode (base : Word) : CodeReq := CodeReq.ofProg base evm_signextend
 
-/-- Weaken concrete register to existential ownership. -/
-private theorem regIs_to_regOwn' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared with the
+-- Byte / Shift / SignExtend opcode files).
 
 /-- If each half of a CodeReq union is subsumed by target, so is the union. -/
 private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
@@ -306,14 +305,14 @@ theorem signext_nochange_high_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by
       simp only [signExtend12_32] at hq
-      have w0 := sepConj_mono_left (regIs_to_regOwn' .x5 _) h
+      have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
            ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
           from by xperm) h).mp hq)
-      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x10 _)) h w0
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h w0
       exact (congrFun (show _ =
         ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -434,14 +433,14 @@ theorem signext_nochange_geq31_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by
       simp only [signExtend12_32] at hq
-      have w0 := sepConj_mono_left (regIs_to_regOwn' .x5 _) h
+      have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
           ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ sltiu_val) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
            ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
           from by xperm) h).mp hq)
-      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x10 _)) h w0
+      have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)) h w0
       exact (congrFun (show _ =
         ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -692,9 +691,9 @@ theorem signext_body_spec (sp base : Word)
             ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) ** ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56)) h := by
     intro r5v r6v r10v m32 m40 m48 m56 h hp
     rw [hse32] at hp
-    have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x5 _)) h hp
-    have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _))) h w1
-    have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x10 _)))) h w2
+    have w1 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x5 _)) h hp
+    have w2 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _))) h w1
+    have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _)))) h w2
     xperm_hyp w3
   -- Apply weakening to each body+done
   have hbd0_w := cpsTriple_consequence _ _ _ _ _ _ _
@@ -737,9 +736,9 @@ theorem signext_body_spec (sp base : Word)
       (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) ** bmem **
       ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ m56))
       from by xperm) h).mp hp
-    have w1 := sepConj_mono_left (regIs_to_regOwn' .x5 _) h hp'
-    have w2 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x6 _)) h w1
-    have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn' .x10 _))) h w2
+    have w1 := sepConj_mono_left (regIs_to_regOwn .x5 _) h hp'
+    have w2 := sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x6 _)) h w1
+    have w3 := sepConj_mono_right (sepConj_mono_right (sepConj_mono_left (regIs_to_regOwn .x10 _))) h w2
     exact (congrFun (show _ = _ from by xperm) h).mp w3
   -- signextend bridge: connect body outputs to (EvmWord.signextend b x).getLimb i
   -- Key facts

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -300,8 +300,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
 -- Phase A: Check b >= 31 (9 instructions, cpsBranch)
 -- ============================================================================
 
-private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Phase A code as explicit union of sub-CRs (matching disjoint composition structure).
     9 instructions: LD + LD/OR + LD/OR + BNE + LD + SLTIU + BEQ -/

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -19,8 +19,7 @@ open EvmAsm.Rv64
 -- Helpers
 -- ============================================================================
 
-private theorem regIs_to_regOwn'' (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
-  fun _ hp => ⟨v, hp⟩
+-- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Helper: lift a no-change raw-limb spec to evmWordIs form (with x6 framing). -/
 private theorem signext_nochange_lift (sp base : Word)
@@ -59,7 +58,7 @@ private theorem signext_nochange_lift (sp base : Word)
       have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
       have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
       simp only [ha40, ha48, ha56]
-      have w := sepConj_mono_right (regIs_to_regOwn'' .x6 _) h hq
+      have w := sepConj_mono_right (regIs_to_regOwn .x6 _) h hq
       xperm_hyp w)
     hmain_f
 

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -351,6 +351,14 @@ def regOwn (r : Reg) : Assertion := fun h => ∃ v, regIs r v h
 /-- Ownership of memory at address a with unspecified value. -/
 def memOwn (a : Word) : Assertion := fun h => ∃ v, memIs a v h
 
+/-- Weaken a concrete register assertion `r ↦ᵣ v` to the existential
+    `regOwn r` ownership form. Shared across Evm64 opcode files that
+    previously re-declared this as a `private theorem`
+    (`Evm64/SignExtend/*`, `Evm64/Shift/*`, `Evm64/Byte/Spec.lean`). -/
+theorem regIs_to_regOwn (r : Reg) (v : Word) :
+    ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
+  fun _ hp => ⟨v, hp⟩
+
 /-- The empty assertion: owns no resources. -/
 def empAssertion : Assertion := fun h => h = PartialState.empty
 


### PR DESCRIPTION
## Summary

\`regIs_to_regOwn : ∀ h, (r ↦ᵣ v) h → (regOwn r) h\` with proof \`fun _ hp => ⟨v, hp⟩\` was independently redeclared as a \`private theorem\` in **8 Evm64 opcode files** under three different name shapes:

| Name shape | Files |
|---|---|
| \`regIs_to_regOwn\` (no prime) | \`Byte/Spec.lean\`, \`Shift/LimbSpec.lean\`, \`SignExtend/LimbSpec.lean\` |
| \`regIs_to_regOwn'\` (one prime) | \`SignExtend/Compose.lean\`, \`Shift/Semantic.lean\`, \`Shift/SarSemantic.lean\`, \`Shift/ShlSemantic.lean\` |
| \`regIs_to_regOwn''\` (two primes) | \`SignExtend/Spec.lean\` |

Every copy has identical type and identical \`fun _ hp => ⟨v, hp⟩\` proof — the primes were a workaround for same-file name conflicts that don't arise once the lemma lives in one canonical home.

## Changes

- Add \`theorem regIs_to_regOwn\` to \`EvmAsm/Rv64/SepLogic.lean\` next to \`regOwn\` (the natural home), non-private so every downstream consumer reaches it via the \`open EvmAsm.Rv64\` they already have.
- Drop the 8 private shadows; each file gains a one-line pointer comment.
- Rename prime-suffixed call-sites (\`regIs_to_regOwn'\` / \`regIs_to_regOwn''\`) to the canonical unprefixed \`regIs_to_regOwn\`.

No proof body changes.

## Net

- **−8 duplicate 2-line blocks** (16 lines of duplicated theorem).
- **+1 shared canonical theorem** in \`Rv64/SepLogic.lean\` (6 lines with docstring).
- **8 pointer comments** explaining where the replacement lives.
- **No behavioural change** — identical proof term in both old and new call-sites.

## Test plan

- [x] \`lake build\` — full repo green (3513 jobs).
- [x] \`grep -rn '^private theorem regIs_to_regOwn' EvmAsm/\` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)