### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract Div128Clamp specs (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -11,6 +11,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.AddBack
 import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
 import EvmAsm.Evm64.DivMod.LimbSpec.CopyAU
 import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Phase1
 import EvmAsm.Evm64.DivMod.LimbSpec.Epilogue
 import EvmAsm.Evm64.DivMod.LimbSpec.LoopSetup
@@ -517,109 +518,10 @@ theorem divK_div128_restore_return_spec (sp v2_old ret_addr : Word) (base : Word
   rw [halign] at I1
   runBlock I0 I1
 
--- ============================================================================
--- div128 subroutine: Clamp q1 section [13]-[16].
--- 4 instructions: SRLI + BEQ + ADDI + ADD.
--- BEQ skips correction if q1 < 2^32, else q1-- and rhat+=d_hi.
--- ============================================================================
-
-/-- div128 clamp q1: test q1 >= 2^32, conditionally decrement and adjust rhat.
-    Instrs [13]-[16]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Word) :
-    let hi := q1 >>> (32 : BitVec 6).toNat
-    let q1' := if hi = 0 then q1 else q1 + signExtend12 4095
-    let rhat' := if hi = 0 then rhat else rhat + d_hi
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x5 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x5 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 12) (.ADD .x7 .x7 .x6))))
-    cpsTriple base (base + 16) cr
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
-       (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
-      ((.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ d_hi) **
-       (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
-  intro hi q1' rhat' cr
-  -- 1. SRLI body
-  have I0 := srli_spec_gen .x5 .x10 v5_old q1 32 base (by nofun)
-  have hbody : cpsTriple base (base + 4) cr
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
-       (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
-       (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
-    runBlock I0
-  -- 2. BEQ at base+4 (keep pure facts)
-  have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
-  rw [ha_t, ha_f] at hbeq_raw
-  -- 3. Frame BEQ with x10, x7, x6
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
-    ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
-    (by pcFree) hbeq_raw
-  -- 4. Extend to full cr
-  have hbeq_ext : cpsBranch (base + 4) cr
-      (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
-       ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
-      (base + 16)
-        (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
-         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
-      (base + 8)
-        (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
-         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))) :=
-    fun R hR s hcr hPR hpc =>
-      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
-        show cr (base + 4) = _
-        simp only [cr, CodeReq.union, CodeReq.singleton]
-        have h0 : ¬(base + 4 = base) := by bv_omega
-        simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
-  -- 5. Compose body → BEQ
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
-  -- 6. by_cases on hi = 0
-  by_cases hcond : hi = 0
-  · -- hi = 0 → BEQ taken (skip correction)
-    have hq : q1' = q1 := if_pos hcond
-    have hr : rhat' = rhat := if_pos hcond
-    rw [hq, hr]
-    -- Eliminate ntaken path (hi ≠ 0 contradicts hcond)
-    have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
-      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    -- Strip pure fact from taken postcondition and permute
-    exact cpsTriple_consequence _ _ _ _ _ _ _
-      (fun h hp => hp)
-      (fun h hp => by
-        have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
-        xperm_hyp hp') taken
-  · -- hi ≠ 0 → BEQ not-taken (execute correction)
-    have hq : q1' = q1 + signExtend12 4095 := if_neg hcond
-    have hr : rhat' = rhat + d_hi := if_neg hcond
-    rw [hq, hr]
-    -- Eliminate taken path (hi = 0 contradicts hcond)
-    have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
-      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
-    -- Correction: ADDI + ADD from base+8 to base+16
-    have I1 := addi_spec_gen_same .x10 q1 4095 (base + 8) (by nofun)
-    have I2 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat d_hi (base + 12) (by nofun)
-    have hcorr : cpsTriple (base + 8) (base + 16) cr
-        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
-        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
-      runBlock I1 I2
-    have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
-      ((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
-      (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
-      (fun h hp => by
-        have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
-        xperm_hyp hp') ntaken hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
-      (fun h hp => hp)
-      (fun h hp => by xperm_hyp hp) full
+-- div128 clamp q1 merged spec (divK_div128_clamp_q1_merged_spec) moved to
+-- EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp (twenty-third chunk of #312 split).
+-- Re-exported via the import at the top of this file, so downstream surface
+-- is unchanged.
 -- ============================================================================
 -- div128 subroutine: Product check 1 section [17]-[24].
 -- 8 instructions: LD+MUL+SLLI+OR (body) + BLTU+JAL (branch) + ADDI+ADD (correction).
@@ -783,106 +685,10 @@ theorem divK_div128_prodcheck1_merged_spec
       (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
--- ============================================================================
--- div128 subroutine: Clamp q0 section [33]-[36].
--- 4 instructions: SRLI + BEQ + ADDI + ADD.
--- BEQ skips correction if q0 < 2^32, else q0-- and rhat2+=d_hi.
--- ============================================================================
-
-/-- div128 clamp q0: test q0 >= 2^32, conditionally decrement and adjust rhat2.
-    Instrs [33]-[36]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : Word) :
-    let hi := q0 >>> (32 : BitVec 6).toNat
-    let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
-    let rhat2' := if hi = 0 then rhat2 else rhat2 + d_hi
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x1 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x5 .x5 4095))
-       (CodeReq.singleton (base + 12) (.ADD .x11 .x11 .x6))))
-    cpsTriple base (base + 16) cr
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
-       (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
-      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ d_hi) **
-       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
-  intro hi q0' rhat2' cr
-  -- 1. SRLI body
-  have hbody : cpsTriple base (base + 4) cr
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
-       (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
-       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
-    have I0 := srli_spec_gen .x1 .x5 v1_old q0 32 base (by nofun)
-    runBlock I0
-  -- 2. BEQ at base+4 (keep pure facts)
-  have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
-  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
-  rw [ha_t, ha_f] at hbeq_raw
-  -- 3. Frame BEQ with x5, x11, x6
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
-    ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
-    (by pcFree) hbeq_raw
-  -- 4. Extend to full cr
-  have hbeq_ext : cpsBranch (base + 4) cr
-      (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
-       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
-      (base + 16)
-        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
-         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
-      (base + 8)
-        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
-         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))) :=
-    fun R hR s hcr hPR hpc =>
-      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
-        show cr (base + 4) = _
-        simp only [cr, CodeReq.union, CodeReq.singleton]
-        have h0 : ¬(base + 4 = base) := by bv_omega
-        simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
-  -- 5. Compose body → BEQ
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
-  -- 6. by_cases on hi = 0
-  by_cases hcond : hi = 0
-  · -- hi = 0 → BEQ taken (skip correction)
-    have hq : q0' = q0 := if_pos hcond
-    have hr : rhat2' = rhat2 := if_pos hcond
-    rw [hq, hr]
-    have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
-      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    exact cpsTriple_consequence _ _ _ _ _ _ _
-      (fun h hp => hp)
-      (fun h hp => by
-        have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
-        xperm_hyp hp') taken
-  · -- hi ≠ 0 → BEQ not-taken (execute correction)
-    have hq : q0' = q0 + signExtend12 4095 := if_neg hcond
-    have hr : rhat2' = rhat2 + d_hi := if_neg hcond
-    rw [hq, hr]
-    have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
-      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
-    -- Correction: ADDI + ADD from base+8 to base+16
-    have I1 := addi_spec_gen_same .x5 q0 4095 (base + 8) (by nofun)
-    have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 d_hi (base + 12) (by nofun)
-    have hcorr : cpsTriple (base + 8) (base + 16) cr
-        ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
-        ((.x5 ↦ᵣ (q0 + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2 + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
-      runBlock I1 I2
-    have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
-      ((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
-      (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
-      (fun h hp => by
-        have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
-        xperm_hyp hp') ntaken hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
-      (fun h hp => hp)
-      (fun h hp => by xperm_hyp hp) full
+-- div128 clamp q0 merged spec (divK_div128_clamp_q0_merged_spec) moved to
+-- EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp (twenty-third chunk of #312 split).
+-- Re-exported via the import at the top of this file, so downstream surface
+-- is unchanged.
 -- ============================================================================
 -- div128 subroutine: Product check 2 section [37]-[44].
 -- 8 instructions: LD+MUL+SLLI+LD+OR (body) + BLTU+JAL (branch) + ADDI (correction).

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -1,0 +1,202 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp
+
+  CPS specs for the two q-clamp sections of the `div128` trial-division
+  subroutine:
+    * `divK_div128_clamp_q1_merged_spec` — Instrs [13]-[16]. SRLI test
+      q1 >= 2^32, BEQ skips correction when q1 < 2^32, else ADDI
+      q1-- and ADD rhat += d_hi. Both branches merge at base + 16.
+    * `divK_div128_clamp_q0_merged_spec` — the same shape on x5/x11 for
+      q0/rhat2.
+
+  Twenty-third chunk of the `LimbSpec.lean` split tracked by issue #312.
+  The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
+  so every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees both
+  specs.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- div128 clamp q1: test q1 >= 2^32, conditionally decrement and adjust rhat.
+    Instrs [13]-[16]. Both BEQ paths merge at base+16. -/
+theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Word) :
+    let hi := q1 >>> (32 : BitVec 6).toNat
+    let q1' := if hi = 0 then q1 else q1 + signExtend12 4095
+    let rhat' := if hi = 0 then rhat else rhat + d_hi
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 12) (.ADD .x7 .x7 .x6))))
+    cpsTriple base (base + 16) cr
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
+      ((.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+  intro hi q1' rhat' cr
+  have I0 := srli_spec_gen .x5 .x10 v5_old q1 32 base (by nofun)
+  have hbody : cpsTriple base (base + 4) cr
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+    runBlock I0
+  have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
+  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [ha_t, ha_f] at hbeq_raw
+  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+    ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
+    (by pcFree) hbeq_raw
+  have hbeq_ext : cpsBranch (base + 4) cr
+      (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
+       ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
+      (base + 16)
+        (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
+         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
+      (base + 8)
+        (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
+         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))) :=
+    fun R hR s hcr hPR hpc =>
+      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+        show cr (base + 4) = _
+        simp only [cr, CodeReq.union, CodeReq.singleton]
+        have h0 : ¬(base + 4 = base) := by bv_omega
+        simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
+  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
+  by_cases hcond : hi = 0
+  · have hq : q1' = q1 := if_pos hcond
+    have hr : rhat' = rhat := if_pos hcond
+    rw [hq, hr]
+    have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
+      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
+      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by
+        have hp' := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        xperm_hyp hp') taken
+  · have hq : q1' = q1 + signExtend12 4095 := if_neg hcond
+    have hr : rhat' = rhat + d_hi := if_neg hcond
+    rw [hq, hr]
+    have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
+      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
+      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
+    have I1 := addi_spec_gen_same .x10 q1 4095 (base + 8) (by nofun)
+    have I2 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat d_hi (base + 12) (by nofun)
+    have hcorr : cpsTriple (base + 8) (base + 16) cr
+        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
+        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
+      runBlock I1 I2
+    have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
+      ((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcFree) hcorr
+    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+      (fun h hp => by
+        have hp' := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        xperm_hyp hp') ntaken hcorr_framed
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by xperm_hyp hp) full
+
+/-- div128 clamp q0: test q0 >= 2^32, conditionally decrement and adjust rhat2.
+    Instrs [33]-[36]. Both BEQ paths merge at base+16. -/
+theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : Word) :
+    let hi := q0 >>> (32 : BitVec 6).toNat
+    let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
+    let rhat2' := if hi = 0 then rhat2 else rhat2 + d_hi
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x5 .x5 4095))
+       (CodeReq.singleton (base + 12) (.ADD .x11 .x11 .x6))))
+    cpsTriple base (base + 16) cr
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+       (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
+      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ d_hi) **
+       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+  intro hi q0' rhat2' cr
+  have hbody : cpsTriple base (base + 4) cr
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+       (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+       (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
+    have I0 := srli_spec_gen .x1 .x5 v1_old q0 32 base (by nofun)
+    runBlock I0
+  have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
+  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [ha_t, ha_f] at hbeq_raw
+  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+    ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
+    (by pcFree) hbeq_raw
+  have hbeq_ext : cpsBranch (base + 4) cr
+      (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
+       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
+      (base + 16)
+        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
+         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
+      (base + 8)
+        (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
+         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))) :=
+    fun R hR s hcr hPR hpc =>
+      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+        show cr (base + 4) = _
+        simp only [cr, CodeReq.union, CodeReq.singleton]
+        have h0 : ¬(base + 4 = base) := by bv_omega
+        simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
+  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
+  by_cases hcond : hi = 0
+  · have hq : q0' = q0 := if_pos hcond
+    have hr : rhat2' = rhat2 := if_pos hcond
+    rw [hq, hr]
+    have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
+      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
+      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by
+        have hp' := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        xperm_hyp hp') taken
+  · have hq : q0' = q0 + signExtend12 4095 := if_neg hcond
+    have hr : rhat2' = rhat2 + d_hi := if_neg hcond
+    rw [hq, hr]
+    have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
+      obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
+      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
+    have I1 := addi_spec_gen_same .x5 q0 4095 (base + 8) (by nofun)
+    have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 d_hi (base + 12) (by nofun)
+    have hcorr : cpsTriple (base + 8) (base + 16) cr
+        ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
+        ((.x5 ↦ᵣ (q0 + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2 + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
+      runBlock I1 I2
+    have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
+      ((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcFree) hcorr
+    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+      (fun h hp => by
+        have hp' := sepConj_mono_left (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        xperm_hyp hp') ntaken hcorr_framed
+    exact cpsTriple_consequence _ _ _ _ _ _ _
+      (fun h hp => hp)
+      (fun h hp => by xperm_hyp hp) full
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Twenty-third chunk of the `LimbSpec.lean` split tracked by #312.
- Moves `divK_div128_clamp_q1_merged_spec` and `divK_div128_clamp_q0_merged_spec` into `EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes. Each of these specs is ~95 lines of proof script (cpsBranch composition), so this chunk gives good size reduction in the parent file.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green