### PR TITLE
feat(stack): add evmStackIs_cons_right mid-tree fold

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -179,9 +179,7 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
     (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) := by
   unfold evmWordIs
-  rw [show (sp + 64 : Word) + 8 = sp + 72 from by bv_omega,
-      show (sp + 64 : Word) + 16 = sp + 80 from by bv_omega,
-      show (sp + 64 : Word) + 24 = sp + 88 from by bv_omega]
+  rw [spAddr64_8, spAddr64_16, spAddr64_24]
 
 /-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
     equalities. Decouples the caller's representation of `v` from the limb

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -48,6 +48,16 @@ instance (sp : Word) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp v
 theorem evmStackIs_cons (sp : Word) (v : EvmWord) (vs : List EvmWord) :
     evmStackIs sp (v :: vs) = (evmWordIs sp v ** evmStackIs (sp + 32) vs) := rfl
 
+/-- Mid-tree variant of `evmStackIs_cons`: threads a remainder `Q` through
+    the equality so `rw ←` can fold `evmWordIs sp v ** evmStackIs (sp+32) vs`
+    back into `evmStackIs sp (v :: vs)` even when those atoms sit in the
+    middle of a longer sepConj chain. Parallels the `_right` family on
+    `evmStackIs_{single,pair,triple,append}`. -/
+theorem evmStackIs_cons_right (sp : Word) (v : EvmWord) (vs : List EvmWord)
+    (Q : Assertion) :
+    ((evmWordIs sp v ** evmStackIs (sp + 32) vs) ** Q) =
+    (evmStackIs sp (v :: vs) ** Q) := rfl
+
 theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 


### PR DESCRIPTION
## Summary
- Add `evmStackIs_cons_right`: mid-tree variant of `evmStackIs_cons`.
- Threads `Q` through so `rw ←` can fold `evmWordIs sp v ** evmStackIs (sp+32) vs` back into `evmStackIs sp (v :: vs)` even when those atoms sit mid-chain.
- Parallels the `_right` family on `evmStackIs_{single,pair,triple,append}`.
- Proof is `rfl` (the underlying `evmStackIs_cons` is definitional).

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)