### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract Div128PhaseEnd (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -13,6 +13,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.CLZ
 import EvmAsm.Evm64.DivMod.LimbSpec.CopyAU
 import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Phase1
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128UnProdCheck
 import EvmAsm.Evm64.DivMod.LimbSpec.Epilogue
 import EvmAsm.Evm64.DivMod.LimbSpec.LoopSetup
@@ -1154,92 +1155,10 @@ theorem divK_div128_step2_spec
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     h123
--- ============================================================================
--- div128 subroutine: Phase 1 [0]-[9] — save ret/d, split d and u_lo.
--- 10 instructions: SD+SD+SRLI+SLLI+SRLI+SD + SRLI+SLLI+SRLI+SD.
--- ============================================================================
-
-/-- div128 Phase 1: save return addr/d, split d and u_lo. Instrs [0]-[9].
-    Input: x12=sp, x2=ret_addr, x10=d, x5=u_lo, x7=u_hi.
-    Output: x6=d_hi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
-theorem divK_div128_phase1_spec
-    (sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-     ret_mem d_mem dlo_mem un0_mem : Word) (base : Word) :
-    let d_hi := d >>> (32 : BitVec 6).toNat
-    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x6 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x1 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.SRLI .x11 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SLLI .x5 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.SRLI .x5 .x5 32))
-       (CodeReq.singleton (base + 36) (.SD .x12 .x5 3944))))))))))
-    cpsTriple base (base + 40) cr
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ u_lo) **
-       (.x11 ↦ᵣ v11_old) ** (.x7 ↦ᵣ u_hi) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ d_lo) ** (.x5 ↦ᵣ un0) **
-       (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ u_hi) **
-       (sp + signExtend12 3968 ↦ₘ ret_addr) **
-       (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
-       (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro d_hi d_lo un1 un0 cr
-  -- Instructions from save_split_d (6 instrs at base)
-  have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
-  have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
-  have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
-  have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
-  have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen .x12 .x1 sp d_lo dlo_mem 3952 (base + 20)
-  -- Instructions from split_ulo (4 instrs at base+24)
-  have I6 := srli_spec_gen .x11 .x5 v11_old u_lo 32 (base + 24) (by nofun)
-  have I7 := slli_spec_gen_same .x5 u_lo 32 (base + 28) (by nofun)
-  have I8 := srli_spec_gen_same .x5 (u_lo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)
-  have I9 := sd_spec_gen .x12 .x5 sp un0 un0_mem 3944 (base + 36)
-  runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9
--- ============================================================================
--- div128 subroutine: End phase [45]-[48] — combine q + restore/return.
--- 4 instructions: SLLI + OR + LD + JALR.
--- ============================================================================
-
-/-- div128 end phase: combine q1,q0 into q, restore return addr, return.
-    Instrs [45]-[48]. Exit to ret_addr. -/
-theorem divK_div128_end_spec
-    (sp q1 q0 v2_old v11_old ret_addr : Word) (base : Word)
-    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
-    let q1_hi := q1 <<< (32 : BitVec 6).toNat
-    let q := q1_hi ||| q0
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SLLI .x11 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.OR .x11 .x11 .x5))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x2 .x12 3968))
-       (CodeReq.singleton (base + 12) (.JALR .x0 .x2 0))))
-    cpsTriple base ret_addr cr
-      ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ v11_old) **
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ ret_addr))
-      ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q) **
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr)) := by
-  intro q1_hi q cr
-  -- Instructions from combine_q (2 instrs at base)
-  have I0 := slli_spec_gen .x11 .x10 v11_old q1 32 base (by nofun)
-  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1_hi q0 (base + 4) (by nofun)
-  -- Instructions from restore_return (2 instrs at base+8)
-  have I2 := ld_spec_gen .x2 .x12 sp v2_old ret_addr 3968 (base + 8) (by nofun)
-  have I3 := jalr_x0_spec_gen .x2 ret_addr 0 (base + 12)
-  rw [halign] at I3
-  runBlock I0 I1 I2 I3
+-- div128 Phase 1 + End composition specs (divK_div128_phase1_spec,
+-- divK_div128_end_spec) moved to EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd
+-- (twenty-seventh chunk of #312 split). Re-exported via the import at the
+-- top of this file, so downstream surface is unchanged.
 -- ============================================================================
 -- Composed per-limb specs: mulsub_limb, addback_limb.
 -- These compose partA+partB into single per-limb operations.

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -1,0 +1,106 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd
+
+  Full compositions for the first and last straight-line phases of the
+  `div128` trial-division subroutine:
+    * `divK_div128_phase1_spec` — Instrs [0]-[9], 10 instructions:
+      SD+SD+SRLI+SLLI+SRLI+SD (save_split_d) followed by
+      SRLI+SLLI+SRLI+SD (split_ulo). Saves the return address and `d`,
+      splits `d` into `d_hi`/`d_lo`, splits `u_lo` into `un1`/`un0`.
+    * `divK_div128_end_spec` — Instrs [45]-[48], 4 instructions:
+      SLLI+OR (combine_q → `q = q1<<32 | q0`) followed by LD+JALR
+      (restore return addr and jump back). Exits at `ret_addr`.
+
+  Twenty-seventh chunk of the `LimbSpec.lean` split tracked by issue #312.
+  The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
+  so every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees both
+  specs.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- div128 Phase 1: save return addr/d, split d and u_lo. Instrs [0]-[9].
+    Input: x12=sp, x2=ret_addr, x10=d, x5=u_lo, x7=u_hi.
+    Output: x6=d_hi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
+theorem divK_div128_phase1_spec
+    (sp ret_addr d u_lo u_hi v1_old v6_old v11_old
+     ret_mem d_mem dlo_mem un0_mem : Word) (base : Word) :
+    let d_hi := d >>> (32 : BitVec 6).toNat
+    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := u_lo >>> (32 : BitVec 6).toNat
+    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x6 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SLLI .x1 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.SRLI .x11 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SLLI .x5 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.SRLI .x5 .x5 32))
+       (CodeReq.singleton (base + 36) (.SD .x12 .x5 3944))))))))))
+    cpsTriple base (base + 40) cr
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ u_lo) **
+       (.x11 ↦ᵣ v11_old) ** (.x7 ↦ᵣ u_hi) **
+       (sp + signExtend12 3968 ↦ₘ ret_mem) **
+       (sp + signExtend12 3960 ↦ₘ d_mem) **
+       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3944 ↦ₘ un0_mem))
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ d_lo) ** (.x5 ↦ᵣ un0) **
+       (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ u_hi) **
+       (sp + signExtend12 3968 ↦ₘ ret_addr) **
+       (sp + signExtend12 3960 ↦ₘ d) **
+       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3944 ↦ₘ un0)) := by
+  intro d_hi d_lo un1 un0 cr
+  have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
+  have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
+  have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
+  have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
+  have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
+  have I5 := sd_spec_gen .x12 .x1 sp d_lo dlo_mem 3952 (base + 20)
+  have I6 := srli_spec_gen .x11 .x5 v11_old u_lo 32 (base + 24) (by nofun)
+  have I7 := slli_spec_gen_same .x5 u_lo 32 (base + 28) (by nofun)
+  have I8 := srli_spec_gen_same .x5 (u_lo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)
+  have I9 := sd_spec_gen .x12 .x5 sp un0 un0_mem 3944 (base + 36)
+  runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9
+
+/-- div128 end phase: combine q1,q0 into q, restore return addr, return.
+    Instrs [45]-[48]. Exit to ret_addr. -/
+theorem divK_div128_end_spec
+    (sp q1 q0 v2_old v11_old ret_addr : Word) (base : Word)
+    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
+    let q1_hi := q1 <<< (32 : BitVec 6).toNat
+    let q := q1_hi ||| q0
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SLLI .x11 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.OR .x11 .x11 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x2 .x12 3968))
+       (CodeReq.singleton (base + 12) (.JALR .x0 .x2 0))))
+    cpsTriple base ret_addr cr
+      ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ v11_old) **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ ret_addr))
+      ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q) **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr)) := by
+  intro q1_hi q cr
+  have I0 := slli_spec_gen .x11 .x10 v11_old q1 32 base (by nofun)
+  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1_hi q0 (base + 4) (by nofun)
+  have I2 := ld_spec_gen .x2 .x12 sp v2_old ret_addr 3968 (base + 8) (by nofun)
+  have I3 := jalr_x0_spec_gen .x2 ret_addr 0 (base + 12)
+  rw [halign] at I3
+  runBlock I0 I1 I2 I3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Twenty-seventh chunk of the `LimbSpec.lean` split tracked by #312.
- Moves `divK_div128_phase1_spec` (10-instr straight-line [0]-[9]) and `divK_div128_end_spec` (4-instr [45]-[48]) into `EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes. Both specs use only low-level `spec_gen` + `runBlock` and don't depend on any of my other open PRs.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green