### PR TITLE
refactor(rv64_addr): add zero_add_se12_{1,2}_toNat, migrate 16 callsites (#263)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -23,7 +23,8 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se21_24 se21_32 se21_48)
+open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se21_24 se21_32 se21_48
+  zero_add_se12_1_toNat zero_add_se12_2_toNat)
 
 -- ============================================================================
 -- Full program CodeReq
@@ -750,11 +751,11 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     have hn1 : limb_from_msb.toNat ≠ 1 :=
       fun hc => h1 (BitVec.eq_of_toNat_eq (by
         show limb_from_msb.toNat = ((0 : Word) + signExtend12 1).toNat
-        simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide]; exact hc))
+        simp only [zero_add_se12_1_toNat]; exact hc))
     have hn2 : limb_from_msb.toNat ≠ 2 :=
       fun hc => h2 (BitVec.eq_of_toNat_eq (by
         show limb_from_msb.toNat = ((0 : Word) + signExtend12 2).toNat
-        simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide]; exact hc))
+        simp only [zero_add_se12_2_toNat]; exact hc))
     have hlt4 : limb_from_msb.toNat < 4 := by omega
     omega
   -- Build body+store specs WITHOUT the dispatch fact (just compose and weaken regs)

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_96 se13_1020 se21_24)
+open EvmAsm.Rv64.AddrNorm (se13_96 se13_1020 se21_24 bv64_4mul_3)
 
 -- ============================================================================
 -- Section 10l: Denorm composition (25 instructions at base+904)
@@ -135,7 +135,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+        rw [bv64_4mul_3,
             show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -13,6 +13,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv64_4mul_3)
 
 -- ============================================================================
 -- Denorm code subsumption for modCode (block 9, skip 9 blocks)
@@ -79,7 +80,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+        rw [bv64_4mul_3,
             show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for block 3 (PhaseC2) and block 4 (NormB)
@@ -34,7 +34,7 @@ private theorem beq_shift_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_464 se21_40)
+open EvmAsm.Rv64.AddrNorm (se13_464 se21_40 bv64_4mul_3)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for blocks 5, 6, 7
@@ -240,7 +240,7 @@ private theorem blt_loopSetup_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_modCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -14,7 +14,9 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4 se12_4095)
-open EvmAsm.Rv64.AddrNorm (se13_24)
+open EvmAsm.Rv64.AddrNorm (se13_24
+  bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+  bv64_4mul_14 bv64_4mul_15)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for blocks 0 and 1
@@ -62,7 +64,7 @@ theorem addi_x5_singleton_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by decide,
+  rw [bv64_4mul_9,
       show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -74,7 +76,7 @@ theorem bne_x10_singleton_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by decide,
+  rw [bv64_4mul_10,
       show (base + phaseBOff : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -183,7 +185,7 @@ theorem addi_x5_3_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by decide,
+  rw [bv64_4mul_11,
       show (base + phaseBOff : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -196,7 +198,7 @@ theorem bne_x7_16_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by decide,
+  rw [bv64_4mul_12,
       show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -209,7 +211,7 @@ theorem addi_x5_2_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by decide,
+  rw [bv64_4mul_13,
       show (base + phaseBOff : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -222,7 +224,7 @@ theorem bne_x6_8_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by decide,
+  rw [bv64_4mul_14,
       show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1
@@ -235,7 +237,7 @@ theorem addi_x5_1_sub_modCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by decide,
+  rw [bv64_4mul_15,
       show (base + phaseBOff : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left base _ a i h1

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
 
 /-- Phase C2 code (block 3) is subsumed by divCode. -/
 private theorem divK_phaseC2_code_sub_divCode (base : Word) :
@@ -28,7 +28,7 @@ private theorem beq_shift_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseC2Off) (divK_phaseC2 172) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hlookup
   exact divK_phaseC2_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -39,7 +39,7 @@ private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
 -- signExtend13/21 rewrites pulled from the rv64_addr global set (Rv64/AddrNorm.lean).
-open EvmAsm.Rv64.AddrNorm (se13_464 se21_40)
+open EvmAsm.Rv64.AddrNorm (se13_464 se21_40 bv64_4mul_3)
 
 /-- Full NormA: normalize dividend a[0..3] → u[0..4] and jump to loopSetup.
     base+312 → base+432 (21 instructions including JAL).
@@ -241,7 +241,7 @@ private theorem blt_loopSetup_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + loopSetupOff) (divK_loopSetup 464) 3
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 3) = (12 : Word) from by decide,
+  rw [bv64_4mul_3,
       show (base + loopSetupOff : Word) + 12 = base + 444 from by bv_addr] at hlookup
   exact divK_loopSetup_code_sub_divCode base a i
     (CodeReq.singleton_mono hlookup a i h)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -14,7 +14,9 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se13_1020)
+open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se13_1020
+  bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+  bv64_4mul_14 bv64_4mul_15)
 
 -- ============================================================================
 -- Section 5: CodeReq subsumption lemmas (via mono_unionAll / mono_sub_unionAll)
@@ -91,7 +93,7 @@ private theorem addi_x5_singleton_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 9) = (36 : Word) from by decide,
+  rw [bv64_4mul_9,
       show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -104,7 +106,7 @@ private theorem bne_x10_singleton_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 10
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 10) = (40 : Word) from by decide,
+  rw [bv64_4mul_10,
       show (base + phaseBOff : Word) + 40 = base + 72 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -421,7 +423,7 @@ private theorem addi_x5_3_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 11
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 11) = (44 : Word) from by decide,
+  rw [bv64_4mul_11,
       show (base + phaseBOff : Word) + 44 = base + 76 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -434,7 +436,7 @@ private theorem bne_x7_16_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 12) = (48 : Word) from by decide,
+  rw [bv64_4mul_12,
       show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -447,7 +449,7 @@ private theorem addi_x5_2_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 13
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 13) = (52 : Word) from by decide,
+  rw [bv64_4mul_13,
       show (base + phaseBOff : Word) + 52 = base + 84 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -460,7 +462,7 @@ private theorem bne_x6_8_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 14) = (56 : Word) from by decide,
+  rw [bv64_4mul_14,
       show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1
@@ -473,7 +475,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 15
     (by decide) (by decide)
-  rw [show BitVec.ofNat 64 (4 * 15) = (60 : Word) from by decide,
+  rw [bv64_4mul_15,
       show (base + phaseBOff : Word) + 60 = base + 92 from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left base _ a i h1

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -15,7 +15,8 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252)
+open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
+  zero_add_se12_1_toNat zero_add_se12_2_toNat)
 
 -- ============================================================================
 -- Section 1: shrCode definition and helpers
@@ -866,7 +867,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         show value >>> shift.toNat = value >>> s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 1 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide] at this
+        simp only [zero_add_se12_1_toNat] at this
         exact this
       have eq0 := shr_bridge_merge value s0 result hresult 1 0 hL (by omega) (by omega)
       have eq1 := shr_bridge_merge value s0 result hresult 1 1 hL (by omega) (by omega)
@@ -884,7 +885,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         show value >>> shift.toNat = value >>> s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 2 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide] at this
+        simp only [zero_add_se12_2_toNat] at this
         exact this
       have eq0 := shr_bridge_merge value s0 result hresult 2 0 hL (by omega) (by omega)
       have eq1 := shr_bridge_last value s0 result hresult 2 1 hL (by omega)
@@ -912,12 +913,12 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         have hn1 : limb_shift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 1).toNat
-            simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide]
+            simp only [zero_add_se12_1_toNat]
             exact hc))
         have hn2 : limb_shift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 2).toNat
-            simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide]
+            simp only [zero_add_se12_2_toNat]
             exact hc))
         show limb_shift.toNat = 3; omega
       have eq0 := shr_bridge_last value s0 result hresult 3 0 hL (by omega)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -18,7 +18,8 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268)
+open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268
+  zero_add_se12_1_toNat zero_add_se12_2_toNat)
 
 -- ============================================================================
 -- Section 1: sarCode definition and helpers
@@ -1022,7 +1023,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 1 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide] at this
+        simp only [zero_add_se12_1_toNat] at this
         exact this
       have eq0 := sar_bridge_merge value s0 result hresult 1 0 hL (by omega) (by omega)
       have eq1 := sar_bridge_merge value s0 result hresult 1 1 hL (by omega) (by omega)
@@ -1041,7 +1042,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 2 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide] at this
+        simp only [zero_add_se12_2_toNat] at this
         exact this
       have eq0 := sar_bridge_merge value s0 result hresult 2 0 hL (by omega) (by omega)
       have eq1 := sar_bridge_last value s0 result hresult 2 1 hL (by omega)
@@ -1070,12 +1071,12 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         have hn1 : limb_shift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 1).toNat
-            simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide]
+            simp only [zero_add_se12_1_toNat]
             exact hc))
         have hn2 : limb_shift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 2).toNat
-            simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide]
+            simp only [zero_add_se12_2_toNat]
             exact hc))
         show limb_shift.toNat = 3; omega
       have eq0 := sar_bridge_last value s0 result hresult 3 0 hL (by omega)

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -18,7 +18,8 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252)
+open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
+  zero_add_se12_1_toNat zero_add_se12_2_toNat)
 
 -- ============================================================================
 -- Section 1: shlCode definition and helpers
@@ -840,7 +841,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         show value <<< shift.toNat = value <<< s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 1 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide] at this
+        simp only [zero_add_se12_1_toNat] at this
         exact this
       have eq0 := shl_bridge_zero value s0 result hresult 1 0 hL (by omega)
       have eq1 := shl_bridge_first value s0 result hresult 1 1 hL (by omega)
@@ -859,7 +860,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         show value <<< shift.toNat = value <<< s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 2 := by
         have := congrArg BitVec.toNat hls
-        simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide] at this
+        simp only [zero_add_se12_2_toNat] at this
         exact this
       have eq0 := shl_bridge_zero value s0 result hresult 2 0 hL (by omega)
       have eq1 := shl_bridge_zero value s0 result hresult 2 1 hL (by omega)
@@ -888,12 +889,12 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         have hn1 : limb_shift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 1).toNat
-            simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide]
+            simp only [zero_add_se12_1_toNat]
             exact hc))
         have hn2 : limb_shift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limb_shift.toNat = ((0 : Word) + signExtend12 2).toNat
-            simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide]
+            simp only [zero_add_se12_2_toNat]
             exact hc))
         show limb_shift.toNat = 3; omega
       have eq0 := shl_bridge_zero value s0 result hresult 3 0 hL (by omega)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -17,7 +17,8 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se21_68 se21_96)
+open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se21_68 se21_96
+  zero_add_se12_1_toNat zero_add_se12_2_toNat)
 
 -- ============================================================================
 -- Section 1: signextCode definition and helpers
@@ -786,7 +787,7 @@ theorem signext_body_spec (sp base : Word)
     hbd1_w (fun (hli : limb_idx = (0 : Word) + signExtend12 1) h hq => by
       have hL : b.toNat / 8 = 1 := by
         have := congrArg BitVec.toNat hli; rw [hlimb_idx_eq] at this
-        simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide] at this; exact this
+        simp only [zero_add_se12_1_toNat] at this; exact this
       have hv1_eq : v1 = x.getLimbN (b.toNat / 8) := by rw [hL]; exact rfl
       have heq0 := EvmWord.signextend_getLimb_below b x hnotge (0 : Fin 4) (by simp [hL])
       have heq1 := EvmWord.signextend_getLimb_target b x hnotge (1 : Fin 4) (by simp [hL])
@@ -803,7 +804,7 @@ theorem signext_body_spec (sp base : Word)
     hbd2_w (fun (hli : limb_idx = (0 : Word) + signExtend12 2) h hq => by
       have hL : b.toNat / 8 = 2 := by
         have := congrArg BitVec.toNat hli; rw [hlimb_idx_eq] at this
-        simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide] at this; exact this
+        simp only [zero_add_se12_2_toNat] at this; exact this
       have hv2_eq : v2 = x.getLimbN (b.toNat / 8) := by rw [hL]; exact rfl
       have heq0 := EvmWord.signextend_getLimb_below b x hnotge (0 : Fin 4) (by simp [hL])
       have heq1 := EvmWord.signextend_getLimb_below b x hnotge (1 : Fin 4) (by simp [hL])
@@ -829,11 +830,11 @@ theorem signext_body_spec (sp base : Word)
         have hn1 : limb_idx.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limb_idx.toNat = ((0 : Word) + signExtend12 1).toNat
-            simp only [show ((0 : Word) + signExtend12 1).toNat = 1 from by decide]; exact hc))
+            simp only [zero_add_se12_1_toNat]; exact hc))
         have hn2 : limb_idx.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limb_idx.toNat = ((0 : Word) + signExtend12 2).toNat
-            simp only [show ((0 : Word) + signExtend12 2).toNat = 2 from by decide]; exact hc))
+            simp only [zero_add_se12_2_toNat]; exact hc))
         omega
       have hv3_eq : v3 = x.getLimbN (b.toNat / 8) := by rw [hL]; exact rfl
       have heq0 := EvmWord.signextend_getLimb_below b x hnotge (0 : Fin 4) (by simp [hL])

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -113,6 +113,33 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem se21_560 : signExtend21 (560 : BitVec 21) = (560 : Word) := by decide
 
 -- ============================================================================
+-- `BitVec.ofNat 64 (4 * N)` evaluations (RV64 instruction stride × index)
+--
+-- `CodeReq.ofProg_lookup` produces address offsets of the form
+-- `BitVec.ofNat 64 (4 * k)` where `4` is the RV64 instruction width in bytes
+-- and `k` is the instruction index inside a program. Lean does not reduce
+-- `BitVec.ofNat 64 (4 * k)` to a numeric literal automatically, so ~34
+-- consumer sites historically close the address match with an ad-hoc
+-- `show BitVec.ofNat 64 (4 * N) = (4·N : Word) from by decide` rewrite
+-- (Compose/{PhaseAB,ModPhaseB,ModNorm,ModNormA,Epilogue,ModEpilogue,Norm}.lean).
+-- Migrating those sites to the `rv64_addr` grindset localizes the knowledge.
+-- ============================================================================
+
+@[rv64_addr, grind =] theorem bv64_4mul_1  : BitVec.ofNat 64 (4 * 1)  = (4  : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_3  : BitVec.ofNat 64 (4 * 3)  = (12 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_5  : BitVec.ofNat 64 (4 * 5)  = (20 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_9  : BitVec.ofNat 64 (4 * 9)  = (36 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_10 : BitVec.ofNat 64 (4 * 10) = (40 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_11 : BitVec.ofNat 64 (4 * 11) = (44 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_12 : BitVec.ofNat 64 (4 * 12) = (48 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_13 : BitVec.ofNat 64 (4 * 13) = (52 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_14 : BitVec.ofNat 64 (4 * 14) = (56 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_15 : BitVec.ofNat 64 (4 * 15) = (60 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_17 : BitVec.ofNat 64 (4 * 17) = (68 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_20 : BitVec.ofNat 64 (4 * 20) = (80 : Word) := by decide
+@[rv64_addr, grind =] theorem bv64_4mul_21 : BitVec.ofNat 64 (4 * 21) = (84 : Word) := by decide
+
+-- ============================================================================
 -- `rv64_addr` tactic
 --
 -- Primary: `grind` (sees every `@[grind =]` fact in this file + BitVec
@@ -154,5 +181,8 @@ example (a : Word) : a + signExtend13 (7736 : BitVec 13) =
 
 -- signExtend21 on a small positive offset.
 example (a : Word) : a + signExtend21 (252 : BitVec 21) = a + 252 := by rv64_addr
+
+-- `BitVec.ofNat 64 (4 * k)` embedded in `CodeReq.ofProg_lookup` style goals.
+example (a : Word) : a + BitVec.ofNat 64 (4 * 12) = a + 48 := by rv64_addr
 
 end Sanity

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -140,6 +140,25 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem bv64_4mul_21 : BitVec.ofNat 64 (4 * 21) = (84 : Word) := by decide
 
 -- ============================================================================
+-- `((0 : Word) + signExtend12 N).toNat` evaluations
+--
+-- This shape appears in shift/sign-extend/byte opcodes where a BLTU/BEQ
+-- postcondition returns `((0 : Word) + signExtend12 1).toNat` (or `... 2`)
+-- as the PC offset. The expression is ground but Lean does not reduce
+-- `((0 : Word) + signExtend12 N).toNat` automatically, so ~16 consumer sites
+-- (Shift/{Compose,ShlCompose,SarCompose}.lean, SignExtend/Compose.lean,
+-- Byte/Spec.lean) close the address match with an inline
+--     show ((0 : Word) + signExtend12 N).toNat = N from by decide
+-- rewrite. Centralising the identity here lets `rv64_addr` / `grind` handle
+-- it uniformly.
+-- ============================================================================
+
+@[rv64_addr, grind =] theorem zero_add_se12_1_toNat :
+    ((0 : Word) + signExtend12 1).toNat = 1 := by decide
+@[rv64_addr, grind =] theorem zero_add_se12_2_toNat :
+    ((0 : Word) + signExtend12 2).toNat = 2 := by decide
+
+-- ============================================================================
 -- `rv64_addr` tactic
 --
 -- Primary: `grind` (sees every `@[grind =]` fact in this file + BitVec


### PR DESCRIPTION
## Summary

Follow-up to #467 addressing [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Adds two more atomic facts to the `rv64_addr` grindset for a shape that appears in shift / sign-extend / byte opcodes.

## Changes

- `EvmAsm/Rv64/AddrNorm.lean`:
  ```lean
  @[rv64_addr, grind =] theorem zero_add_se12_1_toNat :
      ((0 : Word) + signExtend12 1).toNat = 1 := by decide
  @[rv64_addr, grind =] theorem zero_add_se12_2_toNat :
      ((0 : Word) + signExtend12 2).toNat = 2 := by decide
  ```
- 5 consumer files in `EvmAsm/Evm64/{Shift,SignExtend,Byte}/`: 16 call sites migrated from the historical
  ```lean
  simp only [show ((0 : Word) + signExtend12 N).toNat = N from by decide]
  ```
  to the named lemma. No proof logic changes.

## Rationale

BLTU/BEQ postconditions surface the branch offset as `((0 : Word) + signExtend12 N).toNat`; the expression is ground but Lean doesn't reduce it automatically, so every consumer embedded its own `by decide`. Centralising localises address-matching knowledge to `AddrNorm.lean` — parallel to `bv64_4mul_N` (#467) and the `se12/13/21_N` families.

## Stacked on #467

This branch is cut from #467 so both share the grindset-growth rationale. #467 must merge first (or be landed in the queue before this PR), otherwise this PR will conflict on `AddrNorm.lean`.

## Test plan

- [x] `lake build` clean
- [x] `git grep 'show ((0 : Word) + signExtend12 [12]).toNat'` shows only AddrNorm.lean (the lemma definitions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)