### PR TITLE
refactor(divmod): use divScratchValues_implies_divScratchOwn in weakeners

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -30,10 +30,13 @@
   * Weakeners: `div_n4_max_skip_stack_weaken`, `mod_n4_max_skip_stack_weaken` —
     turn specific register values + `evmWordIs` operand atoms + `divScratchValues`
     into `divN4MaxSkipStackPost` / `modN4MaxSkipStackPost`.
-  * `pcFree` instances for every bundle (`divScratchOwn`, `divScratchValues`,
-    `divN4StackPre`, `modN4StackPre`, `divN4MaxSkipStackPost`,
-    `modN4MaxSkipStackPost`, `fullDivN4MaxSkipPost`, `denormDivPost`,
-    `denormModPost`, `loopSetupPost`, `normBPost`).
+  * `pcFree` instances for the stack-pre/post bundles defined here
+    (`divN4StackPre`, `modN4StackPre`, `divN4MaxSkipStackPost`,
+    `modN4MaxSkipStackPost`). `pcFree` instances for the post bundles
+    defined in `Compose/Base.lean` (`divScratchOwn`, `denormDivPost`,
+    `denormModPost`, `loopSetupPost`, `normBPost`) live next to their
+    defs, as does `pcFree_fullDivN4MaxSkipPost` in
+    `Compose/FullPathN4.lean`.
   * Pre-wrapper: `evm_div_n4_full_max_skip_stack_pre_spec` and its bundled
     variant `evm_div_n4_full_max_skip_stack_pre_spec_bundled` — wrap the
     limb-level full-path spec in the EvmWord-level pre shape.

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -426,16 +426,15 @@ theorem div_n4_max_skip_stack_weaken
          u5_p u6_p u7_p shift_p n_p j_p) h →
       divN4MaxSkipStackPost sp a b h := by
   intro h hp
-  rw [divScratchValues_unfold] at hp
   delta divN4MaxSkipStackPost
-  unfold divScratchOwn
   refine sepConj_mono_right ?_ h hp
   iterate 7 apply sepConj_mono (regIs_implies_regOwn _ _)
   apply sepConj_mono_right
   apply sepConj_mono_right
   apply sepConj_mono_right
-  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
-  exact memIs_implies_memOwn _ _
+  exact divScratchValues_implies_divScratchOwn
+    sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    shift_p n_p j_p
 
 /-- MOD counterpart of `divN4MaxSkipStackPost`: same structure, same register
     and scratch handling, but the second operand slot holds `EvmWord.mod a b`
@@ -656,16 +655,15 @@ theorem mod_n4_max_skip_stack_weaken
          u5_p u6_p u7_p shift_p n_p j_p) h →
       modN4MaxSkipStackPost sp a b h := by
   intro h hp
-  rw [divScratchValues_unfold] at hp
   delta modN4MaxSkipStackPost
-  unfold divScratchOwn
   refine sepConj_mono_right ?_ h hp
   iterate 7 apply sepConj_mono (regIs_implies_regOwn _ _)
   apply sepConj_mono_right
   apply sepConj_mono_right
   apply sepConj_mono_right
-  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
-  exact memIs_implies_memOwn _ _
+  exact divScratchValues_implies_divScratchOwn
+    sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    shift_p n_p j_p
 
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
     guarantee (full-path DIV from `base` to `base + nopOff` on the n=4 max+skip


### PR DESCRIPTION
## Summary
- Simplify both `div_n4_max_skip_stack_weaken` and `mod_n4_max_skip_stack_weaken`: delegate the 15-cell memIs → memOwn weakening to the named `divScratchValues_implies_divScratchOwn` lemma instead of inlining 15 `sepConj_mono` applications.
- Drops the now-unnecessary `rw [divScratchValues_unfold]` + `unfold divScratchOwn` — the named weakening lemma handles those through its own `@[irreducible]`-safe proof.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)