### PR TITLE
refactor(divmod): move pcFree_divScratchOwn to Compose/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -354,6 +354,15 @@ instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
   ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem⟩
 
+/-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
+    through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
+theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+  rw [divScratchOwn_unfold]; pcFree
+
+instance pcFreeInst_divScratchOwn (sp : Word) :
+    Assertion.PCFree (divScratchOwn sp) :=
+  ⟨pcFree_divScratchOwn sp⟩
+
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
 theorem divScratchValues_implies_divScratchOwn

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -393,12 +393,6 @@ theorem divN4MaxSkipStackPost_unfold_atoms (sp : Word) (a b : EvmWord) :
   rw [divN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchOwn_unfold]
 
-theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
-  unfold divScratchOwn; pcFree
-
-instance (sp : Word) : Assertion.PCFree (divScratchOwn sp) :=
-  ⟨pcFree_divScratchOwn sp⟩
-
 theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
     (divN4MaxSkipStackPost sp a b).pcFree := by
   rw [divN4MaxSkipStackPost_unfold]; pcFree

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -239,6 +239,34 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
   unfold evmWordIs
   rw [spAddr64_8, spAddr64_16, spAddr64_24]
 
+/-- Mid-tree variant of `evmWordIs_sp_unfold`: threads a remainder `Q` so
+    `rw ←` can fold `(sp ↦ₘ v.getLimbN 0) ** …` back into `evmWordIs sp v`
+    even when the atoms sit mid-chain. Simpler call than
+    `evmWordIs_sp_limbs_eq_right` when the caller already has the atoms
+    in `v.getLimbN k` form (no explicit `hk : v.getLimbN k = wk` threads). -/
+theorem evmWordIs_sp_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
+     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs sp v ** Q) := by
+  rw [evmWordIs_sp_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `evmWordIs_sp32_unfold`. -/
+theorem evmWordIs_sp32_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
+     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs (sp + 32) v ** Q) := by
+  rw [evmWordIs_sp32_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
+/-- Mid-tree variant of `evmWordIs_sp64_unfold`. Third-slot companion. -/
+theorem evmWordIs_sp64_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+    (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
+     ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3) ** Q) =
+    (evmWordIs (sp + 64) v ** Q) := by
+  rw [evmWordIs_sp64_unfold]
+  rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
+
 /-- Rewrite `evmWordIs sp v` to four limb atoms given explicit getLimbN
     equalities. Decouples the caller's representation of `v` from the limb
     form — works uniformly whether the equalities come from


### PR DESCRIPTION
## Summary
- Move `pcFree_divScratchOwn` theorem + instance from `Spec.lean` to `Compose/Base.lean`, next to the `divScratchOwn` definition (co-located with `pcFree_divScratchValues`).
- Switch the proof from `unfold divScratchOwn; pcFree` to `rw [divScratchOwn_unfold]; pcFree` — the supported entry through the `@[irreducible]` marker.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)