### PR TITLE
feat(stack): add evmWordIs_sp64_unfold / evmWordIs_sp64_limbs_eq

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -292,6 +292,18 @@ theorem evmStackIs_snoc (sp : Word) (xs : List EvmWord) (v : EvmWord) :
     (evmStackIs sp xs ** evmWordIs (sp + BitVec.ofNat 64 (xs.length * 32)) v) := by
   rw [evmStackIs_append, evmStackIs_single]
 
+/-- Mid-tree variant of `evmStackIs_append`: threads a remainder `Q` so
+    `rw ←` can fold two contiguous `evmStackIs` segments back into a single
+    `evmStackIs sp (xs ++ ys)` bundle even when they sit in the middle of a
+    longer sepConj chain. Parallels the `_right` family on the other
+    `evmStackIs` unfolds. -/
+theorem evmStackIs_append_right (sp : Word) (xs ys : List EvmWord)
+    (Q : Assertion) :
+    ((evmStackIs sp xs **
+      evmStackIs (sp + BitVec.ofNat 64 (xs.length * 32)) ys) ** Q) =
+    (evmStackIs sp (xs ++ ys) ** Q) := by
+  rw [evmStackIs_append]
+
 /-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
 theorem evmStackIs_split_at (sp : Word) (stack : List EvmWord) (k : Nat)
     (hk : k < stack.length) :

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -171,6 +171,19 @@ theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
       show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
       show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
 
+/-- Unfold `evmWordIs (sp+64) v` into four limb-level memory atoms at the
+    absolute stack addresses `sp+64, sp+72, sp+80, sp+88`. Third-slot
+    counterpart to `evmWordIs_sp32_unfold` — useful for ternary-op stack
+    specs (ADDMOD / MULMOD) whose third operand lives at `sp + 64`. -/
+theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
+    evmWordIs (sp + 64) v =
+    (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
+     ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) := by
+  unfold evmWordIs
+  rw [show (sp + 64 : Word) + 8 = sp + 72 from by bv_omega,
+      show (sp + 64 : Word) + 16 = sp + 80 from by bv_omega,
+      show (sp + 64 : Word) + 24 = sp + 88 from by bv_omega]
+
 /-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
     equalities. Decouples the caller's representation of `v` from the limb
     form — works uniformly whether the equalities come from
@@ -192,6 +205,16 @@ theorem evmWordIs_sp32_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
     (((sp + 32) ↦ₘ w0) ** ((sp + 40) ↦ₘ w1) **
      ((sp + 48) ↦ₘ w2) ** ((sp + 56) ↦ₘ w3)) := by
   rw [evmWordIs_sp32_unfold, h0, h1, h2, h3]
+
+/-- Rewrite `evmWordIs (sp+64) v` to four limb atoms given explicit getLimbN
+    equalities. Third-slot companion to `evmWordIs_sp32_limbs_eq`. -/
+theorem evmWordIs_sp64_limbs_eq (sp : Word) (v : EvmWord) (w0 w1 w2 w3 : Word)
+    (h0 : v.getLimbN 0 = w0) (h1 : v.getLimbN 1 = w1)
+    (h2 : v.getLimbN 2 = w2) (h3 : v.getLimbN 3 = w3) :
+    evmWordIs (sp + 64) v =
+    (((sp + 64) ↦ₘ w0) ** ((sp + 72) ↦ₘ w1) **
+     ((sp + 80) ↦ₘ w2) ** ((sp + 88) ↦ₘ w3)) := by
+  rw [evmWordIs_sp64_unfold, h0, h1, h2, h3]
 
 /-- Mid-tree variant of `evmWordIs_sp_limbs_eq`: fold four limb atoms into
     `evmWordIs sp v` **even when they sit in the middle of a sepConj chain**,

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -283,6 +283,15 @@ theorem evmStackIs_append (sp : Word) (xs ys : List EvmWord) :
     simp only [List.cons_append, evmStackIs_cons, List.length_cons]
     rw [ih (sp + 32), hshift, sepConj_assoc']
 
+/-- Snoc: `evmStackIs sp (xs ++ [v]) = evmStackIs sp xs **
+    evmWordIs (sp + 32 * xs.length) v`. Specialized corollary of
+    `evmStackIs_append` with `ys = [v]` — PUSH-style stack extensions
+    that tack exactly one element onto the top reach for this variant. -/
+theorem evmStackIs_snoc (sp : Word) (xs : List EvmWord) (v : EvmWord) :
+    evmStackIs sp (xs ++ [v]) =
+    (evmStackIs sp xs ** evmWordIs (sp + BitVec.ofNat 64 (xs.length * 32)) v) := by
+  rw [evmStackIs_append, evmStackIs_single]
+
 /-- Split evmStackIs at position k: extract the kth element (0-indexed). -/
 theorem evmStackIs_split_at (sp : Word) (stack : List EvmWord) (k : Nat)
     (hk : k < stack.length) :


### PR DESCRIPTION
## Summary
- Third-slot counterparts to the `_sp32_` family:
  - `evmWordIs_sp64_unfold`: `evmWordIs (sp+64) v` → four memIs atoms at `sp+64, 72, 80, 88`.
  - `evmWordIs_sp64_limbs_eq`: same, parameterized by explicit `getLimbN` equalities.
- Useful for ternary-op stack specs (ADDMOD / MULMOD) whose third operand lives at `sp + 64`, paralleling the `(sp+32)` slot used by binary ops.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)