### PR TITLE
refactor(divmod/limbspec): migrate Div128 + CLZ to cpsTriple_weaken (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -166,7 +166,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
       xperm_hyp hp')
     ntaken hframed
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => by rw [heq] at hp; xperm_hyp hp)
     full
@@ -292,7 +292,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
       xperm_hyp hp')
     ntaken hframed
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => by rw [heq] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -84,7 +84,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
     have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
       exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
@@ -110,7 +110,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp') ntaken hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by xperm_hyp hp) full
 
@@ -169,7 +169,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
     have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
       exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
@@ -195,7 +195,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp') ntaken hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by xperm_hyp hp) full
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -120,7 +120,7 @@ theorem divK_div128_prodcheck1_merged_spec
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp')
       taken_br hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by xperm_hyp hp) full
   · have hq : q1' = q1 := if_neg hcond
@@ -154,7 +154,7 @@ theorem divK_div128_prodcheck1_merged_spec
         ((.x1 ↦ᵣ rhat_un1) ** (.x5 ↦ᵣ q_dlo) **
          (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
          (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo)) :=
-      cpsTriple_consequence _ _ _ _ _ _ _
+      cpsTriple_weaken
         (fun h hp => hp)
         (fun h hp => by
           have hp' : (((.x1 ↦ᵣ rhat_un1) ** (.x5 ↦ᵣ q_dlo)) **
@@ -164,7 +164,7 @@ theorem divK_div128_prodcheck1_merged_spec
               (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
           xperm_hyp hp')
         ntaken_br
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -120,7 +120,7 @@ theorem divK_div128_prodcheck2_merged_spec
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp')
       taken_br hcorr_framed
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by xperm_hyp hp) full
   · have hq : q0' = q0 := if_neg hcond
@@ -153,7 +153,7 @@ theorem divK_div128_prodcheck2_merged_spec
         ((.x1 ↦ᵣ rhat2_un0) ** (.x7 ↦ᵣ q0_dlo) **
          (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) :=
-      cpsTriple_consequence _ _ _ _ _ _ _
+      cpsTriple_weaken
         (fun h hp => hp)
         (fun h hp => by
           have hp' : (((.x1 ↦ᵣ rhat2_un0) ** (.x7 ↦ᵣ q0_dlo)) **
@@ -163,7 +163,7 @@ theorem divK_div128_prodcheck2_merged_spec
               (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
           xperm_hyp hp')
         ntaken_br
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -151,7 +151,7 @@ theorem divK_div128_step1_spec
     (by pcFree) h3
   have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h12 h3f
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     h123

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -152,7 +152,7 @@ theorem divK_div128_step2_spec
     (by pcFree) h3
   have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h12 h3f
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     h123


### PR DESCRIPTION
## Summary
Mechanical migration of all remaining \`cpsTriple_consequence _ _ _ _ _ _ _\` callsites in \`EvmAsm/Evm64/DivMod/LimbSpec/\`:

- \`CLZ.lean\` (2 callsites)
- \`Div128Clamp.lean\` (4)
- \`Div128ProdCheck1.lean\` (3)
- \`Div128ProdCheck2.lean\` (3)
- \`Div128Step1.lean\` (1)
- \`Div128Step2.lean\` (1)

14 callsites total. Follows the #565 pattern — clears deprecation warnings from the #556 transition for the div128-subroutine helpers.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)