### PR TITLE
refactor(divmod): rename u_addr/vtop_base to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -701,24 +701,24 @@ private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 
 theorem divK_save_trial_load_spec
     (sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
     (base : Word) :
-    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + 500) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
        (sp + signExtend12 3976 ↦ₘ j_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
        (sp + signExtend12 3976 ↦ₘ j) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
-  intro u_addr vtop_base
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+  intro uAddr vtopBase
   -- 1. Save j: instr [0] at base+448
   have SJ := divK_save_j_spec sp j j_old (base + loopBodyOff)
   rw [lb_save_j] at SJ
@@ -729,8 +729,8 @@ theorem divK_save_trial_load_spec
     ((.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
      (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
      (sp + signExtend12 3984 ↦ₘ n) **
-     (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-     (vtop_base + signExtend12 32 ↦ₘ v_top))
+     (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+     (vtopBase + signExtend12 32 ↦ₘ v_top))
     (by pcFree) SJe
   -- 2. Trial load: instrs [1]-[12] at base+452
   have TL := divK_trial_load_spec sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top
@@ -802,7 +802,7 @@ private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
     Entry: base+512, Exit: base+516, CodeReq: sharedDivModCode base.
     Computes q_hat = div128(u_hi, u_lo, v_top). -/
 theorem divK_trial_call_path_spec
-    (sp j u_lo u_hi v_top vtop_base : Word) (base : Word)
+    (sp j u_lo u_hi v_top vtopBase : Word) (base : Word)
     (v2_old v11_old : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516) :
@@ -834,7 +834,7 @@ theorem divK_trial_call_path_spec
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
        (.x2 ↦ᵣ v2_old) ** (.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
@@ -858,13 +858,13 @@ theorem divK_trial_call_path_spec
     lb_sub base 16 _ _ (by decide) (by bv_addr) (by decide)) J
   -- 2. div128 subroutine: base+1072 → base+516
   have D := div128_spec sp (base + 516) v_top u_lo u_hi base
-    j vtop_base v11_old ret_mem d_mem dlo_mem un0_mem
+    j vtopBase v11_old ret_mem d_mem dlo_mem un0_mem
     halign
   dsimp only [] at D
   -- 3. Frame JAL with all registers/memory for div128
   have Jf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-     (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+     (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
      (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
      (.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) **
@@ -1676,24 +1676,24 @@ theorem divK_trial_max_full_spec
     (sp j n j_old v5_old v6_old v7_old v10_old v11_old u_hi u_lo v_top : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u_hi v_top) :
-    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtop_base) **
+       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top)) := by
-  intro u_addr vtop_base
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+  intro uAddr vtopBase
   -- 1. Save j + trial load (base+448 → base+500)
   have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top
     base
@@ -1742,8 +1742,8 @@ theorem divK_trial_call_full_spec
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u_hi v_top) :
-    let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v_top >>> (32 : BitVec 6).toNat
     let d_lo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1776,8 +1776,8 @@ theorem divK_trial_call_full_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top) **
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -1787,13 +1787,13 @@ theorem divK_trial_call_full_spec
        (.x7 ↦ᵣ q0_dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (u_addr ↦ₘ u_hi) ** ((u_addr + 8) ↦ₘ u_lo) **
-       (vtop_base + signExtend12 32 ↦ₘ v_top) **
+       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
+       (vtopBase + signExtend12 32 ↦ₘ v_top) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v_top) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ un0_div)) := by
-  intro u_addr vtop_base
+  intro uAddr vtopBase
         d_hi d_lo un1 un0_div q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
   -- 1. Save j + trial load (base+448 → base+500)
@@ -1815,7 +1815,7 @@ theorem divK_trial_call_full_spec
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp) taken
   -- 3. Trial call path (base+512 → base+516)
-  have TCP := divK_trial_call_path_spec sp j u_lo u_hi v_top vtop_base base
+  have TCP := divK_trial_call_path_spec sp j u_lo u_hi v_top vtopBase base
     v2_old v11_old ret_mem d_mem dlo_mem un0_mem
     halign
   dsimp only [] at TCP

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -2,16 +2,16 @@
   EvmAsm.Evm64.DivMod.LoopBodyN1
 
   Fixed loop body compositions for n=1 (1-limb divisor).
-  Eliminates the u_addr/window-cell and vtop/v0 overlaps in the generic spec.
+  Eliminates the uAddr/window-cell and vtop/v0 overlaps in the generic spec.
 
   For n=1, three address overlaps exist:
-  1. u_addr = u_base + signExtend12 4088  (both refer to u[j+1])
-  2. u_addr + 8 = u_base + signExtend12 0  (both refer to u[j+0])
-  3. vtop_base + signExtend12 32 = sp + signExtend12 32  (both refer to v[0])
+  1. uAddr = u_base + signExtend12 4088  (both refer to u[j+1])
+  2. uAddr + 8 = u_base + signExtend12 0  (both refer to u[j+0])
+  3. vtopBase + signExtend12 32 = sp + signExtend12 32  (both refer to v[0])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting u_addr and vtop_base to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical u_base-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,7 +29,7 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=1 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=1: u_addr = u_base + signExtend12 4088 -/
+/-- For n=1: uAddr = u_base + signExtend12 4088 -/
 theorem u_addr_eq_n1 (sp j : Word) :
     sp + signExtend12 4056 - (j + (1 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
@@ -41,7 +41,7 @@ theorem u_addr8_eq_n1 (sp j : Word) :
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0 := by
   divmod_addr
 
-/-- For n=1: vtop_base + signExtend12 32 = sp + signExtend12 32 -/
+/-- For n=1: vtopBase + signExtend12 32 = sp + signExtend12 32 -/
 theorem vtop_eq_v0_n1 (sp : Word) :
     (sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 32 := by
@@ -57,7 +57,7 @@ theorem divK_trial_max_full_spec_n1
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -67,13 +67,13 @@ theorem divK_trial_max_full_spec_n1
        ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u0) ** (.x6 ↦ᵣ vtop_base) **
+       (.x5 ↦ᵣ u0) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u1) ** (.x10 ↦ᵣ v0) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
        ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0)) := by
-  intro u_base vtop_base
+  intro u_base vtopBase
   have TF := divK_trial_max_full_spec sp j (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
@@ -211,15 +211,15 @@ theorem divK_loop_body_n1_max_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full for n=1 (base+448 → base+516)
   have TF := divK_trial_max_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u0 vtop_base u1 v0 v2_old base
+    j u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -309,14 +309,14 @@ theorem divK_loop_body_n1_max_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full for n=1 (base+448 → base+516)
   have TF := divK_trial_max_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u0 vtop_base u1 v0 v2_old base
+    j u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -457,7 +457,7 @@ theorem divK_loop_body_n1_call_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full for n=1 (base+448 → base+516)
   have TF := divK_trial_call_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
@@ -601,7 +601,7 @@ theorem divK_loop_body_n1_call_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full for n=1 (base+448 → base+516)
   have TF := divK_trial_call_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -2,16 +2,16 @@
   EvmAsm.Evm64.DivMod.LoopBodyN2
 
   Fixed loop body compositions for n=2 (2-limb divisor).
-  Eliminates the u_addr/window-cell and vtop/v1 overlaps in the generic spec.
+  Eliminates the uAddr/window-cell and vtop/v1 overlaps in the generic spec.
 
   For n=2, three address overlaps exist:
-  1. u_addr = u_base + signExtend12 4080  (both refer to u[j+2])
-  2. u_addr + 8 = u_base + signExtend12 4088  (both refer to u[j+1])
-  3. vtop_base + signExtend12 32 = sp + signExtend12 40  (both refer to v[1])
+  1. uAddr = u_base + signExtend12 4080  (both refer to u[j+2])
+  2. uAddr + 8 = u_base + signExtend12 4088  (both refer to u[j+1])
+  3. vtopBase + signExtend12 32 = sp + signExtend12 40  (both refer to v[1])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting u_addr and vtop_base to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical u_base-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,7 +29,7 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=2 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=2: u_addr = u_base + signExtend12 4080 -/
+/-- For n=2: uAddr = u_base + signExtend12 4080 -/
 theorem u_addr_eq_n2 (sp j : Word) :
     sp + signExtend12 4056 - (j + (2 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
@@ -41,7 +41,7 @@ theorem u_addr8_eq_n2 (sp j : Word) :
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- For n=2: vtop_base + signExtend12 32 = sp + signExtend12 40 -/
+/-- For n=2: vtopBase + signExtend12 32 = sp + signExtend12 40 -/
 theorem vtop_eq_v1_n2 (sp : Word) :
     (sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 40 := by
@@ -108,21 +108,21 @@ theorem divK_loop_body_n2_max_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516), instantiated with n=2, u_hi=u2, u_lo=u1, v_top=v1
   have TF := divK_trial_max_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite u_addr → u_base + signExtend12 4080, and (u_addr+8) → u_base + signExtend12 4088
+  -- Rewrite uAddr → u_base + signExtend12 4080, and (uAddr+8) → u_base + signExtend12 4088
   rw [u_addr_eq_n2 sp j] at TF
   rw [u_addr8_eq_n2 sp j] at TF
-  -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 40
+  -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 40
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u1 vtop_base u2 v1 v2_old base
+    j u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -212,7 +212,7 @@ theorem divK_loop_body_n2_max_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
@@ -222,7 +222,7 @@ theorem divK_loop_body_n2_max_addback_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u1 vtop_base u2 v1 v2_old base
+    j u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -362,7 +362,7 @@ theorem divK_loop_body_n2_call_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
@@ -509,7 +509,7 @@ theorem divK_loop_body_n2_call_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -2,16 +2,16 @@
   EvmAsm.Evm64.DivMod.LoopBodyN3
 
   Fixed loop body compositions for n=3 (3-limb divisor).
-  Eliminates the u_addr/window-cell and vtop/v2 overlaps in the generic spec.
+  Eliminates the uAddr/window-cell and vtop/v2 overlaps in the generic spec.
 
   For n=3, three address overlaps exist:
-  1. u_addr = u_base + signExtend12 4072  (both refer to u[j+3])
-  2. u_addr + 8 = u_base + signExtend12 4080  (both refer to u[j+2])
-  3. vtop_base + signExtend12 32 = sp + signExtend12 48  (both refer to v[2])
+  1. uAddr = u_base + signExtend12 4072  (both refer to u[j+3])
+  2. uAddr + 8 = u_base + signExtend12 4080  (both refer to u[j+2])
+  3. vtopBase + signExtend12 32 = sp + signExtend12 48  (both refer to v[2])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting u_addr and vtop_base to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical u_base-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,7 +29,7 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=3 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=3: u_addr = u_base + signExtend12 4072 -/
+/-- For n=3: uAddr = u_base + signExtend12 4072 -/
 theorem u_addr_eq_n3 (sp j : Word) :
     sp + signExtend12 4056 - (j + (3 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
@@ -41,7 +41,7 @@ theorem u_addr8_eq_n3 (sp j : Word) :
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- For n=3: vtop_base + signExtend12 32 = sp + signExtend12 48 -/
+/-- For n=3: vtopBase + signExtend12 32 = sp + signExtend12 48 -/
 theorem vtop_eq_v2_n3 (sp : Word) :
     (sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 48 := by
@@ -107,21 +107,21 @@ theorem divK_loop_body_n3_max_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516), instantiated with n=3, u_hi=u3, u_lo=u2, v_top=v2
   have TF := divK_trial_max_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite u_addr → u_base + signExtend12 4072, and (u_addr+8) → u_base + signExtend12 4080
+  -- Rewrite uAddr → u_base + signExtend12 4072, and (uAddr+8) → u_base + signExtend12 4080
   rw [u_addr_eq_n3 sp j] at TF
   rw [u_addr8_eq_n3 sp j] at TF
-  -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 48
+  -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 48
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u2 vtop_base u3 v2 v2_old base
+    j u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -211,8 +211,8 @@ theorem divK_loop_body_n3_max_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
@@ -222,7 +222,7 @@ theorem divK_loop_body_n3_max_addback_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u2 vtop_base u3 v2 v2_old base
+    j u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -362,7 +362,7 @@ theorem divK_loop_body_n3_call_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
@@ -509,7 +509,7 @@ theorem divK_loop_body_n3_call_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -2,16 +2,16 @@
   EvmAsm.Evm64.DivMod.LoopBodyN4
 
   Fixed loop body compositions for n=4 (4-limb divisor, m=0, single iteration).
-  Eliminates the u_addr/window-cell and vtop/v3 overlaps in the generic spec.
+  Eliminates the uAddr/window-cell and vtop/v3 overlaps in the generic spec.
 
   For n=4, three address overlaps exist:
-  1. u_addr = u_base + signExtend12 4064  (both refer to u[j+4])
-  2. u_addr + 8 = u_base + signExtend12 4072  (both refer to u[j+3])
-  3. vtop_base + signExtend12 32 = sp + signExtend12 56  (both refer to v[3])
+  1. uAddr = u_base + signExtend12 4064  (both refer to u[j+4])
+  2. uAddr + 8 = u_base + signExtend12 4072  (both refer to u[j+3])
+  3. vtopBase + signExtend12 32 = sp + signExtend12 56  (both refer to v[3])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting u_addr and vtop_base to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical u_base-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,7 +29,7 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=4 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=4: u_addr = u_base + signExtend12 4064 -/
+/-- For n=4: uAddr = u_base + signExtend12 4064 -/
 theorem u_addr_eq_n4 (sp j : Word) :
     sp + signExtend12 4056 - (j + (4 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -41,7 +41,7 @@ theorem u_addr8_eq_n4 (sp j : Word) :
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- For n=4: vtop_base + signExtend12 32 = sp + signExtend12 56 -/
+/-- For n=4: vtopBase + signExtend12 32 = sp + signExtend12 56 -/
 theorem vtop_eq_v3_n4 (sp : Word) :
     (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 56 := by
@@ -109,21 +109,21 @@ theorem divK_loop_body_n4_max_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516), instantiated with n=4, u_hi=u_top, u_lo=u3, v_top=v3
   have TF := divK_trial_max_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u_top u3 v3 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite u_addr → u_base + signExtend12 4064, and (u_addr+8) → u_base + signExtend12 4072
+  -- Rewrite uAddr → u_base + signExtend12 4064, and (uAddr+8) → u_base + signExtend12 4072
   rw [u_addr_eq_n4 sp j] at TF
   rw [u_addr8_eq_n4 sp j] at TF
-  -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 56
+  -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 56
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u3 vtop_base u_top v3 v2_old base
+    j u3 vtopBase u_top v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -213,8 +213,8 @@ theorem divK_loop_body_n4_max_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  -- Abbreviation for vtop_base (register value, not a memory address)
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  -- Abbreviation for vtopBase (register value, not a memory address)
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u_top u3 v3 base hbltu
@@ -224,7 +224,7 @@ theorem divK_loop_body_n4_max_addback_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u3 vtop_base u_top v3 v2_old base
+    j u3 vtopBase u_top v3 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -365,7 +365,7 @@ theorem divK_loop_body_n4_call_skip_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
   let j' := j + signExtend12 4095
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
@@ -511,7 +511,7 @@ theorem divK_loop_body_n4_call_addback_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -80,7 +80,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
@@ -90,7 +90,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u1 vtop_base u2 v1 v2_old base
+    (0 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -188,7 +188,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN2Call div128Quot at hborrow
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
@@ -309,7 +309,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
@@ -317,7 +317,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (1 : Word) u1 vtop_base u2 v1 v2_old base
+    (1 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -408,7 +408,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
@@ -524,7 +524,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
@@ -532,7 +532,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (2 : Word) u1 vtop_base u2 v1 v2_old base
+    (2 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -623,7 +623,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
@@ -738,7 +738,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
@@ -746,7 +746,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u1 vtop_base u2 v1 v2_old base
+    (0 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
@@ -853,7 +853,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
@@ -951,7 +951,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
@@ -959,7 +959,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (1 : Word) u1 vtop_base u2 v1 v2_old base
+    (1 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
@@ -1065,7 +1065,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
@@ -1157,7 +1157,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
@@ -1165,7 +1165,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (2 : Word) u1 vtop_base u2 v1 v2_old base
+    (2 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
@@ -1271,7 +1271,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -75,7 +75,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
@@ -85,7 +85,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u2 vtop_base u3 v2 v2_old base
+    (0 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -183,7 +183,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level q_hat
   unfold isSkipBorrowN3Call div128Quot at hborrow
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
@@ -311,7 +311,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
@@ -321,7 +321,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (1 : Word) u2 vtop_base u3 v2 v2_old base
+    (1 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -420,7 +420,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN3Call div128Quot at hborrow
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
@@ -541,7 +541,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
@@ -551,7 +551,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u2 vtop_base u3 v2 v2_old base
+    (0 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -661,7 +661,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
@@ -763,7 +763,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
@@ -773,7 +773,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (1 : Word) u2 vtop_base u3 v2 v2_old base
+    (1 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -884,7 +884,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -74,7 +74,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
 
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u_top u3 v3 base hbltu
@@ -84,7 +84,7 @@ theorem divK_loop_body_n4_max_skip_j0_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u3 vtop_base u_top v3 v2_old base
+    (0 : Word) u3 vtopBase u_top v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -210,7 +210,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := u_top - c3
 
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
@@ -310,7 +310,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u_top u3 v3 base hbltu
@@ -320,7 +320,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u3 vtop_base u_top v3 v2_old base
+    (0 : Word) u3 vtopBase u_top v3 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Max isAddbackCarry2Nz at hcarry2_nz
@@ -446,7 +446,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base


### PR DESCRIPTION
## Summary
Renames \`u_addr\` → \`uAddr\` and \`vtop_base\` → \`vtopBase\` across the DivMod loop files:

- \`LoopBody.lean\`
- \`LoopBodyN{1,2,3,4}.lean\`
- \`LoopIterN{2,3,4}.lean\`

Total: 133 occurrences across 8 files. Positional callers unaffected.

Per Mathlib rule 4. Continues the gradual #189 migration (follows #632 for LimbSpec/Trial* and #639/#640 for q_addr).

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)