### PR TITLE
refactor(divmod_addr): migrate FullPath{N1,N2}Loop word_shl3_0 sites (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -18,6 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 
 -- ============================================================================
 -- Address normalization lemmas for n=1 preloop+loop composition
@@ -131,7 +132,7 @@ theorem loopExitPostN1_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
       u_base_off4072_j0, u_base_off4064_j0, u_base_j0, q_addr_j0]
-  simp only [show (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) from by decide]
+  simp only [bv6_toNat_3, word_shl3_0]
   rw [show (0 : Word) + signExtend12 4095 = signExtend12 4095 from BitVec.zero_add _]
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -18,6 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 
 -- ============================================================================
 -- Address normalization lemmas for n=2 preloop+loop composition
@@ -121,7 +122,7 @@ theorem loopExitPostN2_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
       u_base_off4072_j0, u_base_off4064_j0, u_base_j0, q_addr_j0]
-  simp only [show (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) from by decide]
+  simp only [bv6_toNat_3, word_shl3_0]
   rw [show (0 : Word) + signExtend12 4095 = signExtend12 4095 from BitVec.zero_add _]
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Small cleanup addressing [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Migrates the two remaining
\`simp only [show (0 : Word) <<< (3 : BitVec 6).toNat = (0 : Word) from by decide]\`
sites in \`FullPathN1Loop.lean\` and \`FullPathN2Loop.lean\` to the named \`divmod_addr\` lemmas \`bv6_toNat_3\` and \`word_shl3_0\` (both already live in \`Evm64/DivMod/AddrNorm.lean\`).

## Changes

- \`EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean\`: open the two names; migrate the one inline site.
- \`EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean\`: same.

## Test plan

- [x] \`lake build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)