### PR TITLE
refactor(LoopIter): factor hj_pos decides into divmod_addr lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNorm.lean
@@ -107,6 +107,20 @@ open EvmAsm.Rv64
 @[divmod_addr, grind =] theorem word_zero_add (x : Word) : (0 : Word) + x = x := BitVec.zero_add x
 
 -- ============================================================================
+-- Loop-counter positivity: after `ADDI j j -1` (ie. `j + signExtend12 4095`),
+-- `j - 1 ≥ 0` for `j ∈ {1, 2, 3}`. Used by the `hj_pos` hypotheses in
+-- LoopIterN1/{Max,MaxBeq,Call,CallBeq} and LoopIterN{2,3} to discharge the
+-- BLT-not-taken side condition (the 4-bit signed encoding of j − 1).
+-- ============================================================================
+
+@[divmod_addr, grind =] theorem slt_jpos_1 :
+    BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+@[divmod_addr, grind =] theorem slt_jpos_2 :
+    BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+@[divmod_addr, grind =] theorem slt_jpos_3 :
+    BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
+
+-- ============================================================================
 -- `divmod_addr` tactic
 --
 -- Primary: `grind` (sees all @[grind =]-registered atomic facts).

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -12,6 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- n=1, BLTU taken (call path) + BEQ skip, j=0 → cpsTriple to base+904
@@ -226,7 +227,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -350,7 +351,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -474,7 +475,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  have hj_pos : BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_3
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -12,6 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- BEQ variants: call path addback with double-addback handling (no sorry)
@@ -220,7 +221,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -339,7 +340,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -458,7 +459,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_3
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -12,6 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- n=1, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTriple to base+904
@@ -177,7 +178,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos : BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_3
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -266,7 +267,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -355,7 +356,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -12,6 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- BEQ variants: max path addback with double-addback handling (no sorry)
@@ -154,7 +155,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_3
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -237,7 +238,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -320,7 +321,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -22,6 +22,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2)
 
 -- ============================================================================
 -- n=2, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTriple to base+904
@@ -320,7 +321,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -438,7 +439,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -535,7 +536,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -653,7 +654,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -963,7 +964,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -1078,7 +1079,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -1169,7 +1170,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -1284,7 +1285,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos : BitVec.slt ((2 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -17,6 +17,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1)
 
 -- ============================================================================
 -- n=3, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTriple to base+904
@@ -325,7 +326,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+880 → base+448)
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
@@ -454,7 +455,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   -- 3. Store + loop back j=1 (cpsTriple base+880 → base+448)
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, u_top in frame)
@@ -777,7 +778,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+884 → base+448)
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frame_left _ _ _ _ _
@@ -900,7 +901,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop back j=1 (cpsTriple base+884 → base+448)
-  have hj_pos : BitVec.slt ((1 : Word) + signExtend12 4095) 0 = false := by decide
+  have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF


### PR DESCRIPTION
## Summary

Addresses [#263](https://github.com/Verified-zkEVM/evm-asm/issues/263). Six files had **24** copies of the same three inline
\`\`\`lean
have hj_pos : BitVec.slt ((N : Word) + signExtend12 4095) 0 = false := by decide
\`\`\`
facts (for N ∈ {1, 2, 3}). These are the post-\`ADDI j, j, -1\` loop-counter positivity checks (j − 1 ≥ 0 for small j), which LoopIter specs need to discharge the \`BLT\` not-taken side condition.

This PR adds three named lemmas to the \`divmod_addr\` grindset — \`slt_jpos_1\`, \`slt_jpos_2\`, \`slt_jpos_3\` — and migrates every call site to
\`\`\`lean
have hj_pos := slt_jpos_N
\`\`\`

24 inline \`have hj_pos ... := by decide\` lines eliminated.

## Files touched

| File | Sites |
|---|---|
| \`DivMod/AddrNorm.lean\` | 3 new \`@[divmod_addr, grind =]\` lemmas |
| \`DivMod/LoopIterN1/Max.lean\` | 3 |
| \`DivMod/LoopIterN1/MaxBeq.lean\` | 3 |
| \`DivMod/LoopIterN1/Call.lean\` | 3 |
| \`DivMod/LoopIterN1/CallBeq.lean\` | 3 |
| \`DivMod/LoopIterN2.lean\` | 8 |
| \`DivMod/LoopIterN3.lean\` | 4 |

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)