### PR TITLE
refactor(mulsub-limbspec): rename let-bound locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
@@ -2,14 +2,14 @@
   EvmAsm.Evm64.DivMod.LimbSpec.MulSub
 
   CPS specs for one limb of the Knuth Algorithm D mul-sub inner step,
-  which computes `u[j..j+4] -= q_hat * v[0..3]` one limb at a time:
+  which computes `u[j..j+4] -= qHat * v[0..3]` one limb at a time:
     * `divK_mulsub_partA_spec` — 6 instructions (LD, MUL, MULHU, ADD,
-      SLTU, ADD): load v[i], compute `prod_lo = q_hat * v_i`,
-      `prod_hi = MULHU q_hat v_i`, and form `full_sub = prod_lo +
-      carry_in` and `partial_carry = (full_sub < carry_in) + prod_hi`.
+      SLTU, ADD): load v[i], compute `prodLo = qHat * v_i`,
+      `prodHi = MULHU qHat v_i`, and form `fullSub = prodLo +
+      carry_in` and `partialCarry = (fullSub < carry_in) + prodHi`.
     * `divK_mulsub_partB_spec` — 5 instructions (LD, SLTU, SUB, ADD, SD):
-      load u[j+i], compute `u_new = u_i - full_sub`,
-      `carry_out = partial_carry + (u_i < full_sub)`, store `u_new`.
+      load u[j+i], compute `uNew = u_i - fullSub`,
+      `carryOut = partialCarry + (u_i < fullSub)`, store `uNew`.
 
   Fourteenth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -30,14 +30,14 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Mul-sub limb Part A: LD v[i], MUL, MULHU, ADD, SLTU, ADD.
-    6 instructions. Produces full_sub (x7) and partial_carry (x10). -/
-theorem divK_mulsub_partA_spec (sp q_hat carry_in v5_old v7_old v_i : Word)
+    6 instructions. Produces fullSub (x7) and partialCarry (x10). -/
+theorem divK_mulsub_partA_spec (sp qHat carry_in v5_old v7_old v_i : Word)
     (v_off : BitVec 12) (base : Word) :
-    let prod_lo := q_hat * v_i
-    let prod_hi := rv64_mulhu q_hat v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let partial_carry := borrow_add + prod_hi
+    let prodLo := qHat * v_i
+    let prodHi := rv64_mulhu qHat v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let partialCarry := borrowAdd + prodHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x11 .x5))
@@ -46,28 +46,28 @@ theorem divK_mulsub_partA_spec (sp q_hat carry_in v5_old v7_old v_i : Word)
       (CodeReq.union (CodeReq.singleton (base + 16) (.SLTU .x10 .x7 .x10))
        (CodeReq.singleton (base + 20) (.ADD .x10 .x10 .x5))))))
     cpsTriple base (base + 24) cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carry_in) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ partial_carry) **
-       (.x5 ↦ᵣ prod_hi) ** (.x7 ↦ᵣ full_sub) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ partialCarry) **
+       (.x5 ↦ᵣ prodHi) ** (.x7 ↦ᵣ fullSub) **
        ((sp + signExtend12 v_off) ↦ₘ v_i)) := by
-  intro prod_lo prod_hi full_sub borrow_add partial_carry cr
+  intro prodLo prodHi fullSub borrowAdd partialCarry cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
-  have I1 := mul_spec_gen .x7 .x11 .x5 v7_old q_hat v_i (base + 4) (by nofun)
-  have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 q_hat v_i (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prod_lo carry_in (base + 12) (by nofun)
-  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 full_sub carry_in (base + 16) (by nofun)
-  have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrow_add prod_hi (base + 20) (by nofun)
+  have I1 := mul_spec_gen .x7 .x11 .x5 v7_old qHat v_i (base + 4) (by nofun)
+  have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 qHat v_i (base + 8) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carry_in (base + 12) (by nofun)
+  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carry_in (base + 16) (by nofun)
+  have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrowAdd prodHi (base + 20) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5
 
 /-- Mul-sub limb Part B: LD u[j+i], SLTU, SUB, ADD, SD.
-    5 instructions. Produces carry_out (x10) and stores u_new. -/
-theorem divK_mulsub_partB_spec (u_base partial_carry prod_hi full_sub v2_old u_i : Word)
+    5 instructions. Produces carryOut (x10) and stores uNew. -/
+theorem divK_mulsub_partB_spec (u_base partialCarry prodHi fullSub v2_old u_i : Word)
     (u_off : BitVec 12) (base : Word) :
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    let u_new := u_i - full_sub
-    let carry_out := partial_carry + borrow_sub
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    let uNew := u_i - fullSub
+    let carryOut := partialCarry + borrowSub
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x2 .x6 u_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLTU .x5 .x2 .x7))
@@ -75,18 +75,18 @@ theorem divK_mulsub_partB_spec (u_base partial_carry prod_hi full_sub v2_old u_i
       (CodeReq.union (CodeReq.singleton (base + 12) (.ADD .x10 .x10 .x5))
        (CodeReq.singleton (base + 16) (.SD .x6 .x2 u_off)))))
     cpsTriple base (base + 20) cr
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ partial_carry) **
-       (.x5 ↦ᵣ prod_hi) ** (.x7 ↦ᵣ full_sub) ** (.x2 ↦ᵣ v2_old) **
+      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ partialCarry) **
+       (.x5 ↦ᵣ prodHi) ** (.x7 ↦ᵣ fullSub) ** (.x2 ↦ᵣ v2_old) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_out) **
-       (.x5 ↦ᵣ borrow_sub) ** (.x7 ↦ᵣ full_sub) ** (.x2 ↦ᵣ u_new) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_new)) := by
-  intro borrow_sub u_new carry_out cr
+      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryOut) **
+       (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) ** (.x2 ↦ᵣ uNew) **
+       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+  intro borrowSub uNew carryOut cr
   have I0 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off base (by nofun)
-  have I1 := sltu_spec_gen .x5 .x2 .x7 prod_hi u_i full_sub (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i full_sub (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs1 .x10 .x5 partial_carry borrow_sub (base + 12) (by nofun)
-  have I4 := sd_spec_gen .x6 .x2 u_base u_new u_i u_off (base + 16)
+  have I1 := sltu_spec_gen .x5 .x2 .x7 prodHi u_i fullSub (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i fullSub (base + 8) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs1 .x10 .x5 partialCarry borrowSub (base + 12) (by nofun)
+  have I4 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 16)
   runBlock I0 I1 I2 I3 I4
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
@@ -4,11 +4,11 @@
   Composed per-limb specs for the `mul-sub` and `add-back` inner loops
   of the Knuth Algorithm D step:
     * `divK_mulsub_limb_spec` — 11-instruction straight-line composition
-      of `partA` (6 instrs) + `partB` (5 instrs): `u -= q_hat * v_i`
+      of `partA` (6 instrs) + `partB` (5 instrs): `u -= qHat * v_i`
       with carry propagation.
     * `divK_addback_limb_spec` — 8-instruction straight-line composition
       of add-back `partA` (5 instrs) + `partB` (3 instrs): `u += v_i`
-      with carry propagation, used when `q_hat` was over-shot.
+      with carry propagation, used when `qHat` was over-shot.
 
   Twenty-sixth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -29,19 +29,19 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Mul-sub full limb: partA (6 instrs) + partB (5 instrs) = 11 instructions.
-    Input: q_hat (x11), carry_in (x10), v[i] and u[j+i] in memory.
-    Output: carry_out (x10), u_new stored. -/
+    Input: qHat (x11), carry_in (x10), v[i] and u[j+i] in memory.
+    Output: carryOut (x10), uNew stored. -/
 theorem divK_mulsub_limb_spec
-    (sp u_base q_hat carry_in v5_old v7_old v2_old v_i u_i : Word)
+    (sp u_base qHat carry_in v5_old v7_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
-    let prod_lo := q_hat * v_i
-    let prod_hi := rv64_mulhu q_hat v_i
-    let full_sub := prod_lo + carry_in
-    let borrow_add := if BitVec.ult full_sub carry_in then (1 : Word) else 0
-    let partial_carry := borrow_add + prod_hi
-    let borrow_sub := if BitVec.ult u_i full_sub then (1 : Word) else 0
-    let u_new := u_i - full_sub
-    let carry_out := partial_carry + borrow_sub
+    let prodLo := qHat * v_i
+    let prodHi := rv64_mulhu qHat v_i
+    let fullSub := prodLo + carry_in
+    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let partialCarry := borrowAdd + prodHi
+    let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
+    let uNew := u_i - fullSub
+    let carryOut := partialCarry + borrowSub
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x11 .x5))
@@ -55,41 +55,41 @@ theorem divK_mulsub_limb_spec
       (CodeReq.union (CodeReq.singleton (base + 36) (.ADD .x10 .x10 .x5))
        (CodeReq.singleton (base + 40) (.SD .x6 .x2 u_off)))))))))))
     cpsTriple base (base + 44) cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carry_in) **
        (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ carry_out) **
-       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ borrow_sub) ** (.x7 ↦ᵣ full_sub) **
-       (.x2 ↦ᵣ u_new) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryOut) **
+       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) **
+       (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_new)) := by
-  intro prod_lo prod_hi full_sub borrow_add partial_carry borrow_sub u_new carry_out cr
+       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+  intro prodLo prodHi fullSub borrowAdd partialCarry borrowSub uNew carryOut cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
-  have I1 := mul_spec_gen .x7 .x11 .x5 v7_old q_hat v_i (base + 4) (by nofun)
-  have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 q_hat v_i (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prod_lo carry_in (base + 12) (by nofun)
-  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 full_sub carry_in (base + 16) (by nofun)
-  have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrow_add prod_hi (base + 20) (by nofun)
+  have I1 := mul_spec_gen .x7 .x11 .x5 v7_old qHat v_i (base + 4) (by nofun)
+  have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 qHat v_i (base + 8) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carry_in (base + 12) (by nofun)
+  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carry_in (base + 16) (by nofun)
+  have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrowAdd prodHi (base + 20) (by nofun)
   have I6 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 24) (by nofun)
-  have I7 := sltu_spec_gen .x5 .x2 .x7 prod_hi u_i full_sub (base + 28) (by nofun)
-  have I8 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i full_sub (base + 32) (by nofun)
-  have I9 := add_spec_gen_rd_eq_rs1 .x10 .x5 partial_carry borrow_sub (base + 36) (by nofun)
-  have I10 := sd_spec_gen .x6 .x2 u_base u_new u_i u_off (base + 40)
+  have I7 := sltu_spec_gen .x5 .x2 .x7 prodHi u_i fullSub (base + 28) (by nofun)
+  have I8 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i fullSub (base + 32) (by nofun)
+  have I9 := add_spec_gen_rd_eq_rs1 .x10 .x5 partialCarry borrowSub (base + 36) (by nofun)
+  have I10 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 40)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10
 
 /-- Add-back full limb: partA (5 instrs) + partB (3 instrs) = 8 instructions.
     Input: carry_in (x7), v[i] and u[j+i] in memory.
-    Output: carry_out (x7), u_new stored. -/
+    Output: carryOut (x7), uNew stored. -/
 theorem divK_addback_limb_spec
     (sp u_base carry_in v5_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
     let u_plus_carry := u_i + carry_in
     let carry1 := if BitVec.ult u_plus_carry carry_in then (1 : Word) else 0
-    let u_new := u_plus_carry + v_i
-    let carry2 := if BitVec.ult u_new v_i then (1 : Word) else 0
-    let carry_out := carry1 ||| carry2
+    let uNew := u_plus_carry + v_i
+    let carry2 := if BitVec.ult uNew v_i then (1 : Word) else 0
+    let carryOut := carry1 ||| carry2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x2 .x6 u_off))
@@ -104,19 +104,19 @@ theorem divK_addback_limb_spec
        (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry_out) **
-       (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ u_new) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryOut) **
+       (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_new)) := by
-  intro u_plus_carry carry1 u_new carry2 carry_out cr
+       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+  intro u_plus_carry carry1 uNew carry2 carryOut cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
   have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carry_in (base + 8) (by nofun)
   have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 u_plus_carry carry_in (base + 12) (by nofun)
   have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 u_plus_carry v_i (base + 16) (by nofun)
-  have I5 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 u_new v_i (base + 20) (by nofun)
+  have I5 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 uNew v_i (base + 20) (by nofun)
   have I6 := or_spec_gen_rd_eq_rs1 .x7 .x5 carry1 carry2 (base + 24) (by nofun)
-  have I7 := sd_spec_gen .x6 .x2 u_base u_new u_i u_off (base + 28)
+  have I7 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 28)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
@@ -28,7 +28,7 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Mul-sub setup: restore j from scratch, compute u_base, zero carry. -/
-theorem divK_mulsub_setup_spec (sp q_hat j v1_old v5_old v6_old v10_old : Word)
+theorem divK_mulsub_setup_spec (sp qHat j v1_old v5_old v6_old v10_old : Word)
     (base : Word) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let sp_m40 := sp + signExtend12 4056
@@ -40,11 +40,11 @@ theorem divK_mulsub_setup_spec (sp q_hat j v1_old v5_old v6_old v10_old : Word)
       (CodeReq.union (CodeReq.singleton (base + 12) (.SUB .x6 .x6 .x5))
        (CodeReq.singleton (base + 16) (.ADDI .x10 .x0 0)))))
     cpsTriple base (base + 20) cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x10 ↦ᵣ v10_old) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ j_x8) ** (.x6 ↦ᵣ u_base) **
        (.x10 ↦ᵣ signExtend12 0) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j)) := by


### PR DESCRIPTION
## Summary
Applies Mathlib rule 4 to the three MulSub* limb specs:
- \`DivMod/LimbSpec/MulSub.lean\`
- \`DivMod/LimbSpec/MulSubLimb.lean\`
- \`DivMod/LimbSpec/MulSubSetup.lean\`

9 renames: \`prod_lo\` → \`prodLo\`, \`prod_hi\` → \`prodHi\`, \`full_sub\` → \`fullSub\`, \`borrow_add\` → \`borrowAdd\`, \`borrow_sub\` → \`borrowSub\`, \`u_new\` → \`uNew\`, \`carry_out\` → \`carryOut\`, \`partial_carry\` → \`partialCarry\`, \`q_hat\` → \`qHat\`.

## Test plan
- [x] \`lake build\` clean (3547 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)