### PR TITLE
refactor(shift): use word_add_zero instead of inline bv_omega proof (#263)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -17,7 +17,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
 
 -- ============================================================================
 -- Section 1: shrCode definition and helpers
@@ -407,7 +407,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   -- Step 5: LD x5 x12 0 at base+24 → extend to shrCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, shr_off_24] at hld_raw
+  rw [word_add_zero, shr_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_shrCode base) hld_raw
   -- Step 6: SLTIU at base+28 → extend to shrCode
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
@@ -714,7 +714,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, shr_off_24] at hld_raw
+  rw [word_add_zero, shr_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_shrCode base) hld_raw
   -- SLTIU at base+28
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
 
 -- ============================================================================
 -- Section 1: sarCode definition and helpers
@@ -440,7 +440,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   -- Step 5: LD x5 x12 0 at base+24 → extend to sarCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, sar_off_24] at hld_raw
+  rw [word_add_zero, sar_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_sarCode base) hld_raw
   -- Step 6: SLTIU at base+28 → extend to sarCode
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
@@ -871,7 +871,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, sar_off_24] at hld_raw
+  rw [word_add_zero, sar_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_sarCode base) hld_raw
   -- SLTIU at base+28
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
 
 -- ============================================================================
 -- Section 1: shlCode definition and helpers
@@ -395,7 +395,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   -- Step 5: LD x5 x12 0 at base+24 → extend to shlCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, shl_off_24] at hld_raw
+  rw [word_add_zero, shl_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_shlCode base) hld_raw
   -- Step 6: SLTIU at base+28 → extend to shlCode
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
@@ -689,7 +689,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
-  rw [show sp + (0 : Word) = sp from by bv_omega, shl_off_24] at hld_raw
+  rw [word_add_zero, shl_off_24] at hld_raw
   have hld := cpsTriple_extend_code (ld_s0_sub_shlCode base) hld_raw
   -- SLTIU at base+28
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)


### PR DESCRIPTION
## Summary
- Six callsites in \`Shift/{Compose,ShlCompose,SarCompose}.lean\` used \`rw [show sp + (0 : Word) = sp from by bv_omega, …_off_24]\` to normalize \`sp + 0 = sp\` before chaining a block-offset rewrite.
- Replace the anonymous proof term with the named \`word_add_zero\` lemma from \`EvmAsm.Rv64.AddrNorm\` (added to each file's local \`open\` list).

Part of #263 (prefer named grindset lemmas over inline bv_omega proofs).

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)