### PR TITLE
refactor(addback,subcarry): rename let-bound locals to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
@@ -4,11 +4,11 @@
   CPS specs for one limb of the Knuth Algorithm D "add-back" correction,
   which un-does the mul-sub when `q_hat` over-shot by 1:
     * `divK_addback_partA_spec` — 5 instructions (LD, LD, ADD, SLTU, ADD):
-      load v[i] and u[j+i], form `u_plus_carry = u_i + carry_in`, its
-      SLTU `carry1`, and `u_new = u_plus_carry + v_i`.
+      load v[i] and u[j+i], form `uPlusCarry = u_i + carry_in`, its
+      SLTU `carry1`, and `uNew = uPlusCarry + v_i`.
     * `divK_addback_partB_spec` — 3 instructions (SLTU, OR, SD): form
-      `carry2 = u_new < v_i`, OR with `carry1` for `carry_out`, store
-      `u_new`.
+      `carry2 = uNew < v_i`, OR with `carry1` for `carryOut`, store
+      `uNew`.
 
   Fifteenth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -32,9 +32,9 @@ open EvmAsm.Rv64
     5 instructions. Produces sum (x2) and carry1 (x7). -/
 theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word)
     (v_off : BitVec 12) (u_off : BitVec 12) (base : Word) :
-    let u_plus_carry := u_i + carry_in
-    let carry1 := if BitVec.ult u_plus_carry carry_in then (1 : Word) else 0
-    let u_new := u_plus_carry + v_i
+    let uPlusCarry := u_i + carry_in
+    let carry1 := if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0
+    let uNew := uPlusCarry + v_i
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x2 .x6 u_off))
@@ -47,38 +47,38 @@ theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry1) **
-       (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ u_new) **
+       (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i)) := by
-  intro u_plus_carry carry1 u_new cr
+  intro uPlusCarry carry1 uNew cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
   have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carry_in (base + 8) (by nofun)
-  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 u_plus_carry carry_in (base + 12) (by nofun)
-  have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 u_plus_carry v_i (base + 16) (by nofun)
+  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carry_in (base + 12) (by nofun)
+  have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 uPlusCarry v_i (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
-/-- Add-back Part B: SLTU carry2, OR carry_out, SD u_new.
-    3 instructions. Produces carry_out (x7) and stores u_new. -/
-theorem divK_addback_partB_spec (u_base carry1 v_i u_new u_i : Word)
+/-- Add-back Part B: SLTU carry2, OR carryOut, SD uNew.
+    3 instructions. Produces carryOut (x7) and stores uNew. -/
+theorem divK_addback_partB_spec (u_base carry1 v_i uNew u_i : Word)
     (u_off : BitVec 12) (base : Word) :
-    let carry2 := if BitVec.ult u_new v_i then (1 : Word) else 0
-    let carry_out := carry1 ||| carry2
+    let carry2 := if BitVec.ult uNew v_i then (1 : Word) else 0
+    let carryOut := carry1 ||| carry2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLTU .x5 .x2 .x5))
       (CodeReq.union (CodeReq.singleton (base + 4) (.OR .x7 .x7 .x5))
        (CodeReq.singleton (base + 8) (.SD .x6 .x2 u_off)))
     cpsTriple base (base + 12) cr
       ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry1) **
-       (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ u_new) **
+       (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ uNew) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry_out) **
-       (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ u_new) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_new)) := by
-  intro carry2 carry_out cr
-  have I0 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 u_new v_i base (by nofun)
+      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryOut) **
+       (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ uNew) **
+       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+  intro carry2 carryOut cr
+  have I0 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 uNew v_i base (by nofun)
   have I1 := or_spec_gen_rd_eq_rs1 .x7 .x5 carry1 carry2 (base + 4) (by nofun)
-  have I2 := sd_spec_gen .x6 .x2 u_base u_new u_i u_off (base + 8)
+  have I2 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 8)
   runBlock I0 I1 I2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -31,7 +31,7 @@ open EvmAsm.Rv64
 /-- Add-back finalization after limb corrections. -/
 theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
     (u_off : BitVec 12) (base : Word) :
-    let u_new := u_top + carry
+    let uNew := u_top + carry
     let q_hat' := q_hat + signExtend12 4095
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
@@ -42,11 +42,11 @@ theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
       ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (u_base + signExtend12 u_off ↦ₘ u_top))
       ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat') **
-       (.x5 ↦ᵣ u_new) ** (u_base + signExtend12 u_off ↦ₘ u_new)) := by
-  intro u_new q_hat' cr
+       (.x5 ↦ᵣ uNew) ** (u_base + signExtend12 u_off ↦ₘ uNew)) := by
+  intro uNew q_hat' cr
   have I0 := ld_spec_gen .x5 .x6 u_base v5_old u_top u_off base (by nofun)
   have I1 := add_spec_gen_rd_eq_rs1 .x5 .x7 u_top carry (base + 4) (by nofun)
-  have I2 := sd_spec_gen .x6 .x5 u_base u_new u_top u_off (base + 8)
+  have I2 := sd_spec_gen .x6 .x5 u_base uNew u_top u_off (base + 8)
   have I3 := addi_spec_gen_same .x11 q_hat 4095 (base + 12) (by nofun)
   runBlock I0 I1 I2 I3
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -7,9 +7,9 @@
       subtract the final carry from `u[j+4]` and record the resulting
       borrow.
     * `divK_store_qj_addr_spec` — 3 instructions (SLLI, ADDI, SUB) that
-      compute `q_addr = sp + 4088 - 8*j` into x7.
+      compute `qAddr = sp + 4088 - 8*j` into x7.
     * `divK_store_qj_write_spec` — 1-instruction SD that actually
-      writes `q_hat` at `q_addr`.
+      writes `q_hat` at `qAddr`.
 
   Sixteenth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -36,7 +36,7 @@ open EvmAsm.Rv64
 theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
     (u_off : BitVec 12) (base : Word) :
     let borrow := if BitVec.ult u_top carry_in then (1 : Word) else 0
-    let u_new := u_top - carry_in
+    let uNew := u_top - carry_in
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLTU .x7 .x5 .x10))
@@ -47,22 +47,22 @@ theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        ((u_base + signExtend12 u_off) ↦ₘ u_top))
       ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_in) **
-       (.x5 ↦ᵣ u_new) ** (.x7 ↦ᵣ borrow) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_new)) := by
-  intro borrow u_new cr
+       (.x5 ↦ᵣ uNew) ** (.x7 ↦ᵣ borrow) **
+       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+  intro borrow uNew cr
   have I0 := ld_spec_gen .x5 .x6 u_base v5_old u_top u_off base (by nofun)
   have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old u_top carry_in (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 u_top carry_in (base + 8) (by nofun)
-  have I3 := sd_spec_gen .x6 .x5 u_base u_new u_top u_off (base + 12)
+  have I3 := sd_spec_gen .x6 .x5 u_base uNew u_top u_off (base + 12)
   runBlock I0 I1 I2 I3
 
 /-- Store q[j]: compute &q[j] = sp+4088 - j*8, store q_hat.
-    First 3 instructions compute q_addr. Then SD stores. Split into 3+1. -/
+    First 3 instructions compute qAddr. Then SD stores. Split into 3+1. -/
 theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
     (base : Word) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
     let sp_m8 := sp + signExtend12 4088
-    let q_addr := sp_m8 - j_x8
+    let qAddr := sp_m8 - j_x8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
@@ -71,22 +71,22 @@ theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr)) := by
-  intro j_x8 sp_m8 q_addr cr
+       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr)) := by
+  intro j_x8 sp_m8 qAddr cr
   have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 sp_m8 j_x8 (base + 8) (by nofun)
   runBlock I0 I1 I2
 
-/-- Store q[j]: SD q_hat at q_addr. 1 instruction. -/
-theorem divK_store_qj_write_spec (q_addr q_hat q_old : Word) (base : Word) :
+/-- Store q[j]: SD q_hat at qAddr. 1 instruction. -/
+theorem divK_store_qj_write_spec (qAddr q_hat q_old : Word) (base : Word) :
     let cr := CodeReq.singleton base (.SD .x7 .x11 0)
     cpsTriple base (base + 4) cr
-      ((.x7 ↦ᵣ q_addr) ** (.x11 ↦ᵣ q_hat) ** (q_addr ↦ₘ q_old))
-      ((.x7 ↦ᵣ q_addr) ** (.x11 ↦ᵣ q_hat) ** (q_addr ↦ₘ q_hat)) := by
+      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ q_hat) ** (qAddr ↦ₘ q_old))
+      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ q_hat) ** (qAddr ↦ₘ q_hat)) := by
   intro cr
-  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [se12_0]; bv_omega
-  have I0 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 base
+  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
+  have I0 := sd_spec_gen .x7 .x11 qAddr q_hat q_old 0 base
   rw [haddr] at I0
   runBlock I0
 


### PR DESCRIPTION
## Summary
Renames let-bound locals in the DivMod addback/subcarry limb specs:
- \`u_new\` → \`uNew\`
- \`u_plus_carry\` → \`uPlusCarry\`
- \`carry_out\` → \`carryOut\`
- \`q_addr\` → \`qAddr\`

Files touched: \`DivMod/LimbSpec/{AddBack,AddBackFinalLoopControl,SubCarryStoreQj}.lean\`.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3547 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)