### PR TITLE
refactor(Rv64,Evm64): share CodeReq.union_sub instead of 4 private variants

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -30,15 +30,7 @@ private theorem divK_div128_ofProg_sub_sharedCode (base : Word) :
   exact CodeReq.union_mono_left _ _
 
 -- Helper: combine two subsumption proofs over a union.
-private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
-    (h1 : ∀ a i, cr1 a = some i → target a = some i)
-    (h2 : ∀ a i, cr2 a = some i → target a = some i) :
-    ∀ a i, (cr1.union cr2) a = some i → target a = some i := by
-  intro a i h
-  simp only [CodeReq.union] at h
-  cases h1a : cr1 a with
-  | some j => rw [h1a] at h; simp at h; exact h ▸ h1 a j h1a
-  | none => rw [h1a] at h; simp at h; exact h2 a i h
+-- `CodeReq.union_sub` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).
 
 -- Helper: singleton at index k of divK_div128 with explicit instr ⊆ sharedDivModCode base.
 -- Used to prove each singleton in a block's cr is subsumed by sharedDivModCode.
@@ -54,7 +46,7 @@ private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
       (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
 -- Abbreviation for repeated `by decide` / `by bv_addr` calls
--- Each block's subsumption uses: CodeReq_union_sub (d128_sub ...) (CodeReq_union_sub ...)
+-- Each block's subsumption uses: CodeReq.union_sub (d128_sub ...) (CodeReq.union_sub ...)
 
 -- Address normalization: block entry offsets relative to (base + div128Off)
 private theorem d128_off_40 (base : Word) : (base + div128Off : Word) + 40 = base + 1112 := by bv_addr
@@ -132,15 +124,15 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Extend phase1 cr to sharedDivModCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9
-    exact CodeReq_union_sub (d128_sub base 0 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 1 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 2 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 3 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 4 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 5 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 6 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 7 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 8 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub base 0 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 8 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub base 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
     hph1
   -- Frame phase1 with x0=0 (not used by phase1)
@@ -155,20 +147,20 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 10 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 11 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 12 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 13 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 14 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 15 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 16 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 18 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 19 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 20 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 21 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 22 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 23 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub base 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 11 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 12 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 13 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 14 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 15 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 16 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 20 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 21 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 23 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub base 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
@@ -187,10 +179,10 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 25 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 26 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 27 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 28 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub base 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 28 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub base 29 _ _ (by decide) (by bv_addr) (by decide))))))
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
@@ -213,20 +205,20 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 30 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 31 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 32 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 33 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 34 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 35 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 36 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 37 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 38 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 39 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 42 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 43 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub base 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 31 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 32 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 33 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 34 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 38 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 39 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 42 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 43 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub base 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
@@ -246,9 +238,9 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   have hend := divK_div128_end_spec sp q1' q0' ret_addr un0 ret_addr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (d128_sub base 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (d128_sub base 47 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub base 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub base 47 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub base 48 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -32,15 +32,7 @@ private theorem divK_div128_ofProg_sub_modCode (base : Word) :
   exact CodeReq.union_mono_left _ _
 
 -- Helper: combine two subsumption proofs over a union.
-private theorem CodeReq_union_sub_mod {cr1 cr2 target : CodeReq}
-    (h1 : ∀ a i, cr1 a = some i → target a = some i)
-    (h2 : ∀ a i, cr2 a = some i → target a = some i) :
-    ∀ a i, (cr1.union cr2) a = some i → target a = some i := by
-  intro a i h
-  simp only [CodeReq.union] at h
-  cases h1a : cr1 a with
-  | some j => rw [h1a] at h; simp at h; exact h ▸ h1 a j h1a
-  | none => rw [h1a] at h; simp at h; exact h2 a i h
+-- `CodeReq.union_sub` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).
 
 -- Helper: singleton at index k of divK_div128 with explicit instr ⊆ modCode base.
 -- Used to prove each singleton in a block's cr is subsumed by modCode.
@@ -131,15 +123,15 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Extend phase1 cr to modCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9
-    exact CodeReq_union_sub_mod (d128_sub_mod base 0 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 1 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 2 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 3 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 4 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 5 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 6 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 7 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 8 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub_mod base 0 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 8 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub_mod base 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
     hph1
   -- Frame phase1 with x0=0 (not used by phase1)
@@ -154,20 +146,20 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub_mod (d128_sub_mod base 10 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 11 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 12 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 13 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 14 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 15 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 16 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 17 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 18 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 19 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 20 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 21 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 22 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 23 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub_mod base 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 11 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 12 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 13 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 14 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 15 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 16 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 20 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 21 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 23 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub_mod base 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
@@ -186,10 +178,10 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub_mod (d128_sub_mod base 25 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 26 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 27 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 28 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub_mod base 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 28 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub_mod base 29 _ _ (by decide) (by bv_addr) (by decide))))))
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
@@ -209,20 +201,20 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub_mod (d128_sub_mod base 30 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 31 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 32 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 33 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 34 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 35 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 36 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 37 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 38 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 39 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 42 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 43 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub_mod base 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 31 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 32 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 33 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 34 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 38 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 39 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 42 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 43 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub_mod base 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
@@ -240,9 +232,9 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   have hend := divK_div128_end_spec sp q1' q0' ret_addr un0 ret_addr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub_mod (d128_sub_mod base 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub_mod (d128_sub_mod base 47 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (d128_sub_mod base 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod base 47 _ _ (by decide) (by bv_addr) (by decide))
       (d128_sub_mod base 48 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -46,15 +46,7 @@ private theorem lb_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
       (CodeReq.ofProg_lookup (base + loopBodyOff) (divK_loopBody 560 7736) k hk (by decide)) a i h)
 
 /-- Helper: combine two subsumption proofs over a union. -/
-private theorem CodeReq_union_sub {cr1 cr2 target : CodeReq}
-    (h1 : ∀ a i, cr1 a = some i → target a = some i)
-    (h2 : ∀ a i, cr2 a = some i → target a = some i) :
-    ∀ a i, (cr1.union cr2) a = some i → target a = some i := by
-  intro a i h
-  simp only [CodeReq.union] at h
-  cases h1a : cr1 a with
-  | some j => rw [h1a] at h; simp at h; exact h ▸ h1 a j h1a
-  | none => rw [h1a] at h; simp at h; exact h2 a i h
+-- `CodeReq.union_sub` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).
 
 -- ============================================================================
 -- Section 2: Address normalization lemmas
@@ -143,16 +135,16 @@ theorem divK_mulsub_4limbs_spec
 
   rw [lb_ms1] at L0
   have L0e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 22 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 23 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 24 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 25 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 26 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 27 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 28 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 29 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 30 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 31 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 23 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 24 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 28 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 29 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 31 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 32 _ _ (by decide) (by bv_addr) (by decide))))))))))))
     L0
   -- Limb 1: instrs [33]-[43] at base+580
@@ -161,16 +153,16 @@ theorem divK_mulsub_4limbs_spec
 
   rw [lb_ms2] at L1
   have L1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 33 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 34 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 35 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 36 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 37 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 38 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 39 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 42 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 33 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 34 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 38 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 39 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 42 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 43 _ _ (by decide) (by bv_addr) (by decide))))))))))))
     L1
   -- Frame L0 with memory for limbs 1-3 (so seqFrame can find L1's precondition atoms)
@@ -187,16 +179,16 @@ theorem divK_mulsub_4limbs_spec
 
   rw [lb_ms3] at L2
   have L2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 44 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 47 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 48 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 49 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 50 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 51 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 52 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 53 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 44 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 47 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 48 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 49 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 50 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 51 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 52 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 53 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 54 _ _ (by decide) (by bv_addr) (by decide))))))))))))
     L2
   -- Compose (L0+L1) + L2
@@ -207,16 +199,16 @@ theorem divK_mulsub_4limbs_spec
 
   rw [lb_ms_end] at L3
   have L3e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 55 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 56 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 57 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 58 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 59 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 60 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 61 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 62 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 63 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 64 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 55 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 56 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 57 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 58 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 59 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 60 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 61 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 62 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 63 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 64 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 65 _ _ (by decide) (by bv_addr) (by decide))))))))))))
     L3
   -- Compose (L0+L1+L2) + L3
@@ -318,13 +310,13 @@ theorem divK_addback_full_spec
     v5_init v2_init v0 u0 32 0 (base + 736)
   rw [lb_ab0_end] at A0
   have A0e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 72 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 73 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 74 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 75 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 76 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 77 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 78 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 72 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 73 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 74 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 75 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 76 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 77 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 78 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 79 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A0
   -- Compose init + limb 0
@@ -334,13 +326,13 @@ theorem divK_addback_full_spec
     ac2_0 aun0 v1 u1 40 4088 (base + 768)
   rw [lb_ab1_end] at A1
   have A1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 80 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 81 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 82 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 83 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 84 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 85 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 86 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 80 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 81 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 82 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 83 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 84 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 85 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 86 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A1
   seqFrame IfA0e A1e
@@ -349,13 +341,13 @@ theorem divK_addback_full_spec
     ac2_1 aun1 v2 u2 48 4080 (base + 800)
   rw [lb_ab2_end] at A2
   have A2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 88 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 89 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 90 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 91 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 92 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 93 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 94 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 88 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 89 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 90 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 91 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 92 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 93 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 94 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A2
   seqFrame IfA0eA1e A2e
@@ -364,13 +356,13 @@ theorem divK_addback_full_spec
     ac2_2 aun2 v3 u3 56 4072 (base + 832)
   rw [lb_ab3_end] at A3
   have A3e := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 96 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 97 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 98 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 99 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 100 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 101 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 102 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 96 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 97 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 98 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 99 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 100 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 101 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 102 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A3
   seqFrame IfA0eA1eA2e A3e
@@ -378,9 +370,9 @@ theorem divK_addback_full_spec
   have AF := divK_addback_final_spec u_base aco3 q_hat ac2_3 u4 4064 (base + 864)
   rw [lb_abf_end] at AF
   have AFe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 104 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 105 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 106 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 104 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 105 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 106 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 107 _ _ (by decide) (by bv_addr) (by decide)))))
     AF
   seqFrame IfA0eA1eA2eA3e AFe
@@ -477,10 +469,10 @@ theorem divK_mulsub_full_spec
   have S := divK_mulsub_setup_spec sp q_hat j v1_old v5_old v6_old v10_old (base + 516)
   rw [lb_ms_setup] at S
   have Se := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 18 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 19 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 20 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 20 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 21 _ _ (by decide) (by bv_addr) (by decide)))))) S
   -- Frame setup with all memory + x7/x2 for mulsub
   have Sf := cpsTriple_frame_left _ _ _ _ _
@@ -501,9 +493,9 @@ theorem divK_mulsub_full_spec
   have SC := divK_sub_carry_spec u_base c3 bs3 fs3 u_top 4064 (base + 712)
   rw [lb_sc] at SC
   have SCe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 66 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 67 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 68 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 66 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 67 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 68 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 69 _ _ (by decide) (by bv_addr) (by decide))))) SC
   -- Compose (setup+mulsub) + sub_carry
   seqFrame SfM SCe
@@ -749,17 +741,17 @@ theorem divK_save_trial_load_spec
   dsimp only [] at TL
   rw [lb_trial_load] at TL
   have TLe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 1 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 2 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 3 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 4 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 5 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 6 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 7 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 8 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 9 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 10 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 11 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 8 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 9 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 11 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 12 _ _ (by decide) (by bv_addr) (by decide))))))))))))) TL
   -- 3. Compose save_j + trial_load
   seqFrame SJf TLe
@@ -803,7 +795,7 @@ private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
   dsimp only [] at TM
   rw [lb_trial_max_end] at TM
   exact cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 14 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 14 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 15 _ _ (by decide) (by bv_addr) (by decide))) TM
 
 -- ============================================================================
@@ -1099,16 +1091,16 @@ theorem divK_store_loop_spec
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. Loop control: instrs [113]-[114] at base+900
   have LC := divK_loop_control_spec j (7736 : BitVec 13) (base + 900)
   dsimp only [] at LC
   rw [lb_lc_taken, lb_lc_exit] at LC
   have LCe := cpsBranch_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 113 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 113 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide))) LC
   -- 3. Add x0 to store_qj via frame, then reshape via consequence
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
@@ -1172,9 +1164,9 @@ theorem divK_store_loop_j0_spec
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
   have haddi := addi_spec_gen_same .x1 (0 : Word) 4095 (base + 900) (by nofun)
@@ -1258,9 +1250,9 @@ theorem divK_store_loop_jgt0_spec
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
-    exact CodeReq_union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq_union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
+    exact CodeReq.union_sub (lb_sub base 109 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 110 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (lb_sub base 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub base 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
   have haddi := addi_spec_gen_same .x1 j 4095 (base + 900) (by nofun)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -29,16 +29,7 @@ abbrev signextCode (base : Word) : CodeReq := CodeReq.ofProg base evm_signextend
 -- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared with the
 -- Byte / Shift / SignExtend opcode files).
 
-/-- If each half of a CodeReq union is subsumed by target, so is the union. -/
-private theorem CodeReq_union_sub_both {cr1 cr2 target : CodeReq}
-    (h1 : ∀ a i, cr1 a = some i → target a = some i)
-    (h2 : ∀ a i, cr2 a = some i → target a = some i) :
-    ∀ a i, (cr1.union cr2) a = some i → target a = some i := by
-  intro a i h
-  simp only [CodeReq.union] at h
-  cases h1a : cr1 a with
-  | none => simp [h1a] at h; exact h2 a i h
-  | some v => simp [h1a] at h; subst h; exact h1 a v h1a
+-- `CodeReq_union_sub_both` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).
 
 /-- A singleton at instruction k of evm_signextend is subsumed by signextCode. -/
 private theorem singleton_sub_signextCode (base addr : Word) (instr : Instr) (k : Nat)
@@ -57,24 +48,24 @@ private theorem singleton_sub_signextCode (base addr : Word) (instr : Instr) (k 
 private theorem phase_a_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_a_code base a = some i → signextCode base a = some i := by
   unfold signext_phase_a_code
-  apply CodeReq_union_sub_both
+  apply CodeReq.union_sub
   · exact singleton_sub_signextCode base base (.LD .x5 .x12 8) 0
       (by decide) (by bv_omega) (by decide)
-  · apply CodeReq_union_sub_both
+  · apply CodeReq.union_sub
     · unfold signext_ld_or_acc_code
       exact CodeReq.ofProg_mono_sub base (base + 4) evm_signextend (signext_ld_or_acc_prog 16) 1
         (by bv_omega) (by decide) (by decide) (by decide)
-    · apply CodeReq_union_sub_both
+    · apply CodeReq.union_sub
       · unfold signext_ld_or_acc_code
         exact CodeReq.ofProg_mono_sub base (base + 12) evm_signextend (signext_ld_or_acc_prog 24) 3
           (by bv_omega) (by decide) (by decide) (by decide)
-      · apply CodeReq_union_sub_both
+      · apply CodeReq.union_sub
         · exact singleton_sub_signextCode base (base + 20) (.BNE .x5 .x0 168) 5
             (by decide) (by bv_omega) (by decide)
-        · apply CodeReq_union_sub_both
+        · apply CodeReq.union_sub
           · exact singleton_sub_signextCode base (base + 24) (.LD .x5 .x12 0) 6
               (by decide) (by bv_omega) (by decide)
-          · apply CodeReq_union_sub_both
+          · apply CodeReq.union_sub
             · exact singleton_sub_signextCode base (base + 28) (.SLTIU .x10 .x5 31) 7
                 (by decide) (by bv_omega) (by decide)
             · exact singleton_sub_signextCode base (base + 32) (.BEQ .x10 .x0 156) 8
@@ -101,10 +92,10 @@ private theorem cascade_17_sub_signextCode (base : Word) :
 private theorem phase_c_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_c_code (base + 56) a = some i → signextCode base a = some i := by
   unfold signext_phase_c_code
-  apply CodeReq_union_sub_both
+  apply CodeReq.union_sub
   · exact singleton_sub_signextCode base (base + 56) (.BEQ .x5 .x0 100) 14
       (by decide) (by bv_omega) (by decide)
-  · apply CodeReq_union_sub_both
+  · apply CodeReq.union_sub
     · unfold signext_cascade_step_code
       have : (base + 56 : Word) + 4 = base + 60 := by bv_omega
       rw [this]

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2282,6 +2282,22 @@ theorem CodeReq.union_mono_tail {cr tail1 tail2 : CodeReq}
   | none => simp [hc] at hq ⊢; exact h a i hq
   | some j => simp [hc] at hq ⊢; exact hq
 
+/-- Combine two subsumption witnesses to subsume their union: if both
+    `cr1` and `cr2` are subsumed by `target`, then so is `cr1.union cr2`.
+    Shared across Evm64 opcode compose files (previously redeclared as
+    `private theorem CodeReq_union_sub` / `_sub_both` / `_sub_mod` in
+    `SignExtend/Compose.lean`, `DivMod/LoopBody.lean`,
+    `DivMod/Compose/Div128.lean`, `DivMod/Compose/ModDiv128.lean`). -/
+theorem CodeReq.union_sub {cr1 cr2 target : CodeReq}
+    (h1 : ∀ a i, cr1 a = some i → target a = some i)
+    (h2 : ∀ a i, cr2 a = some i → target a = some i) :
+    ∀ a i, (cr1.union cr2) a = some i → target a = some i := by
+  intro a i h
+  simp only [CodeReq.union] at h
+  cases h1a : cr1 a with
+  | some j => rw [h1a] at h; simp at h; exact h ▸ h1 a j h1a
+  | none => rw [h1a] at h; simp at h; exact h2 a i h
+
 /-- A singleton's only address can be found in a target CodeReq, if target maps that address
     to the same instruction. Useful for proving singleton ⊆ target. -/
 theorem CodeReq.singleton_mono {a : Word} {i : Instr} {cr : CodeReq}


### PR DESCRIPTION
## Summary

4 Evm64 opcode files each carried their own private theorem proving the same statement — if \`cr1 ⊆ target\` and \`cr2 ⊆ target\` then \`cr1.union cr2 ⊆ target\` — under three different name shapes:

| Name | File |
|---|---|
| \`CodeReq_union_sub\`      | \`Evm64/DivMod/LoopBody.lean\` |
| \`CodeReq_union_sub\`      | \`Evm64/DivMod/Compose/Div128.lean\` |
| \`CodeReq_union_sub_both\` | \`Evm64/SignExtend/Compose.lean\` |
| \`CodeReq_union_sub_mod\`  | \`Evm64/DivMod/Compose/ModDiv128.lean\` |

Two minor proof-style variants exist (a \`subst\`-based vs. an \`h ▸\`-based closer); both close the same goal. All four sit on top of \`Rv64/SepLogic.lean\`'s \`CodeReq.union\` / \`CodeReq.union_mono_left\` / \`CodeReq.union_mono_tail\` family — the natural home.

## Changes

- Add \`theorem CodeReq.union_sub\` (non-private) to \`Rv64/SepLogic.lean\`, immediately after \`CodeReq.union_mono_tail\`, with a docstring listing the consumer files.
- Drop the 4 private shadows; each file gains a one-line pointer comment.
- Rename the ~60 call-sites across the 4 files to the canonical \`CodeReq.union_sub\` (dot-notation matches the surrounding \`CodeReq.union_mono_*\` siblings).

No proof body changes beyond the name update.

## Companion PRs

Completes the sweep of duplicate private helpers in the Evm64 opcode compose layer:
- #408 — \`regIs_to_regOwn\` (8 copies → 1 shared in \`SepLogic.lean\`)
- #410 — \`cpsNBranch_{extend_code, frame_left}\` (5 + 5 copies → shared in \`CPSSpec.lean\`)
- #411 — \`cpsTriple_strip_pure_and_convert\` (5 copies → shared in \`CPSSpec.lean\`)
- **this PR** — \`CodeReq.union_sub\` (4 variant copies → shared in \`SepLogic.lean\`)

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs).
- [x] \`grep -rn '^private theorem CodeReq_union_sub' EvmAsm/\` returns zero hits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)