### PR TITLE
refactor(Rv64,Evm64): share cpsTriple_strip_pure_and_convert helper

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -239,27 +239,7 @@ private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
   refine ⟨k, s', hstep, (ex.1, ex.2 ** F), ?_, hpc', holdsFor_sepConj_assoc.mpr hQFR⟩
   exact List.mem_map.mpr ⟨ex, hmem, rfl⟩
 
-/-- Strip a pure fact from a cpsTriple's precondition and use it to convert the postcondition. -/
-private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Word} {cr : CodeReq}
-    {P Q Q' : Assertion} {fact : Prop}
-    (hbody : cpsTriple entry exit_ cr P Q)
-    (hpost : fact → ∀ h, Q h → Q' h) :
-    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
-  intro R hR s hcr hPFR hpc
-  have hfact : fact := by
-    obtain ⟨hp, _, hpq⟩ := hPFR
-    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
-  have hPR : (P ** R).holdsFor s := by
-    obtain ⟨hp, hcompat, hpq⟩ := hPFR
-    exact ⟨hp, hcompat, by
-      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
-  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
-  exact ⟨k, s', hstep, hpc', by
-    obtain ⟨hp', hcompat', hpq'⟩ := hQR
-    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+-- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
 -- ============================================================================
 -- Bridge lemma: connect per-limb body output to EvmWord.byte result

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -547,28 +547,7 @@ private theorem shr_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = 
 -- Body path composition with evmWordIs postcondition
 -- ============================================================================
 
-/-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
-    to convert the postcondition. -/
-private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Word} {cr : CodeReq}
-    {P Q Q' : Assertion} {fact : Prop}
-    (hbody : cpsTriple entry exit_ cr P Q)
-    (hpost : fact → ∀ h, Q h → Q' h) :
-    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
-  intro R hR s hcr hPFR hpc
-  have hfact : fact := by
-    obtain ⟨hp, _, hpq⟩ := hPFR
-    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
-  have hPR : (P ** R).holdsFor s := by
-    obtain ⟨hp, hcompat, hpq⟩ := hPFR
-    exact ⟨hp, hcompat, by
-      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
-  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
-  exact ⟨k, s', hstep, hpc', by
-    obtain ⟨hp', hcompat', hpq'⟩ := hQR
-    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+-- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
 -- ============================================================================
 -- Bridge lemmas: connect per-limb body outputs to getLimb (value >>> n)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -673,28 +673,7 @@ private theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
 -- Address normalization for body path
 private theorem sar_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
 
-/-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
-    to convert the postcondition. -/
-private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Word} {cr : CodeReq}
-    {P Q Q' : Assertion} {fact : Prop}
-    (hbody : cpsTriple entry exit_ cr P Q)
-    (hpost : fact → ∀ h, Q h → Q' h) :
-    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
-  intro R hR s hcr hPFR hpc
-  have hfact : fact := by
-    obtain ⟨hp, _, hpq⟩ := hPFR
-    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
-  have hPR : (P ** R).holdsFor s := by
-    obtain ⟨hp, hcompat, hpq⟩ := hPFR
-    exact ⟨hp, hcompat, by
-      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
-  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
-  exact ⟨k, s', hstep, hpc', by
-    obtain ⟨hp', hcompat', hpq'⟩ := hQR
-    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+-- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
 -- ============================================================================
 -- Section 7: SAR Bridge lemmas

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -511,28 +511,7 @@ private theorem shl_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 8
 private theorem shl_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
   simp only [signExtend12_32]
 
-/-- Strip a pure fact ⌜fact⌝ from a cpsTriple's precondition and use it
-    to convert the postcondition. -/
-private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Word} {cr : CodeReq}
-    {P Q Q' : Assertion} {fact : Prop}
-    (hbody : cpsTriple entry exit_ cr P Q)
-    (hpost : fact → ∀ h, Q h → Q' h) :
-    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
-  intro R hR s hcr hPFR hpc
-  have hfact : fact := by
-    obtain ⟨hp, _, hpq⟩ := hPFR
-    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
-  have hPR : (P ** R).holdsFor s := by
-    obtain ⟨hp, hcompat, hpq⟩ := hPFR
-    exact ⟨hp, hcompat, by
-      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
-  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
-  exact ⟨k, s', hstep, hpc', by
-    obtain ⟨hp', hcompat', hpq'⟩ := hQR
-    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+-- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
 -- ============================================================================
 -- SHL Bridge lemmas: connect per-limb body outputs to getLimb (value <<< n)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -453,28 +453,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
 -- Section 5: Body path helpers
 -- ============================================================================
 
-/-- Strip a pure fact from a cpsTriple's precondition and use it
-    to convert the postcondition. -/
-private theorem cpsTriple_strip_pure_and_convert
-    {entry exit_ : Word} {cr : CodeReq}
-    {P Q Q' : Assertion} {fact : Prop}
-    (hbody : cpsTriple entry exit_ cr P Q)
-    (hpost : fact → ∀ h, Q h → Q' h) :
-    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
-  intro R hR s hcr hPFR hpc
-  have hfact : fact := by
-    obtain ⟨hp, _, hpq⟩ := hPFR
-    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
-  have hPR : (P ** R).holdsFor s := by
-    obtain ⟨hp, hcompat, hpq⟩ := hPFR
-    exact ⟨hp, hcompat, by
-      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
-  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
-  exact ⟨k, s', hstep, hpc', by
-    obtain ⟨hp', hcompat', hpq'⟩ := hQR
-    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+-- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
 private theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
     {P : Assertion} {exits : List (Word × Assertion)}

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -95,6 +95,37 @@ theorem cpsTriple_consequence (entry exit_ : Word) (cr : CodeReq)
     obtain ⟨hp, hcompat, hpq⟩ := hQR
     exact ⟨hp, hcompat, sepConj_mono_left hpost hp hpq⟩⟩
 
+/-- Strip a pure hypothesis from a `cpsTriple`'s precondition and use it
+    simultaneously to weaken the postcondition. The pre-assertion `P ** ⌜fact⌝`
+    lets the consumer simultaneously extract the pure `fact` and the non-pure
+    part `P` — this is the exact shape that arises after `cpsBranch` elimination
+    (the branch's taken/not-taken pre-assertion carries the concrete branch
+    condition as a pure fact that the post-processing step needs).
+
+    Shared across the Evm64 opcode compositions (`Byte/Spec.lean`,
+    `SignExtend/Compose.lean`, `Shift/{Compose, ShlCompose, SarCompose}.lean`)
+    that previously each re-declared this as a `private theorem`. -/
+theorem cpsTriple_strip_pure_and_convert
+    {entry exit_ : Word} {cr : CodeReq}
+    {P Q Q' : Assertion} {fact : Prop}
+    (hbody : cpsTriple entry exit_ cr P Q)
+    (hpost : fact → ∀ h, Q h → Q' h) :
+    cpsTriple entry exit_ cr (P ** ⌜fact⌝) Q' := by
+  intro R hR s hcr hPFR hpc
+  have hfact : fact := by
+    obtain ⟨hp, _, hpq⟩ := hPFR
+    obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
+    exact ((sepConj_pure_right P fact h1).1 hPF).2
+  have hPR : (P ** R).holdsFor s := by
+    obtain ⟨hp, hcompat, hpq⟩ := hPFR
+    exact ⟨hp, hcompat, by
+      obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
+      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
+  obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
+  exact ⟨k, s', hstep, hpc', by
+    obtain ⟨hp', hcompat', hpq'⟩ := hQR
+    exact ⟨hp', hcompat', sepConj_mono_left (hpost hfact) hp' hpq'⟩⟩
+
 /-- Rule of consequence for cpsBranch: strengthen pre, weaken both posts. -/
 theorem cpsBranch_consequence (entry : Word) (cr : CodeReq)
     (P P' : Assertion) (exit_t : Word) (Q_t Q_t' : Assertion)


### PR DESCRIPTION
## Summary

\`cpsTriple_strip_pure_and_convert\` was independently redeclared as a \`private theorem\` in **5 Evm64 opcode files** with byte-for-byte identical definitions:

- \`Evm64/SignExtend/Compose.lean\`
- \`Evm64/Shift/Compose.lean\`
- \`Evm64/Shift/ShlCompose.lean\`
- \`Evm64/Shift/SarCompose.lean\`
- \`Evm64/Byte/Spec.lean\`

The theorem strips a pure fact \`⌜fact⌝\` from a \`cpsTriple\` precondition and simultaneously uses that fact to weaken the postcondition — the canonical shape after \`cpsBranch\` elimination, where the taken/not-taken pre-assertion carries the concrete branch condition as a pure fact that the post-processing step consumes.

It's a general \`cpsTriple\` primitive, not opcode-specific, so it belongs next to \`cpsTriple_consequence\` in \`Rv64/CPSSpec.lean\`.

## Changes

- Add the theorem (non-private) to \`Rv64/CPSSpec.lean\` right after \`cpsTriple_consequence\` with a docstring describing the shape and listing the consumer files.
- Drop all **5 private shadows**; each file gains a one-line pointer comment.
- No proof body changes.

## Net

- **−110 lines** (5 files × ~22-line duplicate block each).
- **+31 lines** of one shared theorem with docstring in \`Rv64/CPSSpec.lean\`.
- **+5 pointer comments**.

Companion to #408 (\`regIs_to_regOwn\` dedup) and #410 (\`cpsNBranch_extend_code\` + \`cpsNBranch_frame_left\` dedup) — same pattern, completes the sweep of shared \`private theorem\` duplicates in the Evm64 opcode compose layer.

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs).
- [x] \`grep -rn '^private theorem cpsTriple_strip_pure_and_convert' EvmAsm/\` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)