### PR TITLE
refactor(LoopBody): migrate 4 inline signExtend decides to rv64_addr (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -18,7 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_7736 se13_8044)
+open EvmAsm.Rv64.AddrNorm (se13_12 se13_156 se13_7736 se13_8044 se21_560)
 
 -- ============================================================================
 -- Section 1: CodeReq subsumption infrastructure for loop body instructions
@@ -511,8 +511,7 @@ theorem divK_mulsub_full_spec
 -- ============================================================================
 
 private theorem lb_beq_taken (base : Word) : (base + 728 : Word) + signExtend13 (156 : BitVec 13) = base + 884 := by
-  have : signExtend13 (156 : BitVec 13) = (156 : Word) := by decide
-  rw [this]; bv_addr
+  rw [se13_156]; bv_addr
 
 private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 732 := by bv_addr
 
@@ -771,13 +770,11 @@ theorem divK_save_trial_load_spec
 
 -- Address normalization for trial quotient
 private theorem lb_bltu_taken (base : Word) : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
-  have : signExtend13 (12 : BitVec 13) = (12 : Word) := by decide
-  rw [this]; bv_addr
+  rw [se13_12]; bv_addr
 private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_addr
 private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_addr
 private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (560 : BitVec 21) = base + div128Off := by
-  have : signExtend21 (560 : BitVec 21) = (560 : Word) := by decide
-  rw [this]; bv_addr
+  rw [se21_560]; bv_addr
 private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_addr
 
 -- ============================================================================
@@ -896,8 +893,7 @@ theorem divK_trial_call_path_spec
 private theorem lb_sqj (base : Word) : (base + 884 : Word) + 16 = base + 900 := by bv_addr
 private theorem lb_lc_taken (base : Word) :
     (base + 900 : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
-  have : signExtend13 (7736 : BitVec 13) = (18446744073709551160 : Word) := by decide
-  rw [this]; bv_addr
+  rw [se13_7736]; bv_addr
 private theorem lb_lc_exit (base : Word) : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
 
 private theorem lb_beq_back_ntaken (base : Word) : (base + 880 : Word) + 4 = base + 884 := by bv_addr


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). \`LoopBody.lean\` had four address-normalization private lemmas of shape
\`\`\`lean
private theorem lb_... (base : Word) : ... signExtend13/21 N ... = ... := by
  have : signExtend13/21 (N : BitVec _) = (N : Word) := by decide
  rw [this]; bv_addr
\`\`\`
All four identities already live in \`rv64_addr\` as \`se13_12\`, \`se13_156\`, \`se13_7736\`, \`se21_560\`. The file was already opening \`se13_7736\` and \`se13_8044\`; this PR extends the open list with \`se13_12\`, \`se13_156\`, \`se21_560\` and drops the inline \`have ... := by decide\` scaffolding at the four sites.

## Sites migrated

| Lemma | Uses |
|---|---|
| \`lb_beq_taken\` | \`se13_156\` |
| \`lb_bltu_taken\` | \`se13_12\` |
| \`lb_jal_target\` | \`se21_560\` |
| \`lb_lc_taken\` | \`se13_7736\` |

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)