### PR TITLE
refactor(divmulsub-carry): rename let-bound Word locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -29,7 +29,7 @@ namespace EvmWord
 
 /-- Helper: when MULHU = 2^64 - 2 (maximum), the low product is at most 1.
     From (2^64-1)² = (2^64-2)·2^64 + 1, so MUL result ≤ 1. -/
-private theorem prod_lo_le_one_of_mulhu_max {q v_i : Word}
+private theorem prodLo_le_one_of_mulhu_max {q v_i : Word}
     (h : (rv64_mulhu q v_i).toNat = 2^64 - 2) :
     (q * v_i).toNat ≤ 1 := by
   have hprod := partial_product_decompose q v_i
@@ -45,59 +45,59 @@ private theorem prod_lo_le_one_of_mulhu_max {q v_i : Word}
 
 /-- The per-limb mulsub carry is strictly less than 2^64.
 
-    The carry is `borrow_add + prod_hi + borrow_sub` where:
-    - borrow_add ∈ {0, 1} (from prod_lo + carry_in overflow)
-    - prod_hi ≤ 2^64 - 2 (from MULHU bound)
-    - borrow_sub ∈ {0, 1} (from u_i < full_sub underflow)
+    The carry is `borrowAdd + prodHi + borrowSub` where:
+    - borrowAdd ∈ {0, 1} (from prodLo + carry_in overflow)
+    - prodHi ≤ 2^64 - 2 (from MULHU bound)
+    - borrowSub ∈ {0, 1} (from u_i < fullSub underflow)
 
-    When prod_hi ≤ 2^64 - 3: carry ≤ 1 + (2^64 - 3) + 1 = 2^64 - 1 < 2^64.
-    When prod_hi = 2^64 - 2: prod_lo ≤ 1, and borrow_add = 1 forces
-    full_sub.toNat = 0 (modular wrap leaves 0), making borrow_sub = 0. -/
+    When prodHi ≤ 2^64 - 3: carry ≤ 1 + (2^64 - 3) + 1 = 2^64 - 1 < 2^64.
+    When prodHi = 2^64 - 2: prodLo ≤ 1, and borrowAdd = 1 forces
+    fullSub.toNat = 0 (modular wrap leaves 0), making borrowSub = 0. -/
 theorem mulsub_limb_carry_strict_lt (q v_i u_i carry_in : Word) :
-    let prod_lo := q * v_i
-    let prod_hi := rv64_mulhu q v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat < 2^64 := by
-  intro prod_lo prod_hi full_sub borrow_add borrow_sub
+    let prodLo := q * v_i
+    let prodHi := rv64_mulhu q v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64 := by
+  intro prodLo prodHi fullSub borrowAdd borrowSub
   have h_ph := mulhu_toNat_le q v_i
   -- Work with Nat-level values: ba_n, bs_n ∈ {0, 1}
-  set ba_n := if full_sub.toNat < carry_in.toNat then 1 else 0 with h_ba_def
-  set bs_n := if u_i.toNat < full_sub.toNat then 1 else 0 with h_bs_def
-  -- Convert borrow_add/borrow_sub toNat to ba_n/bs_n
-  have h_ba : borrow_add.toNat = ba_n := by
-    show (if BitVec.ult full_sub carry_in then (1 : Word) else 0).toNat = ba_n
-    simp only [h_ba_def]; by_cases h : full_sub.toNat < carry_in.toNat <;> simp [BitVec.ult, h]
-  have h_bs : borrow_sub.toNat = bs_n := by
-    show (if BitVec.ult u_i full_sub then (1 : Word) else 0).toNat = bs_n
-    simp only [h_bs_def]; by_cases h : u_i.toNat < full_sub.toNat <;> simp [BitVec.ult, h]
+  set ba_n := if fullSub.toNat < carry_in.toNat then 1 else 0 with h_ba_def
+  set bs_n := if u_i.toNat < fullSub.toNat then 1 else 0 with h_bs_def
+  -- Convert borrowAdd/borrowSub toNat to ba_n/bs_n
+  have h_ba : borrowAdd.toNat = ba_n := by
+    show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = ba_n
+    simp only [h_ba_def]; by_cases h : fullSub.toNat < carry_in.toNat <;> simp [BitVec.ult, h]
+  have h_bs : borrowSub.toNat = bs_n := by
+    show (if BitVec.ult u_i fullSub then (1 : Word) else 0).toNat = bs_n
+    simp only [h_bs_def]; by_cases h : u_i.toNat < fullSub.toNat <;> simp [BitVec.ult, h]
   rw [h_ba, h_bs]
   -- Bridge let-defs so omega can connect them
-  have h_ph_bridge : prod_hi.toNat = (rv64_mulhu q v_i).toNat := rfl
-  -- Now goal is: ba_n + prod_hi.toNat + bs_n < 2^64
+  have h_ph_bridge : prodHi.toNat = (rv64_mulhu q v_i).toNat := rfl
+  -- Now goal is: ba_n + prodHi.toNat + bs_n < 2^64
   have h_ba_01 : ba_n ≤ 1 := by simp only [h_ba_def]; split <;> omega
   have h_bs_01 : bs_n ≤ 1 := by simp only [h_bs_def]; split <;> omega
-  -- Easy case: prod_hi ≤ 2^64 - 3
+  -- Easy case: prodHi ≤ 2^64 - 3
   by_cases h_ph_max : (rv64_mulhu q v_i).toNat ≤ 2^64 - 3
   · -- ba_n ≤ 1, bs_n ≤ 1, ph ≤ 2^64 - 3 → sum ≤ 2^64 - 1
     omega
-  -- Hard case: prod_hi = 2^64 - 2
+  -- Hard case: prodHi = 2^64 - 2
   push Not at h_ph_max
   have h_ph_eq : (rv64_mulhu q v_i).toNat = 2^64 - 2 := by omega
-  have h_plo : (q * v_i).toNat ≤ 1 := prod_lo_le_one_of_mulhu_max h_ph_eq
+  have h_plo : (q * v_i).toNat ≤ 1 := prodLo_le_one_of_mulhu_max h_ph_eq
   -- Suffices: ba_n + bs_n ≤ 1
   suffices ba_n + bs_n ≤ 1 by omega
-  have h_fs_val : full_sub.toNat = ((q * v_i).toNat + carry_in.toNat) % 2^64 :=
+  have h_fs_val : fullSub.toNat = ((q * v_i).toNat + carry_in.toNat) % 2^64 :=
     BitVec.toNat_add (q * v_i) carry_in
   have h_ci := carry_in.isLt
   -- Case: ba_n = 0 → immediate
   by_cases h_ba_0 : ba_n = 0
   · omega
-  -- Case: ba_n = 1 → overflow → full_sub = 0 → bs_n = 0
+  -- Case: ba_n = 1 → overflow → fullSub = 0 → bs_n = 0
   have h_ba_1 : ba_n = 1 := by omega
-  -- ba_n = 1 means full_sub.toNat < carry_in.toNat
-  have h_ov : full_sub.toNat < carry_in.toNat := by
+  -- ba_n = 1 means fullSub.toNat < carry_in.toNat
+  have h_ov : fullSub.toNat < carry_in.toNat := by
     simp only [h_ba_def] at h_ba_1; split at h_ba_1 <;> [assumption; omega]
   -- overflow: (q * v_i).toNat + carry_in.toNat ≥ 2^64
   have h_overflow : (q * v_i).toNat + carry_in.toNat ≥ 2^64 := by
@@ -105,32 +105,32 @@ theorem mulsub_limb_carry_strict_lt (q v_i u_i carry_in : Word) :
     rw [h_fs_val, Nat.mod_eq_of_lt h_no] at h_ov; omega
   -- (q * v_i).toNat = 1 and carry_in = 2^64 - 1
   have h_plo_1 : (q * v_i).toNat = 1 := by omega
-  -- full_sub = 0
-  have h_fs_0 : full_sub.toNat = 0 := by rw [h_fs_val]; omega
+  -- fullSub = 0
+  have h_fs_0 : fullSub.toNat = 0 := by rw [h_fs_val]; omega
   -- bs_n = 0 (nothing is < 0)
   have : bs_n = 0 := by
-    simp only [h_bs_def, show ¬(u_i.toNat < full_sub.toNat) from by omega, ite_false]
+    simp only [h_bs_def, show ¬(u_i.toNat < fullSub.toNat) from by omega, ite_false]
   omega
 
 -- ============================================================================
 -- Word carry = Nat carry (unconditional corollary)
 -- ============================================================================
 
-/-- The Word-level carry `(borrow_add + prod_hi) + borrow_sub` equals the
-    Nat sum `borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat`.
+/-- The Word-level carry `(borrowAdd + prodHi) + borrowSub` equals the
+    Nat sum `borrowAdd.toNat + prodHi.toNat + borrowSub.toNat`.
 
     This follows from `mulsub_limb_carry_strict_lt` (carry < 2^64 means
     the Word additions don't overflow) and `mulsub_carry_word_eq`. -/
 theorem mulsub_limb_word_carry_eq (q v_i u_i carry_in : Word) :
-    let prod_lo := q * v_i
-    let prod_hi := rv64_mulhu q v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    ((borrow_add + prod_hi) + borrow_sub).toNat =
-      borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat := by
-  intro prod_lo prod_hi full_sub borrow_add borrow_sub
-  exact mulsub_carry_word_eq borrow_add prod_hi borrow_sub
+    let prodLo := q * v_i
+    let prodHi := rv64_mulhu q v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    ((borrowAdd + prodHi) + borrowSub).toNat =
+      borrowAdd.toNat + prodHi.toNat + borrowSub.toNat := by
+  intro prodLo prodHi fullSub borrowAdd borrowSub
+  exact mulsub_carry_word_eq borrowAdd prodHi borrowSub
     (mulsub_limb_carry_strict_lt q v_i u_i carry_in)
 
 -- ============================================================================
@@ -141,17 +141,17 @@ theorem mulsub_limb_word_carry_eq (q v_i u_i carry_in : Word) :
     Combines `mulsub_limb_nat_eq` and `mulsub_limb_word_carry_eq` so the
     carry_out can be passed directly as carry_in to the next limb. -/
 theorem mulsub_limb_nat_word_eq (q v_i u_i carry_in : Word) :
-    let prod_lo := q * v_i
-    let prod_hi := rv64_mulhu q v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let u_new := u_i - full_sub
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    let carry_out := (borrow_add + prod_hi) + borrow_sub
+    let prodLo := q * v_i
+    let prodHi := rv64_mulhu q v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let u_new := u_i - fullSub
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    let carry_out := (borrowAdd + prodHi) + borrowSub
     u_i.toNat + carry_out.toNat * 2^64 =
       u_new.toNat + q.toNat * v_i.toNat + carry_in.toNat := by
-  intro prod_lo prod_hi full_sub borrow_add u_new borrow_sub carry_out
-  rw [show carry_out = (borrow_add + prod_hi) + borrow_sub from rfl,
+  intro prodLo prodHi fullSub borrowAdd u_new borrowSub carry_out
+  rw [show carry_out = (borrowAdd + prodHi) + borrowSub from rfl,
       mulsub_limb_word_carry_eq q v_i u_i carry_in]
   exact mulsub_limb_nat_eq q v_i u_i carry_in
 
@@ -163,7 +163,7 @@ theorem mulsub_limb_nat_word_eq (q v_i u_i carry_in : Word) :
 
     This connects the exact register-level computation from `divK_mulsub_full_spec`
     to the mathematical Euclidean equation. The let-bindings match those in the
-    mulsub loop body: for each limb i, compute prod_lo/hi, full_sub, borrows,
+    mulsub loop body: for each limb i, compute prodLo/hi, fullSub, borrows,
     updated u_new, and carry_out.
 
     The initial carry is 0 (first limb). Each subsequent limb uses the


### PR DESCRIPTION
## Summary
Continues #189 migration (#600, #601, #602) for \`DivMulSubCarry.lean\`:
- \`prod_lo\` → \`prodLo\`
- \`prod_hi\` → \`prodHi\`
- \`full_sub\` → \`fullSub\`
- \`borrow_add\` → \`borrowAdd\`
- \`borrow_sub\` → \`borrowSub\`

Applies Mathlib rule 4 to Type-valued \`let\` bindings. Theorem names and hypothesis names remain \`snake_case\`.

## Test plan
- [x] \`lake build\` clean (3547 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)