### PR TITLE
Revert PR #542: restore evm_mod_n2/n3_shift0_to_loopSetup_spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -223,4 +223,133 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (fun h hq => by delta loopSetupPost; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Full n=2 path to LoopSetup (shift = 0): base → base+448
+-- ============================================================================
+
+/-- MOD full n=3 path (shift = 0): b[3]=b[2]=0, b[1]≠0, clzResult(b1).1=0.
+    base → base+448. b[] already normalized, u[] = copy of a[]. -/
+theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_z : (clzResult b1).1 = 0) :
+    cpsTriple base (base + loopBodyOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b1).1) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (2 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) := by
+  -- Step 1: PhaseAB(n=2) + CLZ (base → base+212)
+  have hABCLZ := evm_mod_phaseAB_n2_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1nz
+
+  have hABCLZf := cpsTriple_frame_left _ _ _ _ _
+    ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+     ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+     ((sp + signExtend12 4024) ↦ₘ u4_old) **
+     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+    (by pcFree) hABCLZ
+  -- Step 2: PhaseC2 taken (base+212 → base+396)
+  have hC2 := mod_phaseC2_taken_spec sp ((clzResult b1).1)
+    ((clzResult b1).2 >>> (63 : Nat)) shift_mem base hshift_z
+  have hC2f := cpsTriple_frame_left _ _ _ _ _
+    ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+     ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+     ((sp + signExtend12 4024) ↦ₘ u4_old) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  -- Step 3: CopyAU (base+396 → base+432)
+  have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
+    u0_old u1_old u2_old u3_old u4_old ((clzResult b1).2) base
+
+  simp only [EvmAsm.Evm64.DivMod.AddrNorm.se12_0] at hCopy
+  have hCopyf := cpsTriple_frame_left _ _ _ _ _
+    ((.x6 ↦ᵣ (clzResult b1).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b1).1) **
+     (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
+    (by pcFree) hCopy
+  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABC2 hCopyf
+  -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
+  have hLS := mod_loopSetup_ntaken_spec sp (2 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) a3 base
+    (by decide)
+  have hLSf := cpsTriple_frame_left _ _ _ _ _
+    ((.x10 ↦ᵣ b3) **
+     (.x6 ↦ᵣ (clzResult b1).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b1).1) **
+     (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+     ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
+    (by pcFree) hLS
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABC2C hLSf
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -223,4 +223,133 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (fun h hq => by delta loopSetupPost; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Full n=3 path to LoopSetup (shift = 0): base → base+448
+-- ============================================================================
+
+/-- MOD full n=3 path (shift = 0): b[3]=0, b[2]≠0, clzResult(b2).1=0.
+    base → base+448. b[] already normalized, u[] = copy of a[]. -/
+theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_z : (clzResult b2).1 = 0) :
+    cpsTriple base (base + loopBodyOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+       (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b2).1) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (3 : Word)) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+       ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+       ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+       ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) := by
+  -- Step 1: PhaseAB(n=3) + CLZ (base → base+212)
+  have hABCLZ := evm_mod_phaseAB_n3_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2nz
+
+  have hABCLZf := cpsTriple_frame_left _ _ _ _ _
+    ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+     ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+     ((sp + signExtend12 4024) ↦ₘ u4_old) **
+     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+    (by pcFree) hABCLZ
+  -- Step 2: PhaseC2 taken (base+212 → base+396)
+  have hC2 := mod_phaseC2_taken_spec sp ((clzResult b2).1)
+    ((clzResult b2).2 >>> (63 : Nat)) shift_mem base hshift_z
+  have hC2f := cpsTriple_frame_left _ _ _ _ _
+    ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+     ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+     ((sp + signExtend12 4024) ↦ₘ u4_old) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
+    (by pcFree) hC2
+  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABCLZf hC2f
+  -- Step 3: CopyAU (base+396 → base+432)
+  have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
+    u0_old u1_old u2_old u3_old u4_old ((clzResult b2).2) base
+
+  simp only [EvmAsm.Evm64.DivMod.AddrNorm.se12_0] at hCopy
+  have hCopyf := cpsTriple_frame_left _ _ _ _ _
+    ((.x6 ↦ᵣ (clzResult b2).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b2).1) **
+     (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
+    (by pcFree) hCopy
+  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABC2 hCopyf
+  -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
+  have hLS := mod_loopSetup_ntaken_spec sp (3 : Word)
+    (signExtend12 (4 : BitVec 12) - (4 : Word)) a3 base
+    (by decide)
+  have hLSf := cpsTriple_frame_left _ _ _ _ _
+    ((.x10 ↦ᵣ b3) **
+     (.x6 ↦ᵣ (clzResult b2).1) **
+     (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b2).1) **
+     (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+     ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
+     ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
+    (by pcFree) hLS
+  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp) hABC2C hLSf
+  exact cpsTriple_consequence _ _ _ _ _ _ _
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Reverts #542 which removed `evm_mod_n2_shift0_to_loopSetup_spec` and `evm_mod_n3_shift0_to_loopSetup_spec` from `ModFullPathN2.lean` / `ModFullPathN3.lean`.
- These theorems were flagged as dead code, but are intermediate results intended to be used in upcoming work (n=2/n=3 siblings of the n=4 case reverted in #550).

## Test plan
- [ ] `lake build` succeeds