### PR TITLE
refactor: migrate cpsTriple_seq_cpsBranch_with_perm_same_cr callsites (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -93,7 +93,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ v7) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))) := by
     runBlock I0
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
@@ -146,7 +146,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ v7) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word))) := by
     runBlock I0
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
@@ -218,7 +218,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ v7) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) := by
     runBlock I0
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have taken := cpsBranch_elim_taken _ _ _ _ _ _ _ composed (fun hp hQf => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
@@ -273,7 +273,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ v7) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count) ** (.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) := by
     runBlock I0
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have ntaken := cpsBranch_elim_ntaken _ _ _ _ _ _ _ composed (fun hp hQt => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -75,7 +75,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   by_cases hcond : hi = 0
   · have hq : q1' = q1 := if_pos hcond
@@ -160,7 +160,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   by_cases hcond : hi = 0
   · have hq : q0' = q0 := if_pos hcond

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -95,7 +95,7 @@ theorem divK_div128_prodcheck1_merged_spec
         have h2 : ¬(base + 16 = base + 8) := by bv_omega
         have h3 : ¬(base + 16 = base + 12) := by bv_omega
         simp only [beq_iff_eq, h0, h1, h2, h3, ↓reduceIte]))) hPR hpc
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbltu_ext
   by_cases hcond : BitVec.ult rhat_un1 q_dlo
   · have hq : q1' = q1 + signExtend12 4095 := if_pos hcond

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -97,7 +97,7 @@ theorem divK_div128_prodcheck2_merged_spec
         have h3 : ¬(base + 20 = base + 12) := by bv_omega
         have h4 : ¬(base + 20 = base + 16) := by bv_omega
         simp only [beq_iff_eq, h0, h1, h2, h3, h4, ↓reduceIte]))) hPR hpc
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbltu_ext
   by_cases hcond : BitVec.ult rhat2_un0 q0_dlo
   · have hq : q0' = q0 + signExtend12 4095 := if_pos hcond

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -101,7 +101,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
       exact CodeReq.ofProg_lookup base (divK_loopSetup blt_off) 3
         (by omega) (by omega)
     · simp at h) hblt_framed
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hblt_ext
   exact cpsBranch_consequence _ _
     _ _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -105,7 +105,7 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
       (by decide) (by decide)
     ) hbeq_framed
   -- 5. Compose body → BEQ with permutation (same CR)
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   -- 6. Final permutation of postconditions
   exact cpsBranch_consequence _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -88,7 +88,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
       simp only [beq_iff_eq, h0, ↓reduceIte]
     · simp at h) hbne_framed
   -- 5. Compose
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   exact cpsBranch_consequence _ _
     _ _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -104,7 +104,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
       exact CodeReq.ofProg_lookup base (divK_phaseC2 shift0_off) 3
         (by omega) (by omega)
     · simp at h) hbeq_framed
-  have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   exact cpsBranch_consequence _ _
     _ _ _ _ _ _ _ _

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1126,7 +1126,7 @@ theorem divK_store_loop_spec
          (q_addr ↦ₘ q_hat))
         (by pcFree) LCe)
   -- 5. Compose store_qj(+x0) → loop_control(reshaped)
-  exact cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  exact cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => hp) SQx0 LCp
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -249,7 +249,7 @@ theorem divK_loop_body_n1_max_skip_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
@@ -345,7 +345,7 @@ theorem divK_loop_body_n1_max_addback_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -498,7 +498,7 @@ theorem divK_loop_body_n1_call_skip_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -641,7 +641,7 @@ theorem divK_loop_body_n1_call_addback_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -152,7 +152,7 @@ theorem divK_loop_body_n2_max_skip_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
@@ -251,7 +251,7 @@ theorem divK_loop_body_n2_max_addback_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -406,7 +406,7 @@ theorem divK_loop_body_n2_call_skip_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -552,7 +552,7 @@ theorem divK_loop_body_n2_call_addback_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -151,7 +151,7 @@ theorem divK_loop_body_n3_max_skip_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
@@ -251,7 +251,7 @@ theorem divK_loop_body_n3_max_addback_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -406,7 +406,7 @@ theorem divK_loop_body_n3_call_skip_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -552,7 +552,7 @@ theorem divK_loop_body_n3_call_addback_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -153,7 +153,7 @@ theorem divK_loop_body_n4_max_skip_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
@@ -253,7 +253,7 @@ theorem divK_loop_body_n4_max_addback_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -408,7 +408,7 @@ theorem divK_loop_body_n4_call_skip_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)
@@ -554,7 +554,7 @@ theorem divK_loop_body_n4_call_addback_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
+  have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
Mass mechanical migration of 29 callsites from \`cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _\` to \`cpsTriple_seq_cpsBranch_perm_same_cr\` across 13 files.

Follows the established migration pattern.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)