### PR TITLE
docs(contributing): document Mathlib naming conventions (#189)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,22 @@ Before sending work for review:
 - Keep imports at the top of the file.
 - Follow the naming conventions and proof patterns documented in [`AGENTS.md`](AGENTS.md).
 
+### Naming conventions (Mathlib-aligned)
+
+We follow the [Mathlib4 naming guide](https://leanprover-community.github.io/contribute/naming.html#capitalization). Summary:
+
+1. **Terms of `Prop`s** (proofs, theorem names) — `snake_case`. e.g. `add_comm`, `evm_div_spec`.
+2. **`Prop`s and `Type`s** (inductive types, structures, classes) — `UpperCamelCase`. e.g. `CodeReq`, `PartialState`.
+3. **Functions** — named like their return value (so `Prop`-returning functions are `snake_case`, `Type`-returning functions are `UpperCamelCase`).
+4. **All other terms of `Type`s** — `lowerCamelCase`. e.g. `clzResult`, `loopBodyOff`.
+5. Inside a `snake_case` name, an `UpperCamelCase` segment appears in `lowerCamelCase`. e.g. `List.bitVec_cons`, not `List.BitVec_cons`.
+6. Acronyms are lowercased/uppercased as a group (`LE`, `le`, not `lE`).
+
+**Local variables inside proofs** (bound by `have`, `intro`, `let`) follow the same rules by extension:
+
+- Proof/hypothesis names (most `have`/`intro`) — `snake_case` (rule 1). Short forms like `h`, `hx`, `h1`, `hab` are standard. Descriptive forms like `carry_in`, `u_plus_carry` are fine.
+- `let`-bound values of `Type`s — `lowerCamelCase` (rule 4). e.g. `let midPoint := ...`.
+
 ## Git Workflow
 
 - Main branch: `main`


### PR DESCRIPTION
## Summary
Makes the project's naming convention explicit in \`CONTRIBUTING.md\`, referencing the [Mathlib4 style guide](https://leanprover-community.github.io/contribute/naming.html#capitalization):

- \`Prop\`-terms (theorem names) → \`snake_case\`
- \`Prop\`s / \`Type\`s (structures, classes) → \`UpperCamelCase\`
- \`Type\`-terms (values) → \`lowerCamelCase\`

Also extends the rules to local variables bound by \`have\` / \`intro\` / \`let\` inside proofs.

Context: issue #189 was prompted by an AI review that flagged \`carry_in\` / \`u_plus_carry\` local hypothesis names as non-Mathlib. After checking the authoritative Mathlib style guide, those names are actually consistent with rule 1 (\`Prop\`-terms use \`snake_case\`). Posted a summary on #189 too.

## Test plan
- [x] Doc-only change, no code affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)