### PR TITLE
feat(divmod): add val256_normalize lemma (MOD denorm bridge step B) (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DenormLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DenormLemmas.lean
@@ -129,6 +129,93 @@ theorem val256_denormalize {s : Nat} (hs0 : 0 < s) (hs : s < 64)
       Nat.add_mul_div_right _ _ hspos, Nat.div_eq_of_lt hr0_lt]
   omega
 
+-- ============================================================================
+-- Single-pair normalization: (x <<< s) ||| (y >>> (64 - s))
+-- ============================================================================
+
+/-- Disjointness of the two halves of a normalization funnel-shift: bit
+    positions of `x <<< s` (bits s..63) and `y >>> (64 - s)` (bits 0..s-1)
+    do not overlap when `0 < s < 64`. Mirror of `denorm_pair_and_eq_zero`. -/
+theorem norm_pair_and_eq_zero {s : Nat} (hs0 : 0 < s) (hs : s < 64) (x y : Word) :
+    (x <<< s) &&& (y >>> (64 - s)) = 0 := by
+  ext i
+  simp only [BitVec.getElem_and, BitVec.getElem_shiftLeft,
+             BitVec.getElem_ushiftRight]
+  by_cases hi : (i : Nat) < s
+  · simp [hi]
+  · rw [show y.getLsbD ((64 - s) + i) = false from by apply BitVec.getLsbD_of_ge; omega]
+    simp
+
+/-- Funnel-shift-left at Nat level: combining the low `s` bits of `x`
+    (shifted up) with the high `s` bits of `y` (shifted down) packs into a
+    64-bit word whose Nat value is `(x % 2^(64-s)) * 2^s + y / 2^(64-s)`. -/
+theorem norm_pair_toNat {s : Nat} (hs0 : 0 < s) (hs : s < 64) (x y : Word) :
+    ((x <<< s) ||| (y >>> (64 - s))).toNat =
+    (x.toNat % 2^(64 - s)) * 2^s + y.toNat / 2^(64 - s) := by
+  have hdisj := norm_pair_and_eq_zero hs0 hs x y
+  rw [(BitVec.add_eq_or_of_and_eq_zero (x <<< s) (y >>> (64 - s)) hdisj).symm,
+      BitVec.toNat_add_of_and_eq_zero hdisj,
+      BitVec.toNat_shiftLeft, BitVec.toNat_ushiftRight,
+      Nat.shiftRight_eq_div_pow]
+  simp only [Nat.shiftLeft_eq]
+  -- Goal: x.toNat * 2^s % 2^64 + y.toNat / 2^(64-s)
+  --     = x.toNat % 2^(64-s) * 2^s + y.toNat / 2^(64-s)
+  congr 1
+  -- x.toNat * 2^s % 2^64 = (x.toNat % 2^(64-s)) * 2^s
+  have hpow : (2 : Nat) ^ 64 = 2 ^ (64 - s) * 2 ^ s := by
+    rw [← pow_add, show (64 - s) + s = 64 from by omega]
+  rw [hpow, Nat.mul_mod_mul_right]
+
+-- ============================================================================
+-- 256-bit normalization: val256(norm) = val256(a) * 2^s (under top-bit bound)
+-- ============================================================================
+
+/-- Normalization round-trip at 256-bit level: applying the funnel-shift-left
+    pattern to four limbs produces a Nat value equal to `val256(a) * 2^s`
+    **when the top limb doesn't overflow** (`a3 < 2^(64-s)`). Mirror of
+    `val256_denormalize`. The low limb is just `a0 <<< s` (no feed from below). -/
+theorem val256_normalize {s : Nat} (hs0 : 0 < s) (hs : s < 64)
+    (a0 a1 a2 a3 : Word) (ha3 : a3.toNat < 2 ^ (64 - s)) :
+    val256 (a0 <<< s)
+           ((a1 <<< s) ||| (a0 >>> (64 - s)))
+           ((a2 <<< s) ||| (a1 >>> (64 - s)))
+           ((a3 <<< s) ||| (a2 >>> (64 - s)))
+      = val256 a0 a1 a2 a3 * 2^s := by
+  unfold val256
+  rw [norm_pair_toNat hs0 hs, norm_pair_toNat hs0 hs, norm_pair_toNat hs0 hs,
+      BitVec.toNat_shiftLeft]
+  simp only [Nat.shiftLeft_eq]
+  have hpow64 : (2 : Nat) ^ (64 - s) * 2 ^ s = 2 ^ 64 := by
+    rw [← pow_add, show (64 - s) + s = 64 from by omega]
+  -- Rewrite `a0.toNat * 2^s % 2^64 = (a0 % 2^(64-s)) * 2^s` to line up with other limbs.
+  rw [show (a0.toNat * 2 ^ s) % 2 ^ 64 = (a0.toNat % 2 ^ (64 - s)) * 2 ^ s from by
+        rw [show (2 : Nat) ^ 64 = 2 ^ (64 - s) * 2 ^ s from hpow64.symm,
+            Nat.mul_mod_mul_right]]
+  set mod0 := a0.toNat % 2 ^ (64 - s)
+  set div0 := a0.toNat / 2 ^ (64 - s)
+  set mod1 := a1.toNat % 2 ^ (64 - s)
+  set div1 := a1.toNat / 2 ^ (64 - s)
+  set mod2 := a2.toNat % 2 ^ (64 - s)
+  set div2 := a2.toNat / 2 ^ (64 - s)
+  have ha0 : mod0 + div0 * 2 ^ (64 - s) = a0.toNat := by
+    show a0.toNat % 2 ^ (64 - s) + a0.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a0.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  have ha1 : mod1 + div1 * 2 ^ (64 - s) = a1.toNat := by
+    show a1.toNat % 2 ^ (64 - s) + a1.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a1.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  have ha2 : mod2 + div2 * 2 ^ (64 - s) = a2.toNat := by
+    show a2.toNat % 2 ^ (64 - s) + a2.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a2.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  -- a3 < 2^(64-s), so a3 % 2^(64-s) = a3.
+  rw [show a3.toNat % 2 ^ (64 - s) = a3.toNat from Nat.mod_eq_of_lt ha3]
+  set t := (2 : Nat) ^ (64 - s) with ht_def
+  have ht : t * 2 ^ s = 2 ^ 64 := hpow64
+  rw [show (2 : Nat) ^ 64 = t * 2 ^ s from ht.symm,
+      show (2 : Nat) ^ 128 = t * 2 ^ s * (t * 2 ^ s) from by rw [ht]; decide,
+      show (2 : Nat) ^ 192 = t * 2 ^ s * (t * 2 ^ s) * (t * 2 ^ s) from by rw [ht]; decide,
+      ← ha0, ← ha1, ← ha2]
+  ring
+
 end EvmWord
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DenormLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DenormLemmas.lean
@@ -216,6 +216,60 @@ theorem val256_normalize {s : Nat} (hs0 : 0 < s) (hs : s < 64)
       ← ha0, ← ha1, ← ha2]
   ring
 
+/-- General form of normalization without the top-limb bound: the normalized
+    4-limb value plus the overflow bit `u4 := a3 >>> (64 - s)` (shifted up to
+    the 2^256 position) equals `val256(a) * 2^s`. This is the identity
+    actually used by Knuth algorithm D — the overflow limb `u4` is what the
+    algorithm tracks as the dividend's top limb during mulsub.
+
+    Specializes to `val256_normalize` when `u4 = 0` (i.e. `a3 < 2^(64-s)`). -/
+theorem val256_normalize_general {s : Nat} (hs0 : 0 < s) (hs : s < 64)
+    (a0 a1 a2 a3 : Word) :
+    val256 (a0 <<< s)
+           ((a1 <<< s) ||| (a0 >>> (64 - s)))
+           ((a2 <<< s) ||| (a1 >>> (64 - s)))
+           ((a3 <<< s) ||| (a2 >>> (64 - s)))
+      + (a3 >>> (64 - s)).toNat * 2 ^ 256
+      = val256 a0 a1 a2 a3 * 2^s := by
+  unfold val256
+  rw [norm_pair_toNat hs0 hs, norm_pair_toNat hs0 hs, norm_pair_toNat hs0 hs,
+      BitVec.toNat_shiftLeft, BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
+  simp only [Nat.shiftLeft_eq]
+  have hpow64 : (2 : Nat) ^ (64 - s) * 2 ^ s = 2 ^ 64 := by
+    rw [← pow_add, show (64 - s) + s = 64 from by omega]
+  rw [show (a0.toNat * 2 ^ s) % 2 ^ 64 = (a0.toNat % 2 ^ (64 - s)) * 2 ^ s from by
+        rw [show (2 : Nat) ^ 64 = 2 ^ (64 - s) * 2 ^ s from hpow64.symm,
+            Nat.mul_mod_mul_right]]
+  set mod0 := a0.toNat % 2 ^ (64 - s)
+  set div0 := a0.toNat / 2 ^ (64 - s)
+  set mod1 := a1.toNat % 2 ^ (64 - s)
+  set div1 := a1.toNat / 2 ^ (64 - s)
+  set mod2 := a2.toNat % 2 ^ (64 - s)
+  set div2 := a2.toNat / 2 ^ (64 - s)
+  set mod3 := a3.toNat % 2 ^ (64 - s)
+  set div3 := a3.toNat / 2 ^ (64 - s)
+  have ha0 : mod0 + div0 * 2 ^ (64 - s) = a0.toNat := by
+    show a0.toNat % 2 ^ (64 - s) + a0.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a0.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  have ha1 : mod1 + div1 * 2 ^ (64 - s) = a1.toNat := by
+    show a1.toNat % 2 ^ (64 - s) + a1.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a1.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  have ha2 : mod2 + div2 * 2 ^ (64 - s) = a2.toNat := by
+    show a2.toNat % 2 ^ (64 - s) + a2.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a2.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  have ha3 : mod3 + div3 * 2 ^ (64 - s) = a3.toNat := by
+    show a3.toNat % 2 ^ (64 - s) + a3.toNat / 2 ^ (64 - s) * 2 ^ (64 - s) = a3.toNat
+    rw [Nat.mul_comm]; exact Nat.mod_add_div _ _
+  set t := (2 : Nat) ^ (64 - s) with ht_def
+  have ht : t * 2 ^ s = 2 ^ 64 := hpow64
+  rw [show (2 : Nat) ^ 64 = t * 2 ^ s from ht.symm,
+      show (2 : Nat) ^ 128 = t * 2 ^ s * (t * 2 ^ s) from by rw [ht]; decide,
+      show (2 : Nat) ^ 192 = t * 2 ^ s * (t * 2 ^ s) * (t * 2 ^ s) from by rw [ht]; decide,
+      show (2 : Nat) ^ 256 = t * 2 ^ s * (t * 2 ^ s) * (t * 2 ^ s) * (t * 2 ^ s)
+        from by rw [ht]; decide,
+      ← ha0, ← ha1, ← ha2, ← ha3]
+  ring
+
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Second step in the MOD stack-spec denormalization bridge (Lemma B from `project_mod_denorm_bridge_blocker.md`). Extends `EvmAsm/Evm64/EvmWordArith/DenormLemmas.lean` with three more math lemmas, mirroring Lemma A's structure but for the shift-left (normalization) direction:

- `norm_pair_and_eq_zero` — disjointness of the two halves of a normalization funnel-shift.
- `norm_pair_toNat` — Nat-level funnel-shift-left identity.
- `val256_normalize` — 256-bit identity
  `val256 (normalized 4-limb shape) = val256(a) * 2^s` under the top-bit bound `a3 < 2^(64-s)`.

Combined with Lemma A (`val256_denormalize`, landed #595), these form the algebraic foundation for the MOD stack spec's denormalization round-trip: normalize-then-mulsub-then-denormalize recovers (at val256 level) what un-normalized-mulsub produces directly.

## Context

Remaining steps before `evm_mod_n4_max_skip_stack_spec` closes:

- Lemma C: chain `mulsubN4_val256_eq` on normalized inputs + runtime skip borrow + Lemma B to get `val256(a) * 2^s = q_hat * val256(b) * 2^s + val256(ms_n)`.
- Lemma D: remainder bound `val256(ms_n) < val256(b) * 2^s`.
- Lemma E: instantiate `mod_correct_normalized` with Lemma A/C/D.
- Lemma F: decompose via `getLimbN_fromLimbs_*`.
- Lemma G: stack-spec-ready adapter.

## Test plan

- [x] `lake build EvmAsm.Evm64.EvmWordArith.DenormLemmas` passes
- [x] No `sorry`/`admit`/`native_decide`/`bv_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)