### PR TITLE
feat(stack): add evmStackIs_append + fix stale divScratchValues doc

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -253,9 +253,9 @@ def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   ((sp + signExtend12 3984) ↦ₘ n_mem) **
   ((sp + signExtend12 3976) ↦ₘ j_mem)
 
-/-- Unfold `divScratchValues` into its 15 underlying memory atoms. Since
-    `divScratchValues` is not `@[irreducible]` the `delta`/`unfold` tactics
-    reduce it directly, but this named rewrite is convenient at call sites. -/
+/-- Unfold `divScratchValues` into its 15 underlying memory atoms. The bundle
+    is `@[irreducible]`, so `unfold` won't see through it — this named rewrite
+    is the supported way in at call sites (parallel to `divScratchOwn_unfold`). -/
 theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem : Word) :
     divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -199,6 +199,28 @@ theorem signExtend12_ofNat_small (m : Nat) (hm : m < 2048) :
   · exact BitVec.setWidth_ofNat_of_le_of_lt (by omega) (by omega)
   · rw [BitVec.msb_eq_false_iff_two_mul_lt]; simp [BitVec.toNat_ofNat]; omega
 
+/-- Concatenation: `evmStackIs sp (xs ++ ys)` splits into `xs` at `sp` and
+    `ys` at `sp + 32 * xs.length`. Companion to `evmStackIs_split_at` —
+    where `split_at` isolates the kth element, `append` composes two
+    contiguous stack segments. Useful for "preserve some cells, append
+    a new element" stack transitions (PUSH / stack extension specs). -/
+theorem evmStackIs_append (sp : Word) (xs ys : List EvmWord) :
+    evmStackIs sp (xs ++ ys) =
+    (evmStackIs sp xs ** evmStackIs (sp + BitVec.ofNat 64 (xs.length * 32)) ys) := by
+  induction xs generalizing sp with
+  | nil =>
+    simp only [List.nil_append, List.length_nil, Nat.zero_mul,
+               evmStackIs_nil, sepConj_emp_left']
+    rw [show (BitVec.ofNat 64 0 : Word) = 0 from rfl]
+    rw [show sp + (0 : Word) = sp from by bv_omega]
+  | cons v vs ih =>
+    have hshift : sp + (32 : Word) + BitVec.ofNat 64 (vs.length * 32) =
+                  sp + BitVec.ofNat 64 ((vs.length + 1) * 32) := by
+      apply BitVec.eq_of_toNat_eq
+      simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+    simp only [List.cons_append, evmStackIs_cons, List.length_cons]
+    rw [ih (sp + 32), hshift, sepConj_assoc']
+
 /-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
 theorem evmStackIs_split_at (sp : Word) (stack : List EvmWord) (k : Nat)
     (hk : k < stack.length) :

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -88,6 +88,18 @@ theorem evmStackIs_single (sp : Word) (v : EvmWord) :
     evmStackIs sp [v] = evmWordIs sp v := by
   rw [evmStackIs_cons_nil, sepConj_emp_right']
 
+/-- Three-element stack unfold without the trailing `empAssertion`:
+    `evmStackIs sp [a, b, c] = evmWordIs sp a ** evmWordIs (sp+32) b **
+    evmWordIs (sp+64) c`. Derived from `evmStackIs_cons_cons_cons_nil` by
+    applying `sepConj_emp_right'`. Ternary-op stack specs (ADDMOD /
+    MULMOD) want this cleaner 3-atom form rather than the raw definition.
+    Parallels `evmStackIs_pair` / `evmStackIs_single`. -/
+theorem evmStackIs_triple (sp : Word) (a b c : EvmWord) :
+    evmStackIs sp [a, b, c] =
+    (evmWordIs sp a ** evmWordIs (sp + 32) b **
+     evmWordIs (sp + 32 + 32) c) := by
+  rw [evmStackIs_cons_cons_cons_nil, sepConj_emp_right']
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add `evmStackIs_append`: `evmStackIs sp (xs ++ ys) = evmStackIs sp xs ** evmStackIs (sp + 32*xs.length) ys`. Companion to `evmStackIs_split_at`; useful for stack-extension specs (e.g. PUSH).
- Fix a stale docstring on `divScratchValues_unfold` in `Compose/Base.lean` which claimed the bundle was not `@[irreducible]` — it is, so `unfold` won't see through and the named rewrite is the supported way in.

## Test plan
- [x] `lake build` — 3534 jobs, clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)