### PR TITLE
refactor(compose/base): remove 6 unused phB_off_K theorems (#263)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -589,12 +589,6 @@ theorem normBPost_unfold (sp n_val shift b0 b1 b2 b3 : Word) :
 -- in PhaseAB.lean and `mod_phB_off_28` in ModPhaseB.lean.
 -- ============================================================================
 
-theorem phB_off_4  (base : Word) : (base + phaseBOff : Word) + 4  = base + 36 := by bv_addr
-theorem phB_off_8  (base : Word) : (base + phaseBOff : Word) + 8  = base + 40 := by bv_addr
-theorem phB_off_12 (base : Word) : (base + phaseBOff : Word) + 12 = base + 44 := by bv_addr
-theorem phB_off_16 (base : Word) : (base + phaseBOff : Word) + 16 = base + 48 := by bv_addr
-theorem phB_off_20 (base : Word) : (base + phaseBOff : Word) + 20 = base + 52 := by bv_addr
-theorem phB_off_24 (base : Word) : (base + phaseBOff : Word) + 24 = base + 56 := by bv_addr
 theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
 
 -- n=4 special: x1 = signExtend12 4 - 4 = 0, used by the shift-0 fast path


### PR DESCRIPTION
## Summary
Dead code removal in \`EvmAsm/Evm64/DivMod/Compose/Base.lean\`:
- \`phB_off_4\`, \`phB_off_8\`, \`phB_off_12\`, \`phB_off_16\`, \`phB_off_20\`, \`phB_off_24\`

Only \`phB_off_28\` is currently referenced (by \`PhaseAB\` / \`ModPhaseB\` / \`ModPhaseBn3\` / \`ModPhaseBn21\`). The other 6 were set up as a shared family for phaseB sub-block address normalizations but no consumer ever called them.

Part of #263.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)