### PR TITLE
refactor(divmod/loopbody): remove 2 unused private lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -55,7 +55,6 @@ private theorem lb_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
 -- ============================================================================
 
 -- Mulsub limb base addresses (instrs [22]-[65])
-private theorem lb_ms0 (base : Word) : (base + loopBodyOff : Word) + 88 = base + 536 := by bv_addr
 private theorem lb_ms1 (base : Word) : (base + 536 : Word) + 44 = base + 580 := by bv_addr
 private theorem lb_ms2 (base : Word) : (base + 580 : Word) + 44 = base + 624 := by bv_addr
 private theorem lb_ms3 (base : Word) : (base + 624 : Word) + 44 = base + 668 := by bv_addr
@@ -227,7 +226,6 @@ theorem divK_mulsub_4limbs_spec
 -- ============================================================================
 
 -- Addback base addresses (instrs [71]-[107])
-private theorem lb_ab_init (base : Word) : (base + loopBodyOff : Word) + 284 = base + 732 := by bv_addr
 private theorem lb_ab0 (base : Word) : (base + 732 : Word) + 4 = base + 736 := by bv_addr
 private theorem lb_ab0_end (base : Word) : (base + 736 : Word) + 32 = base + 768 := by bv_addr
 private theorem lb_ab1_end (base : Word) : (base + 768 : Word) + 32 = base + 800 := by bv_addr


### PR DESCRIPTION
## Summary
Dead code removal:

- \`LoopBody.lean\`: \`lb_ms0\`, \`lb_ab_init\` (both unreferenced block-entry address normalizations via \`bv_addr\`).

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)