### PR TITLE
feat(divmod): add pure-Nat u_top_eq_c3_nat_form (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -86,6 +86,54 @@ theorem val256_normalized_mulsub_eq
   rw [h_norm_b] at h_mulsub
   linarith
 
+/-- Fully abstract Nat-level `u_top = c3_n` lemma. Takes all relevant
+    Euclidean equations and bounds as plain Nat facts — lets the caller
+    plug in `val256(ms_un)`, `val256(a) * 2^s`, etc. without forcing
+    the elaborator to unfold `mulsubN4` or `val256_normalized_mulsub_eq`
+    internals. Composes the un-normalized Euclidean equation with the
+    normalization identity and the 2^256 pigeonhole to collapse
+    `u_top - c3_n = 0`. -/
+theorem u_top_eq_c3_nat_form
+    {Va Vb Vms_un Vms_n Vu Vbn : Nat}
+    {u_top c3_n Q : Nat}
+    (s : Nat)
+    (h_Va : Va = Vms_un + Q * Vb)
+    (h_norm_u : Vu + u_top * 2 ^ 256 = Va * 2 ^ s)
+    (h_norm_b : Vbn = Vb * 2 ^ s)
+    (h_Vn : Vu + c3_n * 2 ^ 256 = Vms_n + Q * Vbn)
+    (h_Vms_un_lt_Vb : Vms_un < Vb)
+    (h_Vb_bound : Vb < 2 ^ (256 - s))
+    (hs_le : s ≤ 256)
+    (hs_pos : 0 < 2 ^ s)
+    (h_c3_le : c3_n ≤ u_top) :
+    u_top = c3_n := by
+  -- Scale un-normalized Euclidean by 2^s.
+  have h_Va_scaled : Va * 2 ^ s = Vms_un * 2 ^ s + Q * Vb * 2 ^ s := by
+    rw [h_Va]; ring
+  -- Merge the two Euclidean equations (via Va*2^s pivot).
+  have h_n_combined : Vu + c3_n * 2 ^ 256 = Vms_n + Q * (Vb * 2 ^ s) := by
+    rw [h_norm_b] at h_Vn; exact h_Vn
+  -- Va * 2^s + c3_n * 2^256 = Vms_n + Q * Vb * 2^s + u_top * 2^256
+  have h_shifted : Va * 2 ^ s + c3_n * 2 ^ 256 =
+      Vms_n + Q * Vb * 2 ^ s + u_top * 2 ^ 256 := by
+    have hqa : Q * (Vb * 2 ^ s) = Q * Vb * 2 ^ s := by ring
+    linarith [h_norm_u, h_n_combined, hqa]
+  -- Substitute h_Va_scaled and cancel Q * Vb * 2^s:
+  have h_cancel : Vms_un * 2 ^ s + c3_n * 2 ^ 256 = Vms_n + u_top * 2 ^ 256 := by
+    linarith
+  -- Bound Vms_un * 2^s < 2^256.
+  have hpow : (2 : Nat) ^ (256 - s) * 2 ^ s = 2 ^ 256 := by
+    rw [← pow_add, show (256 - s) + s = 256 from by omega]
+  have h_bound : Vms_un * 2 ^ s < 2 ^ 256 := by
+    calc Vms_un * 2 ^ s
+        < Vb * 2 ^ s := Nat.mul_lt_mul_right hs_pos |>.mpr h_Vms_un_lt_Vb
+      _ < 2 ^ (256 - s) * 2 ^ s := Nat.mul_lt_mul_right hs_pos |>.mpr h_Vb_bound
+      _ = 2 ^ 256 := hpow
+  -- Pigeonhole: from h_cancel + h_bound + h_c3_le → u_top = c3_n.
+  have h_eq_form : Vms_un * 2 ^ s =
+      Vms_n + (u_top - c3_n) * 2 ^ 256 := by omega
+  exact nat_top_eq_of_lt_pow256 h_c3_le h_eq_form h_bound
+
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Stacked on PR #610. Adds \`u_top_eq_c3_nat_form\` to \`ModBridgeUtop.lean\` — the fully Nat-level form of the \`u_top = c3_n\` invariant. Takes the un-normalized Euclidean equation, the two normalization identities, the normalized Euclidean equation, bounds, and the runtime skip borrow as plain Nat hypotheses, and concludes \`u_top = c3_n\`.

## Why Nat-level

Previous attempts to chain through the Word-valued \`mulsubN4\` / \`val256\` expressions directly hit \`whnf\` deterministic heartbeat timeouts on the expanded shift+OR terms, even with \`set\` abbreviations. At Nat level the elaborator has no definitional unfolding to do, and the proof closes quickly via \`linarith\` + \`omega\` + the existing \`nat_top_eq_of_lt_pow256\` pigeonhole.

Callers (a future theorem) will instantiate the abstract \`Va\`, \`Vb\`, \`Vms_un\`, \`Vms_n\`, \`Vu\`, \`Vbn\`, \`u_top\`, \`c3_n\`, \`Q\` from the real Word-level values and supply the Euclidean/normalization equations from \`mulsubN4_val256_eq\`, \`val256_normalize_general\`, \`val256_normalize\`, \`val256_ms_un_lt_val256_b_max_skip\`, and \`val256_lt_of_b3_bound\`.

## Test plan

- [x] \`lake build EvmAsm.Evm64.EvmWordArith.ModBridgeUtop\` clean (~2.4s)
- [x] No \`sorry\`/\`admit\`/\`native_decide\`/\`bv_decide\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)