### PR TITLE
feat(stack): add evmWordIs_congr_both joint address/value congruence

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -196,6 +196,15 @@ theorem evmStackIs_congr_sp {sp sp' : Word} (xs : List EvmWord)
     evmStackIs sp xs = evmStackIs sp' xs :=
   congrArg (fun s => evmStackIs s xs) hsp
 
+/-- Joint congruence for `evmWordIs`: rewrite both the address and the
+    stored value at once. Useful when both sides change together (e.g.
+    moving to a normalized address *and* collapsing a `div a 0` to `0`
+    in a single rewrite). -/
+theorem evmWordIs_congr_both {a b : Word} {v w : EvmWord}
+    (ha : a = b) (hv : v = w) :
+    evmWordIs a v = evmWordIs b w := by
+  rw [ha, hv]
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add `evmWordIs_congr_both : a = b → v = w → evmWordIs a v = evmWordIs b w`.
- Joint congruence rewriting both the address and stored-value arguments at once — avoids two separate `evmWordIs_congr_addr` + `evmWordIs_congr` invocations when both sides change together (e.g. normalizing an address *and* collapsing a `div a 0` to `0` in one rewrite).

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)