### PR TITLE
feat(stack): add evmWordIs_congr for value-equality rewriting

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -61,6 +61,14 @@ theorem evmStackIs_cons_right (sp : Word) (v : EvmWord) (vs : List EvmWord)
 theorem evmStackIs_nil (sp : Word) :
     evmStackIs sp [] = empAssertion := rfl
 
+/-- Mid-tree variant of `evmStackIs_nil`: threads a remainder `Q` so
+    `rw ←` can fold a stray `empAssertion` back into `evmStackIs sp []`
+    even when it sits in the middle of a longer sepConj chain. Useful
+    when a stack spec's post has a dangling empty-stack residual that
+    the stack-level consumer wants expressed as `evmStackIs sp []`. -/
+theorem evmStackIs_nil_right (sp : Word) (Q : Assertion) :
+    (empAssertion ** Q) = (evmStackIs sp [] ** Q) := rfl
+
 /-- Two-element stack: `evmStackIs sp [a, b]` unfolds to
     `evmWordIs sp a ** evmWordIs (sp + 32) b ** empAssertion`. The
     trailing `** empAssertion` comes from the single-element recursion

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -165,6 +165,14 @@ theorem evmStackIs_triple_flat_right (sp : Word) (a b c : EvmWord)
     (evmStackIs sp [a, b, c] ** Q) := by
   rw [evmStackIs_triple_flat]
 
+/-- Congruence: if the stored values agree, `evmWordIs` at the same
+    address agrees. Trivial `congrArg` application, but named for use
+    with `rw [evmWordIs_congr hv]` style rewriting where `hv : v = w`
+    is a hypothesis produced by an upstream bridge lemma. -/
+theorem evmWordIs_congr (addr : Word) {v w : EvmWord} (hv : v = w) :
+    evmWordIs addr v = evmWordIs addr w :=
+  congrArg (evmWordIs addr) hv
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add `evmWordIs_congr (addr : Word) : v = w → evmWordIs addr v = evmWordIs addr w`.
- Thin `congrArg` wrapper, named so call sites can rewrite `evmWordIs addr (EvmWord.div a b)` → `evmWordIs addr 0` via `rw [evmWordIs_congr (div_zero_right a)]` instead of inlining a `have ... := congrArg ...` + `rw` dance at every boundary / bzero spec.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)