### PR TITLE
feat(stack): add evmStackIs_nil_right mid-tree fold

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -308,6 +308,17 @@ theorem evmWordIs_fromLimbs_const (addr : Word) (w : Word) :
   rw [EvmWord.getLimbN_fromLimbs_const_0, EvmWord.getLimbN_fromLimbs_const_1,
       EvmWord.getLimbN_fromLimbs_const_2, EvmWord.getLimbN_fromLimbs_const_3]
 
+/-- Mid-tree variant of `evmWordIs_fromLimbs_const`: threads a remainder
+    `Q` so `rw ←` can fold four identical-valued memIs atoms back into
+    `evmWordIs addr (fromLimbs (fun _ => w))` even when they sit in the
+    middle of a longer sepConj chain. -/
+theorem evmWordIs_fromLimbs_const_right (addr : Word) (w : Word) (Q : Assertion) :
+    ((addr ↦ₘ w) ** ((addr + 8) ↦ₘ w) **
+     ((addr + 16) ↦ₘ w) ** ((addr + 24) ↦ₘ w) ** Q) =
+    (evmWordIs addr (EvmWord.fromLimbs (fun _ => w)) ** Q) := by
+  rw [evmWordIs_fromLimbs_const]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 /-- Mid-tree variant of `evmWordIs_zero`: threads a remainder `Q` so
     `rw ←` can fold four zero memIs atoms back into `evmWordIs addr 0`
     even when they sit in the middle of a longer sepConj chain. -/

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -61,6 +61,14 @@ theorem evmStackIs_cons_right (sp : Word) (v : EvmWord) (vs : List EvmWord)
 theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 
+/-- Mid-tree variant of `evmStackIs_nil`: threads a remainder `Q` so
+    `rw ←` can fold a stray `empAssertion` back into `evmStackIs sp []`
+    even when it sits in the middle of a longer sepConj chain. Useful
+    when a stack spec's post has a dangling empty-stack residual that
+    the stack-level consumer wants expressed as `evmStackIs sp []`. -/
+theorem evmStackIs_nil_right (sp : Word) (Q : Assertion) :
+    (empAssertion ** Q) = (evmStackIs sp [] ** Q) := rfl
+
 /-- Two-element stack: `evmStackIs sp [a, b]` unfolds to
     `evmWordIs sp a ** evmWordIs (sp + 32) b ** empAssertion`. The
     trailing `** empAssertion` comes from the single-element recursion

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -295,6 +295,19 @@ theorem evmWordIs_one (addr : Word) :
   rw [EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
       EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three]
 
+/-- `evmWordIs addr (EvmWord.fromLimbs (fun _ => w))` unfolds to four
+    identical-valued memIs atoms. Specializes the generic
+    `evmWordIs_sp_limbs_eq` to the uniform-limb constant case; covers
+    both the all-zero (`evmWordIs_zero`) and all-ones (e.g. `-1` in
+    two's complement) patterns uniformly. -/
+theorem evmWordIs_fromLimbs_const (addr : Word) (w : Word) :
+    evmWordIs addr (EvmWord.fromLimbs (fun _ => w)) =
+    ((addr ↦ₘ w) ** ((addr + 8) ↦ₘ w) **
+     ((addr + 16) ↦ₘ w) ** ((addr + 24) ↦ₘ w)) := by
+  unfold evmWordIs
+  rw [EvmWord.getLimbN_fromLimbs_const_0, EvmWord.getLimbN_fromLimbs_const_1,
+      EvmWord.getLimbN_fromLimbs_const_2, EvmWord.getLimbN_fromLimbs_const_3]
+
 /-- Mid-tree variant of `evmWordIs_zero`: threads a remainder `Q` so
     `rw ←` can fold four zero memIs atoms back into `evmWordIs addr 0`
     even when they sit in the middle of a longer sepConj chain. -/


### PR DESCRIPTION
## Summary
- Add `evmStackIs_nil_right`: mid-tree variant of `evmStackIs_nil`.
- Threads `Q` so `rw ←` can fold a stray `empAssertion` back into `evmStackIs sp []` mid-chain. Useful when a stack spec's post has a dangling empty-stack residual.
- Completes the `_right` fold family for all `evmStackIs_{nil,cons,single,pair,triple,triple_flat,append}` unfolds.
- Proof is `rfl`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)