### PR TITLE
feat(divmod): add fullDivN4MaxSkipPost_unfold named unfold theorem

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -487,6 +487,37 @@ instance (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
   ⟨pcFree_fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3⟩
 
+/-- Named unfold for `fullDivN4MaxSkipPost`. Restores access to the
+    underlying sepConj structure once the `@[irreducible]` attribute in
+    `FullPathN4.lean` makes `delta` the only way in. Parallel to the
+    `_unfold` theorems for the other post bundles. -/
+theorem fullDivN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    (let shift := (clzResult b3).1
+     let anti_shift := signExtend12 (0 : BitVec 12) - shift
+     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+     let b0' := b0 <<< (shift.toNat % 64)
+     let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+     let u0 := a0 <<< (shift.toNat % 64)
+     let q_hat : Word := signExtend12 4095
+     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+     denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q_hat 0 0 0 **
+     ((sp + signExtend12 3992) ↦ₘ shift) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat)) := by
+  delta fullDivN4MaxSkipPost; rfl
+
 /-- MOD counterpart of `div_n4_max_skip_stack_weaken`. Same pattern, same
     register/memory weakenings — only the result-slot `evmWordIs` holds
     `EvmWord.mod a b` instead of `EvmWord.div a b`. -/

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -211,6 +211,38 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
        shift_mem n_mem j_mem) := by
   delta divN4StackPre; rfl
 
+/-- Full-depth unfold of `divN4StackPre`: expands the bundle, both `evmWordIs`
+    atoms, and `divScratchValues` into primitive `regIs` / `memIs` atoms.
+    Parallel to `divN4MaxSkipStackPost_unfold_atoms` — useful when proving
+    the stack spec by unfolding the target and matching position-by-position
+    against a concrete unfolded hypothesis. -/
+theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shift_mem n_mem j_mem : Word) :
+    divN4StackPre sp a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x11 ↦ᵣ v11) **
+     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
+     (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+      ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
+     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+      ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+      ((sp + signExtend12 3984) ↦ₘ n_mem) **
+      ((sp + signExtend12 3976) ↦ₘ j_mem))) := by
+  rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
+      divScratchValues_unfold]
+
 /-- MOD-side parallel of `divN4StackPre`. Identical content — same registers,
     same operands, same scratch bundle. The name is kept distinct so the
     forthcoming MOD stack spec reads symmetrically with its DIV counterpart.


### PR DESCRIPTION
Named unfold counterpart to the `@[irreducible]` attribute on `fullDivN4MaxSkipPost`. Parallel to the `_unfold` theorems for the other post bundles.

## Test plan
- [x] `lake build` succeeds (3515 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)