### PR TITLE
refactor(shift,signext,byte): remove unused private lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -35,18 +35,6 @@ open EvmAsm.Rv64.AddrNorm (se13_20 se13_44 se13_68 se13_128 se13_140 se21_16 se2
 abbrev evm_byte_code (base : Word) : CodeReq :=
   CodeReq.ofProg base evm_byte
 
--- Program length verification
-private theorem byte_phase_a_len : byte_phase_a.length = 9 := by decide
-private theorem byte_phase_b_len : byte_phase_b.length = 5 := by decide
-private theorem byte_phase_c_len : byte_phase_c.length = 5 := by decide
-private theorem byte_body_3_len : byte_body_3.length = 4 := by decide
-private theorem byte_body_2_len : byte_body_2.length = 4 := by decide
-private theorem byte_body_1_len : byte_body_1.length = 4 := by decide
-private theorem byte_body_0_len : byte_body_0.length = 3 := by decide
-private theorem byte_store_len : byte_store.length = 6 := by decide
-private theorem byte_zero_path_len : byte_zero_path.length = 5 := by decide
-private theorem evm_byte_len : evm_byte.length = 45 := by decide
-
 -- ============================================================================
 -- CodeReq subsumption: each sub-phase code ⊆ evm_byte_code
 -- ============================================================================

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -66,13 +66,6 @@ abbrev shrCode (base : Word) : CodeReq :=
 -- Phase A union-chain ⊆ ofProg bridge (`shr_phase_a_code_sub_ofProg`) is shared
 -- and lives in `ComposeBase`.
 
-/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shrCode (block 0). -/
-private theorem phase_a_sub_shrCode (base : Word) :
-    ∀ a i, shr_phase_a_code base a = some i → shrCode base a = some i := by
-  intro a i h
-  unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i (shr_phase_a_code_sub_ofProg base a i h)
-
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shrCode (block 1). -/
 private theorem phase_b_sub_shrCode (base : Word) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shrCode base a = some i := by

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -65,13 +65,6 @@ abbrev shlCode (base : Word) : CodeReq :=
 -- Phase A union-chain ⊆ ofProg bridge (`shr_phase_a_code_sub_ofProg`) is shared
 -- and lives in `ComposeBase`.
 
-/-- Phase A code (union chain, 9 instrs at +0) is subsumed by shlCode (block 0). -/
-private theorem phase_a_sub_shlCode (base : Word) :
-    ∀ a i, shr_phase_a_code base a = some i → shlCode base a = some i := by
-  intro a i h
-  unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i (shr_phase_a_code_sub_ofProg base a i h)
-
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shlCode (block 1). -/
 private theorem phase_b_sub_shlCode (base : Word) :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shlCode base a = some i := by

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -46,33 +46,6 @@ private theorem singleton_sub_signextCode (base addr : Word) (instr : Instr) (k 
 -- Section 2: Subsumption lemmas
 -- ============================================================================
 
-/-- Phase A code (union chain, 9 instrs at +0) is subsumed by signextCode. -/
-private theorem phase_a_sub_signextCode (base : Word) :
-    ∀ a i, signext_phase_a_code base a = some i → signextCode base a = some i := by
-  unfold signext_phase_a_code
-  apply CodeReq.union_sub
-  · exact singleton_sub_signextCode base base (.LD .x5 .x12 8) 0
-      (by decide) (by bv_omega) (by decide)
-  · apply CodeReq.union_sub
-    · unfold signext_ld_or_acc_code
-      exact CodeReq.ofProg_mono_sub base (base + 4) evm_signextend (signext_ld_or_acc_prog 16) 1
-        (by bv_omega) (by decide) (by decide) (by decide)
-    · apply CodeReq.union_sub
-      · unfold signext_ld_or_acc_code
-        exact CodeReq.ofProg_mono_sub base (base + 12) evm_signextend (signext_ld_or_acc_prog 24) 3
-          (by bv_omega) (by decide) (by decide) (by decide)
-      · apply CodeReq.union_sub
-        · exact singleton_sub_signextCode base (base + 20) (.BNE .x5 .x0 168) 5
-            (by decide) (by bv_omega) (by decide)
-        · apply CodeReq.union_sub
-          · exact singleton_sub_signextCode base (base + 24) (.LD .x5 .x12 0) 6
-              (by decide) (by bv_omega) (by decide)
-          · apply CodeReq.union_sub
-            · exact singleton_sub_signextCode base (base + 28) (.SLTIU .x10 .x5 31) 7
-                (by decide) (by bv_omega) (by decide)
-            · exact singleton_sub_signextCode base (base + 32) (.BEQ .x10 .x0 156) 8
-                (by decide) (by bv_omega) (by decide)
-
 /-- Phase B code (ofProg, 5 instrs at +36) is subsumed by signextCode. -/
 private theorem phase_b_sub_signextCode (base : Word) :
     ∀ a i, signext_phase_b_code (base + 36) a = some i → signextCode base a = some i := by


### PR DESCRIPTION
## Summary
More dead code removal (follow-up to #519):

- \`Shift/Compose.lean\`: \`phase_a_sub_shrCode\`
- \`Shift/ShlCompose.lean\`: \`phase_a_sub_shlCode\`
- \`SignExtend/Compose.lean\`: \`phase_a_sub_signextCode\` (large unused subsumption lemma)
- \`Byte/Spec.lean\`: 9 unused program-length theorems (\`byte_phase_a_len\`, \`byte_phase_b_len\`, \`byte_phase_c_len\`, \`byte_body_{3,2,1,0}_len\`, \`byte_store_len\`, \`byte_zero_path_len\`, \`evm_byte_len\`)

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)