### PR TITLE
refactor(stack): use getLimbN_zero in evmWordIs_zero

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -279,11 +279,8 @@ theorem evmWordIs_zero (addr : Word) :
     ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
      ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
   unfold evmWordIs
-  have h0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by decide
-  have h1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by decide
-  have h2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by decide
-  have h3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
-  rw [h0, h1, h2, h3]
+  rw [EvmWord.getLimbN_zero 0, EvmWord.getLimbN_zero 1,
+      EvmWord.getLimbN_zero 2, EvmWord.getLimbN_zero 3]
 
 -- ============================================================================
 -- Shared infrastructure for stack operation specs

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -48,6 +48,16 @@ instance (sp : Word) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp v
 theorem evmStackIs_cons (sp : Word) (v : EvmWord) (vs : List EvmWord) :
     evmStackIs sp (v :: vs) = (evmWordIs sp v ** evmStackIs (sp + 32) vs) := rfl
 
+/-- Mid-tree variant of `evmStackIs_cons`: threads a remainder `Q` through
+    the equality so `rw ←` can fold `evmWordIs sp v ** evmStackIs (sp+32) vs`
+    back into `evmStackIs sp (v :: vs)` even when those atoms sit in the
+    middle of a longer sepConj chain. Parallels the `_right` family on
+    `evmStackIs_{single,pair,triple,append}`. -/
+theorem evmStackIs_cons_right (sp : Word) (v : EvmWord) (vs : List EvmWord)
+    (Q : Assertion) :
+    ((evmWordIs sp v ** evmStackIs (sp + 32) vs) ** Q) =
+    (evmStackIs sp (v :: vs) ** Q) := rfl
+
 theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 


### PR DESCRIPTION
## Summary
- Replace four `have ... := by decide` `(0 : EvmWord).getLimbN k = 0` facts in `evmWordIs_zero` with direct applications of `EvmWord.getLimbN_zero k` (already defined in `Basic.lean`).
- Four `have` lines → one `rw`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)