### PR TITLE
refactor(AddrNorm): promote se12_* / bv6_toNat_* to rv64_addr (#493)

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNorm.lean
@@ -15,11 +15,17 @@
   `divmod_addr` tactic that tries `grind` first and falls back to
   `simp only [divmod_addr]; bv_omega`.
 
-  Adding a new concrete offset or shift amount is one line here — every
-  downstream proof that uses `by divmod_addr` picks it up automatically.
+  The atomic `signExtend12 N` and `(N : BitVec 6).toNat` facts were promoted
+  to `Rv64/AddrNorm.lean` by issue #493 (so Shift/SignExtend/Byte can use them
+  without pulling in DivMod). They are re-tagged with `@[divmod_addr]` here so
+  the `divmod_addr` grindset keeps the same coverage.
+
+  Adding a new concrete DivMod-specific offset or shift amount is one line
+  here — every downstream proof that uses `by divmod_addr` picks it up
+  automatically.
 -/
 
-import EvmAsm.Rv64.Instructions
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Evm64.DivMod.AddrNormAttr
 
 namespace EvmAsm.Evm64.DivMod.AddrNorm
@@ -27,66 +33,68 @@ namespace EvmAsm.Evm64.DivMod.AddrNorm
 open EvmAsm.Rv64
 
 -- ============================================================================
--- Atomic `signExtend12` evaluations
---
--- For offsets < 2^11, the result equals the input (zero-extended).
--- For offsets ≥ 2^11, the result is (2^64 + offset - 2^12), i.e. the
--- two's-complement encoding of (offset - 4096).
--- All proofs are `by decide` (kernel-checkable).
+-- Re-tag Rv64 atomic `signExtend12` / `BitVec 6.toNat` facts with
+-- `@[divmod_addr]` so the DivMod grindset keeps the same coverage after the
+-- promotion to `Rv64/AddrNorm.lean` (issue #493). Kernel-level definitions
+-- still live in `Rv64.AddrNorm`; we only attach the additional attribute.
 -- ============================================================================
 
--- Small offsets (< 2^11): result = input
-@[divmod_addr, grind =] theorem se12_0  : signExtend12 (0  : BitVec 12) = (0  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_1  : signExtend12 (1  : BitVec 12) = (1  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_2  : signExtend12 (2  : BitVec 12) = (2  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3  : signExtend12 (3  : BitVec 12) = (3  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4  : signExtend12 (4  : BitVec 12) = (4  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_8  : signExtend12 (8  : BitVec 12) = (8  : Word) := by decide
-@[divmod_addr, grind =] theorem se12_12 : signExtend12 (12 : BitVec 12) = (12 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+attribute [divmod_addr]
+  EvmAsm.Rv64.AddrNorm.se12_0
+  EvmAsm.Rv64.AddrNorm.se12_1
+  EvmAsm.Rv64.AddrNorm.se12_2
+  EvmAsm.Rv64.AddrNorm.se12_3
+  EvmAsm.Rv64.AddrNorm.se12_4
+  EvmAsm.Rv64.AddrNorm.se12_8
+  EvmAsm.Rv64.AddrNorm.se12_12
+  EvmAsm.Rv64.AddrNorm.se12_16
+  EvmAsm.Rv64.AddrNorm.se12_24
+  EvmAsm.Rv64.AddrNorm.se12_32
+  EvmAsm.Rv64.AddrNorm.se12_40
+  EvmAsm.Rv64.AddrNorm.se12_48
+  EvmAsm.Rv64.AddrNorm.se12_56
+  EvmAsm.Rv64.AddrNorm.se12_3944
+  EvmAsm.Rv64.AddrNorm.se12_3952
+  EvmAsm.Rv64.AddrNorm.se12_3960
+  EvmAsm.Rv64.AddrNorm.se12_3968
+  EvmAsm.Rv64.AddrNorm.se12_3976
+  EvmAsm.Rv64.AddrNorm.se12_3984
+  EvmAsm.Rv64.AddrNorm.se12_3992
+  EvmAsm.Rv64.AddrNorm.se12_4000
+  EvmAsm.Rv64.AddrNorm.se12_4008
+  EvmAsm.Rv64.AddrNorm.se12_4016
+  EvmAsm.Rv64.AddrNorm.se12_4024
+  EvmAsm.Rv64.AddrNorm.se12_4032
+  EvmAsm.Rv64.AddrNorm.se12_4040
+  EvmAsm.Rv64.AddrNorm.se12_4048
+  EvmAsm.Rv64.AddrNorm.se12_4056
+  EvmAsm.Rv64.AddrNorm.se12_4064
+  EvmAsm.Rv64.AddrNorm.se12_4072
+  EvmAsm.Rv64.AddrNorm.se12_4080
+  EvmAsm.Rv64.AddrNorm.se12_4088
+  EvmAsm.Rv64.AddrNorm.se12_4095
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_2
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_3
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_4
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_8
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_16
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_32
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_48
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_56
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_60
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_62
+  EvmAsm.Rv64.AddrNorm.bv6_toNat_63
 
--- Large offsets (≥ 2^11): result = 2^64 + offset - 2^12
-@[divmod_addr, grind =] theorem se12_3944 : signExtend12 (3944 : BitVec 12) = (18446744073709551464 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3952 : signExtend12 (3952 : BitVec 12) = (18446744073709551472 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3960 : signExtend12 (3960 : BitVec 12) = (18446744073709551480 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3968 : signExtend12 (3968 : BitVec 12) = (18446744073709551488 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3976 : signExtend12 (3976 : BitVec 12) = (18446744073709551496 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3984 : signExtend12 (3984 : BitVec 12) = (18446744073709551504 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_3992 : signExtend12 (3992 : BitVec 12) = (18446744073709551512 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4000 : signExtend12 (4000 : BitVec 12) = (18446744073709551520 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4008 : signExtend12 (4008 : BitVec 12) = (18446744073709551528 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4016 : signExtend12 (4016 : BitVec 12) = (18446744073709551536 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4024 : signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4032 : signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4040 : signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4048 : signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4056 : signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4064 : signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4072 : signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4080 : signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4088 : signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) := by decide
-@[divmod_addr, grind =] theorem se12_4095 : signExtend12 (4095 : BitVec 12) = (18446744073709551615 : Word) := by decide
-
--- ============================================================================
--- Atomic `(k : BitVec 6).toNat` evaluations
--- ============================================================================
-
-@[divmod_addr, grind =] theorem bv6_toNat_2  : (2  : BitVec 6).toNat = 2  := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_3  : (3  : BitVec 6).toNat = 3  := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_4  : (4  : BitVec 6).toNat = 4  := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_8  : (8  : BitVec 6).toNat = 8  := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_16 : (16 : BitVec 6).toNat = 16 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_32 : (32 : BitVec 6).toNat = 32 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_48 : (48 : BitVec 6).toNat = 48 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_56 : (56 : BitVec 6).toNat = 56 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_60 : (60 : BitVec 6).toNat = 60 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_62 : (62 : BitVec 6).toNat = 62 := by decide
-@[divmod_addr, grind =] theorem bv6_toNat_63 : (63 : BitVec 6).toNat = 63 := by decide
+-- Export them under `EvmAsm.Evm64.DivMod.AddrNorm` so existing `open` clauses
+-- that reference e.g. `EvmAsm.Evm64.DivMod.AddrNorm (se12_32 …)` keep working.
+export EvmAsm.Rv64.AddrNorm
+  (se12_0 se12_1 se12_2 se12_3 se12_4 se12_8 se12_12 se12_16 se12_24
+   se12_32 se12_40 se12_48 se12_56
+   se12_3944 se12_3952 se12_3960 se12_3968 se12_3976 se12_3984 se12_3992
+   se12_4000 se12_4008 se12_4016 se12_4024 se12_4032 se12_4040 se12_4048
+   se12_4056 se12_4064 se12_4072 se12_4080 se12_4088 se12_4095
+   bv6_toNat_2 bv6_toNat_3 bv6_toNat_4 bv6_toNat_8 bv6_toNat_16 bv6_toNat_32
+   bv6_toNat_48 bv6_toNat_56 bv6_toNat_60 bv6_toNat_62 bv6_toNat_63)
 
 -- ============================================================================
 -- Atomic `(k : Word) <<< 3` evaluations

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -113,6 +113,74 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem se21_560 : signExtend21 (560 : BitVec 21) = (560 : Word) := by decide
 
 -- ============================================================================
+-- Atomic `signExtend12` evaluations (issue #493)
+--
+-- For offsets < 2^11, the result equals the input (zero-extended).
+-- For offsets ≥ 2^11, the result is (2^64 + offset - 2^12), i.e. the
+-- two's-complement encoding of (offset - 4096).
+-- All proofs are `by decide` (kernel-checkable).
+--
+-- These used to live in `Evm64/DivMod/AddrNorm.lean` under `divmod_addr`,
+-- but `signExtend12` is Rv64-level and the same identities are needed by
+-- Shift/SignExtend/Byte opcodes that cannot import DivMod. Promoted here
+-- and re-tagged with `@[divmod_addr]` in `Evm64/DivMod/AddrNorm.lean` so
+-- the `divmod_addr` grindset keeps the same coverage.
+-- ============================================================================
+
+-- Small offsets (< 2^11): result = input
+@[rv64_addr, grind =] theorem se12_0  : signExtend12 (0  : BitVec 12) = (0  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_1  : signExtend12 (1  : BitVec 12) = (1  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_2  : signExtend12 (2  : BitVec 12) = (2  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3  : signExtend12 (3  : BitVec 12) = (3  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4  : signExtend12 (4  : BitVec 12) = (4  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_8  : signExtend12 (8  : BitVec 12) = (8  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_12 : signExtend12 (12 : BitVec 12) = (12 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_24 : signExtend12 (24 : BitVec 12) = (24 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
+
+-- Large offsets (≥ 2^11): result = 2^64 + offset - 2^12
+@[rv64_addr, grind =] theorem se12_3944 : signExtend12 (3944 : BitVec 12) = (18446744073709551464 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3952 : signExtend12 (3952 : BitVec 12) = (18446744073709551472 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3960 : signExtend12 (3960 : BitVec 12) = (18446744073709551480 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3968 : signExtend12 (3968 : BitVec 12) = (18446744073709551488 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3976 : signExtend12 (3976 : BitVec 12) = (18446744073709551496 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3984 : signExtend12 (3984 : BitVec 12) = (18446744073709551504 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_3992 : signExtend12 (3992 : BitVec 12) = (18446744073709551512 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4000 : signExtend12 (4000 : BitVec 12) = (18446744073709551520 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4008 : signExtend12 (4008 : BitVec 12) = (18446744073709551528 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4016 : signExtend12 (4016 : BitVec 12) = (18446744073709551536 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4024 : signExtend12 (4024 : BitVec 12) = (18446744073709551544 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4032 : signExtend12 (4032 : BitVec 12) = (18446744073709551552 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4040 : signExtend12 (4040 : BitVec 12) = (18446744073709551560 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4048 : signExtend12 (4048 : BitVec 12) = (18446744073709551568 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4056 : signExtend12 (4056 : BitVec 12) = (18446744073709551576 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4064 : signExtend12 (4064 : BitVec 12) = (18446744073709551584 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4072 : signExtend12 (4072 : BitVec 12) = (18446744073709551592 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4080 : signExtend12 (4080 : BitVec 12) = (18446744073709551600 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4088 : signExtend12 (4088 : BitVec 12) = (18446744073709551608 : Word) := by decide
+@[rv64_addr, grind =] theorem se12_4095 : signExtend12 (4095 : BitVec 12) = (18446744073709551615 : Word) := by decide
+
+-- ============================================================================
+-- Atomic `(k : BitVec 6).toNat` evaluations (issue #493, promoted)
+-- ============================================================================
+
+@[rv64_addr, grind =] theorem bv6_toNat_2  : (2  : BitVec 6).toNat = 2  := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_3  : (3  : BitVec 6).toNat = 3  := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_4  : (4  : BitVec 6).toNat = 4  := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_8  : (8  : BitVec 6).toNat = 8  := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_16 : (16 : BitVec 6).toNat = 16 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_32 : (32 : BitVec 6).toNat = 32 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_48 : (48 : BitVec 6).toNat = 48 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_56 : (56 : BitVec 6).toNat = 56 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_60 : (60 : BitVec 6).toNat = 60 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_62 : (62 : BitVec 6).toNat = 62 := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_63 : (63 : BitVec 6).toNat = 63 := by decide
+
+-- ============================================================================
 -- `BitVec.ofNat 64 (4 * N)` evaluations (RV64 instruction stride × index)
 --
 -- `CodeReq.ofProg_lookup` produces address offsets of the form


### PR DESCRIPTION
## Summary

Closes [#493](https://github.com/Verified-zkEVM/evm-asm/issues/493). Promotes the atomic \`signExtend12 N = (N : Word)\` and \`(N : BitVec 6).toNat = N\` lemma families from \`Evm64/DivMod/AddrNorm.lean\` (the \`divmod_addr\` grindset) up to \`Rv64/AddrNorm.lean\` (the \`rv64_addr\` grindset), since \`signExtend12\` and \`BitVec 6\` are Rv64-level concepts, not divmod-specific.

## Changes

- \`Rv64/AddrNorm.lean\`: 33 new \`se12_*\` lemmas + 11 new \`bv6_toNat_*\` lemmas, all tagged \`@[rv64_addr, grind =]\`.
- \`Evm64/DivMod/AddrNorm.lean\`:
  - delete the 44 duplicate definitions;
  - \`attribute [divmod_addr] EvmAsm.Rv64.AddrNorm.se12_0 ...\` preserves the \`divmod_addr\` simp set coverage;
  - \`export EvmAsm.Rv64.AddrNorm (se12_0 ... bv6_toNat_63)\` keeps every existing \`open EvmAsm.Evm64.DivMod.AddrNorm (se12_N ...)\` resolving unchanged;
  - import switches from \`Rv64.Instructions\` to \`Rv64.AddrNorm\`.

## Compatibility

Zero caller churn in this PR. Every existing \`open EvmAsm.Evm64.DivMod.AddrNorm (...)\` clause keeps resolving via \`export\`, and every \`by divmod_addr\` tactic call keeps closing the same goals (the \`@[divmod_addr]\` attribute on the Rv64 theorems keeps them in the simp set, and they already have \`@[grind =]\` for the grind-first path).

## Unblocks

Follow-up migrations that were blocked by the old layering (now cleanly addressable by \`open EvmAsm.Rv64.AddrNorm\` in any Rv64-level file):
- \`Shift/{Compose,SarCompose,ShlCompose}.lean\` — \`h6\` sites
- \`SignExtend/Compose.lean\` — \`h3\`, \`h7\` sites
- \`SignExtend/LimbSpec.lean\` — \`h63\` sites
- \`Byte/Spec.lean\` — remaining inline decides
- \`Rv64/RLP/Phase2LongIter.lean\` — \`h_se0\`, \`h_se1\` sites

## Test plan

- [x] \`lake build\` clean (3546 jobs)
- [x] \`git grep 'open EvmAsm.Evm64.DivMod.AddrNorm'\` — every existing caller still compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)