### PR TITLE
refactor(SignExtend): migrate bv_omega → bv_addr on associativity sites (#263)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -548,7 +548,7 @@ theorem signext_body_spec (sp base : Word)
   let limb_idx := b0 >>> (3 : BitVec 6).toNat
   have hphaseB := cpsTriple_extend_code (phase_b_sub_signextCode base)
     (signext_phase_b_spec b0 r6 sltiu_val (base + 36))
-  rw [show (base + 36 : Word) + 20 = base + 56 from by bv_omega] at hphaseB
+  rw [show (base + 36 : Word) + 20 = base + 56 from by bv_addr] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 56) _ _ _
     ((.x12 ↦ᵣ sp) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hphaseB
@@ -568,7 +568,7 @@ theorem signext_body_spec (sp base : Word)
     (signext_body_1_spec sp limb_idx ((0 : Word) + signExtend12 1) shift_amount v1 v2 v3 (base + 124) (base + 188) 36 (se_body1_exit base))
   have hbody0 := cpsTriple_extend_code (body_0_sub_signextCode base)
     (signext_body_0_spec sp limb_idx byte_shift shift_amount v0 v1 v2 v3 (base + 156))
-  rw [show (base + 156 : Word) + 32 = base + 188 from by bv_omega] at hbody0
+  rw [show (base + 156 : Word) + 32 = base + 188 from by bv_addr] at hbody0
   have hdone := cpsTriple_extend_code (done_sub_signextCode base) (signext_done_spec sp (base + 188))
   rw [se_done_exit] at hdone
   -- Frame bodies with b-mem + x0

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -617,9 +617,9 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))] := by
   -- Address arithmetic
   have hc1 : ((base + 4 : Word) + 4) + signExtend13 60 = e1 := by
-    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_addr]; exact he1
   have hc2 : ((base + 12 : Word) + 4) + signExtend13 24 = e2 := by
-    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_addr]; exact he2
   -- Sub-CRs
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 100)
   let cr_cs1 := signext_cascade_step_code 1 60 (base + 4)
@@ -661,10 +661,10 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
     (.x10 ↦ᵣ v10) (by pcFree) beq0
   -- Step 1: cascade step at base+4
   have cs1 := signext_cascade_step_spec v5 v10 1 60 (base + 4) e1 hc1
-  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1
   -- Step 2: cascade step at base+12
   have cs2 := signext_cascade_step_spec v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
-  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2
   -- Fallthrough at base+20
   have ft := cpsNBranch_refl (base + 20)
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))
@@ -765,9 +765,9 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
        (e2, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 = (0 : Word) + signExtend12 2⌝),
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝)] := by
   have hc1 : ((base + 4 : Word) + 4) + signExtend13 60 = e1 := by
-    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_addr]; exact he1
   have hc2 : ((base + 12 : Word) + 4) + signExtend13 24 = e2 := by
-    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_addr]; exact he2
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 100)
   let cr_cs1 := signext_cascade_step_code 1 60 (base + 4)
   let cr_cs2 := signext_cascade_step_code 2 24 (base + 12)
@@ -801,7 +801,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := signext_cascade_step_spec_pure v5 v10 1 60 (base + 4) e1 hc1
-  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1_raw
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1_raw
   have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
@@ -819,7 +819,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := signext_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
-  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2_raw
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2_raw
   have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). \`SignExtend/LimbSpec.lean\` and \`SignExtend/Compose.lean\` had ten inline
\`\`\`lean
show (a + K₁ : Word) + K₂ = a + K₃ from by bv_omega
\`\`\`
sites for pure \`(a + k₁) + k₂ = a + k₃\` associativity — exactly the shape the existing \`bv_addr\` macro (\`simp only [BitVec.add_assoc]; rfl\` from \`Rv64/Tactics/SeqFrame.lean\`) already handles. Replacing \`bv_omega\` with \`bv_addr\` elaborates these via the cheaper associativity tactic.

## Files touched

- \`EvmAsm/Evm64/SignExtend/LimbSpec.lean\` (8 sites): \`base + 4 + 4 = base + 8\` ×2, \`base + 12 + 4 = base + 16\` ×2, \`base + 4 + 8 = base + 12\` ×2, \`base + 12 + 8 = base + 20\` ×2
- \`EvmAsm/Evm64/SignExtend/Compose.lean\` (2 sites): \`base + 36 + 20 = base + 56\`, \`base + 156 + 32 = base + 188\`

The three remaining \`sp + (0 : Word) = sp\` shapes (LimbSpec line 443, Compose lines 375 and 515) are pure \`add_zero\`, not associativity, so they stay as \`bv_omega\`.

## Test plan

- [x] \`lake build\` clean (3545 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)