### PR TITLE
feat(stack): add evmWordIs_one clean unfold for 1 = true encoding

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -279,11 +279,8 @@ theorem evmWordIs_zero (addr : Word) :
     ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
      ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
   unfold evmWordIs
-  have h0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by decide
-  have h1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by decide
-  have h2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by decide
-  have h3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
-  rw [h0, h1, h2, h3]
+  rw [EvmWord.getLimbN_zero 0, EvmWord.getLimbN_zero 1,
+      EvmWord.getLimbN_zero 2, EvmWord.getLimbN_zero 3]
 
 -- ============================================================================
 -- Shared infrastructure for stack operation specs

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -282,6 +282,19 @@ theorem evmWordIs_zero (addr : Word) :
   rw [EvmWord.getLimbN_zero 0, EvmWord.getLimbN_zero 1,
       EvmWord.getLimbN_zero 2, EvmWord.getLimbN_zero 3]
 
+/-- `evmWordIs addr (1 : EvmWord)` unfolds to one non-zero memIs atom
+    (at the LSB) and three zero memIs atoms (at the higher limbs).
+    Thin wrapper around the definitional unfold specialized to `v = 1` —
+    saves callers from inlining four `(1 : EvmWord).getLimbN k` facts
+    on every IsZero-path spec. Applies at arbitrary `addr`. -/
+theorem evmWordIs_one (addr : Word) :
+    evmWordIs addr (1 : EvmWord) =
+    ((addr ↦ₘ (1 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
+     ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
+  unfold evmWordIs
+  rw [EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
+      EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three]
+
 -- ============================================================================
 -- Shared infrastructure for stack operation specs
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add `evmWordIs_one`: specialized unfold for `evmWordIs addr (1 : EvmWord)` → one non-zero memIs at the LSB plus three zero memIs at the higher limbs.
- Uses existing `EvmWord.getLimbN_one_{zero,one,two,three}` concrete-index lemmas, avoiding four inline `by decide` / `if k = 0 …` proofs on every IsZero / EQ / comparison stack spec where the result encoding is `1`.
- Companion to `evmWordIs_zero`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)