### PR TITLE
feat(stack): add evmStackIs_single clean singleton unfold

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -82,6 +82,12 @@ theorem evmStackIs_pair (sp : Word) (a b : EvmWord) :
     evmStackIs sp [a, b] = (evmWordIs sp a ** evmWordIs (sp + 32) b) := by
   rw [evmStackIs_cons_cons_nil, sepConj_emp_right']
 
+/-- Symmetric companion of `evmStackIs_pair`: singleton stack collapses to a
+    single `evmWordIs`. -/
+theorem evmStackIs_single (sp : Word) (v : EvmWord) :
+    evmStackIs sp [v] = evmWordIs sp v := by
+  rw [evmStackIs_cons_nil, sepConj_emp_right']
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================


### PR DESCRIPTION
Symmetric companion of `evmStackIs_pair` (#442): collapses `evmStackIs sp [v]` to `evmWordIs sp v` (no trailing `empAssertion`).

## Test plan
- [x] `lake build` succeeds (3532 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)