### PR TITLE
refactor: migrate cpsBranch_elim_*_strip_pure callsites (#331)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -257,7 +257,7 @@ theorem evm_byte_zero_high_spec (sp base : Word)
   rw [byte_bne_target, byte_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (byte_bne_sub base) hbne_raw
   -- Eliminate ntaken path (i1|||i2|||i3 = 0 contradicts hhigh)
-  have hbne_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
@@ -334,7 +334,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 140 (i1 ||| i2 ||| i3) (0 : Word) (base + 20)
   rw [byte_bne_target, byte_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (byte_bne_sub base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
@@ -382,7 +382,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   have hsltiu_eq : sltiu_val = (0 : Word) := by
     simp only [sltiu_val, hlarge]; decide
   -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
-  have hbeq_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
@@ -500,7 +500,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 140 (i1 ||| i2 ||| i3) (0 : Word) (base + 20)
   rw [byte_bne_target, byte_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (byte_bne_sub base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
@@ -540,7 +540,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiu_val (0 : Word) (base + 32)
   rw [byte_beq_target, byte_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (byte_beq_sub base) hbeq_raw
-  have hbeq_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       have heq := ((sepConj_pure_right _ _ _).mp h_rest).2

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -321,7 +321,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
   rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [se13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hbz ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -376,7 +376,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
   rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [se13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hbnz)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -720,7 +720,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
-  have hbeq_exit := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeqe
+  have hbeq_exit := cpsBranch_takenStripPure2 hbeqe
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -807,7 +807,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
-  have hbeq_exit := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeqe
+  have hbeq_exit := cpsBranch_takenStripPure2 hbeqe
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -67,7 +67,7 @@ theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
@@ -97,7 +97,7 @@ theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -254,7 +254,7 @@ theorem mod_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [se13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
-  have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
+  have hblt_clean := cpsBranch_ntakenStripPure2 hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hm_ge)
@@ -287,7 +287,7 @@ theorem mod_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [se13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
-  have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
+  have hblt_clean := cpsBranch_takenStripPure2 hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hm_lt ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -156,7 +156,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne_raw
-  have hbne_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne_raw
+  have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb3nz)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -83,7 +83,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -118,7 +118,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -153,7 +153,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [se13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
-  have hbne2_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
+  have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb1nz)
@@ -263,7 +263,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -298,7 +298,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -333,7 +333,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [se13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
-  have hbne2_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
+  have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb1z ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -82,7 +82,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -117,7 +117,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb2nz)

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -61,7 +61,7 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
@@ -91,7 +91,7 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
       show (base + 224 : Word) + 4 = base + normBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -255,7 +255,7 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [se13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
-  have hblt_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
+  have hblt_clean := cpsBranch_ntakenStripPure2 hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hm_ge)
@@ -287,7 +287,7 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   rw [show (base + 444 : Word) + signExtend13 464 = base + denormOff from by
         rw [se13_464]; bv_addr,
       show (base + 444 : Word) + 4 = base + loopBodyOff from by bv_addr] at hblt_raw
-  have hblt_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hblt_raw
+  have hblt_clean := cpsBranch_takenStripPure2 hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hm_lt ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -176,7 +176,7 @@ theorem evm_div_bzero_spec (sp base : Word)
   rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [se13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd hbz ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -234,7 +234,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
   rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
         rw [se13_1020]; bv_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
-  have hbeq_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq_raw
+  have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hbnz)
@@ -307,7 +307,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, phB_bne_4] at hbne_raw
-  have hbne_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne_raw
+  have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb3nz)
@@ -547,7 +547,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -582,7 +582,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb2nz)
@@ -690,7 +690,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -725,7 +725,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -760,7 +760,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [se13_8]; bv_addr, phB_step2_8] at hbne2_raw
-  have hbne2_clean := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
+  have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb1nz)
@@ -869,7 +869,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
         rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
-  have hbne0_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne0_raw
+  have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -904,7 +904,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
         rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
-  have hbne1_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne1_raw
+  have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
@@ -939,7 +939,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
         rw [se13_8]; bv_addr, phB_step2_8] at hbne2_raw
-  have hbne2_clean := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne2_raw
+  have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact absurd hb1z ((sepConj_pure_right _ _ _).mp h_rest).2)

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -281,7 +281,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
   rw [shr_bne_target, shr_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shrCode base) hbne_raw
   -- Eliminate ntaken path (s1|||s2|||s3 = 0 contradicts hhigh)
-  have hbne_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
@@ -384,7 +384,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shr_bne_target, shr_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shrCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
@@ -431,7 +431,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   have hsltiu_eq : sltiu_val = (0 : Word) := by
     simp only [sltiu_val, hlarge]; decide
   -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
-  have hbeq_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
@@ -688,7 +688,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shr_bne_target, shr_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shrCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
@@ -728,7 +728,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiu_val (0 : Word) (base + 32)
   rw [shr_beq_target, shr_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_shrCode base) hbeq_raw
-  have hbeq_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       have heq := ((sepConj_pure_right _ _ _).mp h_rest).2

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -326,7 +326,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
   rw [sar_bne_target, sar_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_sarCode base) hbne_raw
   -- Eliminate ntaken path (s1|||s2|||s3 = 0 contradicts hhigh)
-  have hbne_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
@@ -421,7 +421,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 332 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [sar_bne_target, sar_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_sarCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
@@ -468,7 +468,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   have hsltiu_eq : sltiu_val = (0 : Word) := by
     simp only [sltiu_val, hlarge]; decide
   -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
-  have hbeq_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
@@ -851,7 +851,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 332 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [sar_bne_target, sar_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_sarCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
@@ -891,7 +891,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiu_val (0 : Word) (base + 32)
   rw [sar_beq_target, sar_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_sarCode base) hbeq_raw
-  have hbeq_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       have heq := ((sepConj_pure_right _ _ _).mp h_rest).2

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -270,7 +270,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
   rw [shl_bne_target, shl_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
   -- Eliminate ntaken path (s1|||s2|||s3 = 0 contradicts hhigh)
-  have hbne_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
@@ -372,7 +372,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
@@ -419,7 +419,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have hsltiu_eq : sltiu_val = (0 : Word) := by
     simp only [sltiu_val, hlarge]; decide
   -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
-  have hbeq_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
@@ -663,7 +663,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
@@ -703,7 +703,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiu_val (0 : Word) (base + 32)
   rw [shl_beq_target, shl_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_shlCode base) hbeq_raw
-  have hbeq_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       have heq := ((sepConj_pure_right _ _ _).mp h_rest).2

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -240,7 +240,7 @@ theorem signext_nochange_high_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [se_bne_target, se_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_signextCode base) hbne_raw
-  have hbne_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
@@ -332,7 +332,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [se_bne_target, se_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_signextCode base) hbne_raw
-  have hbne_ntaken := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
@@ -373,7 +373,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
   have hbeq := cpsBranch_extend_code (beq_sub_signextCode base) hbeq_raw
   have hsltiu_eq : sltiu_val = (0 : Word) := by
     simp only [sltiu_val, hlarge]; decide
-  have hbeq_taken := cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
       exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
@@ -477,7 +477,7 @@ theorem signext_body_spec (sp base : Word)
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [se_bne_target, se_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_signextCode base) hbne_raw
-  have hbne_nt := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbne
+  have hbne_nt := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
   have hbne_f := cpsTriple_frame_left (base + 20) (base + 24) _ _ _
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -508,7 +508,7 @@ theorem signext_body_spec (sp base : Word)
   have hbeq_raw := beq_spec_gen .x10 .x0 156 sltiu_val (0 : Word) (base + 32)
   rw [se_beq_target, se_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_signextCode base) hbeq_raw
-  have hbeq_nt := cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _ hbeq
+  have hbeq_nt := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; have := ((sepConj_pure_right _ _ _).mp h_rest).2; simp [hsltiu_eq] at this)
   have hbeq_f := cpsTriple_frame_left (base + 32) (base + 36) _ _ _
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **


### PR DESCRIPTION
## Summary
Mass mechanical migration of the four strip_pure variants:
- \`cpsBranch_elim_taken_strip_pure2 _ _ _ _ _ _ _ _ _\` → \`cpsBranch_takenStripPure2\`
- \`cpsBranch_elim_taken_strip_pure3 _ _ _ _ _ _ _ _ _ _\` → \`cpsBranch_takenStripPure3\`
- \`cpsBranch_elim_ntaken_strip_pure2 _ _ _ _ _ _ _ _ _\` → \`cpsBranch_ntakenStripPure2\`
- \`cpsBranch_elim_ntaken_strip_pure3 _ _ _ _ _ _ _ _ _ _\` → \`cpsBranch_ntakenStripPure3\`

57 callsites across 15 files. Follows the established migration pattern.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)