### PR TITLE
refactor(LoopUnified/LoopCompose): factor hj' decides into jpred_{1,2,3} (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNorm.lean
@@ -129,6 +129,19 @@ export EvmAsm.Rv64.AddrNorm
     BitVec.slt ((3 : Word) + signExtend12 4095) 0 = false := by decide
 
 -- ============================================================================
+-- Concrete value of j − 1 after `ADDI j j -1` (i.e. `j + signExtend12 4095`)
+-- for j ∈ {1, 2, 3}. Used by `hj' : (j : Word) + signExtend12 4095 = (j-1)`
+-- sites in LoopUnified / LoopCompose files.
+-- ============================================================================
+
+@[divmod_addr, grind =] theorem jpred_1 :
+    (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+@[divmod_addr, grind =] theorem jpred_2 :
+    (2 : Word) + signExtend12 4095 = (1 : Word) := by decide
+@[divmod_addr, grind =] theorem jpred_3 :
+    (3 : Word) + signExtend12 4095 = (2 : Word) := by decide
+
+-- ============================================================================
 -- `divmod_addr` tactic
 --
 -- Primary: `grind` (sees all @[grind =]-registered atomic facts).

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -22,6 +22,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 
 -- ============================================================================
 -- Address equality lemmas for j=2 output → j=1 input transition
@@ -448,7 +449,7 @@ theorem divK_loop_n2_max_max_spec
     (fun h hp => by
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -529,7 +530,7 @@ theorem divK_loop_n2_call_call_spec
     (fun h hp => by
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -617,7 +618,7 @@ theorem divK_loop_n2_max_call_spec
     (fun h hp => by
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -703,7 +704,7 @@ theorem divK_loop_n2_call_max_spec
     (fun h hp => by
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -16,6 +16,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 
 -- ============================================================================
 -- Address equality lemmas for j=1 output → j=0 input transition
@@ -106,7 +107,7 @@ theorem divK_loop_n3_max_skip_skip_spec
     (fun h hp => by
       delta loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -410,7 +411,7 @@ theorem divK_loop_n3_max_max_spec
       -- iterN3Max is @[irreducible] so projections stay opaque after delta
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -496,7 +497,7 @@ theorem divK_loop_n3_call_call_spec
       -- iterN3Call is @[irreducible] so projections stay opaque after delta
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -584,7 +585,7 @@ theorem divK_loop_n3_max_call_spec
     (fun h hp => by
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -669,7 +670,7 @@ theorem divK_loop_n3_call_max_spec
     (fun h hp => by
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
-      have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+      have hj' := jpred_1
       rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
           u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
       rw [sepConj_assoc'] at hp

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -25,6 +25,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 jpred_2 jpred_3)
 
 -- ============================================================================
 -- Double-addback () two-iteration (j=1, j=0) unified composition
@@ -111,7 +112,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (fun h hp => by
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
-        have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+        have hj' := jpred_1
         rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
             u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
         rw [sepConj_assoc'] at hp
@@ -178,7 +179,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (fun h hp => by
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
-        have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+        have hj' := jpred_1
         rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
             u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
         rw [sepConj_assoc'] at hp
@@ -246,7 +247,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (fun h hp => by
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
-        have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+        have hj' := jpred_1
         rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
             u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
         rw [sepConj_assoc'] at hp
@@ -312,7 +313,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (fun h hp => by
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
-        have hj' : (1 : Word) + signExtend12 4095 = (0 : Word) := by decide
+        have hj' := jpred_1
         rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
             u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
         rw [sepConj_assoc'] at hp
@@ -400,7 +401,7 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (2 : Word) + signExtend12 4095 = (1 : Word) := by decide
+      have hj' := jpred_2
       rw [hj', u_n1_j2_0_eq_j1_4088 sp, u_n1_j2_4088_eq_j1_4080 sp,
           u_n1_j2_4080_eq_j1_4072 sp, u_n1_j2_4072_eq_j1_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -481,7 +482,7 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (2 : Word) + signExtend12 4095 = (1 : Word) := by decide
+      have hj' := jpred_2
       rw [hj', u_n1_j2_0_eq_j1_4088 sp, u_n1_j2_4088_eq_j1_4080 sp,
           u_n1_j2_4080_eq_j1_4072 sp, u_n1_j2_4072_eq_j1_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -646,7 +647,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (3 : Word) + signExtend12 4095 = (2 : Word) := by decide
+      have hj' := jpred_3
       rw [hj', u_n1_j3_0_eq_j2_4088 sp, u_n1_j3_4088_eq_j2_4080 sp,
           u_n1_j3_4080_eq_j2_4072 sp, u_n1_j3_4072_eq_j2_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -753,7 +754,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (3 : Word) + signExtend12 4095 = (2 : Word) := by decide
+      have hj' := jpred_3
       rw [hj', u_n1_j3_0_eq_j2_4088 sp, u_n1_j3_4088_eq_j2_4080 sp,
           u_n1_j3_4080_eq_j2_4072 sp, u_n1_j3_4072_eq_j2_4064 sp] at hp
       rw [sepConj_assoc'] at hp

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -21,6 +21,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Evm64.DivMod.AddrNorm (jpred_2)
 
 -- ============================================================================
 -- Double-addback () two-iteration (j=1, j=0) unified composition
@@ -182,7 +183,7 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (2 : Word) + signExtend12 4095 = (1 : Word) := by decide
+      have hj' := jpred_2
       rw [hj', u_j2_0_eq_j1_4088 sp, u_j2_4088_eq_j1_4080 sp,
           u_j2_4080_eq_j1_4072 sp, u_j2_4072_eq_j1_4064 sp] at hp
       rw [sepConj_assoc'] at hp
@@ -258,7 +259,7 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
       simp only [] at hp ⊢
-      have hj' : (2 : Word) + signExtend12 4095 = (1 : Word) := by decide
+      have hj' := jpred_2
       rw [hj', u_j2_0_eq_j1_4088 sp, u_j2_4088_eq_j1_4080 sp,
           u_j2_4080_eq_j1_4072 sp, u_j2_4072_eq_j1_4064 sp] at hp
       rw [sepConj_assoc'] at hp


### PR DESCRIPTION
## Summary

Four files had a total of **19** inline
\`\`\`lean
have hj' : (N : Word) + signExtend12 4095 = (N-1 : Word) := by decide
\`\`\`
sites — the concrete value of j − 1 after the \`ADDI j, j, -1\` in the loop's back-step, for j ∈ {1, 2, 3}.

This PR factors the three identities into the \`divmod_addr\` grindset as \`jpred_1\`, \`jpred_2\`, \`jpred_3\` and migrates every call site to
\`\`\`lean
have hj' := jpred_N
\`\`\`

## Files touched

| File | Sites |
|---|---|
| \`DivMod/AddrNorm.lean\` | 3 new \`@[divmod_addr, grind =]\` lemmas |
| \`DivMod/LoopUnifiedN1.lean\` | 8 (jpred_1 ×4, jpred_2 ×2, jpred_3 ×2) |
| \`DivMod/LoopComposeN3.lean\` | 5 (all jpred_1) |
| \`DivMod/LoopComposeN2.lean\` | 4 (all jpred_1) |
| \`DivMod/LoopUnifiedN2.lean\` | 2 (both jpred_2) |

19 inline \`have hj' ... := by decide\` lines eliminated.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)