### PR TITLE
refactor(EvmWord): specialize getLimbN_fromLimbs_const at k=0,1,2,3 (#263)

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -556,6 +556,23 @@ theorem getLimbN_fromLimbs_const (w : Word) (k : Nat) :
   · next h => simp [getLimb_fromLimbs_const]
   · next h => simp_all
 
+/-- `k`-specialized variants of `getLimbN_fromLimbs_const` for `k = 0, 1, 2, 3`.
+    Avoids the chained `getLimbN_fromLimbs_const` + `show (k : Nat) < 4 from by decide`
+    + `ite_true` idiom at call sites that iterate over the four concrete limb
+    indices (issue #263). -/
+theorem getLimbN_fromLimbs_const_0 (w : Word) :
+    (fromLimbs (fun _ => w)).getLimbN 0 = w := by
+  rw [getLimbN_fromLimbs_const, if_pos (by decide)]
+theorem getLimbN_fromLimbs_const_1 (w : Word) :
+    (fromLimbs (fun _ => w)).getLimbN 1 = w := by
+  rw [getLimbN_fromLimbs_const, if_pos (by decide)]
+theorem getLimbN_fromLimbs_const_2 (w : Word) :
+    (fromLimbs (fun _ => w)).getLimbN 2 = w := by
+  rw [getLimbN_fromLimbs_const, if_pos (by decide)]
+theorem getLimbN_fromLimbs_const_3 (w : Word) :
+    (fromLimbs (fun _ => w)).getLimbN 3 = w := by
+  rw [getLimbN_fromLimbs_const, if_pos (by decide)]
+
 end EvmWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -114,10 +114,9 @@ private theorem sar_sign_fill_lift (sp base : Word)
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp)
     (fun h hq => by
-      simp only [evmWordIs, EvmWord.getLimbN_fromLimbs_const,
-                 show (0 : Nat) < 4 from by decide, show (1 : Nat) < 4 from by decide,
-                 show (2 : Nat) < 4 from by decide, show (3 : Nat) < 4 from by decide,
-                 ite_true]
+      simp only [evmWordIs, EvmWord.getLimbN_fromLimbs_const_0,
+                 EvmWord.getLimbN_fromLimbs_const_1, EvmWord.getLimbN_fromLimbs_const_2,
+                 EvmWord.getLimbN_fromLimbs_const_3]
       simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
       have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega


### PR DESCRIPTION
## Summary

Another [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263) cleanup in the `EvmWord` direction. Parallel to #470 (which did the `getLimbN_one` case): adds four specialised `getLimbN_fromLimbs_const_{0,1,2,3}` lemmas in `Evm64/Basic.lean` and migrates the one consumer in `Shift/SarSemantic.lean`.

## Changes

- `EvmAsm/Evm64/Basic.lean`: new lemmas
  ```lean
  theorem getLimbN_fromLimbs_const_0 (w : Word) : (fromLimbs (fun _ => w)).getLimbN 0 = w
  theorem getLimbN_fromLimbs_const_1 (w : Word) : (fromLimbs (fun _ => w)).getLimbN 1 = w
  theorem getLimbN_fromLimbs_const_2 (w : Word) : (fromLimbs (fun _ => w)).getLimbN 2 = w
  theorem getLimbN_fromLimbs_const_3 (w : Word) : (fromLimbs (fun _ => w)).getLimbN 3 = w
  ```
- `EvmAsm/Evm64/Shift/SarSemantic.lean`: 4 inline `show (N : Nat) < 4 from by decide` sites eliminated; the simp block drops from 4 lines to 3.

## Rationale

`getLimbN_fromLimbs_const` produces `if k < 4 then w else 0`. At a call site iterating over `k ∈ {0,1,2,3}`, closing the `if` requires feeding simp a copy of `show (N : Nat) < 4 from by decide` plus `ite_true` for each concrete `N`. The specialised lemmas do the case analysis once.

## Parallel PR note

This touches `Basic.lean` in a different location (after `getLimbN_fromLimbs_const` at line 552) than #470 (which adds near `getLimbN_one` at line 205). The two should merge cleanly in either order.

## Test plan

- [x] `lake build` clean
- [x] `git grep 'show (. : Nat) < 4'` shows no remaining matches in SarSemantic.lean

🤖 Generated with [Claude Code](https://claude.com/claude-code)