### PR TITLE
refactor(DivMod/Spec): use EvmWord.getLimbN_zero for (0 : EvmWord) lookups (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -817,10 +817,10 @@ theorem evm_div_bzero_stack_spec (sp base : Word)
        evmWordIs (sp + 32) (EvmWord.div a b)) := by
   subst hbz
   -- Normalize (0 : EvmWord).getLimb k to (0 : Word)
-  have hg0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by decide
-  have hg1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by decide
-  have hg2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by decide
-  have hg3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
+  have hg0 := EvmWord.getLimbN_zero 0
+  have hg1 := EvmWord.getLimbN_zero 1
+  have hg2 := EvmWord.getLimbN_zero 2
+  have hg3 := EvmWord.getLimbN_zero 3
   -- Get the limb-level zero-path spec
   have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
       (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
@@ -870,10 +870,10 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (regOwn .x10) ** (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs (sp + 32) (EvmWord.mod a b)) := by
   subst hbz
-  have hg0 : (0 : EvmWord).getLimbN 0 = (0 : Word) := by decide
-  have hg1 : (0 : EvmWord).getLimbN 1 = (0 : Word) := by decide
-  have hg2 : (0 : EvmWord).getLimbN 2 = (0 : Word) := by decide
-  have hg3 : (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
+  have hg0 := EvmWord.getLimbN_zero 0
+  have hg1 := EvmWord.getLimbN_zero 1
+  have hg2 := EvmWord.getLimbN_zero 2
+  have hg3 := EvmWord.getLimbN_zero 3
   have hlimbs_or : (0 : EvmWord).getLimbN 0 ||| (0 : EvmWord).getLimbN 1 |||
       (0 : EvmWord).getLimbN 2 ||| (0 : EvmWord).getLimbN 3 = (0 : Word) := by decide
   have h_raw := evm_mod_bzero_spec sp base


### PR DESCRIPTION
## Summary

\`DivMod/Spec.lean\` had two blocks of four inline decides:
\`\`\`lean
have hgN : (0 : EvmWord).getLimbN N = (0 : Word) := by decide
\`\`\`
for N ∈ {0, 1, 2, 3}. The same identity is provided universally by
\`\`\`lean
EvmWord.getLimbN_zero (k : Nat) : (0 : EvmWord).getLimbN k = 0
\`\`\`
Replace the 8 inline decides with \`have hgN := EvmWord.getLimbN_zero N\`.

8 inline \`by decide\` lines eliminated.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)