### PR TITLE
refactor: migrate 4 multi-line cpsBranch_consequence callsites (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -103,8 +103,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
     · simp at h) hblt_framed
   have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hbody hblt_ext
-  exact cpsBranch_consequence _ _
-    _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -108,8 +108,7 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
   have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   -- 6. Final permutation of postconditions
-  exact cpsBranch_consequence _ _
-    _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -90,8 +90,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
   -- 5. Compose
   have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
-  exact cpsBranch_consequence _ _
-    _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -106,8 +106,7 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
     · simp at h) hbeq_framed
   have composed := cpsTriple_seq_cpsBranch_with_perm_same_cr _ _ _ _ _ _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hbody hbeq_ext
-  exact cpsBranch_consequence _ _
-    _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
Handles the multi-line callsite style that simple single-line regex couldn't reach:
\`\`\`
cpsBranch_consequence _ _
    _ _ _ _ _ _ _ _
\`\`\`

Migrates to \`cpsBranch_weaken\` on a single line in \`LimbSpec/{LoopSetup,PhaseA,PhaseBCascade,PhaseC2}.lean\`.

## Test plan
- [x] \`lake build\` clean (3546 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)