### PR TITLE
refactor(divmod): migrate LoopComposeN{1,2,3} to cpsTriple_weaken (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -159,7 +159,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
       hcarry2_nz
     intro_lets at J3
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -170,7 +170,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
     have J3 := divK_loop_body_n1_max_skip_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
     intro_lets at J3
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -207,7 +207,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
       hcarry2_nz
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -218,7 +218,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
     have J2 := divK_loop_body_n1_max_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -256,7 +256,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
       hbltu
       hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -268,7 +268,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -307,7 +307,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
       hbltu
       hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -319,7 +319,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -368,7 +368,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J3
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -380,7 +380,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
       halign
       hbltu hborrow
     intro_lets at J3
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -425,7 +425,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -437,7 +437,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
       halign
       hbltu hborrow
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -482,7 +482,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -494,7 +494,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
       halign
       hbltu hborrow
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -540,7 +540,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -552,7 +552,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
       halign
       hbltu hborrow
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -93,7 +93,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
       hcarry2_nz
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -104,7 +104,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     have J2 := divK_loop_body_n2_max_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -142,7 +142,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
       hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -154,7 +154,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -193,7 +193,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
       hbltu
       hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -205,7 +205,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -255,7 +255,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -267,7 +267,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
       halign
       hbltu hborrow
     intro_lets at J2
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -312,7 +312,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
       hbltu hborrow
       hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -324,7 +324,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
       halign
       hbltu hborrow
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -369,7 +369,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
       halign hbltu hborrow
       hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -381,7 +381,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
       halign
       hbltu hborrow
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
@@ -456,7 +456,7 @@ theorem divK_loop_n2_max_max_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN2MaxPost
@@ -537,7 +537,7 @@ theorem divK_loop_n2_call_call_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN2CallCallPost
@@ -625,7 +625,7 @@ theorem divK_loop_n2_max_call_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN2MaxCallPost
@@ -711,7 +711,7 @@ theorem divK_loop_n2_call_max_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN2CallMaxPost

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -114,7 +114,7 @@ theorem divK_loop_n3_max_skip_skip_spec
       xperm_hyp hp)
     J1f J0f
   -- 4. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxSkipSkipPost
@@ -156,7 +156,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J1 hborrow)
@@ -167,7 +167,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J1 hborrow)
@@ -207,7 +207,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J0 hborrow)
@@ -218,7 +218,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
       hbltu
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J0 hborrow)
@@ -265,7 +265,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J1
@@ -276,7 +276,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
       halign
       hbltu hborrow
     intro_lets at J1
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by rw [← loopIterPostN3Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J1
@@ -323,7 +323,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
@@ -336,7 +336,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec
       halign
       hbltu hborrow
     intro_lets at J0
-    exact cpsTriple_consequence _ _ _ _ _ _ _
+    exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
@@ -418,7 +418,7 @@ theorem divK_loop_n3_max_max_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxPost
@@ -504,7 +504,7 @@ theorem divK_loop_n3_call_call_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallCallPost
@@ -592,7 +592,7 @@ theorem divK_loop_n3_max_call_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN3MaxCallPost
@@ -677,7 +677,7 @@ theorem divK_loop_n3_call_max_spec
       xperm_hyp hp)
     J1f J0f
   -- 5. Clean up postcondition
-  exact cpsTriple_consequence _ _ _ _ _ _ _
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
       delta loopN3CallMaxPost


### PR DESCRIPTION
## Summary
Mechanical migration of 45 \`cpsTriple_consequence _ _ _ _ _ _ _\` callsites to \`cpsTriple_weaken\`:

- \`LoopComposeN1.lean\` (16)
- \`LoopComposeN2.lean\` (16)
- \`LoopComposeN3.lean\` (13)

Follows the #565 / #566 / #567 / #569 pattern.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)