### PR TITLE
refactor(seplogic): remove 9 unused disjointness lemmas (#263)

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1042,10 +1042,6 @@ private theorem singletonReg_disjoint_singletonPublicValues (r : Reg) (v : Word)
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonPublicValues vals) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
 
-private theorem singletonMem_disjoint_singletonPublicValues (a : Word) (v : Word) (vals : List (BitVec 8)) :
-    (PartialState.singletonMem a v).Disjoint (PartialState.singletonPublicValues vals) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-
 -- ============================================================================
 -- holdsFor_sepConj convenience lemmas for publicValuesIs
 -- ============================================================================
@@ -1124,14 +1120,6 @@ instance (vals : List (BitVec 8)) : Assertion.PCFree (privateInputIs vals) :=
 private theorem singletonReg_disjoint_singletonPrivateInput (r : Reg) (v : Word) (vals : List (BitVec 8)) :
     (PartialState.singletonReg r v).Disjoint (PartialState.singletonPrivateInput vals) := by
   exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-
-private theorem singletonMem_disjoint_singletonPrivateInput (a : Word) (v : Word) (vals : List (BitVec 8)) :
-    (PartialState.singletonMem a v).Disjoint (PartialState.singletonPrivateInput vals) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-
-private theorem singletonPublicValues_disjoint_singletonPrivateInput (pv : List (BitVec 8)) (pi : List (BitVec 8)) :
-    (PartialState.singletonPublicValues pv).Disjoint (PartialState.singletonPrivateInput pi) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inr rfl, Or.inl rfl⟩
 
 -- ============================================================================
 -- holdsFor_sepConj convenience lemmas for privateInputIs
@@ -1981,45 +1969,6 @@ theorem holdsFor_instrAt (a : Word) (i : Instr) (s : MachineState) :
     exact (PartialState.CompatibleWith_singletonCode a i s).mp hcompat
   · intro heq
     exact ⟨_, (PartialState.CompatibleWith_singletonCode a i s).mpr heq, rfl⟩
-
--- ============================================================================
--- Disjointness lemmas for singletonCode
--- ============================================================================
-
-private theorem singletonCode_disjoint_singletonCode (a1 a2 : Word) (i1 i2 : Instr)
-    (hne : a1 ≠ a2) :
-    (PartialState.singletonCode a1 i1).Disjoint (PartialState.singletonCode a2 i2) := by
-  refine ⟨fun r => Or.inl rfl, fun _ => Or.inl rfl, fun a => ?_, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-  simp only [PartialState.singletonCode]
-  by_cases h1 : a == a1
-  · simp [h1]
-    by_cases h2 : a == a2
-    · exfalso
-      have := beq_iff_eq.mp h1
-      have := beq_iff_eq.mp h2
-      exact hne (by rw [← ‹a = a1›, ← ‹a = a2›])
-    · exact fun hi2 => h2 (beq_iff_eq.mpr hi2)
-  · simp [h1]
-
-private theorem singletonReg_disjoint_singletonCode (r : Reg) (v : Word) (a : Word) (i : Instr) :
-    (PartialState.singletonReg r v).Disjoint (PartialState.singletonCode a i) := by
-  exact ⟨fun _ => Or.inr rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-
-private theorem singletonMem_disjoint_singletonCode (a : Word) (v : Word) (a' : Word) (i : Instr) :
-    (PartialState.singletonMem a v).Disjoint (PartialState.singletonCode a' i) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inr rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inl rfl⟩
-
-private theorem singletonPC_disjoint_singletonCode (v : Word) (a : Word) (i : Instr) :
-    (PartialState.singletonPC v).Disjoint (PartialState.singletonCode a i) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inr rfl, Or.inl rfl, Or.inl rfl⟩
-
-private theorem singletonPublicValues_disjoint_singletonCode (vals : List (BitVec 8)) (a : Word) (i : Instr) :
-    (PartialState.singletonPublicValues vals).Disjoint (PartialState.singletonCode a i) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inr rfl, Or.inl rfl⟩
-
-private theorem singletonPrivateInput_disjoint_singletonCode (vals : List (BitVec 8)) (a : Word) (i : Instr) :
-    (PartialState.singletonPrivateInput vals).Disjoint (PartialState.singletonCode a i) := by
-  exact ⟨fun _ => Or.inl rfl, fun _ => Or.inl rfl, fun _ => Or.inl rfl, Or.inl rfl, Or.inl rfl, Or.inr rfl⟩
 
 -- ============================================================================
 -- pcFree for code assertions


### PR DESCRIPTION
## Summary
Dead code removal in \`EvmAsm/Rv64/SepLogic.lean\`. All nine lemmas are private and never referenced elsewhere in the codebase:

**cross-region disjointness:**
- \`singletonMem_disjoint_singletonPublicValues\`
- \`singletonMem_disjoint_singletonPrivateInput\`
- \`singletonPublicValues_disjoint_singletonPrivateInput\`

**singletonCode-side disjointness:**
- \`singletonCode_disjoint_singletonCode\`
- \`singletonReg_disjoint_singletonCode\`
- \`singletonMem_disjoint_singletonCode\`
- \`singletonPC_disjoint_singletonCode\`
- \`singletonPublicValues_disjoint_singletonCode\`
- \`singletonPrivateInput_disjoint_singletonCode\`

-51 lines.

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)