### PR TITLE
refactor(divmod): move pcFree_denormModPost to Compose/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -354,6 +354,15 @@ instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
   ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shift_mem n_mem j_mem⟩
 
+/-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
+    through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
+theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+  rw [divScratchOwn_unfold]; pcFree
+
+instance pcFreeInst_divScratchOwn (sp : Word) :
+    Assertion.PCFree (divScratchOwn sp) :=
+  ⟨pcFree_divScratchOwn sp⟩
+
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
 theorem divScratchValues_implies_divScratchOwn

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -517,6 +517,15 @@ theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
     ((sp + 48) ↦ₘ u2') ** ((sp + 56) ↦ₘ u3') := by
   delta denormModPost; rfl
 
+/-- `denormModPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_denormModPost (sp shift u0 u1 u2 u3 : Word) :
+    (denormModPost sp shift u0 u1 u2 u3).pcFree := by
+  rw [denormModPost_unfold]; pcFree
+
+instance pcFreeInst_denormModPost (sp shift u0 u1 u2 u3 : Word) :
+    Assertion.PCFree (denormModPost sp shift u0 u1 u2 u3) :=
+  ⟨pcFree_denormModPost sp shift u0 u1 u2 u3⟩
+
 -- ============================================================================
 -- Postcondition bundle for normB (PhaseAB + CLZ + PhaseC2 + NormB)
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -477,6 +477,15 @@ theorem denormDivPost_unfold (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
     ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3) := by
   delta denormDivPost; rfl
 
+/-- `denormDivPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
+    (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3).pcFree := by
+  rw [denormDivPost_unfold]; pcFree
+
+instance pcFreeInst_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
+    Assertion.PCFree (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
+  ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
+
 /-- Postcondition for MOD denorm + epilogue (shift ≠ 0).
     Encapsulates anti_shift and denormalized u'[0..3]. -/
 @[irreducible]

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -612,15 +612,6 @@ instance (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
   ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
 
-/-- `denormModPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormModPost (sp shift u0 u1 u2 u3 : Word) :
-    (denormModPost sp shift u0 u1 u2 u3).pcFree := by
-  rw [denormModPost_unfold]; pcFree
-
-instance (sp shift u0 u1 u2 u3 : Word) :
-    Assertion.PCFree (denormModPost sp shift u0 u1 u2 u3) :=
-  ⟨pcFree_denormModPost sp shift u0 u1 u2 u3⟩
-
 /-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
 theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
     (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -393,12 +393,6 @@ theorem divN4MaxSkipStackPost_unfold_atoms (sp : Word) (a b : EvmWord) :
   rw [divN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchOwn_unfold]
 
-theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
-  unfold divScratchOwn; pcFree
-
-instance (sp : Word) : Assertion.PCFree (divScratchOwn sp) :=
-  ⟨pcFree_divScratchOwn sp⟩
-
 theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
     (divN4MaxSkipStackPost sp a b).pcFree := by
   rw [divN4MaxSkipStackPost_unfold]; pcFree

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -603,15 +603,6 @@ instance (sp : Word) (a b : EvmWord) :
 -- pcFree for DivMod post bundles
 -- ============================================================================
 
-/-- `denormDivPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
-    (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3).pcFree := by
-  rw [denormDivPost_unfold]; pcFree
-
-instance (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
-    Assertion.PCFree (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
-  ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
-
 /-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
 theorem pcFree_loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by


### PR DESCRIPTION
## Summary
- Move `pcFree_denormModPost` theorem + instance from `Spec.lean` to `Compose/Base.lean`, next to the `denormModPost` definition.
- Continues the migration started in #524/#525.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)