### PR TITLE
refactor(shift,byte): inline trivial *_off_sp32 lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -206,10 +206,6 @@ private theorem byte_store_exit_eq (base : Word) :
     (base + 136 + 20) + signExtend21 (24 : BitVec 21) = base + 180 := by
   rw [se21_24]; bv_omega
 
--- sp address normalization
-private theorem byte_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
-  simp only [signExtend12_32]
-
 -- ============================================================================
 -- Helper lemmas
 -- ============================================================================

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -500,8 +500,6 @@ theorem evm_shr_zero_large_spec (sp base : Word)
 
 -- Address normalization lemmas for body path
 private theorem shr_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
-private theorem shr_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
-  simp only [signExtend12_32]
 
 -- ============================================================================
 -- Section 5a: Phase A ntaken → Phase B composition
@@ -761,7 +759,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hphaseB_raw := shr_phase_b_spec s0 sp r6 r7 r11 (base + 36)
   have hphaseB := cpsTriple_extend_code (phase_b_sub_shrCode base) hphaseB_raw
   rw [shr_off_36_28] at hphaseB
-  rw [shr_off_sp32] at hphaseB
+  simp only [signExtend12_32] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 64) _ _ _
     ((.x10 ↦ᵣ sltiu_val) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -266,9 +266,6 @@ private theorem sar_body1_exit (base : Word) : ((base + 172 : Word) + 76) + sign
 private theorem sar_body0_exit (base : Word) : ((base + 252 : Word) + 96) + signExtend21 32 = base + 380 := by
   rw [se21_32]; bv_omega
 
-private theorem sar_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
-  simp only [signExtend12_32]
-
 -- ============================================================================
 -- Section 4: Sign-fill path composition
 -- ============================================================================
@@ -918,7 +915,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hphaseB_raw := shr_phase_b_spec s0 sp r6 r7 r11 (base + 36)
   have hphaseB := cpsTriple_extend_code (phase_b_sub_sarCode base) hphaseB_raw
   rw [sar_off_36_28] at hphaseB
-  rw [sar_off_sp32] at hphaseB
+  simp only [signExtend12_32] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 64) _ _ _
     ((.x10 ↦ᵣ sltiu_val) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -490,8 +490,6 @@ theorem evm_shl_zero_large_spec (sp base : Word)
 
 -- Address normalization lemmas for body path
 private theorem shl_off_64_20 (base : Word) : (base + 64 : Word) + 20 = base + 84 := by bv_omega
-private theorem shl_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by
-  simp only [signExtend12_32]
 
 -- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
@@ -736,7 +734,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hphaseB_raw := shr_phase_b_spec s0 sp r6 r7 r11 (base + 36)
   have hphaseB := cpsTriple_extend_code (phase_b_sub_shlCode base) hphaseB_raw
   rw [shl_off_36_28] at hphaseB
-  rw [shl_off_sp32] at hphaseB
+  simp only [signExtend12_32] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 64) _ _ _
     ((.x10 ↦ᵣ sltiu_val) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **


### PR DESCRIPTION
## Summary
- Four files each defined a private `*_off_sp32 (sp : Word) : sp + signExtend12 (32 : BitVec 12) = sp + 32` lemma whose entire body was `simp only [signExtend12_32]`.
- `byte_off_sp32` in `Byte/Spec.lean` was unused (dead code).
- The three `shr_off_sp32` / `shl_off_sp32` / `sar_off_sp32` each had a single callsite.
- Inline `simp only [signExtend12_32]` at the callsites and remove the private lemmas.

Part of #263 (replacing one-off address normalization lemmas with the shared grindset / shared simp lemmas).

## Test plan
- [x] `lake build` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)