### PR TITLE
refactor: migrate cpsBranch_frame_left callsites to cpsBranch_frameR (#331)

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -311,7 +311,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_cr)
+      (cpsBranch_frameR (.x10 ↦ᵣ v10) (by pcFree) beq0_cr)
   -- Step 1: ADDI x10 x0 1 at base+4 (extend to cr, frame with x5)
   have addi1_raw := addi_spec_gen .x10 .x0 v10 (0 : Word) 1 (base + 4) (by nofun)
   have addi1_cr := cpsTriple_extend_code (byte_pc_sub_1 base) addi1_raw
@@ -327,7 +327,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
   -- Normalize BEQ1 ntaken exit
   have hbeq1_nf : (base + 8 : Word) + 4 = base + 12 := by bv_omega
   rw [hbeq1_nf] at beq1_raw beq1_cr
-  have beq1f := cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq1_cr
+  have beq1f := cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq1_cr
   -- Compose addi1 + beq1 (let Lean infer intermediate shapes)
   have cs1_composed := cpsTriple_seq_cpsBranch_with_perm_same_cr
     (base + 4) (base + 8) cr _ _ _ e1 _ (base + 12) _
@@ -343,7 +343,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       cs1_composed
   -- Frame cs1 with ⌜v5 ≠ 0⌝, clean up postconditions
-  have cs1_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have cs1_framed := cpsBranch_frameR
     (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_clean
   have cs1_final : cpsBranch (base + 4) cr
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
@@ -376,7 +376,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
   -- Normalize BEQ2 ntaken exit
   have hbeq2_nf : (base + 16 : Word) + 4 = base + 20 := by bv_omega
   rw [hbeq2_nf] at beq2_raw beq2_cr
-  have beq2f := cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq2_cr
+  have beq2f := cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) beq2_cr
   -- Compose addi2 + beq2 (let Lean infer intermediate shapes)
   have cs2_composed := cpsTriple_seq_cpsBranch_with_perm_same_cr
     (base + 12) (base + 16) cr _ _ _ e2 _ (base + 20) _
@@ -392,7 +392,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       cs2_composed
   -- Frame cs2 with ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝, clean up postconditions
-  have cs2_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have cs2_framed := cpsBranch_frameR
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_clean
   have cs2_final : cpsBranch (base + 12) cr
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -69,7 +69,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
-  have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbne_framed := cpsBranch_frameR
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
     (by pcFree) hbne_raw
   have hbne_ext : cpsBranch (base + 4) cr
@@ -123,7 +123,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
-  have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbne_framed := cpsBranch_frameR
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
     (by pcFree) hbne_raw
   have hbne_ext : cpsBranch (base + 4) cr
@@ -195,7 +195,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
-  have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbne_framed := cpsBranch_frameR
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
     (by pcFree) hbne_raw
   have hbne_ext : cpsBranch (base + 4) cr
@@ -250,7 +250,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
   have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
-  have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbne_framed := cpsBranch_frameR
     ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))
     (by pcFree) hbne_raw
   have hbne_ext : cpsBranch (base + 4) cr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -57,7 +57,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbeq_framed := cpsBranch_frameR
     ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
     (by pcFree) hbeq_raw
   have hbeq_ext : cpsBranch (base + 4) cr
@@ -142,7 +142,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
   have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbeq_framed := cpsBranch_frameR
     ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
     (by pcFree) hbeq_raw
   have hbeq_ext : cpsBranch (base + 4) cr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -70,7 +70,7 @@ theorem divK_div128_prodcheck1_merged_spec
   have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [se13_8]; bv_addr
   have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
-  have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbltu_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
      (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) hbltu_raw

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -71,7 +71,7 @@ theorem divK_div128_prodcheck2_merged_spec
   have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [se13_8]; bv_addr
   have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
-  have hbltu_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbltu_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hbltu_raw

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -85,7 +85,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       hblt_raw
-  have hblt_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hblt_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
      ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblt

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -89,7 +89,7 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
     hbeq_raw
   -- 3. Frame BEQ with remaining registers and memory
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbeq_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -72,7 +72,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       hbne_raw
   -- 3. Frame BNE with x5
-  have hbne_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbne_framed := cpsBranch_frameR
     (.x5 ↦ᵣ n)
     (by pcFree) hbne
   -- 4. Extend to full cr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -88,7 +88,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       hbeq_raw
-  have hbeq_framed := cpsBranch_frame_left _ _ _ _ _ _ _
+  have hbeq_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1120,7 +1120,7 @@ theorem divK_store_loop_spec
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _
+      (cpsBranch_frameR
         ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
          (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) **
          (q_addr ↦ₘ q_hat))

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -238,7 +238,7 @@ theorem divK_loop_body_n1_max_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -334,7 +334,7 @@ theorem divK_loop_body_n1_max_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
@@ -483,7 +483,7 @@ theorem divK_loop_body_n1_call_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -626,7 +626,7 @@ theorem divK_loop_body_n1_call_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -141,7 +141,7 @@ theorem divK_loop_body_n2_max_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -240,7 +240,7 @@ theorem divK_loop_body_n2_max_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
@@ -391,7 +391,7 @@ theorem divK_loop_body_n2_call_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -537,7 +537,7 @@ theorem divK_loop_body_n2_call_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -140,7 +140,7 @@ theorem divK_loop_body_n3_max_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -240,7 +240,7 @@ theorem divK_loop_body_n3_max_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
@@ -391,7 +391,7 @@ theorem divK_loop_body_n3_call_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -537,7 +537,7 @@ theorem divK_loop_body_n3_call_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -142,7 +142,7 @@ theorem divK_loop_body_n4_max_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -242,7 +242,7 @@ theorem divK_loop_body_n4_max_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
@@ -393,7 +393,7 @@ theorem divK_loop_body_n4_call_skip_spec
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
@@ -539,7 +539,7 @@ theorem divK_loop_body_n4_call_addback_spec
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
-  have SLf := cpsBranch_frame_left _ _ _ _ _ _ _
+  have SLf := cpsBranch_frameR
     ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
      (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -383,7 +383,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree)
+      (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree)
         (cpsBranch_consequence (base + 4) _ _ _
           target _ _ (base + 8) _ _
           (fun _ hp => hp)
@@ -432,7 +432,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
+      (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
   exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
     (fun _ hp => hp) s1' s2'
 
@@ -605,11 +605,11 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
+      (cpsBranch_frameR (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4 with pure facts, framed with ⌜v5 ≠ 0⌝
   have cs1_raw := shr_cascade_step_spec_pure v5 v10 1 92 (base + 4) e1 hc1
   rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1_raw
-  have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
+  have cs1f := cpsBranch_frameR (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   -- cs1f taken: (regs ** ⌜v5 = 1⌝) ** ⌜v5 ≠ 0⌝
   -- cs1f ntaken: (regs ** ⌜v5 ≠ 1⌝) ** ⌜v5 ≠ 0⌝
   have cs1_clean : cpsBranch (base + 4) cr_cs1
@@ -634,7 +634,7 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   -- Step 2: cascade step at base+12, framed with ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 32 (base + 12) e2 hc2
   rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2_raw
-  have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
+  have cs2f := cpsBranch_frameR
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   -- cs2f taken: (regs ** ⌜v5 = 2⌝) ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
   -- cs2f ntaken: (regs ** ⌜v5 ≠ 2⌝) ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -566,11 +566,11 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
+      (cpsBranch_frameR (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := shr_cascade_step_spec_pure v5 v10 1 100 (base + 4) e1 hc1
   rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1_raw
-  have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
+  have cs1f := cpsBranch_frameR (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
       e1 ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 = (0 : Word) + signExtend12 1⌝)
@@ -588,7 +588,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   -- Step 2: cascade step at base+12
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 36 (base + 12) e2 hc2
   rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2_raw
-  have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
+  have cs2f := cpsBranch_frameR
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝)

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -286,7 +286,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree)
+      (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree)
         (cpsBranch_consequence (base + 4) _ _ _
           target _ _ (base + 8) _ _
           (fun _ hp => hp)
@@ -743,7 +743,7 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
+      (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
   exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
     (fun _ hp => hp) s1' s2'
 
@@ -800,11 +800,11 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
+      (cpsBranch_frameR (.x10 ↦ᵣ v10) (by pcFree) beq0_raw)
   -- Step 1: cascade step at base+4
   have cs1_raw := signext_cascade_step_spec_pure v5 v10 1 60 (base + 4) e1 hc1
   rw [show (base + 4 : Word) + 8 = base + 12 from by bv_addr] at cs1_raw
-  have cs1f := cpsBranch_frame_left _ _ _ _ _ _ _ (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
+  have cs1f := cpsBranch_frameR (⌜v5 ≠ (0 : Word)⌝) (pcFree_pure _) cs1_raw
   have cs1_clean : cpsBranch (base + 4) cr_cs1
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜v5 ≠ (0 : Word)⌝)
       e1 ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 = (0 : Word) + signExtend12 1⌝)
@@ -822,7 +822,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   -- Step 2: cascade step at base+12
   have cs2_raw := signext_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
   rw [show (base + 12 : Word) + 8 = base + 20 from by bv_addr] at cs2_raw
-  have cs2f := cpsBranch_frame_left _ _ _ _ _ _ _
+  have cs2f := cpsBranch_frameR
     (⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) (pcFree_pure _) cs2_raw
   have cs2_clean : cpsBranch (base + 12) cr_cs2
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝)

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -137,7 +137,7 @@ theorem rlp_phase1_step_spec (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _ (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
+      (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
   exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
     (fun _ hp => hp) s1' s2'
 

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -176,7 +176,7 @@ theorem rlp_phase2_long_loop_body_spec
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsBranch_frame_left _ _ _ _ _ _ _
+      (cpsBranch_frameR
         ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x12 ↦ᵣ byte_zext) **
          (dwordAddr ↦ₘ word_val)) (by pcFree) bne_raw)


### PR DESCRIPTION
## Summary
Mass mechanical migration of 49 \`cpsBranch_frame_left _ _ _ _ _ _ _\` callsites to \`cpsBranch_frameR\` across 19 files.

Follows the established migration pattern.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)