### PR TITLE
refactor(Shift/Semantic): migrate sp+32+K blocks to spAddr32_* (#263)

### DIFF
--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -10,6 +10,7 @@
 -/
 
 import EvmAsm.Evm64.Shift.SarCompose
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -108,10 +109,7 @@ private theorem sar_sign_fill_lift (sp base : Word)
     (fun h hp => by
       simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56] at hp
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_fromLimbs_const_0,
@@ -119,10 +117,7 @@ private theorem sar_sign_fill_lift (sp base : Word)
                  EvmWord.getLimbN_fromLimbs_const_3]
       simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56]
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
          ((sp + 16) ↦ₘ shift.getLimb 2) ** ((sp + 24) ↦ₘ shift.getLimb 3) **

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -9,6 +9,7 @@
 -/
 
 import EvmAsm.Evm64.Shift.Compose
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -102,19 +103,13 @@ private theorem shr_zero_lift (sp base : Word)
     (fun h hp => by
       simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56] at hp
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_zero]
       simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56]
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
          ((sp + 16) ↦ₘ shift.getLimb 2) ** ((sp + 24) ↦ₘ shift.getLimb 3) **

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -9,6 +9,7 @@
 -/
 
 import EvmAsm.Evm64.Shift.ShlCompose
+import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 
@@ -102,19 +103,13 @@ private theorem shl_zero_lift (sp base : Word)
     (fun h hp => by
       simp only [evmWordIs, ← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3] at hp
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56] at hp
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24] at hp
       xperm_hyp hp)
     (fun h hq => by
       simp only [evmWordIs, EvmWord.getLimbN_zero]
       simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
                  ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
-      have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
-      have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
-      have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
-      simp only [ha40, ha48, ha56]
+      simp only [spAddr32_8, spAddr32_16, spAddr32_24]
       have hq' : ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ shift.getLimb 0) ** ((sp + 8) ↦ₘ shift.getLimb 1) **
          ((sp + 16) ↦ₘ shift.getLimb 2) ** ((sp + 24) ↦ₘ shift.getLimb 3) **


### PR DESCRIPTION
## Summary

Follow-up to [#475](https://github.com/Verified-zkEVM/evm-asm/pull/475) addressing [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). The three Shift semantic files (SHR \`Semantic\`, SHL \`ShlSemantic\`, SAR \`SarSemantic\`) each had two blocks of the usual four-line
\`\`\`lean
have ha40 : (sp + 32 : Word) + 8 = sp + 40 := by bv_omega
have ha48 : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
have ha56 : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
simp only [ha40, ha48, ha56] (at hp)?
\`\`\`
(pre- and post-condition for the zero-shift-amount path). Each block migrates to
\`\`\`lean
simp only [spAddr32_8, spAddr32_16, spAddr32_24] (at hp)?
\`\`\`
using the shared \`spAddr32_*\` lemmas from #475.

## Files touched

- \`Shift/Semantic.lean\`    — 2 blocks (6 \`have\` lines)
- \`Shift/ShlSemantic.lean\` — 2 blocks (6 \`have\` lines)
- \`Shift/SarSemantic.lean\` — 2 blocks (6 \`have\` lines)

18 inline \`have ... := by bv_omega\` lines eliminated.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)