### PR TITLE
feat(divmod/spec): add reshape sublemmas S2 + S3 for the DIV stack spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -857,4 +857,44 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
         from by xperm) h).mp w1)
     h_raw
 
+-- ============================================================================
+-- Sublemmas towards evm_div_n4_max_skip_stack_spec (reshape plan)
+-- ============================================================================
+
+/-- Output-slot semantic reshape ("S2" from the reshape plan): the four
+    output-slot atoms in `fullDivN4MaxSkipPost` carry the concrete values
+    `signExtend12 4095 / 0 / 0 / 0`. Under the semantic precondition
+    `n4MaxSkipSemanticHolds` (and shift non-zero), those values equal
+    `(EvmWord.div a b).getLimbN 0..3`, so the four atoms fold into
+    `evmWordIs (sp + 32) (EvmWord.div a b)`. -/
+theorem output_slot_to_evmWordIs_div_n4_max_skip (sp : Word) (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0) (hsem : n4MaxSkipSemanticHolds a b) :
+    (((sp + 32) ↦ₘ (signExtend12 4095 : Word)) **
+     ((sp + 40) ↦ₘ (0 : Word)) **
+     ((sp + 48) ↦ₘ (0 : Word)) **
+     ((sp + 56) ↦ₘ (0 : Word))) =
+    evmWordIs (sp + 32) (EvmWord.div a b) := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3, _, _, _, _⟩ :=
+    n4_max_skip_div_mod_getLimbN a b hb3nz hsem
+  rw [evmWordIs_sp32_limbs_eq sp (EvmWord.div a b) _ _ _ _
+      hdiv0 hdiv1 hdiv2 hdiv3]
+
+/-- MOD counterpart of `output_slot_to_evmWordIs_div_n4_max_skip`: on the
+    max+skip path, the mod result limbs equal the four `mulsubN4` outputs. -/
+theorem output_slot_to_evmWordIs_mod_n4_max_skip (sp : Word) (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0) (hsem : n4MaxSkipSemanticHolds a b) :
+    let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (((sp + 32) ↦ₘ ms.1) **
+     ((sp + 40) ↦ₘ ms.2.1) **
+     ((sp + 48) ↦ₘ ms.2.2.1) **
+     ((sp + 56) ↦ₘ ms.2.2.2.1)) =
+    evmWordIs (sp + 32) (EvmWord.mod a b) := by
+  obtain ⟨_, _, _, _, hmod0, hmod1, hmod2, hmod3⟩ :=
+    n4_max_skip_div_mod_getLimbN a b hb3nz hsem
+  intro _
+  rw [evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _
+      hmod0 hmod1 hmod2 hmod3]
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -217,6 +217,20 @@ theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
     ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
      ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
 
+/-- Fold four limb atoms at `sp + 0, sp + 8, sp + 16, sp + 24` into
+    `evmWordIs sp v`, normalizing the `sp + 0` offset to `sp` on the way.
+
+    This is the `← evmWordIs_sp_unfold` direction with the `sp + 0 = sp`
+    rewrite baked in, for use on post-conditions produced by the limb-level
+    DIV/MOD specs (which naturally produce `sp + 0 ↦ₘ …` atoms). Sublemma
+    "S3" from `project_div_n4_reshape_plan.md`. -/
+theorem evmWordIs_sp_fold (sp : Word) (v : EvmWord) :
+    (((sp + 0) ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
+     ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) =
+    evmWordIs sp v := by
+  rw [show (sp + 0 : Word) = sp from by bv_omega]
+  exact (evmWordIs_sp_unfold sp v).symm
+
 /-- Unfold `evmWordIs (sp+32) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+32, sp+40, sp+48, sp+56`. Bridges the
     separation-logic `evmWordIs` predicate and the raw limb atoms that the
@@ -228,6 +242,15 @@ theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
   unfold evmWordIs
   rw [spAddr32_8, spAddr32_16, spAddr32_24]
 
+/-- Companion of `evmWordIs_sp_fold` for the `b`-operand slot at `sp + 32`.
+    Folds four limb atoms at `sp + 32, +40, +48, +56` into
+    `evmWordIs (sp + 32) v`. -/
+theorem evmWordIs_sp32_fold (sp : Word) (v : EvmWord) :
+    (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
+     ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) =
+    evmWordIs (sp + 32) v :=
+  (evmWordIs_sp32_unfold sp v).symm
+
 /-- Unfold `evmWordIs (sp+64) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+64, sp+72, sp+80, sp+88`. Third-slot
     counterpart to `evmWordIs_sp32_unfold` — useful for ternary-op stack
@@ -238,6 +261,13 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) := by
   unfold evmWordIs
   rw [spAddr64_8, spAddr64_16, spAddr64_24]
+
+/-- Third-slot companion (ternary ops / ADDMOD / MULMOD). -/
+theorem evmWordIs_sp64_fold (sp : Word) (v : EvmWord) :
+    (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
+     ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) =
+    evmWordIs (sp + 64) v :=
+  (evmWordIs_sp64_unfold sp v).symm
 
 /-- Mid-tree variant of `evmWordIs_sp_unfold`: threads a remainder `Q` so
     `rw ←` can fold `(sp ↦ₘ v.getLimbN 0) ** …` back into `evmWordIs sp v`


### PR DESCRIPTION
## Summary

Step towards `evm_div_n4_max_skip_stack_spec`. Two building blocks from the reshape plan (see `project_div_n4_reshape_plan.md` in the memory log):

**S3 — `Stack.lean`** (three lemmas): `evmWordIs_sp_fold`, `evmWordIs_sp32_fold`, `evmWordIs_sp64_fold`. Fold four limb atoms at `sp + {0,8,16,24}` / `{32,40,48,56}` / `{64,72,80,88}` into the corresponding `evmWordIs`. The `_sp_fold` variant handles the `sp + 0 = sp` normalization that the limb-level DIV/MOD posts produce.

**S2 — `DivMod/Spec.lean`**: `output_slot_to_evmWordIs_div_n4_max_skip` and its MOD counterpart. Fold the four output-slot atoms (`q_hat / 0 / 0 / 0` for DIV; the four `mulsubN4` components for MOD) into `evmWordIs (sp + 32) (EvmWord.div a b)` / `… (EvmWord.mod a b)` via the `n4_max_skip_div_mod_getLimbN` semantic bridge.

Both are standalone, independent, and will be composed in S6 of the reshape plan.

## Test plan
- [x] `lake build` — clean (3405 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)