### PR TITLE
refactor(sar-compose): rename let-bound locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -459,15 +459,15 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   -- Compose h1234 → h56
   have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h1234 h56
-  -- Step 7: BEQ at base+32 offset 320 → eliminate ntaken (sltiu_val = 0 since s0 ≥ 256)
-  let sltiu_val := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
-  have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiu_val (0 : Word) (base + 32)
+  -- Step 7: BEQ at base+32 offset 320 → eliminate ntaken (sltiuVal = 0 since s0 ≥ 256)
+  let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
+  have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiuVal (0 : Word) (base + 32)
   rw [sar_beq_target, sar_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_sarCode base) hbeq_raw
-  -- sltiu_val = 0 (since s0 ≥ 256 → ult is false)
-  have hsltiu_eq : sltiu_val = (0 : Word) := by
-    simp only [sltiu_val, hlarge]; decide
-  -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
+  -- sltiuVal = 0 (since s0 ≥ 256 → ult is false)
+  have hsltiu_eq : sltiuVal = (0 : Word) := by
+    simp only [sltiuVal, hlarge]; decide
+  -- Eliminate ntaken: ntaken postcondition has ⌜sltiuVal ≠ 0⌝, but sltiuVal = 0
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -483,7 +483,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Sign-fill path (base+352 → base+380)
   have hsfp := cpsTriple_extend_code (sign_fill_sub_sarCode base)
-    (sar_sign_fill_path_spec sp s0 sltiu_val v0 v1 v2 v3 (base + 352))
+    (sar_sign_fill_path_spec sp s0 sltiuVal v0 v1 v2 v3 (base + 352))
   rw [sar_off_352_28] at hsfp
   have hsfp_framed := cpsTriple_frame_left (base + 352) (base + 380) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) **
@@ -498,7 +498,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
     (fun h hq => by
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
-          ((.x5 ↦ᵣ (BitVec.sshiftRight v3 63)) ** (.x10 ↦ᵣ sltiu_val) **
+          ((.x5 ↦ᵣ (BitVec.sshiftRight v3 63)) ** (.x10 ↦ᵣ sltiuVal) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
            ((sp + 32) ↦ₘ (BitVec.sshiftRight v3 63)) ** ((sp + 40) ↦ₘ (BitVec.sshiftRight v3 63)) **
@@ -885,10 +885,10 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h1234 h56
-  -- BEQ at base+32: eliminate TAKEN (sltiu_val=1 since s0<256, so 1=0 is absurd)
-  let sltiu_val := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
-  have hsltiu_eq : sltiu_val = (1 : Word) := by simp only [sltiu_val, hlt_s0]; decide
-  have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiu_val (0 : Word) (base + 32)
+  -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since s0<256, so 1=0 is absurd)
+  let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
+  have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_s0]; decide
+  have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiuVal (0 : Word) (base + 32)
   rw [sar_beq_target, sar_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_sarCode base) hbeq_raw
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
@@ -904,39 +904,39 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Phase B: base+36 -> base+64
-  let bit_shift := s0 &&& signExtend12 63
-  let limb_shift := s0 >>> (6 : BitVec 6).toNat
-  let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
+  let bitShift := s0 &&& signExtend12 63
+  let limbShift := s0 >>> (6 : BitVec 6).toNat
+  let cond := if BitVec.ult (0 : Word) bitShift then (1 : Word) else 0
   let mask := (0 : Word) - cond
-  let anti_shift := (64 : Word) - bit_shift
+  let antiShift := (64 : Word) - bitShift
   have hphaseB_raw := shr_phase_b_spec s0 sp r6 r7 r11 (base + 36)
   have hphaseB := cpsTriple_extend_code (phase_b_sub_sarCode base) hphaseB_raw
   rw [sar_off_36_28] at hphaseB
   simp only [signExtend12_32] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 64) _ _ _
-    ((.x10 ↦ᵣ sltiu_val) **
+    ((.x10 ↦ᵣ sltiuVal) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseB
   have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 64) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+64 (with pure dispatch facts)
-  have hphaseC_raw := sar_phase_c_spec_pure limb_shift sltiu_val (base + 64)
+  have hphaseC_raw := sar_phase_c_spec_pure limbShift sltiuVal (base + 64)
     (base + 252) (base + 172) (base + 116) (base + 84)
     (sar_c_e0 base) (sar_c_e1 base) (sar_c_e2 base) (sar_c_e3 base)
   have hphaseC := cpsNBranch_extend_code (sar_phase_c_sub_sarCode base) hphaseC_raw
   -- Body specs extended to sarCode
   have hbody3 := cpsTriple_extend_code (sar_body_3_sub_sarCode base)
-    (sar_body_3_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
+    (sar_body_3_spec (sp + 32) limbShift ((0 : Word) + signExtend12 2) bitShift antiShift mask
       v0 v1 v2 v3 (base + 84) (base + 380) 268 (sar_body3_exit base))
   have hbody2 := cpsTriple_extend_code (sar_body_2_sub_sarCode base)
-    (sar_body_2_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 2) bit_shift anti_shift mask
+    (sar_body_2_spec (sp + 32) limbShift ((0 : Word) + signExtend12 2) bitShift antiShift mask
       v0 v1 v2 v3 (base + 116) (base + 380) 212 (sar_body2_exit base))
   have hbody1 := cpsTriple_extend_code (sar_body_1_sub_sarCode base)
-    (sar_body_1_spec (sp + 32) limb_shift ((0 : Word) + signExtend12 1) bit_shift anti_shift mask
+    (sar_body_1_spec (sp + 32) limbShift ((0 : Word) + signExtend12 1) bitShift antiShift mask
       v0 v1 v2 v3 (base + 172) (base + 380) 132 (sar_body1_exit base))
   have hbody0 := cpsTriple_extend_code (sar_body_0_sub_sarCode base)
-    (sar_body_0_spec (sp + 32) limb_shift sltiu_val bit_shift anti_shift mask
+    (sar_body_0_spec (sp + 32) limbShift sltiuVal bitShift antiShift mask
       v0 v1 v2 v3 (base + 252) (base + 380) 32 (sar_body0_exit base))
   -- Frame each body with (x0=0 ** shift_mem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 380) _ _ _
@@ -993,7 +993,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      ((sp + 48) ↦ₘ getLimb result 2) ** ((sp + 56) ↦ₘ getLimb result 3)
   -- Body 0 (L=0): merge(0,1,2) + last(3)
   have hbody0_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbody0_w (fun (hls : limb_shift = 0) h hq => by
+    hbody0_w (fun (hls : limbShift = 0) h hq => by
       have hresult : result = BitVec.sshiftRight value s0.toNat := by
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 0 := congrArg BitVec.toNat hls
@@ -1009,7 +1009,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       rw [← eq0, ← eq1, ← eq2, ← eq3]; exact hq)
   -- Body 1 (L=1): merge(0,1) + last(2) + sign(3)
   have hbody1_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbody1_w (fun (hls : limb_shift = (0 : Word) + signExtend12 1) h hq => by
+    hbody1_w (fun (hls : limbShift = (0 : Word) + signExtend12 1) h hq => by
       have hresult : result = BitVec.sshiftRight value s0.toNat := by
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 1 := by
@@ -1019,7 +1019,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       have eq0 := sar_bridge_merge value s0 result hresult 1 0 hL (by omega) (by omega)
       have eq1 := sar_bridge_merge value s0 result hresult 1 1 hL (by omega) (by omega)
       have eq2 := sar_bridge_last value s0 result hresult 1 2 hL (by omega)
-      have eq3 := sar_bridge_sign value s0 result hresult 1 3 hL (by omega) bit_shift rfl
+      have eq3 := sar_bridge_sign value s0 result hresult 1 3 hL (by omega) bitShift rfl
       show ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
            (regOwn .x6) ** (regOwn .x7) ** (regOwn .x11) **
            (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -1028,7 +1028,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       rw [← eq0, ← eq1, ← eq2, ← eq3]; exact hq)
   -- Body 2 (L=2): merge(0) + last(1) + sign(2,3)
   have hbody2_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbody2_w (fun (hls : limb_shift = (0 : Word) + signExtend12 2) h hq => by
+    hbody2_w (fun (hls : limbShift = (0 : Word) + signExtend12 2) h hq => by
       have hresult : result = BitVec.sshiftRight value s0.toNat := by
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 2 := by
@@ -1037,8 +1037,8 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         exact this
       have eq0 := sar_bridge_merge value s0 result hresult 2 0 hL (by omega) (by omega)
       have eq1 := sar_bridge_last value s0 result hresult 2 1 hL (by omega)
-      have eq2 := sar_bridge_sign value s0 result hresult 2 2 hL (by omega) bit_shift rfl
-      have eq3 := sar_bridge_sign value s0 result hresult 2 3 hL (by omega) bit_shift rfl
+      have eq2 := sar_bridge_sign value s0 result hresult 2 2 hL (by omega) bitShift rfl
+      have eq3 := sar_bridge_sign value s0 result hresult 2 3 hL (by omega) bitShift rfl
       show ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
            (regOwn .x6) ** (regOwn .x7) ** (regOwn .x11) **
            (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -1047,33 +1047,33 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       rw [← eq0, ← eq1, ← eq2, ← eq3]; exact hq)
   -- Body 3 (L=3): last(0) + sign(1,2,3)
   have hbody3_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbody3_w (fun (hls : limb_shift ≠ 0 ∧ limb_shift ≠ (0 : Word) + signExtend12 1 ∧
-                limb_shift ≠ (0 : Word) + signExtend12 2) h hq => by
+    hbody3_w (fun (hls : limbShift ≠ 0 ∧ limbShift ≠ (0 : Word) + signExtend12 1 ∧
+                limbShift ≠ (0 : Word) + signExtend12 2) h hq => by
       have hresult : result = BitVec.sshiftRight value s0.toNat := by
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
         have h6 := bv6_toNat_6
-        have hlt4 : limb_shift.toNat < 4 := by
+        have hlt4 : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [h6]; simp [BitVec.toNat_ushiftRight]; omega
-        have hn0 : limb_shift.toNat ≠ 0 :=
+        have hn0 : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
-        have hn1 : limb_shift.toNat ≠ 1 :=
+        have hn1 : limbShift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
-            show limb_shift.toNat = ((0 : Word) + signExtend12 1).toNat
+            show limbShift.toNat = ((0 : Word) + signExtend12 1).toNat
             simp only [zero_add_se12_1_toNat]
             exact hc))
-        have hn2 : limb_shift.toNat ≠ 2 :=
+        have hn2 : limbShift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
-            show limb_shift.toNat = ((0 : Word) + signExtend12 2).toNat
+            show limbShift.toNat = ((0 : Word) + signExtend12 2).toNat
             simp only [zero_add_se12_2_toNat]
             exact hc))
-        show limb_shift.toNat = 3; omega
+        show limbShift.toNat = 3; omega
       have eq0 := sar_bridge_last value s0 result hresult 3 0 hL (by omega)
-      have eq1 := sar_bridge_sign value s0 result hresult 3 1 hL (by omega) bit_shift rfl
-      have eq2 := sar_bridge_sign value s0 result hresult 3 2 hL (by omega) bit_shift rfl
-      have eq3 := sar_bridge_sign value s0 result hresult 3 3 hL (by omega) bit_shift rfl
+      have eq1 := sar_bridge_sign value s0 result hresult 3 1 hL (by omega) bitShift rfl
+      have eq2 := sar_bridge_sign value s0 result hresult 3 2 hL (by omega) bitShift rfl
+      have eq3 := sar_bridge_sign value s0 result hresult 3 3 hL (by omega) bitShift rfl
       show ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
            (regOwn .x6) ** (regOwn .x7) ** (regOwn .x11) **
            (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -1082,7 +1082,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       rw [← eq0, ← eq1, ← eq2, ← eq3]; exact hq)
   -- Frame Phase C and merge with body specs
   have hphaseC_framed := cpsNBranch_frame_left
-    (F := (.x6 ↦ᵣ bit_shift) ** (.x7 ↦ᵣ anti_shift) ** (.x11 ↦ᵣ mask) ** (.x12 ↦ᵣ (sp + 32)) **
+    (F := (.x6 ↦ᵣ bitShift) ** (.x7 ↦ᵣ antiShift) ** (.x11 ↦ᵣ mask) ** (.x12 ↦ᵣ (sp + 32)) **
           (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseC
@@ -1106,9 +1106,9 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
        (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ anti_shift) ** (.x12 ↦ᵣ (sp + 32)) **
-       (.x10 ↦ᵣ sltiu_val) **
+      ((.x5 ↦ᵣ limbShift) ** (.x6 ↦ᵣ bitShift) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + 32)) **
+       (.x10 ↦ᵣ sltiuVal) **
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken


### PR DESCRIPTION
## Summary
Renames the same four let-bound locals (\`sltiu_val\`, \`bit_shift\`, \`limb_shift\`, \`anti_shift\`) in \`Shift/SarCompose.lean\` to lowerCamelCase. Completes the SHR (#624) / SHL (#625) / SAR triplet.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] \`lake build\` succeeds
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)