### PR TITLE
refactor: remove 4 unused private lemmas (#263)

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -459,9 +459,6 @@ theorem eq_iff_limbs (a b : EvmWord) :
       _ = fromLimbs b.getLimb := by congr 1; funext i; exact h i
       _ = b := fromLimbs_getLimb b
 
-private theorem fromLimbs_zero : fromLimbs (fun _ => (0 : Word)) = (0 : EvmWord) := by
-  simp only [fromLimbs]; bv_decide
-
 theorem eq_zero_iff_limbs (a : EvmWord) :
     a = 0 ↔ a.getLimb 0 = 0 ∧ a.getLimb 1 = 0 ∧ a.getLimb 2 = 0 ∧ a.getLimb 3 = 0 := by
   constructor

--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -110,13 +110,6 @@ def evmCodeIs (base : Word) (bytes : List (BitVec 8)) : Assertion :=
 @[simp] theorem evmCodeIs_nil (base : Word) :
     evmCodeIs base [] = empAssertion := rfl
 
-private theorem numChunks_pos {n : Nat} (hn : 0 < n) : 0 < numChunks n := by
-  unfold numChunks; omega
-
-private theorem numChunks_step {n : Nat} (hn : 0 < n) :
-    numChunks n = numChunks (n - min n 8) + 1 := by
-  unfold numChunks; omega
-
 /-- evmCodeIs of a non-empty list decomposes into a chunk and the rest. -/
 theorem evmCodeIs_nonempty (base : Word) (bytes : List (BitVec 8)) (h : bytes ≠ []) :
     evmCodeIs base bytes =

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -55,11 +55,6 @@ theorem toNat_eq_limb_sum (v : EvmWord) :
   have hv := v.isLt  -- v.toNat < 2^256
   omega
 
--- getLimb as toNat division
-private theorem getLimb_toNat_eq (v : EvmWord) (i : Fin 4) :
-    (v.getLimb i).toNat = (v.toNat / 2 ^ (i.val * 64)) % 2 ^ 64 := by
-  simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow]
-
 -- BitVec.ult ↔ toNat comparison
 theorem ult_iff {n : Nat} (x y : BitVec n) : BitVec.ult x y ↔ x.toNat < y.toNat :=
   ⟨fun h => BitVec.lt_def.mp (of_decide_eq_true h),


### PR DESCRIPTION
## Summary
Dead code removal in shared modules:

- \`Basic.lean\`: \`fromLimbs_zero\` (also used banned tactic \`bv_decide\` per CLAUDE.md's kernel-checkable proof convention — removing it is a bonus cleanup)
- \`CodeRegion.lean\`: \`numChunks_pos\`, \`numChunks_step\`
- \`EvmWordArith/Common.lean\`: \`getLimb_toNat_eq\`

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)