### PR TITLE
refactor(signext-limbspec): rename let-bound locals to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -36,21 +36,21 @@ abbrev signext_inplace_code (off : BitVec 12) (base : Word) : CodeReq :=
 /-- Sign-extend in-place spec (4 instructions):
     LD x5, off(x12); SLL x5,x5,x6; SRA x5,x5,x6; SD x12,x5,off
 
-    Loads a 64-bit limb, sign-extends using shift_amount, stores back.
+    Loads a 64-bit limb, sign-extends using shiftAmount, stores back.
     Result = BitVec.sshiftRight (limb <<< (sa % 64)) (sa % 64) -/
 theorem signext_inplace_spec (off : BitVec 12)
-    (sp limb v5 shift_amount : Word) (base : Word) :
-    let result := BitVec.sshiftRight (limb <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
+    (sp limb v5 shiftAmount : Word) (base : Word) :
+    let result := BitVec.sshiftRight (limb <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
     let code := signext_inplace_code off base
     cpsTriple base (base + 16) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 off) ↦ₘ limb))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 off) ↦ₘ result)) := by
   have L := ld_spec_gen .x5 .x12 sp v5 limb off base (by nofun)
-  have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 limb shift_amount (base + 4) (by nofun)
-  have SR := sra_spec_gen_rd_eq_rs1 .x5 .x6 (limb <<< (shift_amount.toNat % 64)) shift_amount (base + 8) (by nofun)
-  have SD_ := sd_spec_gen .x12 .x5 sp (BitVec.sshiftRight (limb <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) limb off (base + 12)
+  have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 limb shiftAmount (base + 4) (by nofun)
+  have SR := sra_spec_gen_rd_eq_rs1 .x5 .x6 (limb <<< (shiftAmount.toNat % 64)) shiftAmount (base + 8) (by nofun)
+  have SD_ := sd_spec_gen .x12 .x5 sp (BitVec.sshiftRight (limb <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) limb off (base + 12)
   runBlock L SL SR SD_
 
 -- ============================================================================
@@ -62,20 +62,20 @@ theorem signext_inplace_spec (off : BitVec 12)
 abbrev signext_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_3_prog jal_off)
 
-/-- Body 3: limb_idx=3, sign-extend limb 3 at sp+56 (5 instrs).
+/-- Body 3: limbIdx=3, sign-extend limb 3 at sp+56 (5 instrs).
     4 instructions: LD + SLL + SRA + SD + JAL. No higher limbs to fill. -/
 theorem signext_body_3_spec (sp : Word)
-    (v5 shift_amount : Word) (v3 : Word)
+    (v5 shiftAmount : Word) (v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 16) + signExtend21 jal_off = exit) :
-    let result := BitVec.sshiftRight (v3 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
+    let result := BitVec.sshiftRight (v3 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
     let code := signext_body_3_code base jal_off
     cpsTriple base exit code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 56) ↦ₘ result)) := by
-  have IP := signext_inplace_spec 56 sp v3 v5 shift_amount base
+  have IP := signext_inplace_spec 56 sp v3 v5 shiftAmount base
   have JL := jal_x0_spec_gen jal_off (base + 16)
   rw [hexit] at JL
   runBlock IP JL
@@ -85,28 +85,28 @@ theorem signext_body_3_spec (sp : Word)
 abbrev signext_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_2_prog jal_off)
 
-/-- Body 2: limb_idx=2, sign-extend limb 2 at sp+48, fill limb 3 (7 instrs).
+/-- Body 2: limbIdx=2, sign-extend limb 2 at sp+48, fill limb 3 (7 instrs).
     LD + SLL + SRA + SD + SRAI + SD + JAL. -/
 theorem signext_body_2_spec (sp : Word)
-    (v5 v10 shift_amount : Word) (v2 v3 : Word)
+    (v5 v10 shiftAmount : Word) (v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit) :
-    let result := BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
+    let result := BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
     let signFill := BitVec.sshiftRight result 63
     let code := signext_body_2_code base jal_off
     cpsTriple base exit code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ v10) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ v10) **
        ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ signFill) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ signFill)) := by
   have h63 := bv6_toNat_63
-  have IP := signext_inplace_spec 48 sp v2 v5 shift_amount base
+  have IP := signext_inplace_spec 48 sp v2 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
-    (BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
+    (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
   simp only [h63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v2 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v3 56 (base + 20)
   have JL := jal_x0_spec_gen jal_off (base + 24)
   rw [hexit] at JL
@@ -117,31 +117,31 @@ theorem signext_body_2_spec (sp : Word)
 abbrev signext_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
   CodeReq.ofProg base (signext_body_1_prog jal_off)
 
-/-- Body 1: limb_idx=1, sign-extend limb 1 at sp+40, fill limbs 2-3 (8 instrs).
+/-- Body 1: limbIdx=1, sign-extend limb 1 at sp+40, fill limbs 2-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + JAL. -/
 theorem signext_body_1_spec (sp : Word)
-    (v5 v10 shift_amount : Word) (v1 v2 v3 : Word)
+    (v5 v10 shiftAmount : Word) (v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 28) + signExtend21 jal_off = exit) :
-    let result := BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
+    let result := BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
     let signFill := BitVec.sshiftRight result 63
     let code := signext_body_1_code base jal_off
     cpsTriple base exit code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ v10) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ v10) **
        ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ signFill) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
   have h63 := bv6_toNat_63
-  have IP := signext_inplace_spec 40 sp v1 v5 shift_amount base
+  have IP := signext_inplace_spec 40 sp v1 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
-    (BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
+    (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
   simp only [h63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v2 48 (base + 20)
   have S1 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v3 56 (base + 24)
   have JL := jal_x0_spec_gen jal_off (base + 28)
   rw [hexit] at JL
@@ -153,33 +153,33 @@ theorem signext_body_1_spec (sp : Word)
 abbrev signext_body_0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base signext_body_0
 
-/-- Body 0: limb_idx=0, sign-extend limb 0 at sp+32, fill limbs 1-3 (8 instrs).
+/-- Body 0: limbIdx=0, sign-extend limb 0 at sp+32, fill limbs 1-3 (8 instrs).
     LD + SLL + SRA + SD + SRAI + SD + SD + SD. Falls through to done. -/
 theorem signext_body_0_spec (sp : Word)
-    (v5 v10 shift_amount : Word) (v0 v1 v2 v3 : Word)
+    (v5 v10 shiftAmount : Word) (v0 v1 v2 v3 : Word)
     (base : Word) :
-    let result := BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)
+    let result := BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)
     let signFill := BitVec.sshiftRight result 63
     let code := signext_body_0_code base
     cpsTriple base (base + 32) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ v10) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ v10) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) ** (.x10 ↦ᵣ signFill) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ signFill) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
   have h63 := bv6_toNat_63
-  have IP := signext_inplace_spec 32 sp v0 v5 shift_amount base
+  have IP := signext_inplace_spec 32 sp v0 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
-    (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64))
+    (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
   simp only [h63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v1 40 (base + 20)
   have S1 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v2 48 (base + 24)
   have S2 := sd_spec_gen .x12 .x10 sp
-    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shift_amount.toNat % 64)) (shift_amount.toNat % 64)) 63)
+    (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v3 56 (base + 28)
   runBlock IP SR S0 S1 S2
 
@@ -197,7 +197,7 @@ theorem signext_done_spec (sp : Word) (base : Word) :
   exact addi_spec_gen_same .x12 sp 32 base (by nofun)
 
 -- ============================================================================
--- Phase B Spec: Compute shift_amount and limb_idx (5 instructions)
+-- Phase B Spec: Compute shiftAmount and limbIdx (5 instructions)
 -- ============================================================================
 
 /-- CodeReq for sign-extend phase B (5 instructions):
@@ -208,17 +208,17 @@ abbrev signext_phase_b_code (base : Word) : CodeReq :=
 /-- Phase B spec: compute sign-extension parameters.
     ANDI x10,x5,7; SLLI x10,x10,3; ADDI x6,x0,56;
     SUB x6,x6,x10; SRLI x5,x5,3.
-    Outputs: x6 = 56 - (b%8)*8 (shift_amount), x5 = b/8 (limb_idx).
+    Outputs: x6 = 56 - (b%8)*8 (shiftAmount), x5 = b/8 (limbIdx).
     Same computation as byte_phase_b_spec. -/
 theorem signext_phase_b_spec (b r6 r10 : Word) (base : Word) :
-    let byte_in_limb := b &&& signExtend12 (7 : BitVec 12)
-    let byte_shift := byte_in_limb <<< (3 : BitVec 6).toNat
-    let shift_amount := (56 : Word) - byte_shift
-    let limb_idx := b >>> (3 : BitVec 6).toNat
+    let byteInLimb := b &&& signExtend12 (7 : BitVec 12)
+    let byteShift := byteInLimb <<< (3 : BitVec 6).toNat
+    let shiftAmount := (56 : Word) - byteShift
+    let limbIdx := b >>> (3 : BitVec 6).toNat
     let code := signext_phase_b_code base
     cpsTriple base (base + 20) code
       ((.x5 ↦ᵣ b) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10))
-      ((.x5 ↦ᵣ limb_idx) ** (.x6 ↦ᵣ shift_amount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byte_shift)) := by
+      ((.x5 ↦ᵣ limbIdx) ** (.x6 ↦ᵣ shiftAmount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byteShift)) := by
   have A := andi_spec_gen .x10 .x5 r10 b 7 base (by nofun)
   have SL := slli_spec_gen_same .x10 (b &&& signExtend12 7) 3 (base + 4) (by nofun)
   have AD := addi_x0_spec_gen .x6 r6 56 (base + 8) (by nofun)
@@ -256,12 +256,12 @@ abbrev signext_cascade_step_code (k : BitVec 12) (offset : BitVec 13) (base : Wo
 theorem signext_cascade_step_spec (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := signext_cascade_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val))
-      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)) := by
+      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal))
+      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal)) := by
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
@@ -348,45 +348,45 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   have ha28 : (base + 28 : Word) + 4 = base + 32 := by bv_omega
   have ha32 : (base + 32 : Word) + 4 = base + 36 := by bv_omega
   -- Sub-CRs for each instruction group
-  let cr_ld1 := CodeReq.singleton base (.LD .x5 .x12 8)
-  let cr_lor2 := signext_ld_or_acc_code 16 (base + 4)
-  let cr_lor3 := signext_ld_or_acc_code 24 (base + 12)
-  let cr_bne := CodeReq.singleton (base + 20) (.BNE .x5 .x0 168)
-  let cr_ld5 := CodeReq.singleton (base + 24) (.LD .x5 .x12 0)
-  let cr_sltiu := CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 31)
-  let cr_beq := CodeReq.singleton (base + 32) (.BEQ .x10 .x0 156)
+  let crLd1 := CodeReq.singleton base (.LD .x5 .x12 8)
+  let crLor2 := signext_ld_or_acc_code 16 (base + 4)
+  let crLor3 := signext_ld_or_acc_code 24 (base + 12)
+  let crBne := CodeReq.singleton (base + 20) (.BNE .x5 .x0 168)
+  let crLd5 := CodeReq.singleton (base + 24) (.LD .x5 .x12 0)
+  let crSltiu := CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 31)
+  let crBeq := CodeReq.singleton (base + 32) (.BEQ .x10 .x0 156)
   -- ── Part 1: Linear chain base..base+20 (LD + LD/OR + LD/OR) ──
   have lw1 := ld_spec_gen .x5 .x12 sp r5 b1 8 base (by nofun)
   simp only [signExtend12_8] at lw1
   have lor2 := signext_ld_or_acc_spec sp b1 r10 b2 16 (base + 4)
   simp only [signExtend12_16] at lor2
   rw [ha48] at lor2
-  have hd_ld1_lor2 : cr_ld1.Disjoint cr_lor2 :=
+  have hd_ld1_lor2 : crLd1.Disjoint crLor2 :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-  have lw1f := cpsTriple_frame_left base (base + 4) cr_ld1
+  have lw1f := cpsTriple_frame_left base (base + 4) crLd1
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** ((sp + 8) ↦ₘ b1))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** ((sp + 8) ↦ₘ b1))
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ b0) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) lw1
-  have lor2f := cpsTriple_frame_left (base + 4) (base + 12) cr_lor2
+  have lor2f := cpsTriple_frame_left (base + 4) (base + 12) crLor2
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ r10) ** ((sp + 16) ↦ₘ b2))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b1 ||| b2)) ** (.x10 ↦ᵣ b2) ** ((sp + 16) ↦ₘ b2))
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) lor2
-  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) cr_ld1 cr_lor2 hd_ld1_lor2
+  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) crLd1 crLor2 hd_ld1_lor2
     _ _ _ _
     (fun h hp => by xperm_hyp hp) lw1f lor2f
   have lor3 := signext_ld_or_acc_spec sp (b1 ||| b2) b2 b3 24 (base + 12)
   simp only [signExtend12_24] at lor3
   rw [ha128] at lor3
-  have lor3f := cpsTriple_frame_left (base + 12) (base + 20) cr_lor3
+  have lor3f := cpsTriple_frame_left (base + 12) (base + 20) crLor3
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b1 ||| b2)) ** (.x10 ↦ᵣ b2) ** ((sp + 24) ↦ₘ b3))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** ((sp + 24) ↦ₘ b3))
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2))
     (by pcFree) lor3
-  have hd_12_lor3 : (cr_ld1.union cr_lor2).Disjoint cr_lor3 :=
+  have hd_12_lor3 : (crLd1.union crLor2).Disjoint crLor3 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
@@ -399,14 +399,14 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
   have c13 := cpsTriple_seq_with_perm base (base + 12) (base + 20)
-    (cr_ld1.union cr_lor2) cr_lor3 hd_12_lor3
+    (crLd1.union crLor2) crLor3 hd_12_lor3
     _ _ _ _
     (fun h hp => by xperm_hyp hp) c12 lor3f
-  let cr_linear := (cr_ld1.union cr_lor2).union cr_lor3
+  let crLinear := (crLd1.union crLor2).union crLor3
   -- ── Part 2: BNE at base+20 (first branch) ──
   have bne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [hdone1, ha20] at bne_raw
-  have bne1 : cpsBranch (base + 20) cr_bne
+  have bne1 : cpsBranch (base + 20) crBne
       ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x0 ↦ᵣ (0 : Word)))
       done_path ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 24) ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x0 ↦ᵣ (0 : Word))) :=
@@ -417,12 +417,12 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       bne_raw
-  have bne1f := cpsBranch_frame_left (base + 20) cr_bne
+  have bne1f := cpsBranch_frame_left (base + 20) crBne
     ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x0 ↦ᵣ (0 : Word)))
     done_path _ (base + 24) _
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) bne1
-  have hd_lin_bne : cr_linear.Disjoint cr_bne :=
+  have hd_lin_bne : crLinear.Disjoint crBne :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
@@ -432,7 +432,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _))
-  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) cr_linear cr_bne hd_lin_bne
+  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) crLinear crBne hd_lin_bne
     _ _ _ done_path _ (base + 24) _
     (fun h hp => by xperm_hyp hp) c13 bne1f
   -- ── Part 3: Fall-through path (base+24..base+32): LD + SLTIU + BEQ ──
@@ -443,29 +443,29 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   rw [ha24] at lw5
   have sltiu_raw := sltiu_spec_gen .x10 .x5 b3 b0 31 (base + 28) (by nofun)
   rw [ha28] at sltiu_raw
-  let sltiu_val := (if BitVec.ult b0 (signExtend12 (31 : BitVec 12)) then (1 : Word) else (0 : Word))
-  have hd_ld5_sltiu : cr_ld5.Disjoint cr_sltiu :=
+  let sltiuVal := (if BitVec.ult b0 (signExtend12 (31 : BitVec 12)) then (1 : Word) else (0 : Word))
+  have hd_ld5_sltiu : crLd5.Disjoint crSltiu :=
     CodeReq.Disjoint.singleton (by bv_omega) _ _
-  have lw5f := cpsTriple_frame_left (base + 24) (base + 28) cr_ld5
+  have lw5f := cpsTriple_frame_left (base + 24) (base + 28) crLd5
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (sp ↦ₘ b0))
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0))
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) lw5
-  have sltiuf := cpsTriple_frame_left (base + 28) (base + 32) cr_sltiu
+  have sltiuf := cpsTriple_frame_left (base + 28) (base + 32) crSltiu
     ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3))
-    ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ sltiu_val))
+    ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ sltiuVal))
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) sltiu_raw
   have c56 := cpsTriple_seq_with_perm (base + 24) (base + 28) (base + 32)
-    cr_ld5 cr_sltiu hd_ld5_sltiu
+    crLd5 crSltiu hd_ld5_sltiu
     _ _ _ _
     (fun h hp => by xperm_hyp hp) lw5f sltiuf
-  have beq_raw := beq_spec_gen .x10 .x0 156 sltiu_val (0 : Word) (base + 32)
+  have beq_raw := beq_spec_gen .x10 .x0 156 sltiuVal (0 : Word) (base + 32)
   rw [hdone2, ha32] at beq_raw
-  have beq1 : cpsBranch (base + 32) cr_beq
-      ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
-      done_path ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
-      (base + 36) ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word))) :=
+  have beq1 : cpsBranch (base + 32) crBeq
+      ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
+      done_path ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 36) ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word))) :=
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
@@ -473,47 +473,47 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       beq_raw
-  have beq1f := cpsBranch_frame_left (base + 32) cr_beq
-    ((.x10 ↦ᵣ sltiu_val) ** (.x0 ↦ᵣ (0 : Word)))
+  have beq1f := cpsBranch_frame_left (base + 32) crBeq
+    ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
     done_path _ (base + 36) _
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) beq1
-  have hd_56_beq : (cr_ld5.union cr_sltiu).Disjoint cr_beq :=
+  have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
   have br2 := cpsTriple_seq_cpsBranch_with_perm (base + 24) (base + 32)
-    (cr_ld5.union cr_sltiu) cr_beq hd_56_beq
+    (crLd5.union crSltiu) crBeq hd_56_beq
     _ _ _ done_path _ (base + 36) _
     (fun h hp => by xperm_hyp hp) c56 beq1f
-  let cr_tail := (cr_ld5.union cr_sltiu).union cr_beq
+  let crTail := (crLd5.union crSltiu).union crBeq
   -- ── Part 4: Combine br1 and br2 ──
   have sd_tail (a : Word) (i : Instr)
       (h24 : a ≠ base + 24) (h28 : a ≠ base + 28) (h32 : a ≠ base + 32) :
-      (CodeReq.singleton a i).Disjoint cr_tail :=
+      (CodeReq.singleton a i).Disjoint crTail :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.union_right
         (CodeReq.Disjoint.singleton h24 _ _)
         (CodeReq.Disjoint.singleton h28 _ _))
       (CodeReq.Disjoint.singleton h32 _ _)
-  have hd_lor2_tail : cr_lor2.Disjoint cr_tail :=
+  have hd_lor2_tail : crLor2.Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (sd_tail (base + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
       (sd_tail (base + 4 + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
-  have hd_lor3_tail : cr_lor3.Disjoint cr_tail :=
+  have hd_lor3_tail : crLor3.Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (sd_tail (base + 12) _ (by bv_omega) (by bv_omega) (by bv_omega))
       (sd_tail (base + 12 + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
-  have hd_ld1_tail : cr_ld1.Disjoint cr_tail :=
+  have hd_ld1_tail : crLd1.Disjoint crTail :=
     sd_tail base _ (by bv_omega) (by bv_omega) (by bv_omega)
-  have hd_bne_tail : cr_bne.Disjoint cr_tail :=
+  have hd_bne_tail : crBne.Disjoint crTail :=
     sd_tail (base + 20) _ (by bv_omega) (by bv_omega) (by bv_omega)
-  have hd_lin_bne_tail : (cr_linear.union cr_bne).Disjoint cr_tail :=
+  have hd_lin_bne_tail : (crLinear.union crBne).Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.union_left hd_ld1_tail hd_lor2_tail) hd_lor3_tail)
       hd_bne_tail
-  have hd_br1_br2 : (cr_linear.union cr_bne).Disjoint cr_tail :=
+  have hd_br1_br2 : (crLinear.union crBne).Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.union_left hd_ld1_tail hd_lor2_tail) hd_lor3_tail)
@@ -521,7 +521,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   -- Combine: br1 (taken → done_path, ntaken → base+24) with br2 (base+24 → done_path or base+36)
   have combined := cpsBranch_seq_cpsBranch_with_perm
     base (base + 24) done_path (base + 36)
-    (cr_linear.union cr_bne) cr_tail hd_br1_br2
+    (crLinear.union crBne) crTail hd_br1_br2
     _ _ _ _ _ _ _
     br1 (fun h hp => by xperm_hyp hp) br2
     -- ht1: weaken BNE taken path (x5 = b1|||b2|||b3, x10 = b3) → regOwn
@@ -537,11 +537,11 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
         ((.x12 ↦ᵣ sp) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
         from by xperm) h).mp w1)
-    -- ht2: weaken BEQ taken path (x5 = b0, x10 = sltiu_val) → regOwn
+    -- ht2: weaken BEQ taken path (x5 = b0, x10 = sltiuVal) → regOwn
     (fun h hp => by
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
-          ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ sltiu_val) **
+          ((.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ sltiuVal) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
           from by xperm) h).mp hp)
@@ -550,8 +550,8 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
         ((.x12 ↦ᵣ sp) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
          (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
         from by xperm) h).mp w1)
-  -- CR reassociation: (cr_linear ∪ cr_bne) ∪ cr_tail = signext_phase_a_code base
-  have hcr_eq : (cr_linear.union cr_bne).union cr_tail = signext_phase_a_code base := by
+  -- CR reassociation: (crLinear ∪ crBne) ∪ crTail = signext_phase_a_code base
+  have hcr_eq : (crLinear.union crBne).union crTail = signext_phase_a_code base := by
     show ((((CodeReq.singleton base (.LD .x5 .x12 8)).union (signext_ld_or_acc_code 16 (base + 4))).union
             (signext_ld_or_acc_code 24 (base + 12))).union
            (CodeReq.singleton (base + 20) (.BNE .x5 .x0 168))).union
@@ -576,7 +576,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => by
         have w0 := sepConj_mono_left (regIs_to_regOwn .x10 _) h
           ((congrFun (show _ =
-            ((.x10 ↦ᵣ sltiu_val) **
+            ((.x10 ↦ᵣ sltiuVal) **
              (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x0 ↦ᵣ (0 : Word)) **
              (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
             from by xperm) h).mp hp)
@@ -588,7 +588,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   exact result
 
 -- ============================================================================
--- Phase C: Cascade dispatch on limb_idx (5 instructions, cpsNBranch)
+-- Phase C: Cascade dispatch on limbIdx (5 instructions, cpsNBranch)
 -- ============================================================================
 
 /-- Phase C code as explicit union of sub-CRs (matching disjoint composition structure). -/
@@ -597,7 +597,7 @@ abbrev signext_phase_c_code (base : Word) : CodeReq :=
   (CodeReq.union (signext_cascade_step_code 1 60 (base + 4))
   (signext_cascade_step_code 2 24 (base + 12)))
 
-/-- Phase C spec: cascade dispatch on limb_idx (0-3).
+/-- Phase C spec: cascade dispatch on limbIdx (0-3).
     Uses disjoint composition to chain BEQ + two cascade steps. -/
 theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
     (e0 e1 e2 e3 : Word)
@@ -704,16 +704,16 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
 -- Cascade step with pure dispatch facts
 -- ============================================================================
 
-/-- Cascade step with pure dispatch facts: each exit includes ⌜v5 = k_val⌝ / ⌜v5 ≠ k_val⌝. -/
+/-- Cascade step with pure dispatch facts: each exit includes ⌜v5 = kVal⌝ / ⌜v5 ≠ kVal⌝. -/
 theorem signext_cascade_step_spec_pure (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := signext_cascade_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 = k_val⌝)
-      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜v5 ≠ k_val⌝) := by
+      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜v5 = kVal⌝)
+      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜v5 ≠ kVal⌝) := by
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))


### PR DESCRIPTION
## Summary
Renames 15 let-bound locals in \`SignExtend/LimbSpec.lean\` to lowerCamelCase per Mathlib rule 4. Same pattern as #628 (Shift/LimbSpec.lean).

Changes byte-extraction helpers (\`byte_in_limb\` → \`byteInLimb\`, \`byte_shift\` → \`byteShift\`, \`shift_amount\` → \`shiftAmount\`, \`limb_idx\` → \`limbIdx\`), value helpers (\`k_val\`, \`sltiu_val\`), and the \`cr_*\` CodeReq chain.

## Test plan
- [x] Full \`lake build\` succeeds (3547 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)