### PR TITLE
refactor(stack): use spAddr32_* in evmWordIs_sp32_unfold

### DIFF
--- a/EvmAsm/Evm64/SpAddr.lean
+++ b/EvmAsm/Evm64/SpAddr.lean
@@ -30,4 +30,13 @@ theorem spAddr32_8  (sp : Word) : sp + 32 + 8  = sp + 40 := by bv_addr
 theorem spAddr32_16 (sp : Word) : sp + 32 + 16 = sp + 48 := by bv_addr
 theorem spAddr32_24 (sp : Word) : sp + 32 + 24 = sp + 56 := by bv_addr
 
+/-- Third-slot siblings of `spAddr32_*`: flatten `(sp + 64) + {8,16,24}` →
+    `sp + {72,80,88}`. Parallel to the `(sp + 32) + …` family above but for
+    the third operand of ternary 256-bit opcodes (ADDMOD / MULMOD),
+    which lives at stack offset `sp + 64`. Also covers the internal
+    address bumps `evmWordIs_sp64_unfold` needs. -/
+theorem spAddr64_8  (sp : Word) : sp + 64 + 8  = sp + 72 := by bv_addr
+theorem spAddr64_16 (sp : Word) : sp + 64 + 16 = sp + 80 := by bv_addr
+theorem spAddr64_24 (sp : Word) : sp + 64 + 24 = sp + 88 := by bv_addr
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Basic
+import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
@@ -167,9 +168,7 @@ theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
     (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
      ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
   unfold evmWordIs
-  rw [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-      show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-      show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+  rw [spAddr32_8, spAddr32_16, spAddr32_24]
 
 /-- Unfold `evmWordIs (sp+64) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+64, sp+72, sp+80, sp+88`. Third-slot


### PR DESCRIPTION
## Summary
- Replace three inline `show ... := by bv_omega` address-flattening proofs in `evmWordIs_sp32_unfold` with the named `spAddr32_{8,16,24}` rewrites from `EvmAsm.Evm64.SpAddr` (#475).
- Adds the `SpAddr` import to `Stack.lean`.
- Same lemma, shorter proof, consistent with the ten opcode-spec files that already use these helpers.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)