### PR TITLE
refactor(Rv64/RLP): use rv64_addr se12_0 / se12_1 / bv6_toNat_8 (#263)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -17,7 +17,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
 
 -- ============================================================================
 -- Section 1: shrCode definition and helpers
@@ -553,7 +553,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
       getLimbN_lt value (i.val + L) hiL,
@@ -588,7 +588,7 @@ private theorem shr_bridge_last (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div, hiL,
       getLimbN_lt value 3 (by omega), getLimbN_ge value 4 (by omega)]
@@ -604,7 +604,7 @@ private theorem shr_bridge_zero (value : EvmWord) (s0 : Word)
     getLimb result i = 0 := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
       getLimbN_ge value (i.val + L) (by omega),
@@ -901,7 +901,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         show value >>> shift.toNat = value >>> s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 : (6 : BitVec 6).toNat = 6 := by decide
+        have h6 := bv6_toNat_6
         have hlt4 : limb_shift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [h6]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
 
 -- ============================================================================
 -- Section 1: sarCode definition and helpers
@@ -681,7 +681,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   -- sshiftRight agrees with ushiftRight for merge limbs
   rw [getLimb_sshiftRight_eq_ushiftRight value s0.toNat i (by omega)]
@@ -718,7 +718,7 @@ private theorem sar_bridge_last (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_sshiftRight_last value s0.toNat i (by omega)]
   congr 1; omega
@@ -735,7 +735,7 @@ private theorem sar_bridge_sign (value : EvmWord) (s0 : Word)
     getLimb result i := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   -- getLimb (sshiftRight value n) i = sshiftRight (getLimb value 3) 63 for sign limbs
   rw [getLimb_sshiftRight_sign' value s0.toNat i (by omega)]
@@ -1059,7 +1059,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 : (6 : BitVec 6).toNat = 6 := by decide
+        have h6 := bv6_toNat_6
         have hlt4 : limb_shift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [h6]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
 
 -- ============================================================================
 -- Section 1: shlCode definition and helpers
@@ -519,7 +519,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft: i*64 >= s0.toNat since i >= L+1 and s0.toNat = L*64 + bs < (L+1)*64
   rw [getLimb_shiftLeft value s0.toNat i (by omega), hL_div,
@@ -558,7 +558,7 @@ private theorem shl_bridge_first (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_eq_div: i.val = n / 64
   rw [getLimb_shiftLeft_eq_div value s0.toNat i (by omega)]
@@ -577,7 +577,7 @@ private theorem shl_bridge_zero (value : EvmWord) (s0 : Word)
     getLimb result i = 0 := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 : (6 : BitVec 6).toNat = 6 := by decide
+    have h6 := bv6_toNat_6
     rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_low: (i+1)*64 <= s0.toNat since i < L and s0.toNat >= L*64
   exact getLimb_shiftLeft_low value s0.toNat i (by omega)
@@ -877,7 +877,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         show value <<< shift.toNat = value <<< s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 : (6 : BitVec 6).toNat = 6 := by decide
+        have h6 := bv6_toNat_6
         have hlt4 : limb_shift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [h6]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -18,7 +18,8 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se21_68 se21_96
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat
+  se12_7 bv6_toNat_3)
 
 -- ============================================================================
 -- Section 1: signextCode definition and helpers
@@ -716,28 +717,25 @@ theorem signext_body_spec (sp base : Word)
   -- limb_idx.toNat = b.toNat / 8
   have hlimb_idx_eq : limb_idx.toNat = b.toNat / 8 := by
     show (b0 >>> (3 : BitVec 6).toNat).toNat = b.toNat / 8
-    have h3 : (3 : BitVec 6).toNat = 3 := by decide
-    rw [h3, BitVec.toNat_ushiftRight, hb0_eq_b]
+    rw [bv6_toNat_3, BitVec.toNat_ushiftRight, hb0_eq_b]
     simp [Nat.shiftRight_eq_div_pow]
   -- shift_amount.toNat % 64 = 56 - (b.toNat % 8) * 8
   have hsa_mod : shift_amount.toNat % 64 = 56 - (b.toNat % 8) * 8 := by
     show ((56 : Word) - byte_shift).toNat % 64 = 56 - (b.toNat % 8) * 8
-    have h3 : (3 : BitVec 6).toNat = 3 := by decide
     -- byte_shift = (b0 &&& 7) <<< 3
     have hbs : byte_shift = (b0 &&& signExtend12 (7 : BitVec 12)) <<< (3 : BitVec 6).toNat := rfl
-    rw [h3] at hbs
+    rw [bv6_toNat_3] at hbs
     -- b0.toNat < 31 → we can compute everything via bv_omega style
     -- (b0 &&& 7).toNat = b0.toNat % 8
-    have h7 : signExtend12 (7 : BitVec 12) = (7 : Word) := by decide
     have hand : (b0 &&& (7 : Word)).toNat = b0.toNat % 8 := by
       rw [BitVec.toNat_and]; exact Nat.and_two_pow_sub_one_eq_mod b0.toNat 3
     -- ((b0 &&& 7) <<< 3).toNat = (b0.toNat % 8) * 8
     have hm8 : b0.toNat % 8 < 8 := Nat.mod_lt _ (by omega)
     have hshift_val : byte_shift.toNat = (b0.toNat % 8) * 8 := by
-      rw [hbs, h7]; bv_omega
+      rw [hbs, se12_7]; bv_omega
     -- 56 - byte_shift fits in Word and the mod 64 is identity
     have h56_sub : ((56 : Word) - byte_shift).toNat = 56 - (b0.toNat % 8) * 8 := by
-      rw [hbs, h7]; bv_omega
+      rw [hbs, se12_7]; bv_omega
     rw [h56_sub, hb0_eq_b]
     have hm8 : b.toNat % 8 < 8 := Nat.mod_lt _ (by omega)
     omega

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -10,12 +10,14 @@
 -/
 
 import EvmAsm.Evm64.SignExtend.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_63)
 
 namespace EvmAsm.Evm64
 
@@ -97,7 +99,7 @@ theorem signext_body_2_spec (sp : Word)
        ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 48 sp v2 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
@@ -129,7 +131,7 @@ theorem signext_body_1_spec (sp : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ sign_fill) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 40 sp v1 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
@@ -164,7 +166,7 @@ theorem signext_body_0_spec (sp : Word)
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ sign_fill) **
        ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ sign_fill) ** ((sp + 48) ↦ₘ sign_fill) ** ((sp + 56) ↦ₘ sign_fill)) := by
-  have h63 : (63 : BitVec 6).toNat = 63 := by decide
+  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 32 sp v0 v5 shift_amount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -172,6 +172,7 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem bv6_toNat_2  : (2  : BitVec 6).toNat = 2  := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_3  : (3  : BitVec 6).toNat = 3  := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_4  : (4  : BitVec 6).toNat = 4  := by decide
+@[rv64_addr, grind =] theorem bv6_toNat_6  : (6  : BitVec 6).toNat = 6  := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_8  : (8  : BitVec 6).toNat = 8  := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_16 : (16 : BitVec 6).toNat = 16 := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_32 : (32 : BitVec 6).toNat = 32 := by decide

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -133,6 +133,7 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem se12_2  : signExtend12 (2  : BitVec 12) = (2  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_3  : signExtend12 (3  : BitVec 12) = (3  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_4  : signExtend12 (4  : BitVec 12) = (4  : Word) := by decide
+@[rv64_addr, grind =] theorem se12_7  : signExtend12 (7  : BitVec 12) = (7  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_8  : signExtend12 (8  : BitVec 12) = (8  : Word) := by decide
 @[rv64_addr, grind =] theorem se12_12 : signExtend12 (12 : BitVec 12) = (12 : Word) := by decide
 @[rv64_addr, grind =] theorem se12_16 : signExtend12 (16 : BitVec 12) = (16 : Word) := by decide

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -27,11 +27,13 @@ import EvmAsm.Rv64.ByteOps
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.RLP
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_0 se12_1 bv6_toNat_8)
 
 -- ============================================================================
 -- Program definition
@@ -123,9 +125,9 @@ theorem rlp_phase2_long_iter_spec
   simp only [rlp_phase2_long_iter_post_unfold]
   rw [iter_code_split]
   -- Helpers: `signExtend12 1 = 1` and `signExtend12 0 = 0`.
-  have h_se1 : signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
-  have h_se0 : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
-  have h_shamt : (8 : BitVec 6).toNat = 8 := by decide
+  have h_se1 := se12_1
+  have h_se0 := se12_0
+  have h_shamt := bv6_toNat_8
   -- Distinct-addresses plumbing.
   obtain ⟨h01, h02, h03, h04, h12, h13, h14, h23, h24, h34⟩ :=
     iter_addrs_distinct base


### PR DESCRIPTION
## Summary

Third follow-up to [#494](https://github.com/Verified-zkEVM/evm-asm/pull/494) (promotion of \`se12_*\` / \`bv6_toNat_*\` to \`rv64_addr\`). \`Rv64/RLP/Phase2LongIter.lean\` previously had three inline decides it can now replace with direct references to the promoted lemmas.

Before the promotion, Rv64/RLP could not reach these lemmas — they lived under \`EvmAsm.Evm64.DivMod.AddrNorm\`, which Rv64 cannot import (wrong layering direction). This PR demonstrates that #494's cleanup makes the migration clean.

## Changes

- \`Rv64/RLP/Phase2LongIter.lean\`
  - add \`import EvmAsm.Rv64.AddrNorm\` and \`open EvmAsm.Rv64.AddrNorm (se12_0 se12_1 bv6_toNat_8)\`;
  - \`have h_se1 := se12_1\` (was \`:= by decide\`);
  - \`have h_se0 := se12_0\` (was \`:= by decide\`);
  - \`have h_shamt := bv6_toNat_8\` (was \`:= by decide\`).

3 inline \`by decide\` lines eliminated.

## Stacked on #494 → #496 → #497

Merge order: #494 → #496 → #497 → this.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)