### PR TITLE
refactor(Shift): migrate sp+32+K sites to spAddr32_* + bv_omega→bv_addr (#263)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -8,6 +8,7 @@
 -/
 
 import EvmAsm.Evm64.Shift.ComposeBase
+import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics
@@ -652,17 +653,13 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         unfold evmWordIs at hp
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -11,6 +11,7 @@
 
 import EvmAsm.Evm64.Shift.SarSpec
 import EvmAsm.Evm64.Shift.ComposeBase
+import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics
@@ -535,9 +536,9 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
        (e3, (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) **
             ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝)] := by
   have hc1 : ((base + 4 : Word) + 4) + signExtend13 100 = e1 := by
-    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]; exact he1
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_addr]; exact he1
   have hc2 : ((base + 12 : Word) + 4) + signExtend13 36 = e2 := by
-    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega]; exact he2
+    rw [show (base + 12 : Word) + 4 = base + 16 from by bv_addr]; exact he2
   let cr_beq0 := CodeReq.singleton base (.BEQ .x5 .x0 188)
   let cr_cs1 := shr_cascade_step_code 1 100 (base + 4)
   let cr_cs2 := shr_cascade_step_code 2 36 (base + 12)
@@ -571,7 +572,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := shr_cascade_step_spec_pure v5 v10 1 100 (base + 4) e1 hc1
-  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at cs1_raw
+  rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1_raw
   have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
@@ -589,7 +590,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 36 (base + 12) e2 hc2
-  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_omega] at cs2_raw
+  rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2_raw
   have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2
@@ -809,17 +810,13 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         unfold evmWordIs at hp
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -11,6 +11,7 @@
 
 import EvmAsm.Evm64.Shift.ShlSpec
 import EvmAsm.Evm64.Shift.ComposeBase
+import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics
@@ -627,17 +628,13 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         unfold evmWordIs at hp
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega] at hp
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
         xperm_hyp hp)
       (fun h hq => by
         unfold evmWordIs
         simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                    ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-        simp only [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-                   show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-                   show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+        simp only [spAddr32_8, spAddr32_16, spAddr32_24]
         xperm_hyp hq)
       h_raw
   -- Now prove h_raw in flat raw memIs form


### PR DESCRIPTION
## Summary

Follow-up to [#475](https://github.com/Verified-zkEVM/evm-asm/pull/475) (which landed \`EvmAsm/Evm64/SpAddr.lean\` with \`spAddr32_{8,16,24}\`) and [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Migrates the three Shift compose files (SHR \`Compose\`, SHL \`ShlCompose\`, SAR \`SarCompose\`) from the inline
\`\`\`lean
simp only [show (sp + 32 : Word) + 8  = sp + 40 from by bv_omega,
           show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
           show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
\`\`\`
dance to the shared names
\`\`\`lean
simp only [spAddr32_8, spAddr32_16, spAddr32_24]
\`\`\`

Also migrates four remaining \`(base + K₁ : Word) + K₂ = base + K₃\` associativity sites in \`SarCompose.lean\` from \`bv_omega\` to the cheaper \`bv_addr\` macro.

## Files touched

- \`EvmAsm/Evm64/Shift/Compose.lean\` — 6 \`sp+32+K\` sites (2 simp blocks × 3)
- \`EvmAsm/Evm64/Shift/ShlCompose.lean\` — 6 \`sp+32+K\` sites
- \`EvmAsm/Evm64/Shift/SarCompose.lean\` — 6 \`sp+32+K\` sites + 4 \`base+K₁+K₂\` associativities

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)