### PR TITLE
docs(AGENTS): cross-reference TACTICS.md for frame-automation tactics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,14 @@ The project includes concrete test cases using `native_decide`:
 - **sail-riscv-lean**: https://github.com/opencompl/sail-riscv-lean (same toolchain)
 - **Lean 4 docs**: https://lean-lang.org/documentation/
 
+## Frame-automation Tactics
+
+**Primary reference:** [`TACTICS.md`](TACTICS.md) is the user guide for
+`runBlock`, `seqFrame`, `xperm`, `xcancel`, the `@[spec_gen]` registry,
+and the domain-specific grindsets (`divmod_addr`, `rv64_addr`, `reg_ops`,
+`byte_alg`). Read it before hand-writing a `cpsTriple_seq_*` chain or
+wiring a new `@[...]` equality-closing attribute from scratch.
+
 ## Separation Conjunction Permutation Tactic
 
 The `sep_perm` tactic (defined in `SepLogic.lean`) closes goals that require rearranging `sepConj` (`**`) chains. It works by AC-normalizing both the hypothesis and goal using `simp` with three equality lemmas:


### PR DESCRIPTION
## Summary

\`AGENTS.md\` doesn't route contributors to \`TACTICS.md\`, which is the user guide for \`runBlock\`, \`seqFrame\`, \`xperm\`, \`xcancel\`, the \`@[spec_gen]\` registry, and (after #415) the domain-specific grindsets \`divmod_addr\` / \`rv64_addr\` / \`reg_ops\` / \`byte_alg\`. Without a pointer, a contributor reaching for composition automation would either rediscover the tactics from scratch or hand-write \`cpsTriple_seq_*\` chains.

Add a short \"Frame-automation Tactics\" section immediately before the existing \"Separation Conjunction Permutation Tactic\" section, pointing to \`TACTICS.md\` as the primary reference and listing the top-level tactics / grindsets to look for there.

Mirror of #406 (GRIND.md → OPCODE_TEMPLATE.md cross-ref) — strengthens the cross-document navigation mesh so each canonical doc is reachable from the others.

## Test plan

- [x] \`lake build\` — full repo green (3515 jobs). Doc-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)