### PR TITLE
refactor(rv64_addr): add bv64_4mul_N lemmas, migrate 18 callsites (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_96 se13_1020 se21_24)
+open EvmAsm.Rv64.AddrNorm (se13_96 se13_1020 se21_24 bv64_4mul_3)
 
 -- ============================================================================
 -- Section 10l: Denorm composition (25 instructions at base+904)
@@ -135,7 +135,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+        rw [bv64_4mul_3,
             show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -13,6 +13,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv64_4mul_3)
 
 -- ============================================================================
 -- Denorm code subsumption for modCode (block 9, skip 9 blocks)
@@ -79,7 +80,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+        rw [bv64_4mul_3,
             show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for block 3 (PhaseC2) and block 4 (NormB)
@@ -34,7 +34,7 @@ private theorem beq_shift_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_464 se21_40)
+open EvmAsm.Rv64.AddrNorm (se13_464 se21_40 bv64_4mul_3)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for blocks 5, 6, 7
@@ -240,7 +240,7 @@ private theorem blt_loopSetup_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -14,7 +14,9 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4 se12_4095)
-open EvmAsm.Rv64.AddrNorm (se13_24)
+open EvmAsm.Rv64.AddrNorm (se13_24
+  bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+  bv64_4mul_14 bv64_4mul_15)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for blocks 0 and 1
@@ -62,7 +64,7 @@ theorem addi_x5_singleton_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by decide,
+  rw [bv64_4mul_9,
       show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -74,7 +76,7 @@ theorem bne_x10_singleton_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by decide,
+  rw [bv64_4mul_10,
       show (base + phaseBOff : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -183,7 +185,7 @@ theorem addi_x5_3_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by decide,
+  rw [bv64_4mul_11,
       show (base + phaseBOff : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -196,7 +198,7 @@ theorem bne_x7_16_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by decide,
+  rw [bv64_4mul_12,
       show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -209,7 +211,7 @@ theorem addi_x5_2_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by decide,
+  rw [bv64_4mul_13,
       show (base + phaseBOff : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -222,7 +224,7 @@ theorem bne_x6_8_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by decide,
+  rw [bv64_4mul_14,
       show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -235,7 +237,7 @@ theorem addi_x5_1_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by decide,
+  rw [bv64_4mul_15,
       show (base + phaseBOff : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
 
 /-- Phase C2 code (block 3) is subsumed by divCode. -/
 private theorem divK_phaseC2_code_sub_divCode (base : Word) :
@@ -28,7 +28,7 @@ private theorem beq_shift_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -39,7 +39,7 @@ private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
 -- signExtend13/21 rewrites pulled from the rv64_addr global set (Rv64/AddrNorm.lean).
-open EvmAsm.Rv64.AddrNorm (se13_464 se21_40)
+open EvmAsm.Rv64.AddrNorm (se13_464 se21_40 bv64_4mul_3)
 
 /-- Full NormA: normalize dividend a[0..3] → u[0..4] and jump to loopSetup.
     base+312 → base+432 (21 instructions including JAL).
@@ -241,7 +241,7 @@ private theorem blt_loopSetup_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -14,7 +14,9 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se13_1020)
+open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se13_1020
+  bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+  bv64_4mul_14 bv64_4mul_15)
 
 -- ============================================================================
 -- Section 5: CodeReq subsumption lemmas (via mono_unionAll / mono_sub_unionAll)
@@ -91,7 +93,7 @@ private theorem addi_x5_singleton_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by decide,
+  rw [bv64_4mul_9,
       show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -104,7 +106,7 @@ private theorem bne_x10_singleton_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by decide,
+  rw [bv64_4mul_10,
       show (base + phaseBOff : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -421,7 +423,7 @@ private theorem addi_x5_3_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by decide,
+  rw [bv64_4mul_11,
       show (base + phaseBOff : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -434,7 +436,7 @@ private theorem bne_x7_16_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by decide,
+  rw [bv64_4mul_12,
       show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -447,7 +449,7 @@ private theorem addi_x5_2_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by decide,
+  rw [bv64_4mul_13,
       show (base + phaseBOff : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -460,7 +462,7 @@ private theorem bne_x6_8_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by decide,
+  rw [bv64_4mul_14,
       show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -473,7 +475,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by decide,
+  rw [bv64_4mul_15,
       show (base + phaseBOff : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -113,6 +113,33 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem se21_560 : signExtend21 (560 : BitVec 21) = (560 : Word) := by decide
 
 -- ============================================================================
+-- `BitVec.ofNat 64 (4 * N)` evaluations (RV64 instruction stride × index)
+--
+-- `CodeReq.ofProg_lookup` produces address offsets of the form
+-- `BitVec.ofNat 64 (4 * k)` where `4` is the RV64 instruction width in bytes
+-- and `k` is the instruction index inside a program. Lean does not reduce
+-- `BitVec.ofNat 64 (4 * k)` to a numeric literal automatically, so ~34
+-- consumer sites historically close the address match with an ad-hoc
+-- `show BitVec.ofNat 64 (4 * N) = (4·N : Word) from by decide` rewrite
+-- (Compose/{PhaseAB,ModPhaseB,ModNorm,ModNormA,Epilogue,ModEpilogue,Norm}.lean).
+-- Migrating those sites to the `rv64_addr` grindset localizes the knowledge.
+-- ============================================================================
+
+@[rv64_addr, grind =] theorem bv64_4mul_1  : BitVec.ofNat 64 (4 * 1)  = (4  : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_3  : BitVec.ofNat 64 (4 * 3)  = (12 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_5  : BitVec.ofNat 64 (4 * 5)  = (20 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_9  : BitVec.ofNat 64 (4 * 9)  = (36 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_10 : BitVec.ofNat 64 (4 * 10) = (40 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_11 : BitVec.ofNat 64 (4 * 11) = (44 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_12 : BitVec.ofNat 64 (4 * 12) = (48 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_13 : BitVec.ofNat 64 (4 * 13) = (52 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_14 : BitVec.ofNat 64 (4 * 14) = (56 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_15 : BitVec.ofNat 64 (4 * 15) = (60 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_17 : BitVec.ofNat 64 (4 * 17) = (68 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_20 : BitVec.ofNat 64 (4 * 20) = (80 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_21 : BitVec.ofNat 64 (4 * 21) = (84 : Word) := by decide
+
+-- ============================================================================
 -- `rv64_addr` tactic
 --
 -- Primary: `grind` (sees every `@[grind =]` fact in this file + BitVec
@@ -154,5 +181,8 @@ example (a : Word) : a + signExtend13 (7736 : BitVec 13) =
 
 -- signExtend21 on a small positive offset.
 example (a : Word) : a + signExtend21 (252 : BitVec 21) = a + 252 := by rv64_addr
+
+-- `BitVec.ofNat 64 (4 * k)` embedded in `CodeReq.ofProg_lookup` style goals.
+example (a : Word) : a + BitVec.ofNat 64 (4 * 12) = a + 48 := by rv64_addr
 
 end Sanity


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Adds the next batch of atomic facts to the `rv64_addr` grindset: concrete-N evaluations of `BitVec.ofNat 64 (4 * N)` (the shape produced by `CodeReq.ofProg_lookup` where `4` is the RV64 instruction stride and `N` is the intra-block instruction index).

## Changes

- `EvmAsm/Rv64/AddrNorm.lean`: 13 new `@[rv64_addr, grind =]` lemmas `bv64_4mul_{1,3,5,9,10,11,12,13,14,15,17,20,21}`, plus a sanity `example` exercising the new shape via `by rv64_addr`.
- 8 consumer files in `EvmAsm/Evm64/DivMod/Compose/`: 18 call sites migrated from the inline
  ```lean
  show BitVec.ofNat 64 (4 * N) = (K : Word) from by decide
  ```
  shape to the shared `bv64_4mul_N` name. No proof logic changes.

## Rationale

Today every consumer embeds its own `by decide` for this identity. Centralizing it in the grindset means new `4 * N` entries are one-line additions and every downstream `rv64_addr` / `grind` site picks them up automatically — matching how `se13_N` / `se21_N` / `se12_N` are already handled.

## Test plan

- [x] `lake build` clean
- [x] `git grep 'BitVec.ofNat 64 (4 \* [0-9]\+) = '` shows only AddrNorm.lean + shapes that require `bv_addr` (legitimately different signature — not migration candidates)

🤖 Generated with [Claude Code](https://claude.com/claude-code)