### PR TITLE
docs(TACTICS): add grindset pointer table to the tactics overview

### DIFF
--- a/TACTICS.md
+++ b/TACTICS.md
@@ -13,6 +13,21 @@ User guide for the frame automation tactics in `EvmAsm/Tactics/`.
 | `@[spec_gen]` | `SpecDb.lean` | Register instruction specs for auto-resolution |
 | `#spec_db` | `SpecDb.lean` | Print all registered instruction specs |
 
+**For closing arithmetic / address equality goals**, see the grindsets
+documented in [`GRIND.md`](GRIND.md):
+
+| Grindset | File | Closes |
+|----------|------|--------|
+| `divmod_addr` | `Evm64/DivMod/AddrNorm.lean`  | DivMod address arithmetic (signExtend12 + shift + toNat) |
+| `rv64_addr`   | `Rv64/AddrNorm.lean`           | Rv64-wide address arithmetic (signExtend13/21 + assoc), subsumes `bv_addr` |
+| `reg_ops`     | `Rv64/RegOps.lean`             | `MachineState` projection chains (`pc_set<F>`, `getReg_setPC`, etc.) |
+| `byte_alg`    | `Rv64/ByteAlg.lean`            | `extractByte` / `replaceByte` algebra on `Word` |
+
+Each grindset exposes a `by <name>` tactic (`by divmod_addr`, `by rv64_addr`,
+…) that tries `grind` first and falls back to a per-domain `simp only [...]`
+closer. New atomic facts are added as one-line `@[<set>, grind =]` lemmas
+in the set's file; consumers pick them up automatically.
+
 ## runBlock
 
 The primary tactic for verifying basic blocks. Composes instruction specs


### PR DESCRIPTION
## Summary

\`TACTICS.md\` is the user guide for the frame-automation tactics (\`runBlock\`, \`seqFrame\`, \`xperm\`, \`xcancel\`). A contributor reaching for an \"equality-closing\" tactic lands here first — but the document never mentions the grindsets (\`divmod_addr\`, \`rv64_addr\`, \`reg_ops\`, \`byte_alg\`) that are the right tool for closing arithmetic / address / projection equalities.

Add a short table under Overview pointing at each grindset, its file, and the class of goals it closes, with a link to \`GRIND.md\` for the full conventions. Format mirrors the existing \"Tactic / File / Purpose\" table directly above.

Captures the infrastructure that landed over this refactoring cycle:

| Grindset | Landed in | Phase |
|---|---|---|
| \`divmod_addr\` | #263 / #304 | (baseline) |
| \`rv64_addr\` | #373 | GRIND.md Phase 3 |
| \`reg_ops\` | #372 | GRIND.md Phase 5 |
| \`byte_alg\` | #403 (in review) | GRIND.md Phase 4 |

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs). Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)