### PR TITLE
refactor(divmod): move pcFree_normBPost to Compose/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -579,6 +579,15 @@ theorem normBPost_unfold (sp n_val shift b0 b1 b2 b3 : Word) :
     ((sp + signExtend12 3992) ↦ₘ shift) := by
   delta normBPost; rfl
 
+/-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
+    (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by
+  rw [normBPost_unfold]; pcFree
+
+instance pcFreeInst_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (normBPost sp n_val shift b0 b1 b2 b3) :=
+  ⟨pcFree_normBPost sp n_val shift b0 b1 b2 b3⟩
+
 -- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:
 -- they now live canonically in `Rv64/AddrNorm.lean` as part of the

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -438,6 +438,16 @@ theorem loopSetupPost_unfold (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     ((sp + signExtend12 3992) ↦ₘ shift) := by
   delta loopSetupPost; rfl
 
+/-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
+theorem pcFree_loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
+  rw [loopSetupPost_unfold]; pcFree
+
+instance pcFreeInst_loopSetupPost
+    (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
+  ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
+
 -- ============================================================================
 -- Postcondition bundles for denorm + epilogue paths
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -603,15 +603,6 @@ instance (sp : Word) (a b : EvmWord) :
 -- pcFree for DivMod post bundles
 -- ============================================================================
 
-/-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
-    (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by
-  rw [normBPost_unfold]; pcFree
-
-instance (sp n_val shift b0 b1 b2 b3 : Word) :
-    Assertion.PCFree (normBPost sp n_val shift b0 b1 b2 b3) :=
-  ⟨pcFree_normBPost sp n_val shift b0 b1 b2 b3⟩
-
 /-- `fullDivN4MaxSkipPost` is pc-free: all its atoms (inside the
     `denormDivPost` sub-bundle plus the top-level wrapper atoms) are
     `regIs` / `memIs`. Proof goes through `delta` since the bundle is

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -603,15 +603,6 @@ instance (sp : Word) (a b : EvmWord) :
 -- pcFree for DivMod post bundles
 -- ============================================================================
 
-/-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
-  rw [loopSetupPost_unfold]; pcFree
-
-instance (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
-
 /-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
 theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
     (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by


### PR DESCRIPTION
## Summary
- Move `pcFree_normBPost` theorem + instance from `Spec.lean` to `Compose/Base.lean`, next to the `normBPost` definition.
- Continues the pcFree co-location migration (#524 / #525 / #526 / #528).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)