### PR TITLE
refactor(shl): rename let-bound locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -38,20 +38,20 @@ abbrev shl_merge_limb_code (base : Word) (src_off prev_off dst_off : BitVec 12) 
     Mirror of shr_merge_limb_spec with SLL/SRL swapped. -/
 theorem shl_merge_limb_spec (src_off prev_off dst_off : BitVec 12)
     (sp src prev dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
-    let mem_src := sp + signExtend12 src_off
-    let mem_prev := sp + signExtend12 prev_off
-    let mem_dst := sp + signExtend12 dst_off
-    let shifted_src := src <<< (bit_shift.toNat % 64)
-    let shifted_prev := (prev >>> (anti_shift.toNat % 64)) &&& mask
-    let result := shifted_src ||| shifted_prev
+    let memSrc := sp + signExtend12 src_off
+    let memPrev := sp + signExtend12 prev_off
+    let memDst := sp + signExtend12 dst_off
+    let shiftedSrc := src <<< (bit_shift.toNat % 64)
+    let shiftedPrev := (prev >>> (anti_shift.toNat % 64)) &&& mask
+    let result := shiftedSrc ||| shiftedPrev
     let cr := shl_merge_limb_code base src_off prev_off dst_off
     cpsTriple base (base + 28) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
-       (mem_src ↦ₘ src) ** (mem_prev ↦ₘ prev) ** (mem_dst ↦ₘ dst_old))
+       (memSrc ↦ₘ src) ** (memPrev ↦ₘ prev) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shifted_prev) ** (.x11 ↦ᵣ mask) **
-       (mem_src ↦ₘ src) ** (mem_prev ↦ₘ prev) ** (mem_dst ↦ₘ result)) := by
+       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       (memSrc ↦ₘ src) ** (memPrev ↦ₘ prev) ** (memDst ↦ₘ result)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src src_off base (by nofun)
   have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 prev prev_off (base + 8) (by nofun)
@@ -77,15 +77,15 @@ abbrev shl_first_limb_code (base : Word) (dst_off : BitVec 12) : CodeReq :=
     Mirror of shr_last_limb_spec: reads from offset 0 (lowest limb), uses SLL. -/
 theorem shl_first_limb_spec (dst_off : BitVec 12)
     (sp src dst_old v5 bit_shift : Word) (base : Word) :
-    let mem_src := sp + signExtend12 (0 : BitVec 12)
-    let mem_dst := sp + signExtend12 dst_off
+    let memSrc := sp + signExtend12 (0 : BitVec 12)
+    let memDst := sp + signExtend12 dst_off
     let result := src <<< (bit_shift.toNat % 64)
     let cr := shl_first_limb_code base dst_off
     cpsTriple base (base + 12) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (mem_src ↦ₘ src) ** (mem_dst ↦ₘ dst_old))
+       (memSrc ↦ₘ src) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (mem_src ↦ₘ src) ** (mem_dst ↦ₘ result)) := by
+       (memSrc ↦ₘ src) ** (memDst ↦ₘ result)) := by
   have L := ld_spec_gen .x5 .x12 sp v5 src 0 base (by nofun)
   have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have SD_ := sd_spec_gen .x12 .x5 sp (src <<< (bit_shift.toNat % 64)) dst_old dst_off (base + 8)
@@ -108,19 +108,19 @@ abbrev shl_merge_limb_inplace_code (base : Word) (off prev_off : BitVec 12) : Co
     Same as shl_merge_limb_spec but src_off = dst_off. -/
 theorem shl_merge_limb_inplace_spec (off prev_off : BitVec 12)
     (sp src prev v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
-    let mem_loc := sp + signExtend12 off
-    let mem_prev := sp + signExtend12 prev_off
-    let shifted_src := src <<< (bit_shift.toNat % 64)
-    let shifted_prev := (prev >>> (anti_shift.toNat % 64)) &&& mask
-    let result := shifted_src ||| shifted_prev
+    let memLoc := sp + signExtend12 off
+    let memPrev := sp + signExtend12 prev_off
+    let shiftedSrc := src <<< (bit_shift.toNat % 64)
+    let shiftedPrev := (prev >>> (anti_shift.toNat % 64)) &&& mask
+    let result := shiftedSrc ||| shiftedPrev
     let cr := shl_merge_limb_inplace_code base off prev_off
     cpsTriple base (base + 28) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
-       (mem_loc ↦ₘ src) ** (mem_prev ↦ₘ prev))
+       (memLoc ↦ₘ src) ** (memPrev ↦ₘ prev))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shifted_prev) ** (.x11 ↦ᵣ mask) **
-       (mem_loc ↦ₘ result) ** (mem_prev ↦ₘ prev)) := by
+       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       (memLoc ↦ₘ result) ** (memPrev ↦ₘ prev)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src off base (by nofun)
   have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 prev prev_off (base + 8) (by nofun)


### PR DESCRIPTION
## Summary
- Rename snake_case \`let\`-bound Type-valued locals in \`Shift/ShlSpec.lean\`:
  \`mem_src\`, \`mem_prev\`, \`mem_dst\`, \`mem_loc\` → camelCase; \`shifted_src\`, \`shifted_prev\` → \`shiftedSrc\`, \`shiftedPrev\`.
- Parameter names left alone to keep scope small.

Per Mathlib rule 4 (let-bound Type-valued locals use lowerCamelCase).
Continues the gradual #189 migration.

## Test plan
- [x] \`lake build\` succeeds
- [x] No semantic changes — identifiers only

🤖 Generated with [Claude Code](https://claude.com/claude-code)