### PR TITLE
refactor(Compose/Base): remove duplicate se12_32/40/48/56 (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -543,13 +543,12 @@ theorem normBPost_unfold (sp n_val shift b0 b1 b2 b3 : Word) :
   delta normBPost; rfl
 
 -- ============================================================================
--- Shared signExtend12 normalization lemmas (used by FullPathN3/N4 compositions)
+-- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:
+-- they now live canonically in `Rv64/AddrNorm.lean` as part of the
+-- `rv64_addr` grindset. Consumers should `open EvmAsm.Rv64.AddrNorm
+-- (se12_32 se12_40 se12_48 se12_56)` directly instead of relying on these
+-- duplicates.
 -- ============================================================================
-
-theorem se12_32 : signExtend12 (32 : BitVec 12) = (32 : Word) := by decide
-theorem se12_40 : signExtend12 (40 : BitVec 12) = (40 : Word) := by decide
-theorem se12_48 : signExtend12 (48 : BitVec 12) = (48 : Word) := by decide
-theorem se12_56 : signExtend12 (56 : BitVec 12) = (56 : Word) := by decide
 
 -- ============================================================================
 -- Shared `phB_off_*` address rewrites.

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -21,6 +21,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Double-addback () condition predicates for n=1 preloop+loop composition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -22,6 +22,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Double-addback variant: Case (F,F,T) — r2=Max, r1=Max, r0=Call

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -17,6 +17,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- loopExitPostN2_j0_eq is in FullPathN2Loop.lean
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -21,6 +21,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Double-addback () condition predicates for n=2 preloop+loop composition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -15,6 +15,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Double-addback () condition predicates for n=3 preloop+loop composition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -15,12 +15,13 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Address form helpers: signExtend12 K = K for small offsets
 -- ============================================================================
 
--- se12_32, se12_40, se12_48, se12_56 are in Base.lean
+-- se12_32, se12_40, se12_48, se12_56 live in Rv64/AddrNorm.lean (#494).
 
 -- `x1_val_n4` now lives in `Compose/Base.lean` (shared with FullPathN4Shift0).
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -14,6 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Loop body n=4 _da (BEQ): sp-relative precondition

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -17,6 +17,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Address form helpers (duplicated from FullPathN4 where they are private)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -14,7 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3 se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- MOD CodeReq subsumption lemmas for block 3 (PhaseC2) and block 4 (NormB)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4 se12_4095)
-open EvmAsm.Rv64.AddrNorm (se13_24
+open EvmAsm.Rv64.AddrNorm (se13_24 se12_32
   bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
   bv64_4mul_14 bv64_4mul_15)
 

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -8,7 +8,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4)
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24)
+open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se12_32)
 
 -- ============================================================================
 -- MOD Phase B n=2 (b[3]=b[2]=0, b[1]≠0)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -8,7 +8,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_3 se12_4)
-open EvmAsm.Rv64.AddrNorm (se13_16 se13_24)
+open EvmAsm.Rv64.AddrNorm (se13_16 se13_24 se12_32)
 
 -- ============================================================================
 -- MOD Phase B n=3 (b[3]=0, b[2]≠0)

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -12,7 +12,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3)
+open EvmAsm.Rv64.AddrNorm (se13_172 bv64_4mul_3 se12_32 se12_40 se12_48 se12_56)
 
 /-- Phase C2 code (block 3) is subsumed by divCode. -/
 private theorem divK_phaseC2_code_sub_divCode (base : Word) :


### PR DESCRIPTION
## Summary

The four \`EvmAsm.Evm64.se12_32/40/48/56\` theorems in \`Evm64/DivMod/Compose/Base.lean\` duplicated the \`Rv64.AddrNorm\` versions that #494 promoted. Delete them from Base.lean and update the 10 consumer files that referenced the unqualified names so they \`open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)\` directly (or extend an existing \`open\`).

This completes the de-duplication half of #493 for this lemma family. \`word_zero_add\` / the \`phB_off_*\` / \`x1_val_n4\` shared lemmas in Compose/Base remain — they are DivMod-specific.

## Files touched

- \`Compose/Base.lean\` — delete 4 duplicate theorems, replace with a pointer comment
- 9 consumer files that had no AddrNorm open — add new \`open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)\`
- 4 consumer files with existing AddrNorm opens — extend the list

Pure refactor; no proof changes.

## Test plan

- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)