### PR TITLE
feat(divmod): add modN4StackPre_unfold_atoms_right mid-tree fold

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -253,9 +253,9 @@ def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   ((sp + signExtend12 3984) ↦ₘ n_mem) **
   ((sp + signExtend12 3976) ↦ₘ j_mem)
 
-/-- Unfold `divScratchValues` into its 15 underlying memory atoms. Since
-    `divScratchValues` is not `@[irreducible]` the `delta`/`unfold` tactics
-    reduce it directly, but this named rewrite is convenient at call sites. -/
+/-- Unfold `divScratchValues` into its 15 underlying memory atoms. The bundle
+    is `@[irreducible]`, so `unfold` won't see through it — this named rewrite
+    is the supported way in at call sites (parallel to `divScratchOwn_unfold`). -/
 theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem : Word) :
     divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -511,6 +511,36 @@ theorem modN4MaxSkipStackPost_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (modN4MaxSkipStackPost sp a b ** Q) := by
   rw [modN4MaxSkipStackPost_unfold_atoms]
 
+/-- Mid-tree variant of `modN4StackPre_unfold_atoms`: threads a remainder
+    `Q` through the equality so `rw ←` can fold atoms back into the MOD stack
+    pre bundle even when they sit mid-chain. Mirror of
+    `divN4StackPre_unfold_atoms_right`. -/
+theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word)
+    (Q : Assertion) :
+    (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+      (.x11 ↦ᵣ v11) **
+      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
+       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
+      (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
+       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
+      (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
+       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem))) ** Q) =
+    (modN4StackPre sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem ** Q) := by
+  rw [modN4StackPre_unfold_atoms]
+
 /-- Mid-tree variant of `divN4StackPre_unfold_atoms`: threads a remainder
     `Q` through the equality so `rw ←` can fold atoms back into the stack
     pre bundle even when they sit mid-chain. Parallel to the other `_right`

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -199,6 +199,28 @@ theorem signExtend12_ofNat_small (m : Nat) (hm : m < 2048) :
   · exact BitVec.setWidth_ofNat_of_le_of_lt (by omega) (by omega)
   · rw [BitVec.msb_eq_false_iff_two_mul_lt]; simp [BitVec.toNat_ofNat]; omega
 
+/-- Concatenation: `evmStackIs sp (xs ++ ys)` splits into `xs` at `sp` and
+    `ys` at `sp + 32 * xs.length`. Companion to `evmStackIs_split_at` —
+    where `split_at` isolates the kth element, `append` composes two
+    contiguous stack segments. Useful for "preserve some cells, append
+    a new element" stack transitions (PUSH / stack extension specs). -/
+theorem evmStackIs_append (sp : Word) (xs ys : List EvmWord) :
+    evmStackIs sp (xs ++ ys) =
+    (evmStackIs sp xs ** evmStackIs (sp + BitVec.ofNat 64 (xs.length * 32)) ys) := by
+  induction xs generalizing sp with
+  | nil =>
+    simp only [List.nil_append, List.length_nil, Nat.zero_mul,
+               evmStackIs_nil, sepConj_emp_left']
+    rw [show (BitVec.ofNat 64 0 : Word) = 0 from rfl]
+    rw [show sp + (0 : Word) = sp from by bv_omega]
+  | cons v vs ih =>
+    have hshift : sp + (32 : Word) + BitVec.ofNat 64 (vs.length * 32) =
+                  sp + BitVec.ofNat 64 ((vs.length + 1) * 32) := by
+      apply BitVec.eq_of_toNat_eq
+      simp [BitVec.toNat_add, BitVec.toNat_ofNat]; omega
+    simp only [List.cons_append, evmStackIs_cons, List.length_cons]
+    rw [ih (sp + 32), hshift, sepConj_assoc']
+
 /-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
 theorem evmStackIs_split_at (sp : Word) (stack : List EvmWord) (k : Nat)
     (hk : k < stack.length) :


### PR DESCRIPTION
## Summary
- Add `modN4StackPre_unfold_atoms_right`: mid-tree variant of `modN4StackPre_unfold_atoms`, threading a remainder `Q` through the equality so `rw ←` can fold primitive atoms into the MOD stack pre bundle mid-chain.
- Mirror of `divN4StackPre_unfold_atoms_right` — completes the `_right` family for both DIV and MOD stack-pre bundles.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3396 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)