### PR TITLE
refactor: migrate cpsTriple_seq_with_perm_same_cr to cpsTriple_seq_perm_same_cr (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -163,7 +163,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hst1e
   -- Compose phase1 → step1
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- ================================================================
   -- Block 3: Compute un21 (base+1172 → base+1192)
@@ -186,7 +186,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
   -- Compose (phase1→step1) → compute_un21
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hcuf
   -- ================================================================
   -- Block 4: Step 2 (base+1192 → base+1252)
@@ -221,7 +221,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3968 ↦ₘ ret_addr) ** (sp + signExtend12 3960 ↦ₘ d))
     (by pcFree) hst2e
   -- Compose (→step1→compute_un21) → step2
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
   -- Block 5: End (base+1252 → ret_addr via JALR)
@@ -245,7 +245,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hende
   -- Compose (→step2) → end
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 hendf
   -- Final permutation to canonical pre/post order
   exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -76,7 +76,7 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq_clean
   -- 6. Compose LD → BEQ exit
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hldf hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -133,7 +133,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hsube
-  have h_anti := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_anti := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
   have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 924)
@@ -147,7 +147,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hm0e
-  have h_m0 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m0 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
@@ -162,7 +162,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hm1e
-  have h_m1 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m1 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
@@ -177,7 +177,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1'))
     (by pcFree) hm2e
-  have h_m2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 996)
@@ -192,7 +192,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
      ((sp + signExtend12 4040) ↦ₘ u2'))
     (by pcFree) hle
-  have h_all := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_all := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m2 hlef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -256,7 +256,7 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3))
     (by pcFree) hstoree
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hloadef hstoref
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -333,7 +333,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
     (by pcFree) hbeq
   -- Step 4: Compose body → BEQ(taken): base → base+1048
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_framed
   -- Step 5: ZeroPath (base+1048 → base+1068)
   have hzp := cpsTriple_extend_code (divK_zeroPath_code_sub_modCode base)
@@ -344,7 +344,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) hzp
   -- Step 6: Compose AB → ZP: base → base+1068
-  have hABZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hzp_framed
   -- Step 7: Final consequence — rewrite bor → 0
   exact cpsTriple_weaken
@@ -388,7 +388,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
     (by pcFree) hbeq
   -- Step 4: Compose body → BEQ(ntaken): base → base+32
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_framed
   -- Step 5: Final consequence — permute assertions
   exact cpsTriple_weaken
@@ -452,7 +452,7 @@ theorem divK_mod_epilogue_spec (sp : Word) (base : Word)
     (((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hstoree
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hloadef hstoref
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -65,7 +65,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hCLZ
   -- Compose AB → CLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -121,7 +121,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hC2
   -- Compose AB+CLZ → C2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
@@ -138,7 +138,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
   -- Compose AB+CLZ+C2 → NormB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -217,7 +217,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
   -- Compose NormB → NormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
   -- Step 3: LoopSetup ntaken (base+432 → base+448)
   -- For n=4: m = signExtend12(4) - 4 = 0, so BLT 0 < 0 is false → ntaken
@@ -242,7 +242,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
   -- Compose (through NormA) → LoopSetup
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -330,7 +330,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hC2
   -- Compose AB+CLZ → C2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := divK_copyAU_full_spec sp a0 a1 a2 a3
@@ -354,7 +354,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
     (by pcFree) hCopy
   -- Compose → CopyAU
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448)
   -- For n=4: m = signExtend12(4) - 4, BLT 0 < 0 is false → ntaken
@@ -381,7 +381,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
     (by pcFree) hLS
   -- Compose all → LoopSetup
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -437,7 +437,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
      ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3'))
     (by pcFree) hEpi
   -- Compose denorm → epilogue
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hDenormF hEpiF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -488,7 +488,7 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
     ((.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) hEpi
   -- Compose denorm → epilogue
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hDenormF hEpiF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -537,7 +537,7 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
     (((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hDE
   -- Compose preamble → denorm+epilogue
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hPreF hDEF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -608,7 +608,7 @@ theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq_clean
   -- 6. Compose LD → BEQ exit
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hldf hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -653,7 +653,7 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
     (((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hDE
   -- Compose preamble → denorm+epilogue
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hPreF hDEF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -734,7 +734,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq_exit
   -- 6. Compose LD → BEQ taken: base+908 → base+1008
-  have hPre := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hPre := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hldf hbeqf
   -- Frame preamble with q[], output memory
   have hPreF := cpsTriple_frame_left _ _ _ _ _
@@ -753,7 +753,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hEpi
   -- 8. Compose preamble → epilogue: base+908 → base+1068
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hPreF hEpiF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -821,7 +821,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq_exit
   -- 6. Compose LD → BEQ taken: base+908 → base+1008
-  have hPre := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hPre := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hldf hbeqf
   -- Frame preamble with u[], output memory
   have hPreF := cpsTriple_frame_left _ _ _ _ _
@@ -840,7 +840,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hEpi
   -- 8. Compose preamble → epilogue: base+908 → base+1068
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hPreF hEpiF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -57,7 +57,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
   have hB := evm_div_phaseB_n1_spec sp base b0 b1 b2 b3
     (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
     hb3z hb2z hb1z
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hB
   -- CLZ on b0
   have hCLZ := divK_clz_spec b0 b1 b2 base
@@ -70,7 +70,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -150,7 +150,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
@@ -171,7 +171,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
@@ -189,7 +189,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=1, m=3
   have hLS := divK_loopSetup_ntaken_spec sp (1 : Word)
@@ -211,7 +211,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -295,7 +295,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := divK_copyAU_full_spec sp a0 a1 a2 a3
@@ -316,7 +316,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := divK_loopSetup_ntaken_spec sp (1 : Word)
@@ -340,7 +340,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -268,7 +268,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hLoop
   -- 3. Compose preloop + loop
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [x1_val_n1] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -60,7 +60,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   -- CLZ on b1
   have hCLZ := divK_clz_spec b1 b1 b2 base
@@ -73,7 +73,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -153,7 +153,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
@@ -174,7 +174,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
@@ -192,7 +192,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=2, m=2
   have hLS := divK_loopSetup_ntaken_spec sp (2 : Word)
@@ -214,7 +214,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -298,7 +298,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := divK_copyAU_full_spec sp a0 a1 a2 a3
@@ -319,7 +319,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := divK_loopSetup_ntaken_spec sp (2 : Word)
@@ -343,7 +343,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -143,7 +143,7 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_false, ite_false] at hp
@@ -276,7 +276,7 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r2.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_false, ite_false] at hp
@@ -409,7 +409,7 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_false, ite_false] at hp
@@ -542,7 +542,7 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 u3_s))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_true, ite_true] at hp
@@ -675,7 +675,7 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_true, ite_true] at hp
@@ -808,7 +808,7 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r2.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_true, ite_true] at hp
@@ -941,7 +941,7 @@ theorem evm_div_n2_full_TTT_spec (sp base : Word)
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
      (sp + signExtend12 3944 ↦ₘ div128Un0 r1.2.1))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_true, ite_true] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -153,7 +153,7 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
      (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hB
   -- 3. Compose A + B
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta preloopN2UnifiedPost loopN2UnifiedPost at hp
       simp (config := { decide := true }) only [iterN2_false, ite_false] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -232,7 +232,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
     (by pcFree) hLoop
   -- 3. Compose preloop + loop
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [x1_val_n2] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -60,7 +60,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   -- CLZ on b2
   have hCLZ := divK_clz_spec b2 b1 b2 base
@@ -73,7 +73,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -153,7 +153,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
@@ -174,7 +174,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
@@ -192,7 +192,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=3, m=1
   have hLS := divK_loopSetup_ntaken_spec sp (3 : Word)
@@ -214,7 +214,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -298,7 +298,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := divK_copyAU_full_spec sp a0 a1 a2 a3
@@ -319,7 +319,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := divK_loopSetup_ntaken_spec sp (3 : Word)
@@ -343,7 +343,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -195,7 +195,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
     (by pcFree) hLoop
   -- 3. Compose preloop + loop
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [x1_val_n3] at hp

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -188,7 +188,7 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLoop'
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [x1_val_n4] at hp
@@ -475,7 +475,7 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
      (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat))
     (by pcFree) hB
   -- 3. Compose A + B
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       simp only [preloopMaxSkipPostN4_unfold] at hp
       xperm_hyp hp) hA hBF
@@ -731,7 +731,7 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLoop'
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [x1_val_n4] at hp
@@ -855,7 +855,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) hB
   -- 3. Compose
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       simp only [preloopCallSkipPostN4_unfold] at hp
       xperm_hyp hp) hA hBF

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -278,7 +278,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLoop'
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [EvmAsm.Evm64.DivMod.AddrNorm.se12_4, BitVec.sub_self] at hp
@@ -436,7 +436,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLoop'
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
       simp only [EvmAsm.Evm64.DivMod.AddrNorm.se12_4, BitVec.sub_self] at hp
@@ -641,7 +641,7 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       simp only [preloopMaxAddbackBeqPostN4_unfold] at hp
       xperm_hyp hp) hA hBF
@@ -860,7 +860,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
      (sp + signExtend12 3968 ↦ₘ (base + 516)) ** (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ d_lo) ** (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) hB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by simp only [preloopCallAddbackBeqPostN4_unfold] at hp; xperm_hyp hp) hA hBF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -137,7 +137,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
     (by pcFree) hLoop'
   -- Compose preloop → loop body
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       simp only [x1_val_n4] at hp
       xperm_hyp hp) hPreF hLoopF
@@ -289,7 +289,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
      (sp + signExtend12 3944 ↦ₘ (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat))
     (by pcFree) hB
   -- 3. Compose A + B
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       simp only [preloopShift0CallSkipPostN4_unfold] at hp
       xperm_hyp hp) hA hBF

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -162,7 +162,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hst1e
   -- Compose phase1 → step1
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- ================================================================
   -- Block 3: Compute un21 (base+1172 → base+1192)
@@ -185,7 +185,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
   -- Compose (phase1→step1) → compute_un21
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hcuf
   -- ================================================================
   -- Block 4: Step 2 (base+1192 → base+1252)
@@ -217,7 +217,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3968 ↦ₘ ret_addr) ** (sp + signExtend12 3960 ↦ₘ d))
     (by pcFree) hst2e
   -- Compose (→step1→compute_un21) → step2
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
   -- Block 5: End (base+1252 → ret_addr via JALR)
@@ -239,7 +239,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
      (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hende
   -- Compose (→step2) → end
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 hendf
   -- Final permutation to canonical pre/post order
   exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -78,7 +78,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hsube
-  have h_anti := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_anti := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
   have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 924)
@@ -92,7 +92,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hm0e
-  have h_m0 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m0 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
@@ -107,7 +107,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) hm1e
-  have h_m1 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m1 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
@@ -122,7 +122,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     ((.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1'))
     (by pcFree) hm2e
-  have h_m2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_m2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
   have hl := divK_denorm_last_spec 4032 sp u3 u2' shift (base + 996)
@@ -137,7 +137,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
      ((sp + signExtend12 4040) ↦ₘ u2'))
     (by pcFree) hle
-  have h_all := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h_all := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m2 hlef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -60,7 +60,7 @@ theorem evm_mod_phaseAB_n4_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -107,7 +107,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -158,7 +158,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- NormB
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
@@ -173,7 +173,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -248,7 +248,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by delta normBPost at hp; xperm_hyp hp) hNormBf hNormAf
   -- Step 3: LoopSetup ntaken (base+432 → base+448)
   have hLS := mod_loopSetup_ntaken_spec sp (4 : Word)
@@ -270,7 +270,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -353,7 +353,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
@@ -374,7 +374,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448)
   have hLS := mod_loopSetup_ntaken_spec sp (4 : Word)
@@ -398,7 +398,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -59,7 +59,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
   have hB := evm_mod_phaseB_n1_spec sp base b0 b1 b2 b3
     (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
     hb3z hb2z hb1z
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hB
   -- CLZ on b0
   have hCLZ := mod_clz_spec b0 b1 b2 base
@@ -72,7 +72,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -152,7 +152,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
@@ -173,7 +173,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
@@ -191,7 +191,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=1, m=3
   have hLS := mod_loopSetup_ntaken_spec sp (1 : Word)
@@ -213,7 +213,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -297,7 +297,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
@@ -318,7 +318,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (1 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := mod_loopSetup_ntaken_spec sp (1 : Word)
@@ -342,7 +342,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -62,7 +62,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   -- CLZ on b1
   have hCLZ := mod_clz_spec b1 b1 b2 base
@@ -75,7 +75,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -155,7 +155,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
@@ -176,7 +176,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
@@ -194,7 +194,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=2, m=2
   have hLS := mod_loopSetup_ntaken_spec sp (2 : Word)
@@ -216,7 +216,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -300,7 +300,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
@@ -321,7 +321,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (2 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := mod_loopSetup_ntaken_spec sp (2 : Word)
@@ -345,7 +345,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -62,7 +62,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   -- CLZ on b2
   have hCLZ := mod_clz_spec b2 b1 b2 base
@@ -75,7 +75,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hCLZ
-  have hABCLZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABCLZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hCLZf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -155,7 +155,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
@@ -176,7 +176,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNB
-  have hABC2NB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2NB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
@@ -194,7 +194,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hNormA
-  have hNA := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hNA := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2NB hNormAf
   -- Step 5: LoopSetup ntaken (base+432 → base+448), n=3, m=1
   have hLS := mod_loopSetup_ntaken_spec sp (3 : Word)
@@ -216,7 +216,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hNA hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -300,7 +300,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)))
     (by pcFree) hC2
-  have hABC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABCLZf hC2f
   -- Step 3: CopyAU (base+396 → base+432)
   have hCopy := mod_copyAU_full_spec sp a0 a1 a2 a3
@@ -321,7 +321,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (3 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
     (by pcFree) hCopy
-  have hABC2C := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABC2C := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2 hCopyf
   -- Step 4: LoopSetup ntaken (base+432 → base+448), n=3
   have hLS := mod_loopSetup_ntaken_spec sp (3 : Word)
@@ -345,7 +345,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1))
     (by pcFree) hLS
-  have hFull := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hABC2C hLSf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -76,7 +76,7 @@ theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq
-  have hC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -106,7 +106,7 @@ theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq
-  have hC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -168,7 +168,7 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hm2e
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hm1ef hm2ef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -216,7 +216,7 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
     ((.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
      ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hle
-  have h34 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h34 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hm3ef hlef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -246,7 +246,7 @@ theorem mod_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
-    (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) h1 h2)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -89,7 +89,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hma1e
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) htopef hma1ef
   -- MergeB: u[2] = (a[2]<<<shift) | (a[1]>>>anti) (base+344 -> base+364)
   have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (anti_shift.toNat % 64))
@@ -106,7 +106,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4048) ↦ₘ u1_old) ** ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hmbe
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hmbef
   -- MergeA 2: u[1] = (a[1]<<<shift) | (a[0]>>>anti) (base+364 -> base+384)
   have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (anti_shift.toNat % 64))
@@ -123,7 +123,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hma2e
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hma2ef
   -- Last: u[0] = a[0]<<<shift (base+384 -> base+392)
   have hlast := divK_normA_last_spec 4056 sp a0 shift u0_old (base + 384)
@@ -140,7 +140,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1))
     (by pcFree) hlaste
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 hlastef
   -- JAL x0 40 at base+392 -> base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
@@ -169,7 +169,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
       (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
       (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
       hjalef
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hjal_clean
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -262,7 +262,7 @@ theorem mod_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   have hbltef := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbodye hbltef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -295,7 +295,7 @@ theorem mod_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   have hbltef := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbodye hbltef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -62,7 +62,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -77,7 +77,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -97,7 +97,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -112,7 +112,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -132,7 +132,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
@@ -147,7 +147,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi2
-  have h1234567 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
@@ -167,7 +167,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne2
-  have h12345678 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 n_mem (base + 96)
@@ -182,7 +182,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -242,7 +242,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -257,7 +257,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -277,7 +277,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -292,7 +292,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -312,7 +312,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
@@ -327,7 +327,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi2
-  have h1234567 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
@@ -347,7 +347,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne2
-  have h12345678 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Fallthrough: ADDI x5=1 (base+92 → base+96)
   have haddi3_raw := addi_x0_spec_gen .x5 (2 : Word) 1 (base + 92) (by nofun)
@@ -362,7 +362,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi3
-  have h123456789 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456789 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 n_mem (base + 96)
@@ -377,7 +377,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456789 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -61,7 +61,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -76,7 +76,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -96,7 +96,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -111,7 +111,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -131,7 +131,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 n_mem (base + 96)
@@ -146,7 +146,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -70,7 +70,7 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq
-  have hC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -100,7 +100,7 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hbeq
-  have hC2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hC2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeqf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -162,7 +162,7 @@ private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) 
   have hm2ef := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0) ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hm2e
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hm1ef hm2ef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -210,7 +210,7 @@ private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (bas
     ((.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
      ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hle
-  have h34 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h34 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hm3ef hlef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -241,7 +241,7 @@ theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (bas
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
-    (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    (cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) h1 h2)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -88,7 +88,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hma1e
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) htopef hma1ef
   -- MergeB: u[2] = (a[2]<<<shift) | (a[1]>>>anti) (base+344 → base+364)
   have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (anti_shift.toNat % 64))
@@ -105,7 +105,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4048) ↦ₘ u1_old) ** ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hmbe
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hmbef
   -- MergeA 2: u[1] = (a[1]<<<shift) | (a[0]>>>anti) (base+364 → base+384)
   have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (anti_shift.toNat % 64))
@@ -122,7 +122,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) hma2e
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hma2ef
   -- Last: u[0] = a[0]<<<shift (base+384 → base+392)
   have hlast := divK_normA_last_spec 4056 sp a0 shift u0_old (base + 384)
@@ -139,7 +139,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1))
     (by pcFree) hlaste
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 hlastef
   -- JAL x0 40 at base+392 → base+432 (1 instruction, empAssertion pre/post)
   have hjal := jal_x0_spec_gen 40 (base + 392)
@@ -171,7 +171,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
       (fun h hp => by show (empAssertion ** postAll) h; rw [sepConj_emp_left']; exact hp)
       (fun h hp => by rw [sepConj_emp_left'] at hp; exact hp)
       hjalef
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hjal_clean
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -263,7 +263,7 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   have hbltef := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbodye hbltef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -295,7 +295,7 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   have hbltef := cpsTriple_frame_left _ _ _ _ _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
     (by pcFree) hblte
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbodye hbltef
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -189,7 +189,7 @@ theorem evm_div_bzero_spec (sp base : Word)
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
     (by pcFree) hbeq
   -- Step 4: Compose body → BEQ(taken): base → base+1048
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_framed
   -- Step 5: ZeroPath (base+1048 → base+1068)
   -- Extend to divCode CodeReq
@@ -201,7 +201,7 @@ theorem evm_div_bzero_spec (sp base : Word)
     ((.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) hzp
   -- Step 6: Compose AB → ZP: base → base+1068
-  have hABZ := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hABZ := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAB hzp_framed
   -- Step 7: Final consequence — rewrite bor → 0
   exact cpsTriple_weaken
@@ -247,7 +247,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
      ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
     (by pcFree) hbeq
   -- Step 4: Compose body → BEQ(ntaken): base → base+32
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_framed
   -- Step 5: Final consequence — permute assertions
   exact cpsTriple_weaken
@@ -368,7 +368,7 @@ theorem evm_div_phaseAB_n4_spec (sp base : Word)
   have hBf := cpsTriple_frame_left _ _ _ _ _
     (((sp + 32) ↦ₘ b0))
     (by pcFree) hB
-  have hAB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -526,7 +526,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -541,7 +541,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -561,7 +561,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -576,7 +576,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -596,7 +596,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 n_mem (base + 96)
@@ -610,7 +610,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -669,7 +669,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -684,7 +684,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -704,7 +704,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -719,7 +719,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -739,7 +739,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
@@ -754,7 +754,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi2
-  have h1234567 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
@@ -774,7 +774,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne2
-  have h12345678 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 n_mem (base + 96)
@@ -788,7 +788,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -848,7 +848,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hinit2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
   have haddi0_raw := addi_x0_spec_gen .x5 v5 4 (base + 68) (by nofun)
@@ -863,7 +863,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi0
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
@@ -883,7 +883,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne0
-  have h1234 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
   -- ---- Cascade step 1: ADDI x5=3 (base+76 → base+80)
   have haddi1_raw := addi_x0_spec_gen .x5 (4 : Word) 3 (base + 76) (by nofun)
@@ -898,7 +898,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi1
-  have h12345 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
@@ -918,7 +918,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne1
-  have h123456 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Cascade step 2: ADDI x5=2 (base+84 → base+88)
   have haddi2_raw := addi_x0_spec_gen .x5 (3 : Word) 2 (base + 84) (by nofun)
@@ -933,7 +933,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi2
-  have h1234567 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
@@ -953,7 +953,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) hbne2
-  have h12345678 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Fallthrough: ADDI x5=1 (base+92 → base+96)
   have haddi3_raw := addi_x0_spec_gen .x5 (2 : Word) 1 (base + 92) (by nofun)
@@ -968,7 +968,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3984) ↦ₘ n_mem))
     (by pcFree) haddi3
-  have h123456789 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123456789 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
   have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 n_mem (base + 96)
@@ -982,7 +982,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)))
     (by pcFree) htail
-  have hphaseB := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have hphaseB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456789 htailf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -160,7 +160,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   have hframed := cpsTriple_frame_left _ _ _ _ _
     ((.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) hslli_addi
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
@@ -286,7 +286,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
   have hframed := cpsTriple_frame_left _ _ _ _ _
     ((.x5 ↦ᵣ val) ** (.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) haddi
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -105,7 +105,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
     have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
       ((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
       (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
@@ -190,7 +190,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
     have hcorr_framed := cpsTriple_frame_left _ _ _ _ _
       ((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
       (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -114,7 +114,7 @@ theorem divK_div128_prodcheck1_merged_spec
       ((.x1 ↦ᵣ rhat_un1) ** (.x5 ↦ᵣ q_dlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un1) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
@@ -167,7 +167,7 @@ theorem divK_div128_prodcheck1_merged_spec
     exact cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+      (cpsTriple_seq_perm_same_cr
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -114,7 +114,7 @@ theorem divK_div128_prodcheck2_merged_spec
       ((.x1 ↦ᵣ rhat2_un0) ** (.x7 ↦ᵣ q0_dlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (by pcFree) hcorr
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
@@ -166,7 +166,7 @@ theorem divK_div128_prodcheck2_merged_spec
     exact cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by xperm_hyp hp)
-      (cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+      (cpsTriple_seq_perm_same_cr
         (fun _ hp => hp)
         ntaken_clean hjal_framed)
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -112,7 +112,7 @@ theorem divK_div128_step1_spec
     ((.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1_old) ** (.x12 ↦ᵣ sp) **
      (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3_raw := divK_div128_prodcheck1_merged_spec sp q1c rhatc d_hi un1
     v1_old hi dlo (base + 28)
@@ -149,7 +149,7 @@ theorem divK_div128_step1_spec
   have h3f := cpsTriple_frame_left _ _ _ _ _
     ((.x0 ↦ᵣ 0))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 h3f
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -113,7 +113,7 @@ theorem divK_div128_step2_spec
     ((.x7 ↦ᵣ un21) ** (.x12 ↦ᵣ sp) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c hi
     un21 dlo un0 (base + 28)
@@ -150,7 +150,7 @@ theorem divK_div128_step2_spec
   have h3f := cpsTriple_frame_left _ _ _ _ _
     ((.x6 ↦ᵣ d_hi) ** (.x0 ↦ᵣ 0))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 h3f
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -873,7 +873,7 @@ theorem divK_trial_call_path_spec
      (sp + signExtend12 3944 ↦ₘ un0_mem))
     (by pcFree) Je
   -- 4. Compose JAL + div128
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) Jf D
   -- 5. Final permutation
   exact cpsTriple_weaken
@@ -1008,7 +1008,7 @@ theorem divK_double_addback_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ aun4))
     (by pcFree) beq_taken'
   -- Compose BEQ → addback2
-  have beq_ab2 := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have beq_ab2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) beq_f AB2
   -- Frame BEQ passthrough with addback2 postcondition atoms
   have BPTf := cpsTriple_frame_left _ _ _ _ _
@@ -1021,7 +1021,7 @@ theorem divK_double_addback_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ aun4'))
     (by pcFree) BPT
   -- Compose (BEQ+addback2) → BEQ passthrough
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) beq_ab2 BPTf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1201,7 +1201,7 @@ theorem divK_store_loop_j0_spec
   have haddi_x0 := cpsTriple_frame_left _ _ _ _ _
       (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_e
   -- Compose ADDI+x0 → BGE exit (both have x1 ** x0)
-  have addi_bge := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have addi_bge := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
   -- Frame with remaining atoms
   have addi_bge_framed := cpsTriple_frame_left _ _ _ _ _
@@ -1210,7 +1210,7 @@ theorem divK_store_loop_j0_spec
        (q_addr ↦ₘ q_hat))
       (by pcFree) addi_bge
   -- 7. Compose: store_qj → (ADDI → BGE exit)
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) SQx0 addi_bge_framed
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1286,7 +1286,7 @@ theorem divK_store_loop_jgt0_spec
   have haddi_x0 := cpsTriple_frame_left _ _ _ _ _
       (.x0 ↦ᵣ (0 : Word)) (by pcFree) haddi_e
   -- Compose ADDI+x0 → BGE exit (both have x1 ** x0)
-  have addi_bge := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have addi_bge := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
   -- Frame with remaining atoms
   have addi_bge_framed := cpsTriple_frame_left _ _ _ _ _
@@ -1295,7 +1295,7 @@ theorem divK_store_loop_jgt0_spec
        (q_addr ↦ₘ q_hat))
       (by pcFree) addi_bge
   -- 7. Compose: store_qj → (ADDI → BGE exit)
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) SQx0 addi_bge_framed
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1655,7 +1655,7 @@ theorem divK_mulsub_correction_addback_spec
      ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
      ((u_base + signExtend12 4064) ↦ₘ aun4))
     (by pcFree) BEQ
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) MSCA BEQf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1932,7 +1932,7 @@ theorem divK_mulsub_correction_addback_beq_spec
        (sp + signExtend12 3976 ↦ₘ j))
       (by pcFree) DA
     -- Compose MCA_N(→880) with DAf(880→884)
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) MCA_N DAf
     exact cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -445,7 +445,7 @@ theorem divK_loop_n2_max_max_spec
      (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
@@ -526,7 +526,7 @@ theorem divK_loop_n2_call_call_spec
      (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
@@ -614,7 +614,7 @@ theorem divK_loop_n2_max_call_spec
      (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 max  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
@@ -700,7 +700,7 @@ theorem divK_loop_n2_call_max_spec
      (sp + signExtend12 3944 ↦ₘ div128Un0 u1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 call  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -103,7 +103,7 @@ theorem divK_loop_n3_max_skip_skip_spec
     (((u_base_1 + signExtend12 4064) ↦ₘ (u_top - ms.2.2.2.2)) ** (q_addr_1 ↦ₘ q_hat))
     (by pcFree) J0s
   -- 3. Compose via perm: rewrite j=1 postcondition addresses → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
@@ -406,7 +406,7 @@ theorem divK_loop_n3_max_max_spec
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
   --    loopIterPostN3Max unfolds to if-then-else, so we case-split on borrow
   --    then unfold the branch to get concrete assertions for xperm_hyp.
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       -- iterN3Max is @[irreducible] so projections stay opaque after delta
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
@@ -492,7 +492,7 @@ theorem divK_loop_n3_call_call_spec
      (q_addr_1 ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       -- iterN3Call is @[irreducible] so projections stay opaque after delta
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
@@ -581,7 +581,7 @@ theorem divK_loop_n3_max_call_spec
      (q_addr_1 ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 max  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
@@ -666,7 +666,7 @@ theorem divK_loop_n3_call_max_spec
      (sp + signExtend12 3944 ↦ₘ div128Un0 u2))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 call  postcondition → j=0 precondition
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -127,7 +127,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -251,7 +251,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -375,7 +375,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -499,7 +499,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -126,7 +126,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -245,7 +245,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -364,7 +364,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -483,7 +483,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -109,7 +109,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -199,7 +199,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -288,7 +288,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -377,7 +377,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -93,7 +93,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -176,7 +176,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -259,7 +259,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -342,7 +342,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -119,7 +119,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -250,7 +250,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -342,7 +342,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -463,7 +463,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -557,7 +557,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -678,7 +678,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -771,7 +771,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -897,7 +897,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -985,7 +985,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1103,7 +1103,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1191,7 +1191,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -1309,7 +1309,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
      (sp + signExtend12 3952 ↦ₘ d_lo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -114,7 +114,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -245,7 +245,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -351,7 +351,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -483,7 +483,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -576,7 +576,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -705,7 +705,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -799,7 +799,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
      ((u_base + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -929,7 +929,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -113,7 +113,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -253,7 +253,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -350,7 +350,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   -- 8. Permute final cpsTriple to match target
   exact cpsTriple_weaken
@@ -490,7 +490,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -108,7 +108,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) J0
     -- Compose j=1 and j=0 via address rewriting
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
@@ -175,7 +175,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
        (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
       (by pcFree) J0
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
@@ -243,7 +243,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
        (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
        (sp + signExtend12 3944 ↦ₘ div128Un0 u0))
       (by pcFree) J0
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
@@ -309,7 +309,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
        (q_addr_1 ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
       (by pcFree) J0
-    have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+    have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
@@ -396,7 +396,7 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
     (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
     (by pcFree) H10
   -- Compose j=2 and iter10
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
@@ -477,7 +477,7 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
     (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
     (by pcFree) H10
   -- Compose j=2 and iter10
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
@@ -642,7 +642,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (((u_base_3 + signExtend12 4064) ↦ₘ r3.2.2.2.2.2) ** (q_addr_3 ↦ₘ r3.1))
     (by pcFree) H210
   -- Compose j=3 and iter210
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢
@@ -749,7 +749,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (((u_base_3 + signExtend12 4064) ↦ₘ r3.2.2.2.2.2) ** (q_addr_3 ↦ₘ r3.1))
     (by pcFree) H210
   -- Compose j=3 and iter210
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -178,7 +178,7 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
   have H10f := cpsTriple_frame_left _ _ _ _ _
     (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
     (by pcFree) H10
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
@@ -254,7 +254,7 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
   have H10f := cpsTriple_frame_left _ _ _ _ _
     (((u_base_2 + signExtend12 4064) ↦ₘ r2.2.2.2.2.2) ** (q_addr_2 ↦ₘ r2.1))
     (by pcFree) H10
-  have full := cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢


### PR DESCRIPTION
## Summary
Mass mechanical migration of 279 callsites from \`cpsTriple_seq_with_perm_same_cr _ _ _ _ _ _ _ _ hperm h1 h2\` to \`cpsTriple_seq_perm_same_cr hperm h1 h2\` across 45 files.

Follows the established migration pattern (#578 / #580 / #581).

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)