### PR TITLE
feat(divmod/spec): add evmWordIs_{div,mod}_zero_right rewrite

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -52,6 +52,20 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- `evmWordIs addr (EvmWord.div a 0) = evmWordIs addr 0`. Specialized
+    rewrite for the zero-divisor path, bundling `evmWordIs_congr` +
+    `EvmWord.div_zero_right` into a single named lemma. Saves the inline
+    `rw [evmWordIs_congr addr (EvmWord.div_zero_right a)]` idiom at each
+    bzero spec's postcondition site. -/
+theorem evmWordIs_div_zero_right (addr : Word) (a : EvmWord) :
+    evmWordIs addr (EvmWord.div a 0) = evmWordIs addr (0 : EvmWord) :=
+  evmWordIs_congr addr (EvmWord.div_zero_right a)
+
+/-- MOD counterpart of `evmWordIs_div_zero_right`. -/
+theorem evmWordIs_mod_zero_right (addr : Word) (a : EvmWord) :
+    evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
+  evmWordIs_congr addr (EvmWord.mod_zero_right a)
+
 -- ============================================================================
 -- EvmWord-level runtime condition predicates for the n=4 max path
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add two specialized rewrites for the zero-divisor path:
  - `evmWordIs_div_zero_right addr a : evmWordIs addr (div a 0) = evmWordIs addr 0`
  - `evmWordIs_mod_zero_right addr a : evmWordIs addr (mod a 0) = evmWordIs addr 0`
- Bundle `evmWordIs_congr` + `EvmWord.{div,mod}_zero_right` into one named lemma — saves the inline `rw [evmWordIs_congr addr (...)]` idiom at each bzero spec's postcondition site.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)