### PR TITLE
feat(stack): add evmStackIs_nil_append / evmStackIs_append_nil

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -196,6 +196,15 @@ theorem evmStackIs_congr_sp {sp sp' : Word} (xs : List EvmWord)
     evmStackIs sp xs = evmStackIs sp' xs :=
   congrArg (fun s => evmStackIs s xs) hsp
 
+/-- Joint congruence for `evmWordIs`: rewrite both the address and the
+    stored value at once. Useful when both sides change together (e.g.
+    moving to a normalized address *and* collapsing a `div a 0` to `0`
+    in a single rewrite). -/
+theorem evmWordIs_congr_both {a b : Word} {v w : EvmWord}
+    (ha : a = b) (hv : v = w) :
+    evmWordIs a v = evmWordIs b w := by
+  rw [ha, hv]
+
 -- ============================================================================
 -- evmWordIs unfold and limb-equality bridges
 -- ============================================================================

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -438,6 +438,20 @@ theorem evmStackIs_snoc (sp : Word) (xs : List EvmWord) (v : EvmWord) :
     (evmStackIs sp xs ** evmWordIs (sp + BitVec.ofNat 64 (xs.length * 32)) v) := by
   rw [evmStackIs_append, evmStackIs_single]
 
+/-- `evmStackIs sp ([] ++ xs) = evmStackIs sp xs`. Trivial consequence of
+    `List.nil_append`. Named so call sites can reach for it by name
+    rather than chaining `List.nil_append` + `evmStackIs_congr`. -/
+theorem evmStackIs_nil_append (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp ([] ++ xs) = evmStackIs sp xs := by
+  rw [List.nil_append]
+
+/-- `evmStackIs sp (xs ++ []) = evmStackIs sp xs`. Symmetric companion
+    of `evmStackIs_nil_append`. Useful when a `List.map`-produced
+    suffix turns out to be empty. -/
+theorem evmStackIs_append_nil (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp (xs ++ []) = evmStackIs sp xs := by
+  rw [List.append_nil]
+
 /-- Mid-tree variant of `evmStackIs_append`: threads a remainder `Q` so
     `rw ←` can fold two contiguous `evmStackIs` segments back into a single
     `evmStackIs sp (xs ++ ys)` bundle even when they sit in the middle of a


### PR DESCRIPTION
## Summary
- Add two trivial corollaries of `List.{nil_append, append_nil}`:
  - `evmStackIs_nil_append sp xs : evmStackIs sp ([] ++ xs) = evmStackIs sp xs`
  - `evmStackIs_append_nil sp xs : evmStackIs sp (xs ++ []) = evmStackIs sp xs`
- Empty-prefix / empty-suffix concatenation leaves `evmStackIs` unchanged. Named so call sites where a `List.map` / spec-side computation produces an empty segment can reach for them by name rather than chaining `List.{nil,append}_{append,nil}` + `evmStackIs_congr`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)