### PR TITLE
refactor(byte): rename let-bound locals to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -3,7 +3,7 @@
 
   CPS specifications for the 256-bit EVM BYTE program (64-bit).
   Modular decomposition:
-  - Phase B: byte_phase_b_spec (5 instrs): compute bit_shift and limb_from_msb
+  - Phase B: byte_phase_b_spec (5 instrs): compute bit_shift and limbFromMsb
   - body_3: extract from limb 0 at sp+32, JAL to store (4 instrs)
   - body_2: extract from limb 1 at sp+40, JAL to store (4 instrs)
   - body_1: extract from limb 2 at sp+48, JAL to store (4 instrs)
@@ -35,14 +35,14 @@ abbrev byte_phase_a_code (base : Word) : CodeReq :=
 /-- Phase A OR-reduce body: LD idx[1], LD idx[2], OR, LD idx[3], OR.
     Produces x5 = idx1 ||| idx2 ||| idx3. Uses full phase_a code. -/
 theorem byte_phase_a_or_reduce_spec (sp v5 v10 idx1 idx2 idx3 : Word) (base : Word) :
-    let or_high := idx1 ||| idx2 ||| idx3
+    let orHigh := idx1 ||| idx2 ||| idx3
     let cr := byte_phase_a_code base
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 8) ↦ₘ idx1) **
        ((sp + signExtend12 16) ↦ₘ idx2) **
        ((sp + signExtend12 24) ↦ₘ idx3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ or_high) ** (.x10 ↦ᵣ idx3) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ orHigh) ** (.x10 ↦ᵣ idx3) **
        ((sp + signExtend12 8) ↦ₘ idx1) **
        ((sp + signExtend12 16) ↦ₘ idx2) **
        ((sp + signExtend12 24) ↦ₘ idx3)) := by
@@ -72,7 +72,7 @@ theorem byte_phase_a_low_check_spec (sp v5 idx0 v10 : Word) (base : Word) :
   runBlock I0 I1
 
 -- ============================================================================
--- Phase B: Compute bit_shift and limb_from_msb (5 instructions)
+-- Phase B: Compute bit_shift and limbFromMsb (5 instructions)
 -- Same computation as SignExtend Phase B
 -- ============================================================================
 
@@ -82,16 +82,16 @@ abbrev byte_phase_b_code (base : Word) : CodeReq :=
 /-- Phase B spec: compute byte extraction parameters.
     ANDI x10,x5,7; SLLI x10,x10,3; ADDI x6,x0,56;
     SUB x6,x6,x10; SRLI x5,x5,3.
-    Outputs: x6 = 56 - (idx%8)*8 (bit_shift), x5 = idx/8 (limb_from_msb). -/
+    Outputs: x6 = 56 - (idx%8)*8 (bit_shift), x5 = idx/8 (limbFromMsb). -/
 theorem byte_phase_b_spec (idx r6 r10 : Word) (base : Word) :
-    let byte_in_limb := idx &&& signExtend12 (7 : BitVec 12)
-    let byte_shift := byte_in_limb <<< (3 : BitVec 6).toNat
-    let shift_amount := (56 : Word) - byte_shift
-    let limb_from_msb := idx >>> (3 : BitVec 6).toNat
+    let byteInLimb := idx &&& signExtend12 (7 : BitVec 12)
+    let byteShift := byteInLimb <<< (3 : BitVec 6).toNat
+    let shiftAmount := (56 : Word) - byteShift
+    let limbFromMsb := idx >>> (3 : BitVec 6).toNat
     let code := byte_phase_b_code base
     cpsTriple base (base + 20) code
       ((.x5 ↦ᵣ idx) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10))
-      ((.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byte_shift)) := by
+      ((.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byteShift)) := by
   have A := andi_spec_gen .x10 .x5 r10 idx 7 base (by nofun)
   have SL := slli_spec_gen_same .x10 (idx &&& signExtend12 7) 3 (base + 4) (by nofun)
   have AD := addi_x0_spec_gen .x6 r6 56 (base + 8) (by nofun)
@@ -105,86 +105,86 @@ theorem byte_phase_b_spec (idx r6 r10 : Word) (base : Word) :
 -- ============================================================================
 
 -- body_3: LD sp+32, SRL, ANDI 0xFF, JAL 48 (4 instrs)
--- limb_from_msb = 3 → extract from limb 0 (LSB) at sp+32
+-- limbFromMsb = 3 → extract from limb 0 (LSB) at sp+32
 
 abbrev byte_body_3_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_3
 
 /-- body_3 spec: load limb 0 from sp+32, extract byte, jump to store. -/
-theorem byte_body_3_spec (sp v5 shift_amount limb : Word) (base : Word) :
-    let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
+theorem byte_body_3_spec (sp v5 shiftAmount limb : Word) (base : Word) :
+    let result := (limb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_3_code base
     cpsTriple base ((base + 12) + signExtend21 (48 : BitVec 21)) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 32) ↦ₘ limb))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 32) ↦ₘ limb)) := by
   have I0 := ld_spec_gen .x5 .x12 sp v5 limb 32 base (by nofun)
-  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shift_amount (base + 4) (by nofun)
-  have I2 := andi_spec_gen_same .x5 (limb >>> (shift_amount.toNat % 64)) 255 (base + 8) (by nofun)
+  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shiftAmount (base + 4) (by nofun)
+  have I2 := andi_spec_gen_same .x5 (limb >>> (shiftAmount.toNat % 64)) 255 (base + 8) (by nofun)
   have I3 := jal_x0_spec_gen (48 : BitVec 21) (base + 12)
   runBlock I0 I1 I2 I3
 
 -- body_2: LD sp+40, SRL, ANDI 0xFF, JAL 32 (4 instrs)
--- limb_from_msb = 2 → extract from limb 1 at sp+40
+-- limbFromMsb = 2 → extract from limb 1 at sp+40
 
 abbrev byte_body_2_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_2
 
 /-- body_2 spec: load limb 1 from sp+40, extract byte, jump to store. -/
-theorem byte_body_2_spec (sp v5 shift_amount limb : Word) (base : Word) :
-    let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
+theorem byte_body_2_spec (sp v5 shiftAmount limb : Word) (base : Word) :
+    let result := (limb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_2_code base
     cpsTriple base ((base + 12) + signExtend21 (32 : BitVec 21)) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 40) ↦ₘ limb))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 40) ↦ₘ limb)) := by
   have I0 := ld_spec_gen .x5 .x12 sp v5 limb 40 base (by nofun)
-  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shift_amount (base + 4) (by nofun)
-  have I2 := andi_spec_gen_same .x5 (limb >>> (shift_amount.toNat % 64)) 255 (base + 8) (by nofun)
+  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shiftAmount (base + 4) (by nofun)
+  have I2 := andi_spec_gen_same .x5 (limb >>> (shiftAmount.toNat % 64)) 255 (base + 8) (by nofun)
   have I3 := jal_x0_spec_gen (32 : BitVec 21) (base + 12)
   runBlock I0 I1 I2 I3
 
 -- body_1: LD sp+48, SRL, ANDI 0xFF, JAL 16 (4 instrs)
--- limb_from_msb = 1 → extract from limb 2 at sp+48
+-- limbFromMsb = 1 → extract from limb 2 at sp+48
 
 abbrev byte_body_1_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_1
 
 /-- body_1 spec: load limb 2 from sp+48, extract byte, jump to store. -/
-theorem byte_body_1_spec (sp v5 shift_amount limb : Word) (base : Word) :
-    let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
+theorem byte_body_1_spec (sp v5 shiftAmount limb : Word) (base : Word) :
+    let result := (limb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_1_code base
     cpsTriple base ((base + 12) + signExtend21 (16 : BitVec 21)) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 48) ↦ₘ limb))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 48) ↦ₘ limb)) := by
   have I0 := ld_spec_gen .x5 .x12 sp v5 limb 48 base (by nofun)
-  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shift_amount (base + 4) (by nofun)
-  have I2 := andi_spec_gen_same .x5 (limb >>> (shift_amount.toNat % 64)) 255 (base + 8) (by nofun)
+  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shiftAmount (base + 4) (by nofun)
+  have I2 := andi_spec_gen_same .x5 (limb >>> (shiftAmount.toNat % 64)) 255 (base + 8) (by nofun)
   have I3 := jal_x0_spec_gen (16 : BitVec 21) (base + 12)
   runBlock I0 I1 I2 I3
 
 -- body_0: LD sp+56, SRL, ANDI 0xFF (3 instrs, falls through to store)
--- limb_from_msb = 0 → extract from limb 3 (MSB) at sp+56
+-- limbFromMsb = 0 → extract from limb 3 (MSB) at sp+56
 
 abbrev byte_body_0_code (base : Word) : CodeReq :=
   CodeReq.ofProg base byte_body_0
 
 /-- body_0 spec: load limb 3 from sp+56, extract byte. Falls through to store. -/
-theorem byte_body_0_spec (sp v5 shift_amount limb : Word) (base : Word) :
-    let result := (limb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
+theorem byte_body_0_spec (sp v5 shiftAmount limb : Word) (base : Word) :
+    let result := (limb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
     let code := byte_body_0_code base
     cpsTriple base (base + 12) code
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 56) ↦ₘ limb))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + signExtend12 56) ↦ₘ limb)) := by
   have I0 := ld_spec_gen .x5 .x12 sp v5 limb 56 base (by nofun)
-  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shift_amount (base + 4) (by nofun)
-  have I2 := andi_spec_gen_same .x5 (limb >>> (shift_amount.toNat % 64)) 255 (base + 8) (by nofun)
+  have I1 := srl_spec_gen_rd_eq_rs1 .x5 .x6 limb shiftAmount (base + 4) (by nofun)
+  have I2 := andi_spec_gen_same .x5 (limb >>> (shiftAmount.toNat % 64)) 255 (base + 8) (by nofun)
   runBlock I0 I1 I2
 
 -- ============================================================================
@@ -241,7 +241,7 @@ theorem byte_zero_path_spec (sp m0 m8 m16 m24 : Word) (base : Word) :
   runBlock I0 I1 I2 I3 I4
 
 -- ============================================================================
--- Phase C: Cascade dispatch on limb_from_msb (5 instructions)
+-- Phase C: Cascade dispatch on limbFromMsb (5 instructions)
 -- ============================================================================
 
 abbrev byte_phase_c_code (base : Word) : CodeReq :=
@@ -282,7 +282,7 @@ private theorem byte_pc_sub_4 (base : Word) :
       (byte_phase_c_code base) a = some i :=
   byte_pc_instr_sub base (base + 16) _ 4 (by decide) (by bv_omega) (by decide)
 
-/-- Phase C cascade dispatch spec: branches on x5 (limb_from_msb) to 4 body entry points.
+/-- Phase C cascade dispatch spec: branches on x5 (limbFromMsb) to 4 body entry points.
     Each exit postcondition includes pure constraints identifying which branch was taken. -/
 theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
     (e0 e1 e2 e3 : Word)

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -373,15 +373,15 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   -- Compose h12 → h34
   have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h12 h34
-  -- Step 5: BEQ at base+32 → eliminate ntaken (sltiu_val = 0 since i0 ≥ 32)
-  let sltiu_val := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
-  have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiu_val (0 : Word) (base + 32)
+  -- Step 5: BEQ at base+32 → eliminate ntaken (sltiuVal = 0 since i0 ≥ 32)
+  let sltiuVal := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
+  have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiuVal (0 : Word) (base + 32)
   rw [byte_beq_target, byte_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (byte_beq_sub base) hbeq_raw
-  -- sltiu_val = 0 (since i0 ≥ 32 → ult is false)
-  have hsltiu_eq : sltiu_val = (0 : Word) := by
-    simp only [sltiu_val, hlarge]; decide
-  -- Eliminate ntaken: ntaken postcondition has ⌜sltiu_val ≠ 0⌝, but sltiu_val = 0
+  -- sltiuVal = 0 (since i0 ≥ 32 → ult is false)
+  have hsltiu_eq : sltiuVal = (0 : Word) := by
+    simp only [sltiuVal, hlarge]; decide
+  -- Eliminate ntaken: ntaken postcondition has ⌜sltiuVal ≠ 0⌝, but sltiuVal = 0
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -401,7 +401,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   simp only [signExtend12_32] at hzp
   rw [byte_off_160_20] at hzp
   have hzp_framed := cpsTriple_frame_left (base + 160) (base + 180) _ _ _
-    ((.x5 ↦ᵣ i0) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ sltiu_val) **
+    ((.x5 ↦ᵣ i0) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ sltiuVal) **
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3))
     (by pcFree) hzp
   -- Compose → ZP: normalize addresses in perm callback
@@ -414,7 +414,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
     (fun h hq => by
       have w0 := sepConj_mono_left (regIs_to_regOwn .x5 _) h
         ((congrFun (show _ =
-          ((.x5 ↦ᵣ i0) ** (.x10 ↦ᵣ sltiu_val) **
+          ((.x5 ↦ᵣ i0) ** (.x10 ↦ᵣ sltiuVal) **
            (.x12 ↦ᵣ (sp + 32)) ** (.x0 ↦ᵣ (0 : Word)) **
            (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
            ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)))
@@ -534,10 +534,10 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h12 h34
-  -- BEQ at base+32: eliminate TAKEN (sltiu_val=1 since i0<32, so 1=0 is absurd)
-  let sltiu_val := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
-  have hsltiu_eq : sltiu_val = (1 : Word) := by simp only [sltiu_val, hlt_i0]; decide
-  have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiu_val (0 : Word) (base + 32)
+  -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since i0<32, so 1=0 is absurd)
+  let sltiuVal := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
+  have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_i0]; decide
+  have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiuVal (0 : Word) (base + 32)
   rw [byte_beq_target, byte_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (byte_beq_sub base) hbeq_raw
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
@@ -553,11 +553,11 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) h1234 hbeq_framed
   -- Phase B: base+36 → base+56
-  let byte_in_limb := i0 &&& signExtend12 (7 : BitVec 12)
-  let byte_shift := byte_in_limb <<< (3 : BitVec 6).toNat
-  let shift_amount := (56 : Word) - byte_shift
-  let limb_from_msb := i0 >>> (3 : BitVec 6).toNat
-  have hphaseB_raw := byte_phase_b_spec i0 r6 sltiu_val (base + 36)
+  let byteInLimb := i0 &&& signExtend12 (7 : BitVec 12)
+  let byteShift := byteInLimb <<< (3 : BitVec 6).toNat
+  let shiftAmount := (56 : Word) - byteShift
+  let limbFromMsb := i0 >>> (3 : BitVec 6).toNat
+  have hphaseB_raw := byte_phase_b_spec i0 r6 sltiuVal (base + 36)
   have hphaseB := cpsTriple_extend_code (byte_phase_b_sub base) hphaseB_raw
   rw [byte_off_36_20] at hphaseB
   have hphaseB_f := cpsTriple_frame_left (base + 36) (base + 56) _ _ _
@@ -568,29 +568,29 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 56) _ _ _ _ _
     (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+56
-  have hphaseC_raw := byte_phase_c_spec limb_from_msb byte_shift (base + 56)
+  have hphaseC_raw := byte_phase_c_spec limbFromMsb byteShift (base + 56)
     (base + 124) (base + 108) (base + 92) (base + 76)
     (byte_c_e0 base) (byte_c_e1 base) (byte_c_e2 base) (byte_c_e3 base)
   have hphaseC := cpsNBranch_extend_code (byte_phase_c_sub base) hphaseC_raw
   -- Body specs extended to evm_byte_code, then composed with store
   -- body_3: base+76 → base+136 (via JAL 48), then store: base+136 → base+180
   -- Body 3 spec (load from sp+32, i.e. limb 0 = v0)
-  have hbody3_raw := byte_body_3_spec sp limb_from_msb shift_amount v0 (base + 76)
+  have hbody3_raw := byte_body_3_spec sp limbFromMsb shiftAmount v0 (base + 76)
   rw [byte_body_3_exit_eq] at hbody3_raw
   simp only [signExtend12_32] at hbody3_raw
   have hbody3 := cpsTriple_extend_code (byte_body_3_sub base) hbody3_raw
   -- Body 2 spec (load from sp+40, i.e. limb 1 = v1)
-  have hbody2_raw := byte_body_2_spec sp limb_from_msb shift_amount v1 (base + 92)
+  have hbody2_raw := byte_body_2_spec sp limbFromMsb shiftAmount v1 (base + 92)
   rw [byte_body_2_exit_eq] at hbody2_raw
   simp only [signExtend12_40] at hbody2_raw
   have hbody2 := cpsTriple_extend_code (byte_body_2_sub base) hbody2_raw
   -- Body 1 spec (load from sp+48, i.e. limb 2 = v2)
-  have hbody1_raw := byte_body_1_spec sp limb_from_msb shift_amount v2 (base + 108)
+  have hbody1_raw := byte_body_1_spec sp limbFromMsb shiftAmount v2 (base + 108)
   rw [byte_body_1_exit_eq] at hbody1_raw
   simp only [signExtend12_48] at hbody1_raw
   have hbody1 := cpsTriple_extend_code (byte_body_1_sub base) hbody1_raw
   -- Body 0 spec (load from sp+56, i.e. limb 3 = v3)
-  have hbody0_raw := byte_body_0_spec sp limb_from_msb shift_amount v3 (base + 124)
+  have hbody0_raw := byte_body_0_spec sp limbFromMsb shiftAmount v3 (base + 124)
   simp only [signExtend12_56] at hbody0_raw
   have hbody0_exit : (base + 124 : Word) + 12 = base + 136 := by bv_omega
   rw [hbody0_exit] at hbody0_raw
@@ -617,40 +617,40 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     byte_getLimb_high idx value (3 : Fin 4) (show (3 : Fin 4).val ≠ 0 by decide)
   have hresult_limb0 := byte_correct idx value hlt
   have h3bv := bv6_toNat_3
-  have hlimb_val : limb_from_msb.toNat = i0.toNat / 8 := by
+  have hlimb_val : limbFromMsb.toNat = i0.toNat / 8 := by
     show (i0 >>> (3 : BitVec 6).toNat).toNat = i0.toNat / 8
     rw [h3bv]; simp [BitVec.toNat_ushiftRight]; omega
-  have hbyte_shift_val : byte_shift.toNat = (i0.toNat % 8) * 8 := by
-    show (byte_in_limb <<< (3 : BitVec 6).toNat).toNat = (i0.toNat % 8) * 8
+  have hbyte_shift_val : byteShift.toNat = (i0.toNat % 8) * 8 := by
+    show (byteInLimb <<< (3 : BitVec 6).toNat).toNat = (i0.toNat % 8) * 8
     rw [h3bv]
-    simp only [byte_in_limb, BitVec.toNat_shiftLeft, BitVec.toNat_and, se12_7,
+    simp only [byteInLimb, BitVec.toNat_shiftLeft, BitVec.toNat_and, se12_7,
                show (7 : Word).toNat = 7 from by decide]
     rw [Nat.and_two_pow_sub_one_eq_mod _ 3]
     have : i0.toNat % 8 < 8 := Nat.mod_lt _ (by omega)
     have : (i0.toNat % 8) * 8 < 2 ^ 64 := by omega
     omega
-  have hshift_val : shift_amount.toNat = 56 - (i0.toNat % 8) * 8 := by
-    show ((56 : Word) - byte_shift).toNat = _
-    have hbs_lt : byte_shift.toNat ≤ 56 := by omega
+  have hshift_val : shiftAmount.toNat = 56 - (i0.toNat % 8) * 8 := by
+    show ((56 : Word) - byteShift).toNat = _
+    have hbs_lt : byteShift.toNat ≤ 56 := by omega
     bv_omega
-  have hshift_lt64 : shift_amount.toNat < 64 := by omega
+  have hshift_lt64 : shiftAmount.toNat < 64 := by omega
   -- Bridge helper: connect body result to getLimb result 0
   have bridge : ∀ (vLimb : Word) (K : Nat) (hK : K = i0.toNat / 8) (_ : K < 4)
       (hvLimb : vLimb = value.getLimb ⟨3 - K, by omega⟩),
-      (vLimb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12) = getLimb result 0 := by
+      (vLimb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12) = getLimb result 0 := by
     intro vLimb K hK hKlt hvLimb
-    have heq := bv_srl_mask_eq vLimb shift_amount.toNat hshift_lt64
+    have heq := bv_srl_mask_eq vLimb shiftAmount.toNat hshift_lt64
     rw [heq]; show _ = getLimb (byte idx value) 0
     -- byte_correct: getLimb (byte idx value) 0 = ofNat 64 ((value.getLimb ⟨3-idx.toNat/8,_⟩.toNat / 2^(56-(idx.toNat%8)*8)) % 256)
     rw [byte_correct idx value hlt]
-    -- Now goal: ofNat 64 ((vLimb.toNat / 2^shift_amount.toNat) % 256) =
+    -- Now goal: ofNat 64 ((vLimb.toNat / 2^shiftAmount.toNat) % 256) =
     --           ofNat 64 ((value.getLimb ⟨3-idx.toNat/8,_⟩.toNat / 2^(56-(idx.toNat%8)*8)) % 256)
     -- Show the Nat arguments are equal
     apply congrArg (BitVec.ofNat 64)
     -- Both sides are Nat, show they're equal
-    -- LHS: (vLimb.toNat / 2^shift_amount.toNat) % 256
+    -- LHS: (vLimb.toNat / 2^shiftAmount.toNat) % 256
     -- RHS: (value.getLimb ⟨3-idx.toNat/8, _⟩.toNat / 2^(56-(idx.toNat%8)*8)) % 256
-    -- vLimb = value.getLimb ⟨3-K, _⟩, K = idx.toNat/8 (via hidx_toNat), shift_amount.toNat = 56-(i0.toNat%8)*8
+    -- vLimb = value.getLimb ⟨3-K, _⟩, K = idx.toNat/8 (via hidx_toNat), shiftAmount.toNat = 56-(i0.toNat%8)*8
     have hval_eq : (3 - idx.toNat / 8) = (3 - K) := by rw [hidx_toNat, hK]
     have h_limb_toNat : (value.getLimb ⟨3 - idx.toNat / 8, by omega⟩).toNat = vLimb.toNat := by
       have : value.getLimb ⟨3 - idx.toNat / 8, by omega⟩ = value.getLimb ⟨3 - K, by omega⟩ := by
@@ -666,75 +666,75 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   -- Build framed body specs (frame each body with remaining val mem cells)
   -- Body 3 (loads v0 from sp+32): already has all 4 val cells in pre/post after framing with val_mem_1,2,3
   -- But the raw body specs have only 1 val cell. Need to frame with other 3 val cells first.
-  -- body_3 has: pre = (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ _) ** (.x6 ↦ᵣ shift_amount) ** ((sp+32)↦ₘv0)
+  -- body_3 has: pre = (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ _) ** (.x6 ↦ᵣ shiftAmount) ** ((sp+32)↦ₘv0)
   have hb3_val_f := cpsTriple_frame_left (base + 76) (base + 136) _ _ _
     (((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbody3
   have hb3_canon : cpsTriple (base + 76) (base + 136) (evm_byte_code base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v0 >>> (shift_amount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v0 >>> (shiftAmount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp) (fun h hq => by xperm_hyp hq) hb3_val_f
   have hb2_val_f := cpsTriple_frame_left (base + 92) (base + 136) _ _ _
     (((sp + 32) ↦ₘ v0) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbody2
   have hb2_canon : cpsTriple (base + 92) (base + 136) (evm_byte_code base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v1 >>> (shift_amount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v1 >>> (shiftAmount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp) (fun h hq => by xperm_hyp hq) hb2_val_f
   have hb1_val_f := cpsTriple_frame_left (base + 108) (base + 136) _ _ _
     (((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbody1
   have hb1_canon : cpsTriple (base + 108) (base + 136) (evm_byte_code base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v2 >>> (shift_amount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v2 >>> (shiftAmount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp) (fun h hq => by xperm_hyp hq) hb1_val_f
   have hb0_val_f := cpsTriple_frame_left (base + 124) (base + 136) _ _ _
     (((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2)) (by pcFree) hbody0
   have hb0_canon : cpsTriple (base + 124) (base + 136) (evm_byte_code base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v3 >>> (shift_amount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shift_amount) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (v3 >>> (shiftAmount.toNat % 64)) &&& signExtend12 255) ** (.x6 ↦ᵣ shiftAmount) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp) (fun h hq => by xperm_hyp hq) hb0_val_f
   -- Frame Phase C and merge with bodies+store
   have hphaseC_framed := cpsNBranch_frame_left
-    (F := (.x6 ↦ᵣ shift_amount) ** (.x12 ↦ᵣ sp) **
+    (F := (.x6 ↦ᵣ shiftAmount) ** (.x12 ↦ᵣ sp) **
           (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- For each Phase C exit, build body+store and thread dispatch fact
   -- Helper to derive K from dispatch fact
-  have derive_K_0 (hd : limb_from_msb = 0) : 0 = i0.toNat / 8 := by
-    have : limb_from_msb.toNat = 0 := by rw [hd]; rfl
+  have derive_K_0 (hd : limbFromMsb = 0) : 0 = i0.toNat / 8 := by
+    have : limbFromMsb.toNat = 0 := by rw [hd]; rfl
     omega
-  have derive_K_1 (hd : limb_from_msb = (0 : Word) + signExtend12 1) : 1 = i0.toNat / 8 := by
-    have : limb_from_msb.toNat = 1 := by rw [hd]; decide
+  have derive_K_1 (hd : limbFromMsb = (0 : Word) + signExtend12 1) : 1 = i0.toNat / 8 := by
+    have : limbFromMsb.toNat = 1 := by rw [hd]; decide
     omega
-  have derive_K_2 (hd : limb_from_msb = (0 : Word) + signExtend12 2) : 2 = i0.toNat / 8 := by
-    have : limb_from_msb.toNat = 2 := by rw [hd]; decide
+  have derive_K_2 (hd : limbFromMsb = (0 : Word) + signExtend12 2) : 2 = i0.toNat / 8 := by
+    have : limbFromMsb.toNat = 2 := by rw [hd]; decide
     omega
-  have derive_K_3 (hd : limb_from_msb ≠ 0 ∧ limb_from_msb ≠ (0 : Word) + signExtend12 1 ∧
-      limb_from_msb ≠ (0 : Word) + signExtend12 2) : 3 = i0.toNat / 8 := by
+  have derive_K_3 (hd : limbFromMsb ≠ 0 ∧ limbFromMsb ≠ (0 : Word) + signExtend12 1 ∧
+      limbFromMsb ≠ (0 : Word) + signExtend12 2) : 3 = i0.toNat / 8 := by
     obtain ⟨h0, h1, h2⟩ := hd
-    have hn0 : limb_from_msb.toNat ≠ 0 :=
+    have hn0 : limbFromMsb.toNat ≠ 0 :=
       fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
-    have hn1 : limb_from_msb.toNat ≠ 1 :=
+    have hn1 : limbFromMsb.toNat ≠ 1 :=
       fun hc => h1 (BitVec.eq_of_toNat_eq (by
-        show limb_from_msb.toNat = ((0 : Word) + signExtend12 1).toNat
+        show limbFromMsb.toNat = ((0 : Word) + signExtend12 1).toNat
         simp only [zero_add_se12_1_toNat]; exact hc))
-    have hn2 : limb_from_msb.toNat ≠ 2 :=
+    have hn2 : limbFromMsb.toNat ≠ 2 :=
       fun hc => h2 (BitVec.eq_of_toNat_eq (by
-        show limb_from_msb.toNat = ((0 : Word) + signExtend12 2).toNat
+        show limbFromMsb.toNat = ((0 : Word) + signExtend12 2).toNat
         simp only [zero_add_se12_2_toNat]; exact hc))
-    have hlt4 : limb_from_msb.toNat < 4 := by omega
+    have hlt4 : limbFromMsb.toNat < 4 := by omega
     omega
   -- Build body+store specs WITHOUT the dispatch fact (just compose and weaken regs)
   -- Then use cpsTriple_strip_pure_and_convert to accept the dispatch fact from Phase C
@@ -743,17 +743,17 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   -- Helper to build body+store (parametric in x10 value)
   have mk_body_store : ∀ (bodyBase : Word) (x10v vLimb : Word)
       (hbodyRaw : cpsTriple bodyBase (base + 136) (evm_byte_code base)
-        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
          ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (vLimb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)) ** (.x6 ↦ᵣ shift_amount) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (vLimb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)) ** (.x6 ↦ᵣ shiftAmount) **
          ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))),
-      let resV := (vLimb >>> (shift_amount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
+      let resV := (vLimb >>> (shiftAmount.toNat % 64)) &&& signExtend12 (255 : BitVec 12)
       cpsTriple bodyBase (base + 180) (evm_byte_code base)
-        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limb_from_msb) ** (.x6 ↦ᵣ shift_amount) **
+        ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ limbFromMsb) ** (.x6 ↦ᵣ shiftAmount) **
          (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
          (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
          ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-        ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ resV) ** (.x6 ↦ᵣ shift_amount) **
+        ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ resV) ** (.x6 ↦ᵣ shiftAmount) **
          (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
          (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
          ((sp + 32) ↦ₘ resV) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
@@ -766,7 +766,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     rw [byte_store_exit_eq] at hstore_raw; simp only [signExtend12_32] at hstore_raw
     have hstore := cpsTriple_extend_code (byte_store_sub base) hstore_raw
     have hstore_f := cpsTriple_frame_left (base + 136) (base + 180) _ _ _
-      ((.x6 ↦ᵣ shift_amount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
+      ((.x6 ↦ᵣ shiftAmount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3))
       (by pcFree) hstore
     have hbs := cpsTriple_seq_with_perm_same_cr bodyBase (base + 136) (base + 180) _ _ _ _ _
@@ -775,15 +775,15 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hq => by xperm_hyp hq) hbs
   -- Build body+store for each body (with Phase C exit x10 values)
-  -- Phase C exits: e0 has x10=byte_shift, e1 has x10=(0:Word)+signExtend12 1,
+  -- Phase C exits: e0 has x10=byteShift, e1 has x10=(0:Word)+signExtend12 1,
   -- e2 has x10=(0:Word)+signExtend12 2, e3 has x10=(0:Word)+signExtend12 2
-  have hbs0 := mk_body_store (base + 124) byte_shift v3 hb0_canon
+  have hbs0 := mk_body_store (base + 124) byteShift v3 hb0_canon
   have hbs1 := mk_body_store (base + 108) ((0:Word) + signExtend12 1) v2 hb1_canon
   have hbs2 := mk_body_store (base + 92) ((0:Word) + signExtend12 2) v1 hb2_canon
   have hbs3 := mk_body_store (base + 76) ((0:Word) + signExtend12 2) v0 hb3_canon
   -- Helper to weaken regs to regOwn
   have body_post_weaken : ∀ (resV x10v : Word),
-      ∀ h, ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ resV) ** (.x6 ↦ᵣ shift_amount) **
+      ∀ h, ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ resV) ** (.x6 ↦ᵣ shiftAmount) **
             (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
             (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
             ((sp + 32) ↦ₘ resV) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) h →
@@ -809,20 +809,20 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   -- Wrap each with cpsTriple_strip_pure_and_convert to accept dispatch fact and bridge to resultPost
   -- The dispatch fact is used to derive K, which is used by bridge to convert memory values
   have hb0_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbs0_w (fun (hd : limb_from_msb = 0) h hq => by
+    hbs0_w (fun (hd : limbFromMsb = 0) h hq => by
       simp only [resultPost, hresult_high1, hresult_high2, hresult_high3]
       rw [← bridge v3 0 (derive_K_0 hd) (by omega) rfl]; exact hq)
   have hb1_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbs1_w (fun (hd : limb_from_msb = (0 : Word) + signExtend12 1) h hq => by
+    hbs1_w (fun (hd : limbFromMsb = (0 : Word) + signExtend12 1) h hq => by
       simp only [resultPost, hresult_high1, hresult_high2, hresult_high3]
       rw [← bridge v2 1 (derive_K_1 hd) (by omega) rfl]; exact hq)
   have hb2_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbs2_w (fun (hd : limb_from_msb = (0 : Word) + signExtend12 2) h hq => by
+    hbs2_w (fun (hd : limbFromMsb = (0 : Word) + signExtend12 2) h hq => by
       simp only [resultPost, hresult_high1, hresult_high2, hresult_high3]
       rw [← bridge v1 2 (derive_K_2 hd) (by omega) rfl]; exact hq)
   have hb3_ev := @cpsTriple_strip_pure_and_convert _ _ _ _ _ resultPost _
-    hbs3_w (fun (hd : limb_from_msb ≠ 0 ∧ limb_from_msb ≠ (0 : Word) + signExtend12 1 ∧
-      limb_from_msb ≠ (0 : Word) + signExtend12 2) h hq => by
+    hbs3_w (fun (hd : limbFromMsb ≠ 0 ∧ limbFromMsb ≠ (0 : Word) + signExtend12 1 ∧
+      limbFromMsb ≠ (0 : Word) + signExtend12 2) h hq => by
       simp only [resultPost, hresult_high1, hresult_high2, hresult_high3]
       rw [← bridge v0 3 (derive_K_3 hd) (by omega) rfl]; exact hq)
   -- Merge Phase C with bodies
@@ -844,8 +844,8 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
        (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
-      ((.x5 ↦ᵣ limb_from_msb) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byte_shift) **
-       (.x6 ↦ᵣ shift_amount) ** (.x12 ↦ᵣ sp) **
+      ((.x5 ↦ᵣ limbFromMsb) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ byteShift) **
+       (.x6 ↦ᵣ shiftAmount) ** (.x12 ↦ᵣ sp) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) :=
     cpsTriple_weaken


### PR DESCRIPTION
## Summary
Renames 7 let-bound locals in the BYTE opcode's \`Byte/Spec.lean\` and \`Byte/LimbSpec.lean\` to lowerCamelCase per Mathlib rule 4.

Mirrors the pattern used in #628 (Shift/LimbSpec) and #633 (SignExtend/LimbSpec).

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)