### PR TITLE
refactor: migrate 5 more cpsBranch_consequence callsites to cpsBranch_weaken (#331)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -378,8 +378,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k))) :=
-    cpsBranch_consequence _ _ _ _
-      target _ _ (base + 8) _ _
+    cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -427,8 +426,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜v5 = (0 : Word) + signExtend12 k⌝)
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜v5 ≠ (0 : Word) + signExtend12 k⌝) :=
-    cpsBranch_consequence _ _ _ _
-      target _ _ (base + 8) _ _
+    cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -495,7 +493,7 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
       e0 ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 4) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence base _ _ _ e0 _ _ (base + 4) _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word)) h').1 hp').1) h hp)
@@ -1000,8 +998,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) := by
     rw [← hcr_eq]
-    exact cpsBranch_consequence base _ _ _
-      zero_path _ _ (base + 36) _ _
+    exact cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun _ hp => hp)
       (fun h hp => by

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -281,8 +281,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k))) :=
-    cpsBranch_consequence _ _ _ _
-      target _ _ (base + 8) _ _
+    cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -574,8 +573,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
        (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) := by
     rw [← hcr_eq]
-    exact cpsBranch_consequence base _ _ _
-      done_path _ _ (base + 36) _ _
+    exact cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun _ hp => hp)
       (fun h hp => by
@@ -650,7 +648,7 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
       e0 ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 4) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word))) :=
-    cpsBranch_consequence base _ _ _ e0 _ _ (base + 4) _ _
+    cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word)) h').1 hp').1) h hp)
@@ -738,8 +736,7 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜v5 = (0 : Word) + signExtend12 k⌝)
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜v5 ≠ (0 : Word) + signExtend12 k⌝) :=
-    cpsBranch_consequence _ _ _ _
-      target _ _ (base + 8) _ _
+    cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
Manually migrates the remaining multi-line \`cpsBranch_consequence\` callsites that simple regex couldn't reach:

**\`SignExtend/LimbSpec.lean\`:**
- \`_ _ _ _ / target _ _ (base + 8) _ _\`
- \`exact ... base _ _ _ / done_path _ _ (base + 36) _ _\`
- \`... base _ _ _ e0 _ _ (base + 4) _ _\`

**\`Shift/LimbSpec.lean\`:**
- \`_ _ _ _ / target _ _ (base + 8) _ _\`
- \`... base _ _ _ e0 _ _ (base + 4) _ _\`
- \`exact ... base _ _ _ / zero_path _ _ (base + 36) _ _\`

After this + #592 land, all \`cpsBranch_consequence\` callsites should be migrated.

## Test plan
- [x] \`lake build\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)