### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract ZeroPath spec (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -8,6 +8,7 @@
 
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
+import EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
@@ -19,31 +20,10 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
--- ============================================================================
--- Zero path: b = 0, push 0. 5 instructions.
--- ============================================================================
-
-abbrev divK_zeroPath_code (base : Word) : CodeReq :=
-  CodeReq.ofProg base divK_zeroPath
-
-/-- Zero path: advance sp by 32, store four zeros at the output location.
-    Used when b = 0 (both DIV and MOD return 0). -/
-theorem divK_zeroPath_spec (sp : Word) (base : Word)
-    (m32 m40 m48 m56 : Word) :
-    let cr := divK_zeroPath_code base
-    cpsTriple base (base + 20) cr
-      ((.x12 ↦ᵣ sp) **
-       ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) **
-       ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56))
-      ((.x12 ↦ᵣ (sp + 32)) **
-       ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
-       ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
-  have I0 := addi_spec_gen_same .x12 sp 32 base (by nofun)
-  have I1 := sd_x0_spec_gen .x12 (sp + 32) m32 0 (base + 4)
-  have I2 := sd_x0_spec_gen .x12 (sp + 32) m40 8 (base + 8)
-  have I3 := sd_x0_spec_gen .x12 (sp + 32) m48 16 (base + 12)
-  have I4 := sd_x0_spec_gen .x12 (sp + 32) m56 24 (base + 16)
-  runBlock I0 I1 I2 I3 I4
+-- Zero path spec (divK_zeroPath_{code,spec}) moved to
+-- EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath (sixth chunk of #312 split).
+-- Re-exported via the import at the top of this file, so downstream surface
+-- is unchanged.
 
 -- ============================================================================
 -- Phase A body: OR-reduce b[0..3]. 7 instructions (straight-line).

--- a/EvmAsm/Evm64/DivMod/LimbSpec/ZeroPath.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/ZeroPath.lean
@@ -1,0 +1,49 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath
+
+  CPS spec for the Knuth Algorithm D zero path:
+    * `divK_zeroPath_code` / `divK_zeroPath_spec` — 5-instruction
+      ADDI+SD*4 block taken when `b = 0`. Advances the stack pointer by
+      32 and writes four zero words at the output location (DIV and MOD
+      both return 0 on division by zero).
+
+  Sixth chunk of the `LimbSpec.lean` split tracked by issue #312. The
+  consumer surface is unchanged: `LimbSpec.lean` re-exports this file so
+  every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees the spec.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+abbrev divK_zeroPath_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base divK_zeroPath
+
+/-- Zero path: advance sp by 32, store four zeros at the output location.
+    Used when b = 0 (both DIV and MOD return 0). -/
+theorem divK_zeroPath_spec (sp : Word) (base : Word)
+    (m32 m40 m48 m56 : Word) :
+    let cr := divK_zeroPath_code base
+    cpsTriple base (base + 20) cr
+      ((.x12 ↦ᵣ sp) **
+       ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) **
+       ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56))
+      ((.x12 ↦ᵣ (sp + 32)) **
+       ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
+       ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
+  have I0 := addi_spec_gen_same .x12 sp 32 base (by nofun)
+  have I1 := sd_x0_spec_gen .x12 (sp + 32) m32 0 (base + 4)
+  have I2 := sd_x0_spec_gen .x12 (sp + 32) m40 8 (base + 8)
+  have I3 := sd_x0_spec_gen .x12 (sp + 32) m48 16 (base + 12)
+  have I4 := sd_x0_spec_gen .x12 (sp + 32) m56 24 (base + 16)
+  runBlock I0 I1 I2 I3 I4
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Sixth chunk of the `LimbSpec.lean` split tracked by #312 (follows the already-merged #420 Denorm and the still-open #421 NormB, #422 NormA, #423 Epilogue, #424 CopyAU).
- Moves the division-by-zero path spec (`divK_zeroPath_{code,spec}`, 5 instructions — ADDI + SD×4) into `EvmAsm/Evm64/DivMod/LimbSpec/ZeroPath.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes. Self-contained: uses standard `@[spec_gen]` ADDI/SD specs + `runBlock`.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green