### PR TITLE
refactor(div128/phase-end,phaseb-tail,div128-step1): camelCase locals (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -6,7 +6,7 @@
     * `divK_div128_phase1_spec` — Instrs [0]-[9], 10 instructions:
       SD+SD+SRLI+SLLI+SRLI+SD (save_split_d) followed by
       SRLI+SLLI+SRLI+SD (split_ulo). Saves the return address and `d`,
-      splits `d` into `d_hi`/`d_lo`, splits `u_lo` into `un1`/`un0`.
+      splits `d` into `dHi`/`dLo`, splits `u_lo` into `un1`/`un0`.
     * `divK_div128_end_spec` — Instrs [45]-[48], 4 instructions:
       SLLI+OR (combine_q → `q = q1<<32 | q0`) followed by LD+JALR
       (restore return addr and jump back). Exits at `ret_addr`.
@@ -31,12 +31,12 @@ open EvmAsm.Rv64
 
 /-- div128 Phase 1: save return addr/d, split d and u_lo. Instrs [0]-[9].
     Input: x12=sp, x2=ret_addr, x10=d, x5=u_lo, x7=u_hi.
-    Output: x6=d_hi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
+    Output: x6=dHi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
 theorem divK_div128_phase1_spec
     (sp ret_addr d u_lo u_hi v1_old v6_old v11_old
      ret_mem d_mem dlo_mem un0_mem : Word) (base : Word) :
-    let d_hi := d >>> (32 : BitVec 6).toNat
-    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := d >>> (32 : BitVec 6).toNat
+    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let cr :=
@@ -59,19 +59,19 @@ theorem divK_div128_phase1_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ un0_mem))
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ d_lo) ** (.x5 ↦ᵣ un0) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
        (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ u_hi) **
        (sp + signExtend12 3968 ↦ₘ ret_addr) **
        (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro d_hi d_lo un1 un0 cr
+  intro dHi dLo un1 un0 cr
   have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
   have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
   have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
   have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
   have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen .x12 .x1 sp d_lo dlo_mem 3952 (base + 20)
+  have I5 := sd_spec_gen .x12 .x1 sp dLo dlo_mem 3952 (base + 20)
   have I6 := srli_spec_gen .x11 .x5 v11_old u_lo 32 (base + 24) (by nofun)
   have I7 := slli_spec_gen_same .x5 u_lo 32 (base + 28) (by nofun)
   have I8 := srli_spec_gen_same .x5 (u_lo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -28,19 +28,19 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- div128 step 1: trial division q1, clamp, product check. Instrs [10]-[24].
-    Input: u_hi in x7, d_hi in x6, un1 in x11, dlo in memory.
+    Input: u_hi in x7, dHi in x6, un1 in x11, dlo in memory.
     Output: refined q1 in x10, refined rhat in x7. -/
 theorem divK_div128_step1_spec
-    (sp u_hi d_hi un1 v1_old v5_old v10_old dlo : Word) (base : Word) :
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+    (sp u_hi dHi un1 v1_old v5_old v10_old dlo : Word) (base : Word) :
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let hi := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * dlo
+    let rhatc := if hi = 0 then rhat else rhat + dHi
+    let qDlo := q1c * dlo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let q1' := if BitVec.ult rhat_un1 qDlo then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhat_un1 qDlo then rhatc + dHi else rhatc
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
@@ -58,13 +58,13 @@ theorem divK_div128_step1_spec
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6)))))))))))))))
     cpsTriple base (base + 60) cr
-      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ d_hi) ** (.x10 ↦ᵣ v10_old) **
+      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10_old) **
        (.x5 ↦ᵣ v5_old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1_old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
-      ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ d_hi) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q_dlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhat_un1) **
+      ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+       (.x5 ↦ᵣ qDlo) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhat_un1) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  intro q1 rhat hi q1c rhatc q_dlo rhat_un1 q1' rhat' cr
+  intro q1 rhat hi q1c rhatc qDlo rhat_un1 q1' rhat' cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
@@ -81,7 +81,7 @@ theorem divK_div128_step1_spec
       (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))))))))))))))) := rfl
-  have h1_raw := divK_div128_step1_init_spec u_hi d_hi v5_old v10_old base
+  have h1_raw := divK_div128_step1_init_spec u_hi dHi v5_old v10_old base
   have h1 : cpsTriple base (base + 12) cr _ _ :=
     cpsTriple_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))
@@ -89,7 +89,7 @@ theorem divK_div128_step1_spec
     ((.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1_old) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) h1
-  have h2_raw := divK_div128_clamp_q1_merged_spec q1 rhat d_hi (q1 * d_hi) (base + 12)
+  have h2_raw := divK_div128_clamp_q1_merged_spec q1 rhat dHi (q1 * dHi) (base + 12)
   have : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   have : (base + 12 : Word) + 8 = base + 20 := by bv_addr
   have : (base + 12 : Word) + 12 = base + 24 := by bv_addr
@@ -114,7 +114,7 @@ theorem divK_div128_step1_spec
     (by pcFree) h2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1f h2f
-  have h3_raw := divK_div128_prodcheck1_merged_spec sp q1c rhatc d_hi un1
+  have h3_raw := divK_div128_prodcheck1_merged_spec sp q1c rhatc dHi un1
     v1_old hi dlo (base + 28)
   have : (base + 28 : Word) + 4 = base + 32 := by bv_addr
   have : (base + 28 : Word) + 8 = base + 36 := by bv_addr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
@@ -32,23 +32,23 @@ abbrev divK_phaseB_tail_code (base : Word) : CodeReq :=
 theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word) :
     let nm1 := n + signExtend12 4095
     let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-    let addr_lead := sp + nm1_x8
+    let addrLead := sp + nm1_x8
     let cr := divK_phaseB_tail_code base
     cpsTriple base (base + 20) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
        ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((addr_lead + signExtend12 32) ↦ₘ leading_limb))
+       ((addrLead + signExtend12 32) ↦ₘ leading_limb))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ leading_limb) **
        ((sp + signExtend12 3984) ↦ₘ n) **
-       ((addr_lead + signExtend12 32) ↦ₘ leading_limb)) := by
-  intro nm1 nm1_x8 addr_lead cr
+       ((addrLead + signExtend12 32) ↦ₘ leading_limb)) := by
+  intro nm1 nm1_x8 addrLead cr
   have I0 := sd_spec_gen .x12 .x5 sp n n_mem 3984 base
   have I1 := addi_spec_gen_same .x5 n 4095 (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x5 nm1 3 (base + 8) (by nofun)
   have I3 := add_spec_gen_rd_eq_rs2 .x5 .x12 sp nm1_x8 (base + 12) (by nofun)
-  have I4 := ld_spec_gen_same .x5 addr_lead leading_limb 32 (base + 16) (by nofun)
+  have I4 := ld_spec_gen_same .x5 addrLead leading_limb 32 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Applies Mathlib rule 4 to:
- \`DivMod/LimbSpec/Div128PhaseEnd.lean\`: \`d_hi\` → \`dHi\`, \`d_lo\` → \`dLo\`
- \`DivMod/LimbSpec/PhaseBTail.lean\`: \`addr_lead\` → \`addrLead\`
- \`DivMod/LimbSpec/Div128Step1.lean\`: \`q_dlo\` → \`qDlo\`

## Test plan
- [x] \`lake build\` clean (3547 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)