### PR TITLE
refactor(Rv64,Evm64): share cpsNBranch_{extend_code, frame_left} helpers

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -216,28 +216,8 @@ private theorem byte_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) =
 private theorem regIs_to_regOwn (r : Reg) (v : Word) : ∀ h, (r ↦ᵣ v) h → (regOwn r) h :=
   fun _ hp => ⟨v, hp⟩
 
-/-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)}
-    (hmono : ∀ a i, cr a = some i → cr' a = some i)
-    (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr' P exits := by
-  intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
-
-/-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
-    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
-  intro R hR s hcr hPFR hpc
-  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
-  have hPFR' : (P ** (F ** R)).holdsFor s :=
-    holdsFor_sepConj_assoc.mp hPFR
-  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
-    h (F ** R) hFR s hcr hPFR' hpc
-  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
-  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+-- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `Rv64/CPSSpec.lean` (shared).
 
 /-- Strip a pure fact from a cpsTriple's precondition and use it to convert the postcondition. -/
 private theorem cpsTriple_strip_pure_and_convert

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -493,30 +493,8 @@ theorem evm_shr_zero_large_spec (sp base : Word)
 -- Section 5: Body path composition
 -- ============================================================================
 
--- Helpers for extending code requirements to cpsNBranch
-
-/-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)}
-    (hmono : ∀ a i, cr a = some i → cr' a = some i)
-    (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr' P exits := by
-  intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
-
-/-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
-    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
-  intro R hR s hcr hPFR hpc
-  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
-  have hPFR' : (P ** (F ** R)).holdsFor s :=
-    holdsFor_sepConj_assoc.mp hPFR
-  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
-    h (F ** R) hFR s hcr hPFR' hpc
-  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
-  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+-- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `Rv64/CPSSpec.lean` (shared).
 
 -- Address normalization lemmas for body path
 private theorem shr_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -647,28 +647,8 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
 -- Section 6: Helpers for body path composition
 -- ============================================================================
 
-/-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)}
-    (hmono : ∀ a i, cr a = some i → cr' a = some i)
-    (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr' P exits := by
-  intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
-
-/-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
-    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
-  intro R hR s hcr hPFR hpc
-  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
-  have hPFR' : (P ** (F ** R)).holdsFor s :=
-    holdsFor_sepConj_assoc.mp hPFR
-  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
-    h (F ** R) hFR s hcr hPFR' hpc
-  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
-  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+-- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `Rv64/CPSSpec.lean` (shared).
 
 -- Address normalization for body path
 private theorem sar_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -483,28 +483,8 @@ theorem evm_shl_zero_large_spec (sp base : Word)
 
 -- Helpers for extending code requirements to cpsNBranch
 
-/-- Monotonicity for cpsNBranch: extend to a larger CodeReq. -/
-private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)}
-    (hmono : ∀ a i, cr a = some i → cr' a = some i)
-    (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr' P exits := by
-  intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
-
-/-- Frame rule for cpsNBranch: frames each exit postcondition with F. -/
-private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
-    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
-  intro R hR s hcr hPFR hpc
-  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
-  have hPFR' : (P ** (F ** R)).holdsFor s :=
-    holdsFor_sepConj_assoc.mp hPFR
-  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
-    h (F ** R) hFR s hcr hPFR' hpc
-  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
-  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+-- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `Rv64/CPSSpec.lean` (shared).
 
 -- Address normalization lemmas for body path
 private theorem shl_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -476,26 +476,8 @@ private theorem cpsTriple_strip_pure_and_convert
     obtain ⟨hp', hcompat', hpq'⟩ := hQR
     exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
 
-private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)}
-    (hmono : ∀ a i, cr a = some i → cr' a = some i)
-    (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr' P exits := by
-  intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
-
-private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
-    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
-    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
-    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
-  intro R hR s hcr hPFR hpc
-  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
-  have hPFR' : (P ** (F ** R)).holdsFor s :=
-    holdsFor_sepConj_assoc.mp hPFR
-  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
-    h (F ** R) hFR s hcr hPFR' hpc
-  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
-  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+-- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `Rv64/CPSSpec.lean` (shared across Evm64 opcode compositions).
 
 -- ============================================================================
 -- Section 6: Body path composition (b < 31)

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -485,6 +485,35 @@ theorem cpsNBranch_weaken_exits (entry : Word) (cr : CodeReq)
   obtain ⟨k, s', hstep, ex, hmem, hpc', hQR⟩ := h R hR s hcr hPR hpc
   exact ⟨k, s', hstep, ex, hsub ex hmem, hpc', hQR⟩
 
+/-- Weaken the code requirement of a `cpsNBranch` via monotonic extension.
+    Shared across the Evm64 opcode compositions (Shift/{Compose,ShlCompose,
+    SarCompose}, Byte/Spec, SignExtend/Compose) that previously each
+    re-declared this as a `private theorem`. -/
+theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)}
+    (hmono : ∀ a i, cr a = some i → cr' a = some i)
+    (h : cpsNBranch entry cr P exits) :
+    cpsNBranch entry cr' P exits := by
+  intro R hR s hcr' hPR hpc
+  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
+
+/-- Frame a `cpsNBranch` on the left by a PC-free frame `F`: the pre-assertion
+    becomes `P ** F` and each exit assertion in the list becomes `ex.2 ** F`.
+    Shared across Evm64 opcode compositions — previously 5× `private theorem`
+    duplicates. -/
+theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
+    (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
+    cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by
+  intro R hR s hcr hPFR hpc
+  have hFR : (F ** R).pcFree := pcFree_sepConj hF hR
+  have hPFR' : (P ** (F ** R)).holdsFor s :=
+    holdsFor_sepConj_assoc.mp hPFR
+  obtain ⟨k, s', hstep, ex, hmem, hpc', hQFR⟩ :=
+    h (F ** R) hFR s hcr hPFR' hpc
+  refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
+  exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
+
 /-- Extend the head exit by composing a cpsTriple after it. -/
 theorem cpsNBranch_extend_head (entry l l' : Word) (cr : CodeReq)
     (P Q R : Assertion)


### PR DESCRIPTION
## Summary

\`cpsNBranch_extend_code\` (CodeReq monotonicity extension) and \`cpsNBranch_frame_left\` (left-frame rule) were independently redeclared as \`private theorem\` in **5 Evm64 opcode files** with byte-for-byte identical definitions:

- \`Evm64/SignExtend/Compose.lean\`
- \`Evm64/Shift/Compose.lean\`
- \`Evm64/Shift/ShlCompose.lean\`
- \`Evm64/Shift/SarCompose.lean\`
- \`Evm64/Byte/Spec.lean\`

Both are general \`cpsNBranch\` primitives — they don't depend on any Evm64-specific vocabulary, and they naturally belong next to the other \`cpsNBranch_*\` siblings (\`cpsNBranch_weaken_pre\`, \`cpsNBranch_weaken_exits\`, \`cpsNBranch_extend_head\`, …) in \`Rv64/CPSSpec.lean\`.

## Changes

- Add the two theorems (non-private) to \`Rv64/CPSSpec.lean\` immediately before \`cpsNBranch_extend_head\`. Each carries a docstring describing which Evm64 files previously redeclared it.
- Drop all **5 × 2 = 10 private shadows**; each file gains a one-line pointer comment. Call-sites reach the new shared theorems via the existing \`open EvmAsm.Rv64\`.
- No proof body changes.

## Net

- **−110 lines** of duplicated theorem blocks (5 files × 2 theorems × ~11 lines each).
- **+29 lines** of two shared theorems with docstrings in \`Rv64/CPSSpec.lean\`.
- **+5 pointer comments**.

Companion to #408 (\`regIs_to_regOwn\` dedup); same pattern.

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs).
- [x] \`grep -rn '^private theorem cpsNBranch_extend_code\\|^private theorem cpsNBranch_frame_left' EvmAsm/\` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)