### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract PhaseC2 specs (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -10,6 +10,7 @@ import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LimbSpec.CopyAU
 import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
 import EvmAsm.Evm64.DivMod.LimbSpec.NormA
+import EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
@@ -363,99 +364,11 @@ theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word) :
   have I4 := ld_spec_gen_same .x5 addr_lead leading_limb 32 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
--- ============================================================================
--- Phase C2 body: store shift, compute anti_shift. 3 instructions.
--- ============================================================================
+-- Phase C2 specs (divK_phaseC2_{code,body_spec,spec}) moved to
+-- EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2 (ninth chunk of #312 split).
+-- Re-exported via the import at the top of this file, so downstream surface
+-- is unchanged.
 
-abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Word) : CodeReq :=
-  CodeReq.ofProg base (divK_phaseC2 shift0_off)
-
-/-- Phase C2 body: SD shift to scratch, ADDI x2 = 0, SUB x2 = -shift.
-    Preserves x6 and x0 for the subsequent BEQ.
-    The postcondition uses `signExtend12 (0 : BitVec 12) - shift` (= 0 - shift)
-    to match the syntactic form produced by addi_x0_spec_gen + sub_spec_gen. -/
-theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
-    (shift0_off : BitVec 13) (base : Word) :
-    let cr := divK_phaseC2_code shift0_off base
-    cpsTriple base (base + 12) cr
-      (
-       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
-      (
-       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  intro cr
-  have I0 := sd_spec_gen .x12 .x6 sp shift shift_mem 3992 base
-  have I1 := addi_x0_spec_gen .x2 v2 0 (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x6
-    (signExtend12 (0 : BitVec 12)) shift (base + 8) (by nofun)
-  runBlock I0 I1 I2
-
--- ============================================================================
--- Phase C2 full: body + BEQ (shift = 0 branch). cpsBranch.
--- ============================================================================
-
-/-- Phase C2: store shift, compute anti_shift, BEQ if shift=0.
-    Taken: shift = 0, skip normalization.
-    Not taken: shift ≠ 0, proceed to normalize.
-    anti_shift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
-theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
-    (shift0_off : BitVec 13) (base : Word) :
-    let cr := divK_phaseC2_code shift0_off base
-    let post :=
-      (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) **
-      (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) ** (.x0 ↦ᵣ (0 : Word)) **
-      ((sp + signExtend12 3992) ↦ₘ shift)
-    cpsBranch base cr
-      (
-       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
-      -- Taken: shift = 0
-      ((base + 12) + signExtend13 shift0_off) post
-      -- Not taken: shift ≠ 0
-      (base + 16) post := by
-  intro cr post
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem shift0_off base
-  have hbeq_raw := beq_spec_gen .x6 .x0 shift0_off shift (0 : Word) (base + 12)
-  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
-  rw [ha1] at hbeq_raw
-  have hbeq : cpsBranch (base + 12) _
-      ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
-      ((base + 12) + signExtend13 shift0_off)
-        ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
-      (base + 16)
-        ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
-      (fun _ hp => hp)
-      (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
-      (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
-      hbeq_raw
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
-    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hbeq
-  have hbeq_ext := cpsBranch_extend_code (cr' := cr) (fun a i h => by
-    simp only [CodeReq.singleton] at h
-    split at h
-    · next heq =>
-      rw [beq_iff_eq] at heq; subst heq
-      simp only [Option.some.injEq] at h; subst h
-      show divK_phaseC2_code shift0_off base (base + 12) = _
-      have hlen : (divK_phaseC2 shift0_off).length = 4 := by
-        unfold divK_phaseC2 SD ADDI single seq; rfl
-      exact CodeReq.ofProg_lookup base (divK_phaseC2 shift0_off) 3
-        (by omega) (by omega)
-    · simp at h) hbeq_framed
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
-  exact cpsBranch_consequence _ _
-    _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by xperm_hyp hp)
-    composed
 -- ============================================================================
 -- Phase B cascade step: ADDI x5 n_val + BNE rx x0 offset. cpsBranch.
 -- Used for each "if b[k]≠0 → n=k" step in the n-computation cascade.

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -1,0 +1,116 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2
+
+  CPS specs for the Knuth Algorithm D "phase C2" — the 3-instruction
+  setup that stores `shift` to scratch, zeros `x2`, then computes
+  `x2 = -shift` (the "anti-shift") — followed by a BEQ that jumps past
+  the normalize/denormalize dance when `shift = 0`:
+    * `divK_phaseC2_code` — `CodeReq.ofProg base (divK_phaseC2 shift0_off)`.
+    * `divK_phaseC2_body_spec` — SD + ADDI + SUB (3 instructions).
+    * `divK_phaseC2_spec` — full `cpsBranch` wrapping body + BEQ.
+
+  Ninth chunk of the `LimbSpec.lean` split tracked by issue #312. The
+  consumer surface is unchanged: `LimbSpec.lean` re-exports this file so
+  every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees both
+  specs.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (divK_phaseC2 shift0_off)
+
+/-- Phase C2 body: SD shift to scratch, ADDI x2 = 0, SUB x2 = -shift.
+    Preserves x6 and x0 for the subsequent BEQ.
+    The postcondition uses `signExtend12 (0 : BitVec 12) - shift` (= 0 - shift)
+    to match the syntactic form produced by addi_x0_spec_gen + sub_spec_gen. -/
+theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
+    (shift0_off : BitVec 13) (base : Word) :
+    let cr := divK_phaseC2_code shift0_off base
+    cpsTriple base (base + 12) cr
+      (
+       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+      (
+       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shift)) := by
+  intro cr
+  have I0 := sd_spec_gen .x12 .x6 sp shift shift_mem 3992 base
+  have I1 := addi_x0_spec_gen .x2 v2 0 (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x6
+    (signExtend12 (0 : BitVec 12)) shift (base + 8) (by nofun)
+  runBlock I0 I1 I2
+
+/-- Phase C2: store shift, compute anti_shift, BEQ if shift=0.
+    Taken: shift = 0, skip normalization.
+    Not taken: shift ≠ 0, proceed to normalize.
+    anti_shift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
+theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
+    (shift0_off : BitVec 13) (base : Word) :
+    let cr := divK_phaseC2_code shift0_off base
+    let post :=
+      (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) **
+      (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((sp + signExtend12 3992) ↦ₘ shift)
+    cpsBranch base cr
+      (
+       (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+      -- Taken: shift = 0
+      ((base + 12) + signExtend13 shift0_off) post
+      -- Not taken: shift ≠ 0
+      (base + 16) post := by
+  intro cr post
+  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem shift0_off base
+  have hbeq_raw := beq_spec_gen .x6 .x0 shift0_off shift (0 : Word) (base + 12)
+  have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
+  rw [ha1] at hbeq_raw
+  have hbeq : cpsBranch (base + 12) _
+      ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
+      ((base + 12) + signExtend13 shift0_off)
+        ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 16)
+        ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word))) :=
+    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+      (fun _ hp => hp)
+      (fun h hp => sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h hp => sepConj_mono_right
+        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      hbeq_raw
+  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+    ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hbeq
+  have hbeq_ext := cpsBranch_extend_code (cr' := cr) (fun a i h => by
+    simp only [CodeReq.singleton] at h
+    split at h
+    · next heq =>
+      rw [beq_iff_eq] at heq; subst heq
+      simp only [Option.some.injEq] at h; subst h
+      show divK_phaseC2_code shift0_off base (base + 12) = _
+      have hlen : (divK_phaseC2 shift0_off).length = 4 := by
+        unfold divK_phaseC2 SD ADDI single seq; rfl
+      exact CodeReq.ofProg_lookup base (divK_phaseC2 shift0_off) 3
+        (by omega) (by omega)
+    · simp at h) hbeq_framed
+  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
+  exact cpsBranch_consequence _ _
+    _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Ninth chunk of the `LimbSpec.lean` split tracked by #312.
- Moves `divK_phaseC2_{code,body_spec,spec}` (the shift=0 BEQ wrapping the SD/ADDI/SUB triple that computes `anti_shift = -shift`) into `EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green