### PR TITLE
feat(divmod): add divK_loop_body_n4_max_skip_j0_norm_modCode

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -14,6 +14,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 -- ============================================================================
 -- Address normalization lemmas for j=0
@@ -172,6 +173,41 @@ theorem divK_loop_body_n4_max_skip_j0_modCode
   refine cpsTriple_weaken ?_ (fun _ hq => hq) h
   intro _ hp
   rw [loopBodyN4SkipJ0Pre_unfold] at hp
+  exact hp
+
+/-- Max_skip j=0 loop body against modCode with sp-relative addresses in the
+    precondition. Mirror of the DIV `divK_loop_body_n4_max_skip_j0_norm`
+    with `divCode → modCode`. `q_hat = signExtend12 4095` is inlined so no
+    `let` bindings appear in the statement. -/
+theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
+    (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (hbltu : ¬BitVec.ult u_top v3)
+    (hborrow : (if BitVec.ult u_top
+                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4088) ↦ₘ q_old))
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+  have raw := divK_loop_body_n4_max_skip_j0_modCode sp j_old v5_old v6_old v7_old
+    v10_old v11_old v2_old v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow
+  refine cpsTriple_weaken ?_ (fun _ hq => hq) raw
+  intro _ hp
+  rw [loopBodyN4SkipJ0Pre_unfold]
+  simp only [se12_32, se12_40, se12_48, se12_56,
+             u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+             u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
   exact hp
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -103,6 +103,77 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
     (divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow)
 
+/-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_modCode` /
+    `_divCode` code-extended loop-body specs. Wraps the 21-atom sepConj
+    chain that the `let u_base / q_addr` bindings make awkward in the
+    raw statement. Marked `@[irreducible]` so the `let`-bound offsets
+    don't pollute callers' types. -/
+@[irreducible]
+def loopBodyN4SkipJ0Pre
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word) : Assertion :=
+  let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+  (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+  (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+  ((u_base + signExtend12 4064) ↦ₘ u_top) **
+  (q_addr ↦ₘ q_old)
+
+/-- Named unfold for `loopBodyN4SkipJ0Pre`. -/
+theorem loopBodyN4SkipJ0Pre_unfold
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word) :
+    loopBodyN4SkipJ0Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old =
+    (let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+     (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
+     (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
+     (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
+     ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     (q_addr ↦ₘ q_old)) := by
+  delta loopBodyN4SkipJ0Pre; rfl
+
+/-- Extend max_skip j=0 loop body from sharedDivModCode to modCode.
+    Mirror of `divK_loop_body_n4_max_skip_j0_divCode` — same proof,
+    swapping `sharedDivModCode_sub_divCode` for
+    `sharedDivModCode_sub_modCode`. Uses the irreducible
+    `loopBodyN4SkipJ0Pre` bundle so the `let`-bound offsets don't
+    appear in the statement. -/
+theorem divK_loop_body_n4_max_skip_j0_modCode
+    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (base : Word)
+    (hbltu : ¬BitVec.ult u_top v3)
+    (hborrow : (if BitVec.ult u_top
+                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) = (0 : Word)) :
+    cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
+      (loopBodyN4SkipJ0Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old)
+      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
+    (divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow)
+  refine cpsTriple_weaken ?_ (fun _ hq => hq) h
+  intro _ hp
+  rw [loopBodyN4SkipJ0Pre_unfold] at hp
+  exact hp
+
 -- ============================================================================
 -- Call path: Loop body j=0 extended to divCode (from sharedDivModCode)
 -- ============================================================================


### PR DESCRIPTION
## Summary

Mirror of the DIV `divK_loop_body_n4_max_skip_j0_norm` theorem for `modCode`: takes sp-relative addresses directly in the precondition (no `u_base + …` form) with `q_hat = signExtend12 4095` inlined, so no `let` bindings appear in the statement.

Proved by wrapping `_modCode` (bundled pre) + `loopBodyN4SkipJ0Pre_unfold` + address normalization via the `u_base_off*_j0` and `q_addr_j0` simp lemmas.

Provides the direct-atoms shape that the forthcoming `evm_mod_n4_preloop_max_skip_spec` composition needs to frame against `evm_mod_n4_to_loopSetup_spec`'s output.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)