### PR TITLE
feat(stack): add evmStackIs_pair clean 2-atom unfold

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -73,6 +73,15 @@ theorem evmStackIs_cons_cons_cons_nil (sp : Word) (a b c : EvmWord) :
     (evmWordIs sp a ** evmWordIs (sp + 32) b **
      evmWordIs (sp + 32 + 32) c ** empAssertion) := rfl
 
+/-- Two-element stack unfold without the trailing `empAssertion`:
+    `evmStackIs sp [a, b] = evmWordIs sp a ** evmWordIs (sp + 32) b`.
+    Derived from `evmStackIs_cons_cons_nil` by applying
+    `sepConj_emp_right'`. Most binary-op stack specs want this cleaner
+    2-atom form rather than the raw definition. -/
+theorem evmStackIs_pair (sp : Word) (a b : EvmWord) :
+    evmStackIs sp [a, b] = (evmWordIs sp a ** evmWordIs (sp + 32) b) := by
+  rw [evmStackIs_cons_cons_nil, sepConj_emp_right']
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================


### PR DESCRIPTION
Derived from `evmStackIs_cons_cons_nil` by `sepConj_emp_right'` to eliminate the trailing `empAssertion`. Binary-op stack specs want this cleaner 2-atom form.

## Test plan
- [x] `lake build` succeeds (3528 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)