### PR TITLE
refactor(SignExtend): use rv64_addr se12_7 / bv6_toNat_3 / bv6_toNat_63 (#263)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -18,7 +18,8 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se21_68 se21_96
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat
+  se12_7 bv6_toNat_3)
 
 -- ============================================================================
 -- Section 1: signextCode definition and helpers
@@ -716,28 +717,25 @@ theorem signext_body_spec (sp base : Word)
   -- limb_idx.toNat = b.toNat / 8
   have hlimb_idx_eq : limb_idx.toNat = b.toNat / 8 := by
     show (b0 >>> (3 : BitVec 6).toNat).toNat = b.toNat / 8
-    have h3 : (3 : BitVec 6).toNat = 3 := by decide
-    rw [h3, BitVec.toNat_ushiftRight, hb0_eq_b]
+    rw [bv6_toNat_3, BitVec.toNat_ushiftRight, hb0_eq_b]
     simp [Nat.shiftRight_eq_div_pow]
   -- shift_amount.toNat % 64 = 56 - (b.toNat % 8) * 8
   have hsa_mod : shift_amount.toNat % 64 = 56 - (b.toNat % 8) * 8 := by
     show ((56 : Word) - byte_shift).toNat % 64 = 56 - (b.toNat % 8) * 8
-    have h3 : (3 : BitVec 6).toNat = 3 := by decide
     -- byte_shift = (b0 &&& 7) <<< 3
     have hbs : byte_shift = (b0 &&& signExtend12 (7 : BitVec 12)) <<< (3 : BitVec 6).toNat := rfl
-    rw [h3] at hbs
+    rw [bv6_toNat_3] at hbs
     -- b0.toNat < 31 → we can compute everything via bv_omega style
     -- (b0 &&& 7).toNat = b0.toNat % 8
-    have h7 : signExtend12 (7 : BitVec 12) = (7 : Word) := by decide
     have hand : (b0 &&& (7 : Word)).toNat = b0.toNat % 8 := by
       rw [BitVec.toNat_and]; exact Nat.and_two_pow_sub_one_eq_mod b0.toNat 3
     -- ((b0 &&& 7) <<< 3).toNat = (b0.toNat % 8) * 8
     have hm8 : b0.toNat % 8 < 8 := Nat.mod_lt _ (by omega)
     have hshift_val : byte_shift.toNat = (b0.toNat % 8) * 8 := by
-      rw [hbs, h7]; bv_omega
+      rw [hbs, se12_7]; bv_omega
     -- 56 - byte_shift fits in Word and the mod 64 is identity
     have h56_sub : ((56 : Word) - byte_shift).toNat = 56 - (b0.toNat % 8) * 8 := by
-      rw [hbs, h7]; bv_omega
+      rw [hbs, se12_7]; bv_omega
     rw [h56_sub, hb0_eq_b]
     have hm8 : b.toNat % 8 < 8 := Nat.mod_lt _ (by omega)
     omega

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -10,12 +10,14 @@
 -/
 
 import EvmAsm.Evm64.SignExtend.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_63)
 
 namespace EvmAsm.Evm64
 
@@ -97,7 +99,7 @@ theorem signext_body_2_spec (sp : Word)
        ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 48 sp v2 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
@@ -129,7 +131,7 @@ theorem signext_body_1_spec (sp : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ sign_fill) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 40 sp v1 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
@@ -164,7 +166,7 @@ theorem signext_body_0_spec (sp : Word)
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ sign_fill) ** ((sp + 48) ↦ₘ sign_fill) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 32 sp v0 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -133,6 +133,7 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem se12_2  : signExtend12 (2  : BitVec 12) = (2  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_3  : signExtend12 (3  : BitVec 12) = (3  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_4  : signExtend12 (4  : BitVec 12) = (4  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_7  : signExtend12 (7  : BitVec 12) = (7  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_8  : signExtend12 (8  : BitVec 12) = (8  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_12 : signExtend12 (12 : BitVec 12) = (12 : Word) := by decide
 @[rv64_addr, grind =] theorem se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide


### PR DESCRIPTION
## Summary

Follow-up to [#494](https://github.com/Verified-zkEVM/evm-asm/pull/494) (which promoted \`se12_*\` / \`bv6_toNat_*\` to the \`rv64_addr\` grindset). With those lemmas now reachable from \`Rv64/AddrNorm\` — without SignExtend needing to pull in DivMod — the three previously-blocked sites in the SignExtend tree can migrate.

## Changes

- \`Rv64/AddrNorm.lean\` — add one new \`se12_7\` lemma (the only small positive offset not already covered).
- \`SignExtend/LimbSpec.lean\` — three copies of \`have h63 : (63 : BitVec 6).toNat = 63 := by decide\` migrated to \`have h63 := bv6_toNat_63\`.
- \`SignExtend/Compose.lean\` — two \`have h3 : (3 : BitVec 6).toNat = 3 := by decide\` and one \`have h7 : signExtend12 (7 : BitVec 12) = (7 : Word) := by decide\` migrated to direct references to \`bv6_toNat_3\` / \`se12_7\`.

5 inline \`by decide\` lines eliminated.

## Stacked on #494

This PR is cut from #494's branch. Reviewer should merge #494 first (the layering promotion), then this one. If #494 rebases, this branch needs a trivial rebase.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)