### PR TITLE
refactor(divmod/compose): remove unused private lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -48,12 +48,6 @@ private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
 -- Abbreviation for repeated `by decide` / `by bv_addr` calls
 -- Each block's subsumption uses: CodeReq.union_sub (d128_sub ...) (CodeReq.union_sub ...)
 
--- Address normalization: block entry offsets relative to (base + div128Off)
-private theorem d128_off_40 (base : Word) : (base + div128Off : Word) + 40 = base + 1112 := by bv_addr
-private theorem d128_off_100 (base : Word) : (base + div128Off : Word) + 100 = base + 1172 := by bv_addr
-private theorem d128_off_120 (base : Word) : (base + div128Off : Word) + 120 = base + 1192 := by bv_addr
-private theorem d128_off_180 (base : Word) : (base + div128Off : Word) + 180 = base + 1252 := by bv_addr
-
 -- ============================================================================
 -- div128_spec: compose 5 block specs into single subroutine theorem.
 -- Entry: base+1072, Exit: ret_addr (via JALR), CodeReq: sharedDivModCode base.

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -27,17 +27,6 @@ private theorem divK_denorm_code_sub_divCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-/-- Helper: Denorm sub-block subsumption via ofProg_mono_sub. -/
-private theorem denorm_sub (base : Word) (sub_prog : List Instr) (k : Nat)
-    (hk : k + sub_prog.length ≤ divK_denorm.length)
-    (hslice : (divK_denorm.drop k).take sub_prog.length = sub_prog)
-    (hbound : 4 * divK_denorm.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + denormOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
-      (divCode base) a = some i := by
-  intro a i h
-  exact divK_denorm_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + denormOff) _ divK_denorm _ k rfl hslice hk hbound a i h)
-
 /-- Denorm preamble for shift≠0: LD shift from memory + BEQ not taken.
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
 theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -47,12 +47,6 @@ private theorem d128_sub_mod (base : Word) (k : Nat) (addr : Word) (instr : Inst
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
--- Address normalization: block entry offsets relative to (base + div128Off)
-private theorem d128_off_40_mod (base : Word) : (base + div128Off : Word) + 40 = base + 1112 := by bv_addr
-private theorem d128_off_100_mod (base : Word) : (base + div128Off : Word) + 100 = base + 1172 := by bv_addr
-private theorem d128_off_120_mod (base : Word) : (base + div128Off : Word) + 120 = base + 1192 := by bv_addr
-private theorem d128_off_180_mod (base : Word) : (base + div128Off : Word) + 180 = base + 1252 := by bv_addr
-
 -- ============================================================================
 -- mod_div128_spec: compose 5 block specs into single subroutine theorem.
 -- Entry: base+1072, Exit: ret_addr (via JALR), CodeReq: modCode base.

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -27,17 +27,6 @@ private theorem divK_denorm_code_sub_modCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-/-- Helper: Denorm sub-block subsumption via ofProg_mono_sub for modCode. -/
-private theorem denorm_sub_mod (base : Word) (sub_prog : List Instr) (k : Nat)
-    (hk : k + sub_prog.length ≤ divK_denorm.length)
-    (hslice : (divK_denorm.drop k).take sub_prog.length = sub_prog)
-    (hbound : 4 * divK_denorm.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + denormOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
-      (modCode base) a = some i := by
-  intro a i h
-  exact divK_denorm_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + denormOff) _ divK_denorm _ k rfl hslice hk hbound a i h)
-
 /-- Full Denorm (shift body only) for modCode: denormalize u[0..3] by right-shifting.
     base+904+16 → base+904+100 (21 instructions: ADDI+SUB + 3×merge + last).
     Used when shift≠0. The BEQ and LD are handled separately.

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -27,17 +27,6 @@ private theorem divK_normA_code_sub_modCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-/-- Helper: NormA sub-block subsumption via ofProg_mono_sub for modCode. -/
-private theorem normA_sub_mod (base : Word) (sub_prog : List Instr) (k : Nat)
-    (hk : k + sub_prog.length ≤ (divK_normA 40).length)
-    (hslice : ((divK_normA 40).drop k).take sub_prog.length = sub_prog)
-    (hbound : 4 * (divK_normA 40).length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + normAOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
-      (modCode base) a = some i := by
-  intro a i h
-  exact divK_normA_code_sub_modCode base a i
-    (CodeReq.ofProg_mono_sub (base + normAOff) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
-
 -- signExtend12 for src/dst offsets used by normA specs
 -- `mod_se12_{0,8,16,24}` removed: use `signExtend12_{0,8,16,24}` from Rv64/Instructions.lean.
 -- `signExtend21_40` → use `signExtend21_40` from `Compose/Base.lean`.

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -119,17 +119,6 @@ private theorem divK_normB_code_sub_divCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-/-- Helper: NormB sub-block subsumption via ofProg_mono_sub. -/
-private theorem normB_sub (base : Word) (sub_prog : List Instr) (k : Nat)
-    (hk : k + sub_prog.length ≤ divK_normB.length)
-    (hslice : (divK_normB.drop k).take sub_prog.length = sub_prog)
-    (hbound : 4 * divK_normB.length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + normBOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
-      (divCode base) a = some i := by
-  intro a i h
-  exact divK_normB_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + normBOff) _ divK_normB _ k rfl hslice hk hbound a i h)
-
 -- se12_32, se12_40, se12_48, se12_56 are in Base.lean
 
 /-- NormB first half: merge1 (b[3] with b[2]) + merge2 (b[2] with b[1]).

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -25,17 +25,6 @@ private theorem divK_normA_code_sub_divCode (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
-/-- Helper: NormA sub-block subsumption via ofProg_mono_sub. -/
-private theorem normA_sub (base : Word) (sub_prog : List Instr) (k : Nat)
-    (hk : k + sub_prog.length ≤ (divK_normA 40).length)
-    (hslice : ((divK_normA 40).drop k).take sub_prog.length = sub_prog)
-    (hbound : 4 * (divK_normA 40).length < 2 ^ 64) :
-    ∀ a i, (CodeReq.ofProg ((base + normAOff) + BitVec.ofNat 64 (4 * k)) sub_prog) a = some i →
-      (divCode base) a = some i := by
-  intro a i h
-  exact divK_normA_code_sub_divCode base a i
-    (CodeReq.ofProg_mono_sub (base + normAOff) _ (divK_normA 40) _ k rfl hslice hk hbound a i h)
-
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
 -- signExtend13/21 rewrites pulled from the rv64_addr global set (Rv64/AddrNorm.lean).


### PR DESCRIPTION
## Summary
More dead-code cleanup under \`EvmAsm/Evm64/DivMod/Compose/\` (follow-up to #519, #521).

**Address-normalization helpers (8 unused):**
- \`Div128.lean\`: \`d128_off_{40,100,120,180}\`
- \`ModDiv128.lean\`: \`d128_off_{40,100,120,180}_mod\`

**Block-subsumption helpers (5 unused):**
- \`Epilogue.lean\`: \`denorm_sub\`
- \`ModEpilogue.lean\`: \`denorm_sub_mod\`
- \`NormA.lean\`: \`normA_sub\`
- \`ModNormA.lean\`: \`normA_sub_mod\`
- \`Norm.lean\`: \`normB_sub\`

-67 lines across 7 files.

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)