### PR TITLE
refactor(norm,denorm): rename shifted_* locals to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
@@ -43,9 +43,9 @@ abbrev divK_denorm_merge_code (curr_off next_off : BitVec 12) (base : Word) : Co
     x6 = shift, x2 = anti_shift. -/
 theorem divK_denorm_merge_spec (curr_off next_off : BitVec 12)
     (sp curr next v5 v7 shift anti_shift : Word) (base : Word) :
-    let shifted_curr := curr >>> (shift.toNat % 64)
-    let shifted_next := next <<< (anti_shift.toNat % 64)
-    let result := shifted_curr ||| shifted_next
+    let shiftedCurr := curr >>> (shift.toNat % 64)
+    let shiftedNext := next <<< (anti_shift.toNat % 64)
+    let result := shiftedCurr ||| shiftedNext
     let cr := divK_denorm_merge_code curr_off next_off base
     cpsTriple base (base + 24) cr
       (
@@ -54,16 +54,16 @@ theorem divK_denorm_merge_spec (curr_off next_off : BitVec 12)
        ((sp + signExtend12 curr_off) ↦ₘ curr) **
        ((sp + signExtend12 next_off) ↦ₘ next))
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shifted_next) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedNext) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + signExtend12 curr_off) ↦ₘ result) **
        ((sp + signExtend12 next_off) ↦ₘ next)) := by
-  intro shifted_curr shifted_next result cr
+  intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 curr curr_off base (by nofun)
   have I1 := ld_spec_gen .x7 .x12 sp v7 next next_off (base + 4) (by nofun)
   have I2 := srl_spec_gen_rd_eq_rs1 .x5 .x6 curr shift (base + 8) (by nofun)
   have I3 := sll_spec_gen_rd_eq_rs1 .x7 .x2 next anti_shift (base + 12) (by nofun)
-  have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shifted_curr shifted_next (base + 16) (by nofun)
+  have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shiftedCurr shiftedNext (base + 16) (by nofun)
   have I5 := sd_spec_gen .x12 .x5 sp result curr curr_off (base + 20)
   runBlock I0 I1 I2 I3 I4 I5
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
@@ -68,9 +68,9 @@ abbrev divK_normA_mergeA_code (next_off dst_off : BitVec 12) (base : Word) : Cod
     Used for u[3] and u[1] computation. -/
 theorem divK_normA_mergeA_spec (next_off dst_off : BitVec 12)
     (sp current next v7 v10 shift anti_shift dst_old : Word) (base : Word) :
-    let shifted_curr := current <<< (shift.toNat % 64)
-    let shifted_next := next >>> (anti_shift.toNat % 64)
-    let result := shifted_curr ||| shifted_next
+    let shiftedCurr := current <<< (shift.toNat % 64)
+    let shiftedNext := next >>> (anti_shift.toNat % 64)
+    let result := shiftedCurr ||| shiftedNext
     let cr := divK_normA_mergeA_code next_off dst_off base
     cpsTriple base (base + 20) cr
       (
@@ -79,15 +79,15 @@ theorem divK_normA_mergeA_spec (next_off dst_off : BitVec 12)
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ dst_old))
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shifted_next) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shiftedNext) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
-  intro shifted_curr shifted_next result cr
+  intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x7 .x12 sp v7 next next_off base (by nofun)
   have I1 := sll_spec_gen_rd_eq_rs1 .x5 .x6 current shift (base + 4) (by nofun)
   have I2 := srl_spec_gen .x10 .x7 .x2 v10 next anti_shift (base + 8) (by nofun)
-  have I3 := or_spec_gen_rd_eq_rs1 .x5 .x10 shifted_curr shifted_next (base + 12) (by nofun)
+  have I3 := or_spec_gen_rd_eq_rs1 .x5 .x10 shiftedCurr shiftedNext (base + 12) (by nofun)
   have I4 := sd_spec_gen .x12 .x5 sp result dst_old dst_off (base + 16)
   runBlock I0 I1 I2 I3 I4
 
@@ -103,9 +103,9 @@ abbrev divK_normA_mergeB_code (next_off dst_off : BitVec 12) (base : Word) : Cod
     Used for u[2] computation. -/
 theorem divK_normA_mergeB_spec (next_off dst_off : BitVec 12)
     (sp current next v5 v10 shift anti_shift dst_old : Word) (base : Word) :
-    let shifted_curr := current <<< (shift.toNat % 64)
-    let shifted_next := next >>> (anti_shift.toNat % 64)
-    let result := shifted_curr ||| shifted_next
+    let shiftedCurr := current <<< (shift.toNat % 64)
+    let shiftedNext := next >>> (anti_shift.toNat % 64)
+    let result := shiftedCurr ||| shiftedNext
     let cr := divK_normA_mergeB_code next_off dst_off base
     cpsTriple base (base + 20) cr
       (
@@ -114,15 +114,15 @@ theorem divK_normA_mergeB_spec (next_off dst_off : BitVec 12)
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ dst_old))
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shifted_next) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shiftedNext) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
-  intro shifted_curr shifted_next result cr
+  intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 next next_off base (by nofun)
   have I1 := sll_spec_gen_rd_eq_rs1 .x7 .x6 current shift (base + 4) (by nofun)
   have I2 := srl_spec_gen .x10 .x5 .x2 v10 next anti_shift (base + 8) (by nofun)
-  have I3 := or_spec_gen_rd_eq_rs1 .x7 .x10 shifted_curr shifted_next (base + 12) (by nofun)
+  have I3 := or_spec_gen_rd_eq_rs1 .x7 .x10 shiftedCurr shiftedNext (base + 12) (by nofun)
   have I4 := sd_spec_gen .x12 .x7 sp result dst_old dst_off (base + 16)
   runBlock I0 I1 I2 I3 I4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
@@ -43,9 +43,9 @@ abbrev divK_normB_merge_code (high_off low_off : BitVec 12) (base : Word) : Code
     x6 = shift, x2 = anti_shift (= 64 - shift as unsigned). -/
 theorem divK_normB_merge_spec (high_off low_off : BitVec 12)
     (sp high low v5 v7 shift anti_shift : Word) (base : Word) :
-    let shifted_high := high <<< (shift.toNat % 64)
-    let shifted_low := low >>> (anti_shift.toNat % 64)
-    let result := shifted_high ||| shifted_low
+    let shiftedHigh := high <<< (shift.toNat % 64)
+    let shiftedLow := low >>> (anti_shift.toNat % 64)
+    let result := shiftedHigh ||| shiftedLow
     let cr := divK_normB_merge_code high_off low_off base
     cpsTriple base (base + 24) cr
       (
@@ -54,16 +54,16 @@ theorem divK_normB_merge_spec (high_off low_off : BitVec 12)
        ((sp + signExtend12 high_off) ↦ₘ high) **
        ((sp + signExtend12 low_off) ↦ₘ low))
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shifted_low) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedLow) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
        ((sp + signExtend12 high_off) ↦ₘ result) **
        ((sp + signExtend12 low_off) ↦ₘ low)) := by
-  intro shifted_high shifted_low result cr
+  intro shiftedHigh shiftedLow result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 high high_off base (by nofun)
   have I1 := ld_spec_gen .x7 .x12 sp v7 low low_off (base + 4) (by nofun)
   have I2 := sll_spec_gen_rd_eq_rs1 .x5 .x6 high shift (base + 8) (by nofun)
   have I3 := srl_spec_gen_rd_eq_rs1 .x7 .x2 low anti_shift (base + 12) (by nofun)
-  have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shifted_high shifted_low (base + 16) (by nofun)
+  have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shiftedHigh shiftedLow (base + 16) (by nofun)
   have I5 := sd_spec_gen .x12 .x5 sp result high high_off (base + 20)
   runBlock I0 I1 I2 I3 I4 I5
 


### PR DESCRIPTION
## Summary
Renames \`shifted_curr\`, \`shifted_next\`, \`shifted_high\`, \`shifted_low\` let-bindings across \`DivMod/LimbSpec/{Denorm,NormA,NormB}.lean\` to lowerCamelCase per Mathlib rule 4.

Continues the gradual #189 migration.

## Test plan
- [x] \`lake build\` succeeds (3437 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)