### PR TITLE
refactor(shift-limbspec): rename let-bound locals to lowerCamelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -40,20 +40,20 @@ abbrev shr_merge_limb_code (src_off next_off dst_off : BitVec 12) (base : Word) 
 
 theorem shr_merge_limb_spec (src_off next_off dst_off : BitVec 12)
     (sp src next dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
-    let mem_src := sp + signExtend12 src_off
-    let mem_next := sp + signExtend12 next_off
-    let mem_dst := sp + signExtend12 dst_off
-    let shifted_src := src >>> (bit_shift.toNat % 64)
-    let shifted_next := (next <<< (anti_shift.toNat % 64)) &&& mask
-    let result := shifted_src ||| shifted_next
+    let memSrc := sp + signExtend12 src_off
+    let memNext := sp + signExtend12 next_off
+    let memDst := sp + signExtend12 dst_off
+    let shiftedSrc := src >>> (bit_shift.toNat % 64)
+    let shiftedNext := (next <<< (anti_shift.toNat % 64)) &&& mask
+    let result := shiftedSrc ||| shiftedNext
     let code := shr_merge_limb_code src_off next_off dst_off base
     cpsTriple base (base + 28) code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
-       (mem_src ↦ₘ src) ** (mem_next ↦ₘ next) ** (mem_dst ↦ₘ dst_old))
+       (memSrc ↦ₘ src) ** (memNext ↦ₘ next) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shifted_next) ** (.x11 ↦ᵣ mask) **
-       (mem_src ↦ₘ src) ** (mem_next ↦ₘ next) ** (mem_dst ↦ₘ result)) := by
+       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+       (memSrc ↦ₘ src) ** (memNext ↦ₘ next) ** (memDst ↦ₘ result)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src src_off base (by nofun)
   have SR := srl_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 next next_off (base + 8) (by nofun)
@@ -70,15 +70,15 @@ abbrev shr_last_limb_code (dst_off : BitVec 12) (base : Word) : CodeReq :=
 
 theorem shr_last_limb_spec (dst_off : BitVec 12)
     (sp src dst_old v5 bit_shift : Word) (base : Word) :
-    let mem_src := sp + signExtend12 (24 : BitVec 12)
-    let mem_dst := sp + signExtend12 dst_off
+    let memSrc := sp + signExtend12 (24 : BitVec 12)
+    let memDst := sp + signExtend12 dst_off
     let result := src >>> (bit_shift.toNat % 64)
     let code := shr_last_limb_code dst_off base
     cpsTriple base (base + 12) code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (mem_src ↦ₘ src) ** (mem_dst ↦ₘ dst_old))
+       (memSrc ↦ₘ src) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (mem_src ↦ₘ src) ** (mem_dst ↦ₘ result)) := by
+       (memSrc ↦ₘ src) ** (memDst ↦ₘ result)) := by
   have L := ld_spec_gen .x5 .x12 sp v5 src 24 base (by nofun)
   have SR := srl_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have SD_ := sd_spec_gen .x12 .x5 sp (src >>> (bit_shift.toNat % 64)) dst_old dst_off (base + 8)
@@ -91,19 +91,19 @@ abbrev shr_merge_limb_inplace_code (off next_off : BitVec 12) (base : Word) : Co
 
 theorem shr_merge_limb_inplace_spec (off next_off : BitVec 12)
     (sp src next v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
-    let mem_loc := sp + signExtend12 off
-    let mem_next := sp + signExtend12 next_off
-    let shifted_src := src >>> (bit_shift.toNat % 64)
-    let shifted_next := (next <<< (anti_shift.toNat % 64)) &&& mask
-    let result := shifted_src ||| shifted_next
+    let memLoc := sp + signExtend12 off
+    let memNext := sp + signExtend12 next_off
+    let shiftedSrc := src >>> (bit_shift.toNat % 64)
+    let shiftedNext := (next <<< (anti_shift.toNat % 64)) &&& mask
+    let result := shiftedSrc ||| shiftedNext
     let code := shr_merge_limb_inplace_code off next_off base
     cpsTriple base (base + 28) code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
-       (mem_loc ↦ₘ src) ** (mem_next ↦ₘ next))
+       (memLoc ↦ₘ src) ** (memNext ↦ₘ next))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shifted_next) ** (.x11 ↦ᵣ mask) **
-       (mem_loc ↦ₘ result) ** (mem_next ↦ₘ next)) := by
+       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+       (memLoc ↦ₘ result) ** (memNext ↦ₘ next)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src off base (by nofun)
   have SR := srl_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 next next_off (base + 8) (by nofun)
@@ -348,12 +348,12 @@ abbrev shr_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Word) 
 theorem shr_cascade_step_spec (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := shr_cascade_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val))
-      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)) := by
+      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal))
+      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal)) := by
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   -- Disjointness of the two singletons
   have hd : CodeReq.Disjoint
@@ -395,16 +395,16 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
     (fun _ hp => hp) s1' s2'
 
 /-- Cascade step variant that preserves pure dispatch facts.
-    Taken postcondition includes `⌜v5 = k_val⌝`, not-taken includes `⌜v5 ≠ k_val⌝`. -/
+    Taken postcondition includes `⌜v5 = kVal⌝`, not-taken includes `⌜v5 ≠ kVal⌝`. -/
 theorem shr_cascade_step_spec_pure (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := shr_cascade_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 = k_val⌝)
-      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 ≠ k_val⌝) := by
+      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜v5 = kVal⌝)
+      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜v5 ≠ kVal⌝) := by
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
@@ -420,7 +420,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
       (cpsTriple_frameR (.x5 ↦ᵣ v5) (by pcFree) s1)
   have s2_raw := beq_spec_gen .x5 .x10 offset v5 ((0 : Word) + signExtend12 k) (base + 4)
   rw [htarget, ha1] at s2_raw
-  -- Keep pure facts: frame with x0 + permute, preserving ⌜v5 = k_val⌝ / ⌜v5 ≠ k_val⌝
+  -- Keep pure facts: frame with x0 + permute, preserving ⌜v5 = kVal⌝ / ⌜v5 ≠ kVal⌝
   have s2' : cpsBranch (base + 4) (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset))
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)))
       target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 k)) ** ⌜v5 = (0 : Word) + signExtend12 k⌝)
@@ -746,51 +746,51 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   have ha28 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
   have ha32 : (base + 32 : Word) + 4 = base + 36 := by bv_omega
   -- Sub-CRs for each instruction group
-  let cr_ld1 := CodeReq.singleton base (.LD .x5 .x12 8)
-  let cr_lor2 := shr_ld_or_acc_code 16 (base + 4)
-  let cr_lor3 := shr_ld_or_acc_code 24 (base + 12)
-  let cr_bne := CodeReq.singleton (base + 20) (.BNE .x5 .x0 320)
-  let cr_ld5 := CodeReq.singleton (base + 24) (.LD .x5 .x12 0)
-  let cr_sltiu := CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256)
-  let cr_beq := CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308)
+  let crLd1 := CodeReq.singleton base (.LD .x5 .x12 8)
+  let crLor2 := shr_ld_or_acc_code 16 (base + 4)
+  let crLor3 := shr_ld_or_acc_code 24 (base + 12)
+  let crBne := CodeReq.singleton (base + 20) (.BNE .x5 .x0 320)
+  let crLd5 := CodeReq.singleton (base + 24) (.LD .x5 .x12 0)
+  let crSltiu := CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256)
+  let crBeq := CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308)
   -- ── Part 1: Linear chain base..base+20 (LD + LD/OR + LD/OR) ──
-  -- Step 1: LD x5 x12 8 at base (CR = cr_ld1)
+  -- Step 1: LD x5 x12 8 at base (CR = crLd1)
   have lw1 := ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun)
   simp only [signExtend12_8] at lw1
-  -- Step 2: shr_ld_or_acc at base+4 (CR = cr_lor2, exit = (base+4)+8 = base+12)
+  -- Step 2: shr_ld_or_acc at base+4 (CR = crLor2, exit = (base+4)+8 = base+12)
   have lor2 := shr_ld_or_acc_spec sp s1 r10 s2 16 (base + 4)
   simp only [signExtend12_16] at lor2
   rw [ha48] at lor2
-  -- Disjoint: cr_ld1 vs cr_lor2
-  have hd_ld1_lor2 : cr_ld1.Disjoint cr_lor2 :=
+  -- Disjoint: crLd1 vs crLor2
+  have hd_ld1_lor2 : crLd1.Disjoint crLor2 :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
   -- Compose LD + LD/OR (need to frame + perm)
-  have lw1f := cpsTriple_frame_left base (base + 4) cr_ld1
+  have lw1f := cpsTriple_frame_left base (base + 4) crLd1
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** ((sp + 8) ↦ₘ s1))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s1) ** ((sp + 8) ↦ₘ s1))
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ s0) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) lw1
-  have lor2f := cpsTriple_frame_left (base + 4) (base + 12) cr_lor2
+  have lor2f := cpsTriple_frame_left (base + 4) (base + 12) crLor2
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s1) ** (.x10 ↦ᵣ r10) ** ((sp + 16) ↦ₘ s2))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (s1 ||| s2)) ** (.x10 ↦ᵣ s2) ** ((sp + 16) ↦ₘ s2))
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) lor2
-  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) cr_ld1 cr_lor2 hd_ld1_lor2
+  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) crLd1 crLor2 hd_ld1_lor2
     _ _ _ _
     (fun h hp => by xperm_hyp hp) lw1f lor2f
-  -- Step 3: shr_ld_or_acc at base+12 (CR = cr_lor3, exit = (base+12)+8 = base+20)
+  -- Step 3: shr_ld_or_acc at base+12 (CR = crLor3, exit = (base+12)+8 = base+20)
   have lor3 := shr_ld_or_acc_spec sp (s1 ||| s2) s2 s3 24 (base + 12)
   simp only [signExtend12_24] at lor3
   rw [ha128] at lor3
-  have lor3f := cpsTriple_frame_left (base + 12) (base + 20) cr_lor3
+  have lor3f := cpsTriple_frame_left (base + 12) (base + 20) crLor3
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (s1 ||| s2)) ** (.x10 ↦ᵣ s2) ** ((sp + 24) ↦ₘ s3))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x10 ↦ᵣ s3) ** ((sp + 24) ↦ₘ s3))
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2))
     (by pcFree) lor3
-  -- Disjoint: (cr_ld1 ∪ cr_lor2) vs cr_lor3
-  have hd_12_lor3 : (cr_ld1.union cr_lor2).Disjoint cr_lor3 :=
+  -- Disjoint: (crLd1 ∪ crLor2) vs crLor3
+  have hd_12_lor3 : (crLd1.union crLor2).Disjoint crLor3 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
@@ -803,16 +803,16 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
   have c13 := cpsTriple_seq_with_perm base (base + 12) (base + 20)
-    (cr_ld1.union cr_lor2) cr_lor3 hd_12_lor3
+    (crLd1.union crLor2) crLor3 hd_12_lor3
     _ _ _ _
     (fun h hp => by xperm_hyp hp) c12 lor3f
-  -- CR so far: (cr_ld1 ∪ cr_lor2) ∪ cr_lor3
-  let cr_linear := (cr_ld1.union cr_lor2).union cr_lor3
+  -- CR so far: (crLd1 ∪ crLor2) ∪ crLor3
+  let crLinear := (crLd1.union crLor2).union crLor3
   -- ── Part 2: BNE at base+20 (first branch) ──
   have bne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [hzero, ha20] at bne_raw
   -- Strip pure facts from BNE
-  have bne1 : cpsBranch (base + 20) cr_bne
+  have bne1 : cpsBranch (base + 20) crBne
       ((.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x0 ↦ᵣ (0 : Word)))
       zero_path ((.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 24) ((.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x0 ↦ᵣ (0 : Word))) :=
@@ -824,13 +824,13 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       bne_raw
   -- Frame BNE with remaining state
-  have bne1f := cpsBranch_frame_left (base + 20) cr_bne
+  have bne1f := cpsBranch_frame_left (base + 20) crBne
     ((.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x0 ↦ᵣ (0 : Word)))
     zero_path _ (base + 24) _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) bne1
-  -- Disjoint: cr_linear vs cr_bne
-  have hd_lin_bne : cr_linear.Disjoint cr_bne :=
+  -- Disjoint: crLinear vs crBne
+  have hd_lin_bne : crLinear.Disjoint crBne :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
@@ -841,10 +841,10 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _))
   -- Compose linear chain + BNE branch
-  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) cr_linear cr_bne hd_lin_bne
+  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) crLinear crBne hd_lin_bne
     _ _ _ zero_path _ (base + 24) _
     (fun h hp => by xperm_hyp hp) c13 bne1f
-  -- BR1 CR: cr_linear ∪ cr_bne
+  -- BR1 CR: crLinear ∪ crBne
   -- ── Part 3: Fall-through path (base+24..base+32): LD + SLTIU + BEQ ──
   -- Step 5: LD x5 x12 0 at base+24
   have lw5 := ld_spec_gen .x5 .x12 sp
@@ -855,33 +855,33 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Step 6: SLTIU x10 x5 256 at base+28
   have sltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
   rw [ha28] at sltiu_raw
-  let sltiu_val := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
-  -- Disjoint: cr_ld5 vs cr_sltiu
-  have hd_ld5_sltiu : cr_ld5.Disjoint cr_sltiu :=
+  let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
+  -- Disjoint: crLd5 vs crSltiu
+  have hd_ld5_sltiu : crLd5.Disjoint crSltiu :=
     CodeReq.Disjoint.singleton (by bv_omega) _ _
   -- Frame and compose LD + SLTIU
-  have lw5f := cpsTriple_frame_left (base + 24) (base + 28) cr_ld5
+  have lw5f := cpsTriple_frame_left (base + 24) (base + 28) crLd5
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (sp ↦ₘ s0))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (sp ↦ₘ s0))
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ s3) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) lw5
-  have sltiuf := cpsTriple_frame_left (base + 28) (base + 32) cr_sltiu
+  have sltiuf := cpsTriple_frame_left (base + 28) (base + 32) crSltiu
     ((.x5 ↦ᵣ s0) ** (.x10 ↦ᵣ s3))
-    ((.x5 ↦ᵣ s0) ** (.x10 ↦ᵣ sltiu_val))
+    ((.x5 ↦ᵣ s0) ** (.x10 ↦ᵣ sltiuVal))
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) sltiu_raw
   have c56 := cpsTriple_seq_with_perm (base + 24) (base + 28) (base + 32)
-    cr_ld5 cr_sltiu hd_ld5_sltiu
+    crLd5 crSltiu hd_ld5_sltiu
     _ _ _ _
     (fun h hp => by xperm_hyp hp) lw5f sltiuf
   -- Step 7: BEQ x10 x0 308 at base+32
-  have beq_raw := beq_spec_gen .x10 .x0 308 sltiu_val (0 : Word) (base + 32)
+  have beq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)
   rw [hzero2, ha32] at beq_raw
   -- Strip pure facts from BEQ
-  have beq1 : cpsBranch (base + 32) cr_beq
-      ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
-      zero_path ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
-      (base + 36) ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word))) :=
+  have beq1 : cpsBranch (base + 32) crBeq
+      ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
+      zero_path ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 36) ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word))) :=
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
@@ -890,58 +890,58 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       beq_raw
   -- Frame BEQ with remaining state
-  have beq1f := cpsBranch_frame_left (base + 32) cr_beq
-    ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
+  have beq1f := cpsBranch_frame_left (base + 32) crBeq
+    ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
     zero_path _ (base + 36) _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) beq1
-  -- Disjoint: (cr_ld5 ∪ cr_sltiu) vs cr_beq
-  have hd_56_beq : (cr_ld5.union cr_sltiu).Disjoint cr_beq :=
+  -- Disjoint: (crLd5 ∪ crSltiu) vs crBeq
+  have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
   -- Compose LD+SLTIU chain with BEQ branch
   have br2 := cpsTriple_seq_cpsBranch_with_perm (base + 24) (base + 32)
-    (cr_ld5.union cr_sltiu) cr_beq hd_56_beq
+    (crLd5.union crSltiu) crBeq hd_56_beq
     _ _ _ zero_path _ (base + 36) _
     (fun h hp => by xperm_hyp hp) c56 beq1f
-  -- BR2 CR: (cr_ld5 ∪ cr_sltiu) ∪ cr_beq
-  let cr_tail := (cr_ld5.union cr_sltiu).union cr_beq
+  -- BR2 CR: (crLd5 ∪ crSltiu) ∪ crBeq
+  let crTail := (crLd5.union crSltiu).union crBeq
   -- ── Part 4: Combine br1 and br2 ──
-  -- Disjoint: (cr_linear ∪ cr_bne) vs cr_tail
+  -- Disjoint: (crLinear ∪ crBne) vs crTail
   -- All addresses in left (base..base+20) distinct from right (base+24..base+32)
-  -- Helper: "singleton at addr is disjoint from cr_tail"
+  -- Helper: "singleton at addr is disjoint from crTail"
   have sd_tail (a : Word) (i : Instr)
       (h24 : a ≠ base + 24) (h28 : a ≠ base + 28) (h32 : a ≠ base + 32) :
-      (CodeReq.singleton a i).Disjoint cr_tail :=
+      (CodeReq.singleton a i).Disjoint crTail :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.union_right
         (CodeReq.Disjoint.singleton h24 _ _)
         (CodeReq.Disjoint.singleton h28 _ _))
       (CodeReq.Disjoint.singleton h32 _ _)
-  -- cr_lor2 = singleton (base+4) ∪ singleton (base+4+4), each vs cr_tail
-  have hd_lor2_tail : cr_lor2.Disjoint cr_tail :=
+  -- crLor2 = singleton (base+4) ∪ singleton (base+4+4), each vs crTail
+  have hd_lor2_tail : crLor2.Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (sd_tail (base + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
       (sd_tail (base + 4 + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
-  -- cr_lor3 = singleton (base+12) ∪ singleton (base+12+4), each vs cr_tail
-  have hd_lor3_tail : cr_lor3.Disjoint cr_tail :=
+  -- crLor3 = singleton (base+12) ∪ singleton (base+12+4), each vs crTail
+  have hd_lor3_tail : crLor3.Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (sd_tail (base + 12) _ (by bv_omega) (by bv_omega) (by bv_omega))
       (sd_tail (base + 12 + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
-  have hd_br1_br2 : (cr_linear.union cr_bne).Disjoint cr_tail :=
+  have hd_br1_br2 : (crLinear.union crBne).Disjoint crTail :=
     CodeReq.Disjoint.union_left
-      -- cr_linear = (cr_ld1 ∪ cr_lor2) ∪ cr_lor3
+      -- crLinear = (crLd1 ∪ crLor2) ∪ crLor3
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.union_left
           (sd_tail base _ (by bv_omega) (by bv_omega) (by bv_omega))
           hd_lor2_tail)
         hd_lor3_tail)
-      -- cr_bne
+      -- crBne
       (sd_tail (base + 20) _ (by bv_omega) (by bv_omega) (by bv_omega))
   have combined := cpsBranch_seq_cpsBranch_with_perm
     base (base + 24) zero_path (base + 36)
-    (cr_linear.union cr_bne) cr_tail hd_br1_br2
+    (crLinear.union crBne) crTail hd_br1_br2
     _ _ _ _ _ _ _
     br1 (fun h hp => by xperm_hyp hp) br2
     -- ht1: weaken first taken path (BNE taken: x5 = s1|||s2|||s3, x10 = s3)
@@ -957,11 +957,11 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         ((.x12 ↦ᵣ sp) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
         from by xperm) h).mp w1)
-    -- ht2: weaken second taken path (BEQ taken: x5 = s0, x10 = sltiu_val)
+    -- ht2: weaken second taken path (BEQ taken: x5 = s0, x10 = sltiuVal)
     (fun h hp => by
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
-          ((.x5 ↦ᵣ s0) ** (.x10 ↦ᵣ sltiu_val) **
+          ((.x5 ↦ᵣ s0) ** (.x10 ↦ᵣ sltiuVal) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
           from by xperm) h).mp hp)
@@ -970,10 +970,10 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         ((.x12 ↦ᵣ sp) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
         from by xperm) h).mp w1)
-  -- The CR is now: (cr_linear ∪ cr_bne) ∪ cr_tail
+  -- The CR is now: (crLinear ∪ crBne) ∪ crTail
   -- Show this equals shr_phase_a_code
   -- hcr_eq: prove the composition CR equals the definition by reassociating unions
-  have hcr_eq : (cr_linear.union cr_bne).union cr_tail = shr_phase_a_code base := by
+  have hcr_eq : (crLinear.union crBne).union crTail = shr_phase_a_code base := by
     -- Unfold let bindings to shr_phase_a_code components
     show ((((CodeReq.singleton base (.LD .x5 .x12 8)).union (shr_ld_or_acc_code 16 (base + 4))).union
             (shr_ld_or_acc_code 24 (base + 12))).union
@@ -1001,7 +1001,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => by
         have w0 := sepConj_mono_left (regIs_to_regOwn .x10 _) h
           ((congrFun (show _ =
-            ((.x10 ↦ᵣ sltiu_val) **
+            ((.x10 ↦ᵣ sltiuVal) **
              (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x0 ↦ᵣ (0 : Word)) **
              (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
             from by xperm) h).mp hp)


### PR DESCRIPTION
## Summary
Renames the obviously-local let-bindings in \`Shift/LimbSpec.lean\` to lowerCamelCase: \`mem_src\`/\`mem_next\`/\`mem_dst\`/\`mem_loc\`, \`shifted_src\`/\`shifted_next\`, \`k_val\`, \`sltiu_val\`, and the \`cr_*\` CodeReq helpers.

Parameter names and the phase-B let-bindings for \`bit_shift\` / \`limb_shift\` / \`anti_shift\` (which leak into the public postcondition) are deferred so this diff stays small.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] \`lake build\` succeeds (all Shift semantic/compose files rebuilt)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)