### PR TITLE
refactor(Byte, Rv64/RLP): use rv64_addr bv6_toNat_{3,8} (#263)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -25,7 +25,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se21_24 se21_32 se21_48
-  zero_add_se12_1_toNat zero_add_se12_2_toNat)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_3)
 
 -- ============================================================================
 -- Full program CodeReq
@@ -634,7 +634,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hresult_high3 : getLimb result 3 = 0 :=
     byte_getLimb_high idx value (3 : Fin 4) (show (3 : Fin 4).val ≠ 0 by decide)
   have hresult_limb0 := byte_correct idx value hlt
-  have h3bv : (3 : BitVec 6).toNat = 3 := by decide
+  have h3bv := bv6_toNat_3
   have hlimb_val : limb_from_msb.toNat = i0.toNat / 8 := by
     show (i0 >>> (3 : BitVec 6).toNat).toNat = i0.toNat / 8
     rw [h3bv]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -27,11 +27,13 @@
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.RLP
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_8)
 
 -- ============================================================================
 -- Program definition
@@ -103,7 +105,7 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
     (len <<< (8 : BitVec 6).toNat) byte (base + 4) (by nofun)
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at s2
   -- Compose. `(8 : BitVec 6).toNat = 8` so the result matches.
-  have heq : (8 : BitVec 6).toNat = 8 := by decide
+  have heq := bv6_toNat_8
   rw [heq] at s1
   exact cpsTriple_seq _ _ _ _ _ hd _ _ _ s1 s2
 


### PR DESCRIPTION
## Summary

Two remaining orphan inline
\`\`\`lean
have h.. : (N : BitVec 6).toNat = N := by decide
\`\`\`
sites — one \`h3bv\` in \`Byte/Spec.lean\` and one \`heq\` in \`Rv64/RLP/Phase2LongAcc.lean\`. Both identities already live in the \`rv64_addr\` grindset (promoted by #494) as \`bv6_toNat_3\` and \`bv6_toNat_8\`.

Open the names in each file and replace the inline \`have ... := by decide\` with a direct reference.

2 inline \`by decide\` lines eliminated.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)