### PR TITLE
feat(divmod): add divScratchCellCount_pos

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -777,6 +777,12 @@ def divScratchCellCount : Nat := 15
     convenient rewriting at call sites. -/
 theorem divScratchCellCount_eq : divScratchCellCount = 15 := rfl
 
+/-- `divScratchCellCount` is strictly positive. Useful for discharging
+    non-emptiness side conditions when reasoning abstractly about the
+    scratch region (e.g. in a size bound `sp + 32 * stack.length ≤
+    sp + ... - 32 * divScratchCellCount`). -/
+theorem divScratchCellCount_pos : 0 < divScratchCellCount := by decide
+
 /-- Bundled version of `evm_div_n4_full_max_skip_stack_pre_spec`: takes the
     precondition as a single `divN4StackPre` atom. Thin wrapper — unfolds the
     bundle and defers to the unbundled spec. Useful when composing into the

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -438,6 +438,20 @@ theorem evmStackIs_snoc (sp : Word) (xs : List EvmWord) (v : EvmWord) :
     (evmStackIs sp xs ** evmWordIs (sp + BitVec.ofNat 64 (xs.length * 32)) v) := by
   rw [evmStackIs_append, evmStackIs_single]
 
+/-- `evmStackIs sp ([] ++ xs) = evmStackIs sp xs`. Trivial consequence of
+    `List.nil_append`. Named so call sites can reach for it by name
+    rather than chaining `List.nil_append` + `evmStackIs_congr`. -/
+theorem evmStackIs_nil_append (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp ([] ++ xs) = evmStackIs sp xs := by
+  rw [List.nil_append]
+
+/-- `evmStackIs sp (xs ++ []) = evmStackIs sp xs`. Symmetric companion
+    of `evmStackIs_nil_append`. Useful when a `List.map`-produced
+    suffix turns out to be empty. -/
+theorem evmStackIs_append_nil (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp (xs ++ []) = evmStackIs sp xs := by
+  rw [List.append_nil]
+
 /-- Mid-tree variant of `evmStackIs_append`: threads a remainder `Q` so
     `rw ←` can fold two contiguous `evmStackIs` segments back into a single
     `evmStackIs sp (xs ++ ys)` bundle even when they sit in the middle of a


### PR DESCRIPTION
## Summary
- Add `divScratchCellCount_pos : 0 < divScratchCellCount`.
- Useful for discharging non-emptiness side conditions when reasoning abstractly about the 15-cell scratch region (e.g. in stack-size bounds involving `32 * divScratchCellCount`) — saves callers from re-deriving it from `divScratchCellCount_eq`.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)