### PR TITLE
feat(divmod/spec): add evmWordIs_{div,mod}_zero_right_atoms unfold

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -66,6 +66,22 @@ theorem evmWordIs_mod_zero_right (addr : Word) (a : EvmWord) :
     evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
   evmWordIs_congr addr (EvmWord.mod_zero_right a)
 
+/-- Full unfold of `evmWordIs addr (EvmWord.div a 0)` straight to four zero
+    memIs atoms, bundling `evmWordIs_div_zero_right` + `evmWordIs_zero`
+    into a single rewrite. -/
+theorem evmWordIs_div_zero_right_atoms (addr : Word) (a : EvmWord) :
+    evmWordIs addr (EvmWord.div a 0) =
+    ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
+     ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
+  rw [evmWordIs_div_zero_right, evmWordIs_zero]
+
+/-- MOD counterpart of `evmWordIs_div_zero_right_atoms`. -/
+theorem evmWordIs_mod_zero_right_atoms (addr : Word) (a : EvmWord) :
+    evmWordIs addr (EvmWord.mod a 0) =
+    ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
+     ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
+  rw [evmWordIs_mod_zero_right, evmWordIs_zero]
+
 -- ============================================================================
 -- EvmWord-level runtime condition predicates for the n=4 max path
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Add one-step unfolds of `evmWordIs addr (EvmWord.{div,mod} a 0)` straight to four zero memIs atoms:
  - `evmWordIs_div_zero_right_atoms`
  - `evmWordIs_mod_zero_right_atoms`
- Bundles the two-step `evmWordIs_{div,mod}_zero_right` + `evmWordIs_zero` chain (from #548 + Stack.lean) into a single named rewrite. Complements the shorter `_right` rewrites from #548.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)