### PR TITLE
refactor(LimbSpec): migrate inline signExtend decides to named lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -21,12 +21,16 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.DivMod.AddrNorm
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se13_8 se13_12)
+open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_63)
 
 namespace EvmAsm.Evm64
 
@@ -62,8 +66,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val K base (by nofun)
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -117,8 +120,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val K base (by nofun)
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -186,10 +188,10 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
               (.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) := by
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   simp only [h63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
+  have hsig := se13_8
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
@@ -241,10 +243,10 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
               (.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   simp only [h63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
+  have hsig := se13_8
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -16,12 +16,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se13_12)
 
 namespace EvmAsm.Evm64
 
@@ -52,8 +54,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
        (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
     runBlock I0
   have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -138,8 +139,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
     have I0 := srli_spec_gen .x1 .x5 v1_old q0 32 base (by nofun)
     runBlock I0
   have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have hsig : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -16,12 +16,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se13_8 se21_12)
 
 namespace EvmAsm.Evm64
 
@@ -65,8 +67,7 @@ theorem divK_div128_prodcheck1_merged_spec
     have I3 := or_spec_gen_rd_eq_rs1 .x1 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
     runBlock I0 I1 I2 I3
   have hbltu_raw := bltu_spec_gen .x1 .x5 (8 : BitVec 13) rhat_un1 q_dlo (base + 16)
-  have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
-  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [hsig]; bv_addr
+  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [se13_8]; bv_addr
   have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -128,9 +129,8 @@ theorem divK_div128_prodcheck1_merged_spec
     have ntaken_br := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    have hj : signExtend21 (12 : BitVec 21) = (12 : Word) := by decide
     have I_jal := jal_x0_spec_gen 12 (base + 20)
-    rw [hj] at I_jal
+    rw [se21_12] at I_jal
     have ha_jal : (base + 20 : Word) + 12 = base + 32 := by bv_addr
     rw [ha_jal] at I_jal
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 20) (.JAL .x0 12) a = some i →

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -17,12 +17,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se13_8 se21_8)
 
 namespace EvmAsm.Evm64
 
@@ -66,8 +68,7 @@ theorem divK_div128_prodcheck2_merged_spec
     have I4 := or_spec_gen_rd_eq_rs1 .x1 .x11 (rhat2 <<< (32 : BitVec 6).toNat) un0 (base + 16) (by nofun)
     runBlock I0 I1 I2 I3 I4
   have hbltu_raw := bltu_spec_gen .x1 .x7 (8 : BitVec 13) rhat2_un0 q0_dlo (base + 20)
-  have hsig : signExtend13 (8 : BitVec 13) = (8 : Word) := by decide
-  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [hsig]; bv_addr
+  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [se13_8]; bv_addr
   have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
@@ -127,9 +128,8 @@ theorem divK_div128_prodcheck2_merged_spec
     have ntaken_br := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    have hj : signExtend21 (8 : BitVec 21) = (8 : Word) := by decide
     have I_jal := jal_x0_spec_gen 8 (base + 24)
-    rw [hj] at I_jal
+    rw [se21_8] at I_jal
     have ha_jal : (base + 24 : Word) + 8 = base + 32 := by bv_addr
     rw [ha_jal] at I_jal
     have hcr_jal : ∀ a i, CodeReq.singleton (base + 24) (.JAL .x0 8) a = some i →

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -18,12 +18,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.DivMod.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -83,8 +85,7 @@ theorem divK_store_qj_write_spec (q_addr q_hat q_old : Word) (base : Word) :
       ((.x7 ↦ᵣ q_addr) ** (.x11 ↦ᵣ q_hat) ** (q_addr ↦ₘ q_old))
       ((.x7 ↦ᵣ q_addr) ** (.x11 ↦ᵣ q_hat) ** (q_addr ↦ₘ q_hat)) := by
   intro cr
-  have hse : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [hse]; bv_omega
+  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [se12_0]; bv_omega
   have I0 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 base
   rw [haddr] at I0
   runBlock I0

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -19,12 +19,16 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.DivMod.AddrNorm
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se21_8)
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -76,8 +80,7 @@ theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
        (sp + signExtend12 3984 ↦ₘ n) **
        (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo)) := by
   intro jpn jpn_x8 u0_base u_addr cr
-  have hse0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [hse0]; bv_omega
+  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
@@ -124,10 +127,9 @@ theorem divK_trial_max_spec (v11_old : Word) (base : Word) :
       ((.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ 0))
       ((.x11 ↦ᵣ signExtend12 4095) ** (.x0 ↦ᵣ 0)) := by
   intro cr
-  have hj : signExtend21 (8 : BitVec 21) = (8 : Word) := by decide
   have I0 := addi_x0_spec_gen .x11 v11_old 4095 base (by nofun)
   have I1 := jal_x0_spec_gen 8 (base + 4)
-  rw [hj] at I1
+  rw [se21_8] at I1
   have ha : (base + 4 : Word) + 8 = base + 12 := by bv_addr
   rw [ha] at I1
   runBlock I0 I1

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -16,12 +16,14 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+import EvmAsm.Evm64.DivMod.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -65,8 +67,7 @@ theorem divK_trial_load_spec
   let jpn := j + n
   let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
   let u0_base := sp + signExtend12 4056
-  have hse0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [hse0]; bv_omega
+  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
@@ -106,8 +107,7 @@ theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
   have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) j_x8 (base + 8) (by nofun)
-  have hse : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [hse]; bv_omega
+  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [se12_0]; bv_omega
   have I3 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 (base + 12)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Seven \`LimbSpec/*.lean\` files each had one or more inline
\`\`\`lean
have hsig : signExtend13 (K : BitVec 13) = (K : Word) := by decide
... rw [hsig]; bv_addr
\`\`\`
closures to normalise the branch/jump offsets their BEQ/BLTU/JAL-style instructions consume. The same identities already live in the \`rv64_addr\` / \`divmod_addr\` grindsets (\`se13_8\`, \`se13_12\`, \`se21_8\`, \`se21_12\`, \`se12_0\`, \`bv6_toNat_63\`).

This PR imports the relevant grindset from each consumer and replaces the inline \`have\` + \`rw [hsig]\` dance with a direct reference to the shared name, eliminating 15 inline \`by decide\` instances.

## Files touched

| File | Named lemmas opened |
|---|---|
| \`LimbSpec/CLZ.lean\` | \`se13_8\`, \`se13_12\`, \`bv6_toNat_63\` |
| \`LimbSpec/Div128Clamp.lean\` | \`se13_12\` |
| \`LimbSpec/Div128ProdCheck1.lean\` | \`se13_8\`, \`se21_12\` |
| \`LimbSpec/Div128ProdCheck2.lean\` | \`se13_8\`, \`se21_8\` |
| \`LimbSpec/TrialQuotient.lean\` | \`se12_0\`, \`se21_8\` |
| \`LimbSpec/TrialStoreComposed.lean\` | \`se12_0\` |
| \`LimbSpec/SubCarryStoreQj.lean\` | \`se12_0\` |

## Test plan

- [x] \`lake build\` clean (3545 jobs)
- [x] \`git grep 'have hsig.*BitVec.*decide\\|have hj.*BitVec.*decide\\|have hse.*BitVec.*decide\\|have h63.*BitVec.*decide'\` on the migrated files returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)