### PR TITLE
refactor(DivMod): split LimbSpec.lean — extract TrialStoreComposed (#312)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -26,6 +26,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.PhaseBInit
 import EvmAsm.Evm64.DivMod.LimbSpec.PhaseBTail
 import EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2
 import EvmAsm.Evm64.DivMod.LimbSpec.SubCarryStoreQj
+import EvmAsm.Evm64.DivMod.LimbSpec.TrialStoreComposed
 import EvmAsm.Evm64.DivMod.LimbSpec.TrialQuotient
 import EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath
 import EvmAsm.Rv64.SyscallSpecs
@@ -1277,99 +1278,8 @@ theorem divK_addback_limb_spec
   have I7 := sd_spec_gen .x6 .x2 u_base u_new u_i u_off (base + 28)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7
 -- ============================================================================
--- Trial quotient load phase: load u[j+n], u[j+n-1], v_top = b[n-1].
--- trial_load_u [1]-[7] + trial_load_vtop [8]-[12] = 12 instructions.
--- ============================================================================
-
-/-- Trial quotient load: fetch u_hi, u_lo, v_top from memory.
-    Instrs [1]-[12] of loop body.
-    Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtop_base. -/
-theorem divK_trial_load_spec
-    (sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
-    (base : Word) :
-    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x7 .x7 3))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.ADDI .x5 .x12 4056))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SUB .x5 .x5 .x7))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.LD .x7 .x5 0))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.LD .x5 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x6 .x12 3984))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x6 .x6 4095))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x6 .x6 3))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.ADD .x6 .x12 .x6))
-       (CodeReq.singleton (base + 44) (.LD .x10 .x6 32))))))))))))
-    cpsTriple base (base + 48) cr
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
-       (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
-       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
-       (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
-  intro u_addr vtop_base cr
-  -- Instructions from trial_load_u (7 instrs at base)
-  let jpn := j + n
-  let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
-  let u0_base := sp + signExtend12 4056
-  have hse0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [hse0]; bv_omega
-  have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
-  have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
-  have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
-  have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
-  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
-  have I5 := ld_spec_gen .x7 .x5 u_addr jpn_x8 u_hi 0 (base + 20) (by nofun)
-  rw [haddr0] at I5
-  have I6 := ld_spec_gen_same .x5 u_addr u_lo 8 (base + 24) (by nofun)
-  -- Instructions from trial_load_vtop (5 instrs at base+28)
-  let nm1 := n + signExtend12 4095
-  let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-  have I7 := ld_spec_gen .x6 .x12 sp v6_old n 3984 (base + 28) (by nofun)
-  have I8 := addi_spec_gen_same .x6 n 4095 (base + 32) (by nofun)
-  have I9 := slli_spec_gen_same .x6 nm1 3 (base + 36) (by nofun)
-  have I10 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 40) (by nofun)
-  have I11 := ld_spec_gen .x10 .x6 vtop_base v10_old v_top 32 (base + 44) (by nofun)
-  runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11
--- ============================================================================
--- Composed store q[j]: addr computation + SD = 4 instructions.
--- ============================================================================
-
-/-- Store q[j]: compute address and store q_hat. 4 instructions.
-    q_addr = sp + 4088 - j*8. -/
-theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
-    (base : Word) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - j_x8
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
-       (CodeReq.singleton (base + 12) (.SD .x7 .x11 0))))
-    cpsTriple base (base + 16) cr
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
-       (q_addr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) **
-       (q_addr ↦ₘ q_hat)) := by
-  intro j_x8 q_addr cr
-  -- Instructions from store_qj_addr (3 instrs at base)
-  have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
-  have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) j_x8 (base + 8) (by nofun)
-  -- SD instruction with signExtend12 normalization
-  have hse : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [hse]; bv_omega
-  have I3 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 (base + 12)
-  rw [haddr] at I3
-  runBlock I0 I1 I2 I3
+-- Trial load + Store qj composed specs (divK_trial_load_spec, divK_store_qj_spec)
+-- moved to EvmAsm.Evm64.DivMod.LimbSpec.TrialStoreComposed (twenty-eighth chunk
+-- of #312 split). Re-exported via the import at the top of this file, so
+-- downstream surface is unchanged.
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -1,0 +1,115 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.TrialStoreComposed
+
+  Two straight-line composition specs for the Knuth loop body:
+    * `divK_trial_load_spec` — 12-instruction composition (trial_load_u
+      + trial_load_vtop) that fetches `u_hi`, `u_lo`, and `v_top` from
+      memory in preparation for the trial-quotient estimation.
+    * `divK_store_qj_spec` — 4-instruction composition (store_qj_addr
+      + store_qj_write) that computes `q_addr = sp + 4088 - 8*j` and
+      stores `q_hat` there.
+
+  Twenty-eighth chunk of the `LimbSpec.lean` split tracked by issue #312.
+  The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
+  so every existing `import EvmAsm.Evm64.DivMod.LimbSpec` still sees both
+  specs.
+-/
+
+import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Trial quotient load: fetch u_hi, u_lo, v_top from memory.
+    Instrs [1]-[12] of loop body.
+    Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtop_base. -/
+theorem divK_trial_load_spec
+    (sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
+    (base : Word) :
+    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x7 .x7 3))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.ADDI .x5 .x12 4056))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SUB .x5 .x5 .x7))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.LD .x7 .x5 0))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.LD .x5 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x6 .x12 3984))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x6 .x6 4095))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x6 .x6 3))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.ADD .x6 .x12 .x6))
+       (CodeReq.singleton (base + 44) (.LD .x10 .x6 32))))))))))))
+    cpsTriple base (base + 48) cr
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
+       (sp + signExtend12 3984 ↦ₘ n) **
+       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
+       (vtop_base + signExtend12 32 ↦ₘ v_top))
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
+       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
+       (sp + signExtend12 3984 ↦ₘ n) **
+       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
+       (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
+  intro u_addr vtop_base cr
+  let jpn := j + n
+  let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
+  let u0_base := sp + signExtend12 4056
+  have hse0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [hse0]; bv_omega
+  have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
+  have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
+  have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
+  have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
+  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
+  have I5 := ld_spec_gen .x7 .x5 u_addr jpn_x8 u_hi 0 (base + 20) (by nofun)
+  rw [haddr0] at I5
+  have I6 := ld_spec_gen_same .x5 u_addr u_lo 8 (base + 24) (by nofun)
+  let nm1 := n + signExtend12 4095
+  let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
+  have I7 := ld_spec_gen .x6 .x12 sp v6_old n 3984 (base + 28) (by nofun)
+  have I8 := addi_spec_gen_same .x6 n 4095 (base + 32) (by nofun)
+  have I9 := slli_spec_gen_same .x6 nm1 3 (base + 36) (by nofun)
+  have I10 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 40) (by nofun)
+  have I11 := ld_spec_gen .x10 .x6 vtop_base v10_old v_top 32 (base + 44) (by nofun)
+  runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11
+
+/-- Store q[j]: compute address and store q_hat. 4 instructions.
+    q_addr = sp + 4088 - j*8. -/
+theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
+    (base : Word) :
+    let j_x8 := j <<< (3 : BitVec 6).toNat
+    let q_addr := sp + signExtend12 4088 - j_x8
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+       (CodeReq.singleton (base + 12) (.SD .x7 .x11 0))))
+    cpsTriple base (base + 16) cr
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+       (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
+       (q_addr ↦ₘ q_old))
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) **
+       (q_addr ↦ₘ q_hat)) := by
+  intro j_x8 q_addr cr
+  have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
+  have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) j_x8 (base + 8) (by nofun)
+  have hse : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [hse]; bv_omega
+  have I3 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 (base + 12)
+  rw [haddr] at I3
+  runBlock I0 I1 I2 I3
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- Twenty-eighth chunk of the `LimbSpec.lean` split tracked by #312.
- Moves `divK_trial_load_spec` (12-instr trial_load_u + trial_load_vtop) and `divK_store_qj_spec` (4-instr store_qj_addr + store_qj_write) into `EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean`.
- Parent `LimbSpec.lean` re-exports via a new `import`, so downstream consumers are unaffected.

Pure relocation — no proof changes. Both specs use only low-level `spec_gen` + `runBlock` and don't depend on any of my other open PRs.

## Test plan

- [x] `lake build` (full) clean
- [ ] CI green