### PR TITLE
refactor(Evm64): add SpAddr lemmas, migrate 20 stack spec sites (#263)

### DIFF
--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.Add.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -108,17 +109,11 @@ theorem evm_add_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at h0 h1 h2 h3
       rw [h0, h1, h2, h3]

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.And.LimbSpec
+import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 
@@ -63,17 +64,11 @@ theorem evm_and_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_and]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.Eq.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -97,10 +98,7 @@ theorem evm_eq_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
@@ -111,10 +109,7 @@ theorem evm_eq_stack_spec (sp base : Word)
                  ← EvmWord.eq_xor_or_reduce_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -108,10 +109,7 @@ theorem evm_gt_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
@@ -122,10 +120,7 @@ theorem evm_gt_stack_spec (sp base : Word)
                  ← EvmWord.lt_borrow_chain_correct b a]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -8,6 +8,7 @@
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -108,10 +109,7 @@ theorem evm_lt_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
@@ -122,10 +120,7 @@ theorem evm_lt_stack_spec (sp base : Word)
                  ← EvmWord.lt_borrow_chain_correct a b]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Or.LimbSpec
+import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 
@@ -49,17 +50,11 @@ theorem evm_or_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_or]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -12,6 +12,7 @@
 import EvmAsm.Evm64.Sgt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.ControlFlow
 
 open EvmAsm.Rv64.Tactics
@@ -148,10 +149,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
@@ -162,10 +160,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
                  ← EvmWord.slt_result_correct b a]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -11,6 +11,7 @@
 import EvmAsm.Evm64.Slt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.ControlFlow
 
 open EvmAsm.Rv64.Tactics
@@ -146,10 +147,7 @@ theorem evm_slt_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       unfold evmWordIs
@@ -160,10 +158,7 @@ theorem evm_slt_stack_spec (sp base : Word)
                  ← EvmWord.slt_result_correct a b]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 

--- a/EvmAsm/Evm64/SpAddr.lean
+++ b/EvmAsm/Evm64/SpAddr.lean
@@ -1,0 +1,33 @@
+/-
+  EvmAsm.Evm64.SpAddr
+
+  Shared helper lemmas for flattening `(sp + 32) + K` address expressions that
+  appear in EvmWord-level stack specs. Every two-input 256-bit opcode (ADD,
+  SUB, AND, OR, XOR, LT, GT, SLT, SGT, EQ) sits at stack offset `sp + 32` for
+  its second operand, so its `evmWordIs (sp + 32) b` post expands to
+  `(sp + 32) ↦ₘ b0`, `(sp + 32 + 8) ↦ₘ b1`, `(sp + 32 + 16) ↦ₘ b2`,
+  `(sp + 32 + 24) ↦ₘ b3`. Normalising those four addresses to
+  `sp + {32,40,48,56}` used to be a three-line `have : ... := by bv_omega`
+  + `rw [‹...›]` dance repeated twice (pre-condition + post-condition) in every
+  stack spec — ten files, ~20 sites, most of them identical.
+
+  These named rewrites replace the inline dance. They are not tagged as simp
+  lemmas so simp normal form remains unchanged; call sites reference them
+  explicitly via `rw [spAddr32_8, spAddr32_16, spAddr32_24]`.
+
+  Issue #263.
+-/
+
+import EvmAsm.Rv64.Instructions
+import EvmAsm.Rv64.Tactics.SeqFrame
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+theorem spAddr32_8  (sp : Word) : sp + 32 + 8  = sp + 40 := by bv_addr
+theorem spAddr32_16 (sp : Word) : sp + 32 + 16 = sp + 48 := by bv_addr
+theorem spAddr32_24 (sp : Word) : sp + 32 + 24 = sp + 56 := by bv_addr
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.Sub.LimbSpec
 import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -108,17 +109,11 @@ theorem evm_sub_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3] at h0 h1 h2 h3
       rw [h0, h1, h2, h3]

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Xor.LimbSpec
+import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 
@@ -49,17 +50,11 @@ theorem evm_xor_stack_spec (sp base : Word)
   exact cpsTriple_consequence _ _ _ _ _ _ _
     (fun h hp => by
       simp only [evmWordIs] at hp
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›] at hp
+      rw [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_xor]
-      have : (sp : Word) + 32 + 8 = sp + 40 := by bv_omega
-      have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
-      have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
-      rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›, ‹sp + 32 + 24 = sp + 56›]
+      rw [spAddr32_8, spAddr32_16, spAddr32_24]
       xperm_hyp hq)
     h_main
 


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Creates \`EvmAsm/Evm64/SpAddr.lean\` with three named rewrites for the \`(sp + 32) + K\` → \`sp + (32+K)\` address-flattening pattern that every two-input 256-bit opcode spec has to do on its \`evmWordIs (sp + 32) b\` pre/post.

\`\`\`lean
theorem spAddr32_8  (sp : Word) : sp + 32 + 8  = sp + 40 := by bv_addr
theorem spAddr32_16 (sp : Word) : sp + 32 + 16 = sp + 48 := by bv_addr
theorem spAddr32_24 (sp : Word) : sp + 32 + 24 = sp + 56 := by bv_addr
\`\`\`

Migrates ten opcode spec files × two sites each = **20 call sites** from the four-line
\`\`\`lean
have : (sp : Word) + 32 + 8  = sp + 40 := by bv_omega
have : (sp : Word) + 32 + 16 = sp + 48 := by bv_omega
have : (sp : Word) + 32 + 24 = sp + 56 := by bv_omega
rw [‹sp + 32 + 8 = sp + 40›, ‹sp + 32 + 16 = sp + 48›,
    ‹sp + 32 + 24 = sp + 56›]
\`\`\`
dance to the single line
\`\`\`lean
rw [spAddr32_8, spAddr32_16, spAddr32_24]
\`\`\`

60 \`have\` lines and 20 \`rw ‹…›\` lines eliminated.

## Files touched

- \`EvmAsm/Evm64/SpAddr.lean\` — new (3 theorems, ~30 lines with docstring)
- \`EvmAsm/Evm64/{Add,Sub,And,Or,Xor}/Spec.lean\` — arithmetic/bitwise opcodes
- \`EvmAsm/Evm64/{Lt,Gt,Slt,Sgt,Eq}/Spec.lean\` — comparison opcodes

## Test plan

- [x] \`lake build\` clean
- [x] \`git grep '(sp : Word) + 32 + 8 = sp + 40'\` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)