### PR TITLE
refactor(trial): rename u_addr/q_addr/vtop_base to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -6,7 +6,7 @@
     * `divK_correction_branch_spec` — single-BEQ `cpsBranch` that skips
       the add-back correction path when the borrow from mul-sub is zero.
     * `divK_trial_load_u_spec` — 7-instruction block loading the high
-      two limbs of `u[j..]` into x7/x5 at `u_addr = sp + 4056 - (j+n)*8`.
+      two limbs of `u[j..]` into x7/x5 at `uAddr = sp + 4056 - (j+n)*8`.
     * `divK_trial_load_vtop_spec` — 5-instruction block loading
       `v_top = b[n-1]` and leaving its address in x6.
     * `divK_trial_max_spec` — 2-instruction MAX path (ADDI x11, JAL)
@@ -54,14 +54,14 @@ theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base
     hbeq
 
 /-- Load u_hi = u[j+n] and u_lo = u[j+n-1] for trial quotient estimation.
-    u_addr = sp + signExtend12 4056 - (j + n) <<< 3.
-    u_hi = mem[u_addr], u_lo = mem[u_addr + 8]. -/
+    uAddr = sp + signExtend12 4056 - (j + n) <<< 3.
+    u_hi = mem[uAddr], u_lo = mem[uAddr + 8]. -/
 theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
     (base : Word) :
     let jpn := j + n
     let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
     let u0_base := sp + signExtend12 4056
-    let u_addr := u0_base - jpn_x8
+    let uAddr := u0_base - jpn_x8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
@@ -74,21 +74,21 @@ theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo))
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo)) := by
-  intro jpn jpn_x8 u0_base u_addr cr
-  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [se12_0]; bv_omega
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo)) := by
+  intro jpn jpn_x8 u0_base uAddr cr
+  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
   have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
   have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
-  have I5 := ld_spec_gen .x7 .x5 u_addr jpn_x8 u_hi 0 (base + 20) (by nofun)
+  have I5 := ld_spec_gen .x7 .x5 uAddr jpn_x8 u_hi 0 (base + 20) (by nofun)
   rw [haddr0] at I5
-  have I6 := ld_spec_gen_same .x5 u_addr u_lo 8 (base + 24) (by nofun)
+  have I6 := ld_spec_gen_same .x5 uAddr u_lo 8 (base + 24) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5 I6
 
 /-- Load v_top = b[n-1] for trial quotient estimation.
@@ -98,7 +98,7 @@ theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
     (base : Word) :
     let nm1 := n + signExtend12 4095
     let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + nm1_x8
+    let vtopBase := sp + nm1_x8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x6 .x12 3984))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x6 .x6 4095))
@@ -107,15 +107,15 @@ theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
        (CodeReq.singleton (base + 16) (.LD .x10 .x6 32)))))
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6_old) ** (.x10 ↦ᵣ v10_old) **
-       (sp + signExtend12 3984 ↦ₘ n) ** (vtop_base + signExtend12 32 ↦ₘ v_top))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtop_base) ** (.x10 ↦ᵣ v_top) **
-       (sp + signExtend12 3984 ↦ₘ n) ** (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
-  intro nm1 nm1_x8 vtop_base cr
+       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ v_top))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ v_top) **
+       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+  intro nm1 nm1_x8 vtopBase cr
   have I0 := ld_spec_gen .x6 .x12 sp v6_old n 3984 base (by nofun)
   have I1 := addi_spec_gen_same .x6 n 4095 (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x6 nm1 3 (base + 8) (by nofun)
   have I3 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 12) (by nofun)
-  have I4 := ld_spec_gen .x10 .x6 vtop_base v10_old v_top 32 (base + 16) (by nofun)
+  have I4 := ld_spec_gen .x10 .x6 vtopBase v10_old v_top 32 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
 /-- Trial quotient MAX path: set q_hat = MAX64, jump over div128 call. -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -6,7 +6,7 @@
       + trial_load_vtop) that fetches `u_hi`, `u_lo`, and `v_top` from
       memory in preparation for the trial-quotient estimation.
     * `divK_store_qj_spec` — 4-instruction composition (store_qj_addr
-      + store_qj_write) that computes `q_addr = sp + 4088 - 8*j` and
+      + store_qj_write) that computes `qAddr = sp + 4088 - 8*j` and
       stores `q_hat` there.
 
   Twenty-eighth chunk of the `LimbSpec.lean` split tracked by issue #312.
@@ -31,12 +31,12 @@ open EvmAsm.Rv64
 
 /-- Trial quotient load: fetch u_hi, u_lo, v_top from memory.
     Instrs [1]-[12] of loop body.
-    Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtop_base. -/
+    Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtopBase. -/
 theorem divK_trial_load_spec
     (sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
     (base : Word) :
-    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
@@ -55,42 +55,42 @@ theorem divK_trial_load_spec
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
-  intro u_addr vtop_base cr
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+  intro uAddr vtopBase cr
   let jpn := j + n
   let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
   let u0_base := sp + signExtend12 4056
-  have haddr0 : u_addr + signExtend12 (0 : BitVec 12) = u_addr := by rw [se12_0]; bv_omega
+  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
   have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
   have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
-  have I5 := ld_spec_gen .x7 .x5 u_addr jpn_x8 u_hi 0 (base + 20) (by nofun)
+  have I5 := ld_spec_gen .x7 .x5 uAddr jpn_x8 u_hi 0 (base + 20) (by nofun)
   rw [haddr0] at I5
-  have I6 := ld_spec_gen_same .x5 u_addr u_lo 8 (base + 24) (by nofun)
+  have I6 := ld_spec_gen_same .x5 uAddr u_lo 8 (base + 24) (by nofun)
   let nm1 := n + signExtend12 4095
   let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
   have I7 := ld_spec_gen .x6 .x12 sp v6_old n 3984 (base + 28) (by nofun)
   have I8 := addi_spec_gen_same .x6 n 4095 (base + 32) (by nofun)
   have I9 := slli_spec_gen_same .x6 nm1 3 (base + 36) (by nofun)
   have I10 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 40) (by nofun)
-  have I11 := ld_spec_gen .x10 .x6 vtop_base v10_old v_top 32 (base + 44) (by nofun)
+  have I11 := ld_spec_gen .x10 .x6 vtopBase v10_old v_top 32 (base + 44) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11
 
 /-- Store q[j]: compute address and store q_hat. 4 instructions.
-    q_addr = sp + 4088 - j*8. -/
+    qAddr = sp + 4088 - j*8. -/
 theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
     (base : Word) :
     let j_x8 := j <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - j_x8
+    let qAddr := sp + signExtend12 4088 - j_x8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
@@ -99,16 +99,16 @@ theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
     cpsTriple base (base + 16) cr
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
-       (q_addr ↦ₘ q_old))
+       (qAddr ↦ₘ q_old))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ q_addr) **
-       (q_addr ↦ₘ q_hat)) := by
-  intro j_x8 q_addr cr
+       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ q_hat)) := by
+  intro j_x8 qAddr cr
   have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) j_x8 (base + 8) (by nofun)
-  have haddr : q_addr + signExtend12 (0 : BitVec 12) = q_addr := by rw [se12_0]; bv_omega
-  have I3 := sd_spec_gen .x7 .x11 q_addr q_hat q_old 0 (base + 12)
+  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
+  have I3 := sd_spec_gen .x7 .x11 qAddr q_hat q_old 0 (base + 12)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3
 


### PR DESCRIPTION
## Summary
Renames the let-bound address locals \`u_addr\`, \`q_addr\`, \`vtop_base\` to lowerCamelCase in \`DivMod/LimbSpec/{TrialQuotient,TrialStoreComposed}.lean\`.

\`LoopBody.lean\` has its own independent let-bindings with the same names; those are left for a follow-up so this diff stays small.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3547 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)