### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract PhaseBTail spec (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -12,6 +12,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
 import EvmAsm.Evm64.DivMod.LimbSpec.Epilogue
 import EvmAsm.Evm64.DivMod.LimbSpec.NormA
 import EvmAsm.Evm64.DivMod.LimbSpec.NormB
+import EvmAsm.Evm64.DivMod.LimbSpec.PhaseBTail
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
@@ -217,37 +218,10 @@ theorem divK_phaseB_init2_spec (sp : Word) (base : Word)
 -- Re-exported via the import at the top of this file, so downstream surface
 -- is unchanged.
 
--- ============================================================================
--- Phase B tail: store n, compute address of b[n-1], load leading limb.
--- 5 instructions: SD, ADDI, SLLI, ADD, LD.
--- ============================================================================
-
-abbrev divK_phaseB_tail_code (base : Word) : CodeReq :=
-  CodeReq.ofProg base (divK_phaseB.drop 16)
-
-/-- Phase B tail: store n to scratch, compute sp + (n-1)*8, load b[n-1].
-    x5 = n on entry. On exit, x5 = leading limb b[n-1]. -/
-theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word) :
-    let nm1 := n + signExtend12 4095
-    let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-    let addr_lead := sp + nm1_x8
-    let cr := divK_phaseB_tail_code base
-    cpsTriple base (base + 20) cr
-      (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((addr_lead + signExtend12 32) ↦ₘ leading_limb))
-      (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ leading_limb) **
-       ((sp + signExtend12 3984) ↦ₘ n) **
-       ((addr_lead + signExtend12 32) ↦ₘ leading_limb)) := by
-  intro nm1 nm1_x8 addr_lead cr
-  have I0 := sd_spec_gen .x12 .x5 sp n n_mem 3984 base
-  have I1 := addi_spec_gen_same .x5 n 4095 (base + 4) (by nofun)
-  have I2 := slli_spec_gen_same .x5 nm1 3 (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs2 .x5 .x12 sp nm1_x8 (base + 12) (by nofun)
-  have I4 := ld_spec_gen_same .x5 addr_lead leading_limb 32 (base + 16) (by nofun)
-  runBlock I0 I1 I2 I3 I4
+-- Phase B tail spec (divK_phaseB_tail_{code,spec}) moved to
+-- EvmAsm.Evm64.DivMod.LimbSpec.PhaseBTail (tenth chunk of #312 split).
+-- Re-exported via the import at the top of this file, so downstream surface
+-- is unchanged.
 
 -- ============================================================================
 -- Phase C2 body: store shift, compute anti_shift. 3 instructions.

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.PhaseBTail
+
+  CPS spec for the Knuth Algorithm D "phase B tail":
+    * `divK_phaseB_tail_code` / `divK_phaseB_tail_spec` — 5-instruction
+      block (SD n, ADDI n-1, SLLI ×8, ADD sp + offset, LD b[n-1]) that
+      stores `n` to scratch and loads the leading limb of the divisor.
+
+  Tenth chunk of the `LimbSpec.lean` split tracked by issue #312. The
+  consumer surface is unchanged: `LimbSpec.lean` re-exports this file so
+  every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees the
+  spec.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+abbrev divK_phaseB_tail_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base (divK_phaseB.drop 16)
+
+/-- Phase B tail: store n to scratch, compute sp + (n-1)*8, load b[n-1].
+    x5 = n on entry. On exit, x5 = leading limb b[n-1]. -/
+theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word) :
+    let nm1 := n + signExtend12 4095
+    let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
+    let addr_lead := sp + nm1_x8
+    let cr := divK_phaseB_tail_code base
+    cpsTriple base (base + 20) cr
+      (
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
+       ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((addr_lead + signExtend12 32) ↦ₘ leading_limb))
+      (
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ leading_limb) **
+       ((sp + signExtend12 3984) ↦ₘ n) **
+       ((addr_lead + signExtend12 32) ↦ₘ leading_limb)) := by
+  intro nm1 nm1_x8 addr_lead cr
+  have I0 := sd_spec_gen .x12 .x5 sp n n_mem 3984 base
+  have I1 := addi_spec_gen_same .x5 n 4095 (base + 4) (by nofun)
+  have I2 := slli_spec_gen_same .x5 nm1 3 (base + 8) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs2 .x5 .x12 sp nm1_x8 (base + 12) (by nofun)
+  have I4 := ld_spec_gen_same .x5 addr_lead leading_limb 32 (base + 16) (by nofun)
+  runBlock I0 I1 I2 I3 I4
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Tenth chunk of the `LimbSpec.lean` split tracked by #312.
- Moves `divK_phaseB_tail_{code,spec}` into `EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green