### PR TITLE
refactor: migrate cpsBranch_consequence all-underscore callsites (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -78,7 +78,7 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
         ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
       (base + 8)
         ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -78,7 +78,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
         ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 16)
         ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -81,7 +81,7 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 bor (0 : Word) (base + 28)
   have ha1 : (base + 28 : Word) + 4 = base + 32 := by bv_addr
   rw [ha1] at hbeq_raw
-  have hbeq := cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  have hbeq := cpsBranch_weaken
     (fun _ hp => hp)
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -64,7 +64,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
         ((rx ↦ᵣ check) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 8)
         ((rx ↦ᵣ check) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -81,7 +81,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
         ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 16)
         ((.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -45,7 +45,7 @@ theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base
       ((.x7 ↦ᵣ borrow) ** (.x0 ↦ᵣ 0)) := by
   intro cr
   have hbeq := beq_spec_gen .x7 .x0 skip_off borrow 0 base
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun _ hp => hp)
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1116,7 +1116,7 @@ theorem divK_store_loop_spec
       (base + denormOff)
       ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) ** (.x0 ↦ᵣ (0 : Word)) ** (q_addr ↦ₘ q_hat)) :=
-    cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -252,7 +252,7 @@ theorem divK_loop_body_n1_max_skip_spec
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -347,7 +347,7 @@ theorem divK_loop_body_n1_max_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -500,7 +500,7 @@ theorem divK_loop_body_n1_call_skip_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -643,7 +643,7 @@ theorem divK_loop_body_n1_call_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -155,7 +155,7 @@ theorem divK_loop_body_n2_max_skip_spec
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -253,7 +253,7 @@ theorem divK_loop_body_n2_max_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -408,7 +408,7 @@ theorem divK_loop_body_n2_call_skip_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -554,7 +554,7 @@ theorem divK_loop_body_n2_call_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -154,7 +154,7 @@ theorem divK_loop_body_n3_max_skip_spec
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -253,7 +253,7 @@ theorem divK_loop_body_n3_max_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -408,7 +408,7 @@ theorem divK_loop_body_n3_call_skip_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -554,7 +554,7 @@ theorem divK_loop_body_n3_call_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -156,7 +156,7 @@ theorem divK_loop_body_n4_max_skip_spec
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -255,7 +255,7 @@ theorem divK_loop_body_n4_max_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -410,7 +410,7 @@ theorem divK_loop_body_n4_call_skip_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN4SkipPost loopBodySkipPost mulsubN4 loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -556,7 +556,7 @@ theorem divK_loop_body_n4_call_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN4AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN4 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -172,7 +172,7 @@ theorem rlp_phase2_long_loop_body_spec
          (dwordAddr ↦ₘ word_val) ** ⌜cnt' = 0⌝) := by
     have h_eq_20_4 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
     rw [h_eq_20_4] at bne_raw
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
Mass mechanical migration of 24 \`cpsBranch_consequence _ _ _ _ _ _ _ _ _ _\` callsites to \`cpsBranch_weaken\` across 12 files.

The remaining \`cpsBranch_consequence\` callsites have an explicit exit address (e.g. \`cpsBranch_consequence _ _ _ _ e0 _ _ …\`) so they can't be rewritten by simple regex; those will need case-by-case migration in a follow-up.

Follows the established migration pattern.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)