### PR TITLE
refactor(divmulsub-limb): rename let-bound Word locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -46,95 +46,95 @@ theorem mulhu_toNat_le (a b : Word) : (rv64_mulhu a b).toNat ≤ 2^64 - 2 := by
 /-- Per-limb multiply-subtract Nat-level equation.
 
     The mulsub_limb operation computes:
-    - prod_lo = MUL(q, v_i), prod_hi = MULHU(q, v_i)
-    - full_sub = ADD(prod_lo, carry_in), borrow_add = SLTU(full_sub, carry_in)
-    - u_new = SUB(u_i, full_sub), borrow_sub = SLTU(u_i, full_sub)
+    - prodLo = MUL(q, v_i), prodHi = MULHU(q, v_i)
+    - fullSub = ADD(prodLo, carry_in), borrowAdd = SLTU(fullSub, carry_in)
+    - uNew = SUB(u_i, fullSub), borrowSub = SLTU(u_i, fullSub)
 
     At the Nat level, this produces:
-      u_i + C * 2^64 = u_new + q * v_i + carry_in
-    where C = borrow_add + prod_hi + borrow_sub (Nat sum).
+      u_i + C * 2^64 = uNew + q * v_i + carry_in
+    where C = borrowAdd + prodHi + borrowSub (Nat sum).
 
     This is exactly the per-limb equation needed by `mulsub_chain_nat`. -/
 theorem mulsub_limb_nat_eq (q v_i u_i carry_in : Word) :
-    let prod_lo := q * v_i
-    let prod_hi := rv64_mulhu q v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let u_new := u_i - full_sub
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    u_i.toNat + (borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat) * 2^64 =
-      u_new.toNat + q.toNat * v_i.toNat + carry_in.toNat := by
-  intro prod_lo prod_hi full_sub borrow_add u_new borrow_sub
-  -- Full product: q * v_i = prod_hi * 2^64 + prod_lo
+    let prodLo := q * v_i
+    let prodHi := rv64_mulhu q v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let uNew := u_i - fullSub
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    u_i.toNat + (borrowAdd.toNat + prodHi.toNat + borrowSub.toNat) * 2^64 =
+      uNew.toNat + q.toNat * v_i.toNat + carry_in.toNat := by
+  intro prodLo prodHi fullSub borrowAdd uNew borrowSub
+  -- Full product: q * v_i = prodHi * 2^64 + prodLo
   have h_prod := partial_product_decompose q v_i
-  -- full_sub = (prod_lo + carry_in) mod 2^64
-  have h_fs : full_sub.toNat = (prod_lo.toNat + carry_in.toNat) % 2^64 :=
-    BitVec.toNat_add prod_lo carry_in
-  -- borrow_add = (prod_lo + carry_in) / 2^64 (is 0 or 1)
-  have h_ba : borrow_add.toNat = (prod_lo.toNat + carry_in.toNat) / 2^64 := by
-    have hpl := prod_lo.isLt; have hci := carry_in.isLt
-    by_cases hov : prod_lo.toNat + carry_in.toNat < 2^64
+  -- fullSub = (prodLo + carry_in) mod 2^64
+  have h_fs : fullSub.toNat = (prodLo.toNat + carry_in.toNat) % 2^64 :=
+    BitVec.toNat_add prodLo carry_in
+  -- borrowAdd = (prodLo + carry_in) / 2^64 (is 0 or 1)
+  have h_ba : borrowAdd.toNat = (prodLo.toNat + carry_in.toNat) / 2^64 := by
+    have hpl := prodLo.isLt; have hci := carry_in.isLt
+    by_cases hov : prodLo.toNat + carry_in.toNat < 2^64
     · -- no overflow
-      have hge : full_sub.toNat ≥ carry_in.toNat := by rw [h_fs, Nat.mod_eq_of_lt hov]; omega
-      show (if BitVec.ult full_sub carry_in then (1 : Word) else 0).toNat = _
-      have : ¬(full_sub.toNat < carry_in.toNat) := by omega
+      have hge : fullSub.toNat ≥ carry_in.toNat := by rw [h_fs, Nat.mod_eq_of_lt hov]; omega
+      show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = _
+      have : ¬(fullSub.toNat < carry_in.toNat) := by omega
       simp [BitVec.ult, this]
       show 0 = _; omega
     · -- overflow
       push Not at hov
-      have hlt : full_sub.toNat < carry_in.toNat := by rw [h_fs]; omega
-      show (if BitVec.ult full_sub carry_in then (1 : Word) else 0).toNat = _
+      have hlt : fullSub.toNat < carry_in.toNat := by rw [h_fs]; omega
+      show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = _
       simp [BitVec.ult, hlt]
       show 1 = _
-      have : prod_lo.toNat + carry_in.toNat < 2 * 2^64 := by omega
+      have : prodLo.toNat + carry_in.toNat < 2 * 2^64 := by omega
       omega
-  -- borrow_sub = if u_i < full_sub then 1 else 0
-  have h_bs : borrow_sub.toNat = if u_i.toNat < full_sub.toNat then 1 else 0 := by
-    show (if BitVec.ult u_i full_sub then (1 : Word) else 0).toNat = _
-    by_cases h : u_i.toNat < full_sub.toNat
+  -- borrowSub = if u_i < fullSub then 1 else 0
+  have h_bs : borrowSub.toNat = if u_i.toNat < fullSub.toNat then 1 else 0 := by
+    show (if BitVec.ult u_i fullSub then (1 : Word) else 0).toNat = _
+    by_cases h : u_i.toNat < fullSub.toNat
     · simp [BitVec.ult, h]
-    · simp [BitVec.ult, show ¬(u_i.toNat < full_sub.toNat) from h]
-  -- u_new via sub
-  have hu := u_i.isLt; have hfs := full_sub.isLt
-  have h_un : u_new.toNat = if full_sub.toNat ≤ u_i.toNat
-    then u_i.toNat - full_sub.toNat
-    else u_i.toNat + 2^64 - full_sub.toNat := by
-    show (u_i - full_sub).toNat = _; rw [BitVec.toNat_sub]
-    by_cases h : full_sub.toNat ≤ u_i.toNat
+    · simp [BitVec.ult, show ¬(u_i.toNat < fullSub.toNat) from h]
+  -- uNew via sub
+  have hu := u_i.isLt; have hfs := fullSub.isLt
+  have h_un : uNew.toNat = if fullSub.toNat ≤ u_i.toNat
+    then u_i.toNat - fullSub.toNat
+    else u_i.toNat + 2^64 - fullSub.toNat := by
+    show (u_i - fullSub).toNat = _; rw [BitVec.toNat_sub]
+    by_cases h : fullSub.toNat ≤ u_i.toNat
     · simp [h]; omega
-    · push Not at h; simp [show ¬(full_sub.toNat ≤ u_i.toNat) from by omega]; omega
+    · push Not at h; simp [show ¬(fullSub.toNat ≤ u_i.toNat) from by omega]; omega
   -- div_add_mod for the add carry
-  have hdm := Nat.div_add_mod (prod_lo.toNat + carry_in.toNat) (2^64)
+  have hdm := Nat.div_add_mod (prodLo.toNat + carry_in.toNat) (2^64)
   -- Combine: normalize 2^64 to the literal everywhere
   have hB : (2:Nat)^64 = 18446744073709551616 := by norm_num
   -- Use B as shorthand for 2^64 literal
   set B := (18446744073709551616 : Nat) with hBdef
   rw [show (2:Nat)^64 = B from by omega] at h_ba h_fs h_prod hdm hu hfs h_un ⊢
-  -- Key: from hdm, (prod_lo + carry_in) / B * B + full_sub = prod_lo + carry_in
-  have hkey : (prod_lo.toNat + carry_in.toNat) / B * B =
-      prod_lo.toNat + carry_in.toNat - full_sub.toNat := by
+  -- Key: from hdm, (prodLo + carry_in) / B * B + fullSub = prodLo + carry_in
+  have hkey : (prodLo.toNat + carry_in.toNat) / B * B =
+      prodLo.toNat + carry_in.toNat - fullSub.toNat := by
     rw [h_fs]; omega
-  -- Key: prod_hi * B + prod_lo = q * v_i
-  -- (prod_hi and prod_lo are let-defs for rv64_mulhu and MUL, so this is h_prod rewritten)
-  have h_prod' : prod_hi.toNat * B + prod_lo.toNat = q.toNat * v_i.toNat := by
+  -- Key: prodHi * B + prodLo = q * v_i
+  -- (prodHi and prodLo are let-defs for rv64_mulhu and MUL, so this is h_prod rewritten)
+  have h_prod' : prodHi.toNat * B + prodLo.toNat = q.toNat * v_i.toNat := by
     show (rv64_mulhu q v_i).toNat * B + (q * v_i).toNat = _; linarith
   -- Expand the compound carry multiplication
-  have hfs_le : full_sub.toNat ≤ prod_lo.toNat + carry_in.toNat := by
+  have hfs_le : fullSub.toNat ≤ prodLo.toNat + carry_in.toNat := by
     rw [h_fs]; exact Nat.mod_le _ _
-  have hpl_le : prod_lo.toNat ≤ prod_hi.toNat * B + prod_lo.toNat := Nat.le_add_left _ _
+  have hpl_le : prodLo.toNat ≤ prodHi.toNat * B + prodLo.toNat := Nat.le_add_left _ _
   rw [h_ba, h_bs, h_un]
-  -- Eliminate the nonlinear q*v_i term by replacing with prod_hi*B + prod_lo (linear!)
-  rw [show q.toNat * v_i.toNat = prod_hi.toNat * B + prod_lo.toNat from h_prod'.symm]
-  -- Now everything is linear in div, prod_hi, B, prod_lo, carry_in, full_sub, u_i
-  by_cases hcmp : full_sub.toNat ≤ u_i.toNat
-  · simp only [hcmp, show ¬(u_i.toNat < full_sub.toNat) from by omega, ite_true, ite_false]
-    have h1 := Nat.add_mul ((prod_lo.toNat + carry_in.toNat) / B) prod_hi.toNat B
+  -- Eliminate the nonlinear q*v_i term by replacing with prodHi*B + prodLo (linear!)
+  rw [show q.toNat * v_i.toNat = prodHi.toNat * B + prodLo.toNat from h_prod'.symm]
+  -- Now everything is linear in div, prodHi, B, prodLo, carry_in, fullSub, u_i
+  by_cases hcmp : fullSub.toNat ≤ u_i.toNat
+  · simp only [hcmp, show ¬(u_i.toNat < fullSub.toNat) from by omega, ite_true, ite_false]
+    have h1 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B) prodHi.toNat B
     omega
   · push Not at hcmp
-    simp only [show ¬(full_sub.toNat ≤ u_i.toNat) from by omega,
-      show u_i.toNat < full_sub.toNat from by omega, ite_false, ite_true]
-    have h1 := Nat.add_mul ((prod_lo.toNat + carry_in.toNat) / B) prod_hi.toNat B
-    have h2 := Nat.add_mul ((prod_lo.toNat + carry_in.toNat) / B + prod_hi.toNat) 1 B
+    simp only [show ¬(fullSub.toNat ≤ u_i.toNat) from by omega,
+      show u_i.toNat < fullSub.toNat from by omega, ite_false, ite_true]
+    have h1 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B) prodHi.toNat B
+    have h2 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B + prodHi.toNat) 1 B
     omega
 
 -- ============================================================================
@@ -142,15 +142,15 @@ theorem mulsub_limb_nat_eq (q v_i u_i carry_in : Word) :
 -- ============================================================================
 
 /-- The Nat-level carry from one mulsub_limb step is at most 2^64.
-    borrow_add ≤ 1, prod_hi ≤ 2^64 - 2, borrow_sub ≤ 1. -/
+    borrowAdd ≤ 1, prodHi ≤ 2^64 - 2, borrowSub ≤ 1. -/
 theorem mulsub_limb_carry_le (q v_i : Word)
-    (borrow_add_nat borrow_sub_nat : Nat)
-    (h_ba : borrow_add_nat ≤ 1) (h_bs : borrow_sub_nat ≤ 1) :
-    borrow_add_nat + (rv64_mulhu q v_i).toNat + borrow_sub_nat ≤ 2^64 := by
+    (borrowAdd_nat borrowSub_nat : Nat)
+    (h_ba : borrowAdd_nat ≤ 1) (h_bs : borrowSub_nat ≤ 1) :
+    borrowAdd_nat + (rv64_mulhu q v_i).toNat + borrowSub_nat ≤ 2^64 := by
   have := mulhu_toNat_le q v_i; omega
 
-/-- When carry_in + prod_lo doesn't overflow, the add-borrow is 0. -/
-theorem borrow_add_eq_zero_of_no_overflow (q v_i carry_in : Word)
+/-- When carry_in + prodLo doesn't overflow, the add-borrow is 0. -/
+theorem borrowAdd_eq_zero_of_no_overflow (q v_i carry_in : Word)
     (h : (q * v_i).toNat + carry_in.toNat < 2^64) :
     (if BitVec.ult (q * v_i + carry_in) carry_in then (1 : Word) else 0) = 0 := by
   have hge : (q * v_i + carry_in).toNat ≥ carry_in.toNat := by
@@ -164,23 +164,23 @@ theorem borrow_add_eq_zero_of_no_overflow (q v_i carry_in : Word)
 -- ============================================================================
 
 /-- The per-limb carry is strictly < 2^64 whenever
-    borrow_add + borrow_sub ≤ 1 (not both overflow and underflow).
+    borrowAdd + borrowSub ≤ 1 (not both overflow and underflow).
     This ensures the carry fits in a Word. -/
 theorem mulsub_limb_carry_lt_of_sum_le_one (q v_i : Word)
-    (borrow_add_nat borrow_sub_nat : Nat)
-    (h_sum : borrow_add_nat + borrow_sub_nat ≤ 1) :
-    borrow_add_nat + (rv64_mulhu q v_i).toNat + borrow_sub_nat < 2^64 := by
+    (borrowAdd_nat borrowSub_nat : Nat)
+    (h_sum : borrowAdd_nat + borrowSub_nat ≤ 1) :
+    borrowAdd_nat + (rv64_mulhu q v_i).toNat + borrowSub_nat < 2^64 := by
   have := mulhu_toNat_le q v_i; omega
 
 /-- When the carry is < 2^64, the Word-level carry equals the Nat-level carry.
     This ensures the register-level carry_out correctly tracks the Nat-level
     carry for use as the next limb's carry_in. -/
-theorem mulsub_carry_word_eq (borrow_add prod_hi borrow_sub : Word)
-    (h : borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat < 2^64) :
-    ((borrow_add + prod_hi) + borrow_sub).toNat =
-    borrow_add.toNat + prod_hi.toNat + borrow_sub.toNat := by
+theorem mulsub_carry_word_eq (borrowAdd prodHi borrowSub : Word)
+    (h : borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64) :
+    ((borrowAdd + prodHi) + borrowSub).toNat =
+    borrowAdd.toNat + prodHi.toNat + borrowSub.toNat := by
   rw [BitVec.toNat_add, BitVec.toNat_add]
-  have h1 : borrow_add.toNat + prod_hi.toNat < 2^64 := by omega
+  have h1 : borrowAdd.toNat + prodHi.toNat < 2^64 := by omega
   rw [Nat.mod_eq_of_lt h1, Nat.mod_eq_of_lt (by omega)]
 
 -- ============================================================================


### PR DESCRIPTION
## Summary
Continues #189 migration (#600-#603) for \`DivMulSubLimb.lean\`:
- \`prod_lo\` → \`prodLo\`
- \`prod_hi\` → \`prodHi\`
- \`full_sub\` → \`fullSub\`
- \`borrow_add\` → \`borrowAdd\`
- \`borrow_sub\` → \`borrowSub\`
- \`u_new\` → \`uNew\`

## Test plan
- [x] \`lake build\` clean (3547 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)