### PR TITLE
refactor(limbspec): use word_add_zero in Shift/SignExtend LimbSpec (#263)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -16,12 +16,14 @@
 -/
 
 import EvmAsm.Evm64.Shift.Program
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (word_add_zero)
 
 namespace EvmAsm.Evm64
 
@@ -852,7 +854,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   have lw5 := ld_spec_gen .x5 .x12 sp
     (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at lw5
-  rw [show sp + (0 : Word) = sp from by bv_omega] at lw5
+  rw [word_add_zero] at lw5
   rw [ha24] at lw5
   -- Step 6: SLTIU x10 x5 256 at base+28
   have sltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -17,7 +17,7 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64.AddrNorm (bv6_toNat_63)
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_63 word_add_zero)
 
 namespace EvmAsm.Evm64
 
@@ -442,7 +442,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   have lw5 := ld_spec_gen .x5 .x12 sp
     (b1 ||| b2 ||| b3) b0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at lw5
-  rw [show sp + (0 : Word) = sp from by bv_omega] at lw5
+  rw [word_add_zero] at lw5
   rw [ha24] at lw5
   have sltiu_raw := sltiu_spec_gen .x10 .x5 b3 b0 31 (base + 28) (by nofun)
   rw [ha28] at sltiu_raw


### PR DESCRIPTION
## Summary
- Two callsites (one each in \`Shift/LimbSpec.lean\` and \`SignExtend/LimbSpec.lean\`) used \`rw [show sp + (0 : Word) = sp from by bv_omega] at lw5\`.
- Replace with the named \`word_add_zero\` lemma from \`EvmAsm.Rv64.AddrNorm\`.
- \`Shift/LimbSpec.lean\` did not previously import \`EvmAsm.Rv64.AddrNorm\`; adding the import and a local \`open\` for \`word_add_zero\`.

Part of #263. Complements #515 and #516.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)