### PR TITLE
refactor(stack): use spAddr64_* in evmWordIs_sp64_unfold

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Basic
+import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
@@ -167,9 +168,7 @@ theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
     (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
      ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
   unfold evmWordIs
-  rw [show (sp + 32 : Word) + 8 = sp + 40 from by bv_omega,
-      show (sp + 32 : Word) + 16 = sp + 48 from by bv_omega,
-      show (sp + 32 : Word) + 24 = sp + 56 from by bv_omega]
+  rw [spAddr32_8, spAddr32_16, spAddr32_24]
 
 /-- Unfold `evmWordIs (sp+64) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+64, sp+72, sp+80, sp+88`. Third-slot

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -179,9 +179,7 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
     (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) := by
   unfold evmWordIs
-  rw [show (sp + 64 : Word) + 8 = sp + 72 from by bv_omega,
-      show (sp + 64 : Word) + 16 = sp + 80 from by bv_omega,
-      show (sp + 64 : Word) + 24 = sp + 88 from by bv_omega]
+  rw [spAddr64_8, spAddr64_16, spAddr64_24]
 
 /-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
     equalities. Decouples the caller's representation of `v` from the limb


### PR DESCRIPTION
## Summary
- Replace three inline `show ... := by bv_omega` address-flattening proofs in `evmWordIs_sp64_unfold` with the named `spAddr64_{8,16,24}` rewrites added earlier in this stack.
- Mirrors the parallel cleanup already done for `evmWordIs_sp32_unfold`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)