### PR TITLE
feat(stack): add evmWordIs_sp{,32,64}_unfold_right mid-tree variants

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -777,6 +777,12 @@ def divScratchCellCount : Nat := 15
     convenient rewriting at call sites. -/
 theorem divScratchCellCount_eq : divScratchCellCount = 15 := rfl
 
+/-- `divScratchCellCount` is strictly positive. Useful for discharging
+    non-emptiness side conditions when reasoning abstractly about the
+    scratch region (e.g. in a size bound `sp + 32 * stack.length ≤
+    sp + ... - 32 * divScratchCellCount`). -/
+theorem divScratchCellCount_pos : 0 < divScratchCellCount := by decide
+
 /-- Bundled version of `evm_div_n4_full_max_skip_stack_pre_spec`: takes the
     precondition as a single `divN4StackPre` atom. Thin wrapper — unfolds the
     bundle and defers to the unbundled spec. Useful when composing into the

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -239,6 +239,34 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
   unfold evmWordIs
   rw [spAddr64_8, spAddr64_16, spAddr64_24]
 
+/-- Mid-tree variant of `evmWordIs_sp_unfold`: threads a remainder `Q` so
+    `rw ←` can fold `(sp ↦ₘ v.getLimbN 0) ** …` back into `evmWordIs sp v`
+    even when the atoms sit mid-chain. Simpler call than
+    `evmWordIs_sp_limbs_eq_right` when the caller already has the atoms
+    in `v.getLimbN k` form (no explicit `hk : v.getLimbN k = wk` threads). -/
+theorem evmWordIs_sp_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
+     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs sp v ** Q) := by
+  rw [evmWordIs_sp_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `evmWordIs_sp32_unfold`. -/
+theorem evmWordIs_sp32_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
+     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs (sp + 32) v ** Q) := by
+  rw [evmWordIs_sp32_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `evmWordIs_sp64_unfold`. Third-slot companion. -/
+theorem evmWordIs_sp64_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
+     ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs (sp + 64) v ** Q) := by
+  rw [evmWordIs_sp64_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 /-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
     equalities. Decouples the caller's representation of `v` from the limb
     form — works uniformly whether the equalities come from

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -438,6 +438,20 @@ theorem evmStackIs_snoc (sp : Word) (xs : List EvmWord) (v : EvmWord) :
     (evmStackIs sp xs ** evmWordIs (sp + BitVec.ofNat 64 (xs.length * 32)) v) := by
   rw [evmStackIs_append, evmStackIs_single]
 
+/-- `evmStackIs sp ([] ++ xs) = evmStackIs sp xs`. Trivial consequence of
+    `List.nil_append`. Named so call sites can reach for it by name
+    rather than chaining `List.nil_append` + `evmStackIs_congr`. -/
+theorem evmStackIs_nil_append (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp ([] ++ xs) = evmStackIs sp xs := by
+  rw [List.nil_append]
+
+/-- `evmStackIs sp (xs ++ []) = evmStackIs sp xs`. Symmetric companion
+    of `evmStackIs_nil_append`. Useful when a `List.map`-produced
+    suffix turns out to be empty. -/
+theorem evmStackIs_append_nil (sp : Word) (xs : List EvmWord) :
+    evmStackIs sp (xs ++ []) = evmStackIs sp xs := by
+  rw [List.append_nil]
+
 /-- Mid-tree variant of `evmStackIs_append`: threads a remainder `Q` so
     `rw ←` can fold two contiguous `evmStackIs` segments back into a single
     `evmStackIs sp (xs ++ ys)` bundle even when they sit in the middle of a


### PR DESCRIPTION
## Summary
- Add direct mid-tree fold variants of `evmWordIs_sp{,32,64}_unfold`:
  - `evmWordIs_sp_unfold_right`
  - `evmWordIs_sp32_unfold_right`
  - `evmWordIs_sp64_unfold_right`
- Thread a remainder `Q` so `rw ←` can fold `(sp ↦ₘ v.getLimbN 0) ** …` back into `evmWordIs sp v` (resp. `sp+32`, `sp+64`) even when the atoms sit mid-chain.
- Simpler call than the `_limbs_eq_right` family when the caller already has the atoms in `v.getLimbN k` form — no explicit `hk` threads needed.

## Test plan
- [x] `lake build EvmAsm.Evm64.Stack` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)