### PR TITLE
feat(divmod): prove evm_mod_n4_full_max_skip_spec

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -96,4 +96,89 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
     (fun h hq => by delta preloopMaxSkipPostN4; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Full n=4 MOD path (max+skip, shift≠0): base → base+1068
+-- ============================================================================
+
+/-- Full n=4 MOD path: base → base+1068 (shift ≠ 0, max+skip).
+    Composes pre-loop + loop body + denorm preamble + MOD denorm +
+    MOD epilogue. Mirror of `evm_div_n4_full_max_skip_spec`, using
+    `modCode` and the MOD-specific post-loop composer. -/
+theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hbltu : isMaxTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11_old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
+       ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
+       ((sp + signExtend12 4024) ↦ₘ u4_old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3976) ↦ₘ j_mem))
+      (fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let q_hat : Word := signExtend12 4095
+  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  -- 1. Pre-loop + loop body: base → base+denormOff
+  have hA := evm_mod_n4_preloop_max_skip_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    hbnz hb3nz hshift_nz hbltu hborrow
+  -- 2. Post-loop: base+denormOff → base+nopOff (modCode)
+  have hB := evm_mod_preamble_denorm_epilogue_spec sp base
+    ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 shift
+    ms.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    ms.2.2.2.2
+    b0' b1' b2' b3'
+    hshift_nz
+  -- Frame post-loop with remainder atoms (4 q cells, a-atoms, zeros, x1, x11)
+  have hBF := cpsTriple_frameR
+    (((sp + signExtend12 4088) ↦ₘ q_hat) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat))
+    (by pcFree) hB
+  -- 3. Compose A + B
+  have hFull := cpsTriple_seq_perm_same_cr
+    (fun h hp => by
+      simp only [preloopMaxSkipPostN4_unfold] at hp
+      xperm_hyp hp) hA hBF
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullModN4MaxSkipPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Full n=4 MOD path: `base → base+1068` (shift ≠ 0, max+skip) against `modCode`. Mirror of `evm_div_n4_full_max_skip_spec`, composing:

```
  evm_mod_n4_preloop_max_skip_spec
    → preloopMaxSkipPostN4
    (frame 4 q cells + a-atoms + zeros + x1 + x11)
  → evm_mod_preamble_denorm_epilogue_spec
    → denormModPost … ** shift_mem
  → fullModN4MaxSkipPost
```

With the preloop composer (#583) and the MOD scaffolding from earlier stack steps, the full MOD limb-level composer falls out. This is the first MOD n=4 full-path spec; **it unblocks `evm_mod_n4_max_skip_stack_spec`** (the MOD counterpart of the DIV stack spec landed in #563).

No sorry, no native_decide.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)