### PR TITLE
refactor(divmod): rename d_hi/d_lo to dHi/dLo module-wide (#189)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -58,31 +58,31 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
     -- Phase 1 intermediates
-    let d_hi := d >>> (32 : BitVec 6).toNat
-    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := d >>> (32 : BitVec 6).toNat
+    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     -- Step 1 intermediates
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     -- Compute un21 intermediates (x5, x1 values after compute_un21)
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
     -- Step 2 intermediates
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
@@ -100,14 +100,14 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ q1') **
        (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0_dlo) **
-       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ rhat2_un0) ** (.x11 ↦ᵣ q) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2_un0) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ ret_addr) **
        (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
-  intro d_hi d_lo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
+  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and u_lo into halves.
@@ -137,7 +137,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Block 2: Step 1 (base+1112 → base+1172)
   -- Trial division q1, clamp, product check.
   -- ================================================================
-  have hst1 := divK_div128_step1_spec sp u_hi d_hi un1 d_lo un0 d d_lo
+  have hst1 := divK_div128_step1_spec sp u_hi dHi un1 dLo un0 d dLo
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
@@ -167,9 +167,9 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- ================================================================
   -- Block 3: Compute un21 (base+1172 → base+1192)
-  -- un21 = rhat*2^32 + un1 - q1*d_lo.
+  -- un21 = rhat*2^32 + un1 - q1*dLo.
   -- ================================================================
-  have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo d_lo
+  have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo dLo
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
@@ -181,7 +181,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
-    ((.x6 ↦ᵣ d_hi) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
@@ -191,11 +191,11 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- ================================================================
   -- Block 4: Step 2 (base+1192 → base+1252)
   -- Trial division q0, clamp, product check.
-  -- Params: un21(x7), d_hi(x6), v1_old=cu_q1_dlo(x1),
+  -- Params: un21(x7), dHi(x6), v1_old=cu_q1_dlo(x1),
   --         v5_old=cu_rhat_un1(x5), v11_old=un1(x11),
-  --         dlo=d_lo(mem[3952]), un0(mem[3944])
+  --         dlo=dLo(mem[3952]), un0(mem[3944])
   -- ================================================================
-  have hst2 := divK_div128_step2_spec sp un21 d_hi cu_q1_dlo cu_rhat_un1 un1 d_lo un0
+  have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
@@ -239,9 +239,9 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ rhat2_un0) **
+    ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2_un0) **
      (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hende
   -- Compose (→step2) → end

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -541,7 +541,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u_top v3) :
     let q_hat := div128Quot u_top u3 v3
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
@@ -564,9 +564,9 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
       (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro q_hat d_lo div_un0 hborrow
+  intro q_hat dLo div_un0 hborrow
   have raw := divK_loop_body_n4_call_skip_j0_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu
   have raw' := raw hborrow
@@ -594,12 +594,12 @@ def preloopCallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   loopBodyN4SkipPost sp (0 : Word) q_hat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
-  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -626,7 +626,7 @@ theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     let q_hat := div128Quot u4 u3 b3'
-    let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
@@ -642,7 +642,7 @@ theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
      ((sp + signExtend12 4088) ↦ₘ q_hat)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ b3') **
-    (sp + signExtend12 3952 ↦ₘ d_lo) **
+    (sp + signExtend12 3952 ↦ₘ dLo) **
     (sp + signExtend12 3944 ↦ₘ div_un0) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -757,7 +757,7 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
   denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q_hat 0 0 0 **
@@ -773,7 +773,7 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
-  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0)
 
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+skip). -/
@@ -822,7 +822,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
   -- 1. Pre-loop + loop body: base → base+904
@@ -851,7 +851,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
      (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) hB
   -- 3. Compose

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -100,7 +100,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     (hbltu : BitVec.ult u_top v3)
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let q_hat := div128Quot u_top u3 v3
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
@@ -123,9 +123,9 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
       (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro q_hat d_lo div_un0 hborrow
+  intro q_hat dLo div_un0 hborrow
   rw [← se12_32] at hv_v0; rw [← se12_40] at
   rw [← se12_48] at hv_v2; rw [← se12_56] at
   rw [← u_base_off0_j0] at hv_u0; rw [← u_base_off4088_j0] at
@@ -309,12 +309,12 @@ def preloopCallAddbackBeqPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   loopBodyN4AddbackBeqPost sp (0 : Word) q_hat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
-  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -669,7 +669,7 @@ theorem preloopCallAddbackBeqPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     let q_hat := div128Quot u4 u3 b3'
-    let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
     let c3 := ms.2.2.2.2
@@ -697,7 +697,7 @@ theorem preloopCallAddbackBeqPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
      ((sp + signExtend12 4088) ↦ₘ q_out)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ b3') **
-    (sp + signExtend12 3952 ↦ₘ d_lo) **
+    (sp + signExtend12 3952 ↦ₘ dLo) **
     (sp + signExtend12 3944 ↦ₘ div_un0) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -726,7 +726,7 @@ def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -754,7 +754,7 @@ def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
-  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0)
 
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+addback BEQ). -/
@@ -817,7 +817,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
   let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   let q_hat := div128Quot u4 u3 b3'
-  let d_lo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let ms := mulsubN4 q_hat b0' b1' b2' b3' u0
     ((a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64)))
@@ -858,7 +858,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) ** (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) ** (sp + signExtend12 3960 ↦ₘ b3') **
-     (sp + signExtend12 3952 ↦ₘ d_lo) ** (sp + signExtend12 3944 ↦ₘ div_un0))
+     (sp + signExtend12 3952 ↦ₘ dLo) ** (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) hB
   have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by simp only [preloopCallAddbackBeqPostN4_unfold] at hp; xperm_hyp hp) hA hBF

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -224,28 +224,28 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     (hbltu : BitVec.ult u_top v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -270,10 +270,10 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
       (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
@@ -325,28 +325,28 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -371,10 +371,10 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
       (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -46,12 +46,12 @@ def isSkipBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 @[irreducible]
 def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let q_hat := div128Quot (0 : Word) a3 b3
-  let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   loopBodyN4SkipPost sp (0 : Word) q_hat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
-  (sp + signExtend12 3952 ↦ₘ d_lo) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ div_un0) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -154,7 +154,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
 theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let q_hat := div128Quot (0 : Word) a3 b3
-    let d_lo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
@@ -170,7 +170,7 @@ theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
      ((sp + signExtend12 4088) ↦ₘ q_hat)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ b3) **
-    (sp + signExtend12 3952 ↦ₘ d_lo) **
+    (sp + signExtend12 3952 ↦ₘ dLo) **
     (sp + signExtend12 3944 ↦ₘ div_un0) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -57,31 +57,31 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
     -- Phase 1 intermediates
-    let d_hi := d >>> (32 : BitVec 6).toNat
-    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := d >>> (32 : BitVec 6).toNat
+    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     -- Step 1 intermediates
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     -- Compute un21 intermediates (x5, x1 values after compute_un21)
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
     -- Step 2 intermediates
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
@@ -99,14 +99,14 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ q1') **
        (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0_dlo) **
-       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ rhat2_un0) ** (.x11 ↦ᵣ q) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2_un0) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ ret_addr) **
        (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
-  intro d_hi d_lo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
+  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and u_lo into halves.
@@ -136,7 +136,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Block 2: Step 1 (base+1112 → base+1172)
   -- Trial division q1, clamp, product check.
   -- ================================================================
-  have hst1 := divK_div128_step1_spec sp u_hi d_hi un1 d_lo un0 d d_lo
+  have hst1 := divK_div128_step1_spec sp u_hi dHi un1 dLo un0 d dLo
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
@@ -166,9 +166,9 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- ================================================================
   -- Block 3: Compute un21 (base+1172 → base+1192)
-  -- un21 = rhat*2^32 + un1 - q1*d_lo.
+  -- un21 = rhat*2^32 + un1 - q1*dLo.
   -- ================================================================
-  have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo d_lo
+  have hcu := divK_div128_compute_un21_spec sp q1' rhat' un1 rhat_un1 q_dlo dLo
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
@@ -180,7 +180,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
-    ((.x6 ↦ᵣ d_hi) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
@@ -191,7 +191,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Block 4: Step 2 (base+1192 → base+1252)
   -- Trial division q0, clamp, product check.
   -- ================================================================
-  have hst2 := divK_div128_step2_spec sp un21 d_hi cu_q1_dlo cu_rhat_un1 un1 d_lo un0
+  have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
@@ -233,9 +233,9 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ rhat2_un0) **
+    ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2_un0) **
      (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hende
   -- Compose (→step2) → end

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -5,7 +5,7 @@
   subroutine:
     * `divK_div128_clamp_q1_merged_spec` — Instrs [13]-[16]. SRLI test
       q1 >= 2^32, BEQ skips correction when q1 < 2^32, else ADDI
-      q1-- and ADD rhat += d_hi. Both branches merge at base + 16.
+      q1-- and ADD rhat += dHi. Both branches merge at base + 16.
     * `divK_div128_clamp_q0_merged_spec` — the same shape on x5/x11 for
       q0/rhat2.
 
@@ -31,26 +31,26 @@ open EvmAsm.Rv64
 
 /-- div128 clamp q1: test q1 >= 2^32, conditionally decrement and adjust rhat.
     Instrs [13]-[16]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Word) :
+theorem divK_div128_clamp_q1_merged_spec (q1 rhat dHi v5_old : Word) (base : Word) :
     let hi := q1 >>> (32 : BitVec 6).toNat
     let q1' := if hi = 0 then q1 else q1 + signExtend12 4095
-    let rhat' := if hi = 0 then rhat else rhat + d_hi
+    let rhat' := if hi = 0 then rhat else rhat + dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SRLI .x5 .x10 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x5 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 12) (.ADD .x7 .x7 .x6))))
     cpsTriple base (base + 16) cr
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
        (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
-      ((.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ d_hi) **
+      ((.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) **
        (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
   intro hi q1' rhat' cr
   have I0 := srli_spec_gen .x5 .x10 v5_old q1 32 base (by nofun)
   have hbody : cpsTriple base (base + 4) cr
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
        (.x5 ↦ᵣ v5_old) ** (.x0 ↦ᵣ 0))
-      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
+      ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
        (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
     runBlock I0
   have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
@@ -58,17 +58,17 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frameR
-    ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
+    ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))
     (by pcFree) hbeq_raw
   have hbeq_ext : cpsBranch (base + 4) cr
       (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
-       ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
+       ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi)))
       (base + 16)
         (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
-         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi)))
+         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi)))
       (base + 8)
         (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
-         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))) :=
+         ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))) :=
     fun R hR s hcr hPR hpc =>
       hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
         show cr (base + 4) = _
@@ -91,16 +91,16 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp') taken
   · have hq : q1' = q1 + signExtend12 4095 := if_neg hcond
-    have hr : rhat' = rhat + d_hi := if_neg hcond
+    have hr : rhat' = rhat + dHi := if_neg hcond
     rw [hq, hr]
     have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
     have I1 := addi_spec_gen_same .x10 q1 4095 (base + 8) (by nofun)
-    have I2 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat d_hi (base + 12) (by nofun)
+    have I2 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat dHi (base + 12) (by nofun)
     have hcorr : cpsTriple (base + 8) (base + 16) cr
-        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
-        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
+        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))
+        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + dHi)) ** (.x6 ↦ᵣ dHi)) := by
       runBlock I1 I2
     have hcorr_framed := cpsTriple_frameR
       ((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))
@@ -116,25 +116,25 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat d_hi v5_old : Word) (base : Wo
 
 /-- div128 clamp q0: test q0 >= 2^32, conditionally decrement and adjust rhat2.
     Instrs [33]-[36]. Both BEQ paths merge at base+16. -/
-theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : Word) :
+theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 dHi v1_old : Word) (base : Word) :
     let hi := q0 >>> (32 : BitVec 6).toNat
     let q0' := if hi = 0 then q0 else q0 + signExtend12 4095
-    let rhat2' := if hi = 0 then rhat2 else rhat2 + d_hi
+    let rhat2' := if hi = 0 then rhat2 else rhat2 + dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x5 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.BEQ .x1 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 8) (.ADDI .x5 .x5 4095))
        (CodeReq.singleton (base + 12) (.ADD .x11 .x11 .x6))))
     cpsTriple base (base + 16) cr
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
        (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
-      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ d_hi) **
+      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi) **
        (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
   intro hi q0' rhat2' cr
   have hbody : cpsTriple base (base + 4) cr
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
        (.x1 ↦ᵣ v1_old) ** (.x0 ↦ᵣ 0))
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi) **
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi) **
        (.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
     have I0 := srli_spec_gen .x1 .x5 v1_old q0 32 base (by nofun)
     runBlock I0
@@ -143,17 +143,17 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frameR
-    ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
+    ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))
     (by pcFree) hbeq_raw
   have hbeq_ext : cpsBranch (base + 4) cr
       (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word))) **
-       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
+       ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi)))
       (base + 16)
         (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi = 0⌝) **
-         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi)))
+         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi)))
       (base + 8)
         (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
-         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))) :=
+         ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))) :=
     fun R hR s hcr hPR hpc =>
       hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
         show cr (base + 4) = _
@@ -176,16 +176,16 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 d_hi v1_old : Word) (base : W
           (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
         xperm_hyp hp') taken
   · have hq : q0' = q0 + signExtend12 4095 := if_neg hcond
-    have hr : rhat2' = rhat2 + d_hi := if_neg hcond
+    have hr : rhat2' = rhat2 + dHi := if_neg hcond
     rw [hq, hr]
     have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
       exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
     have I1 := addi_spec_gen_same .x5 q0 4095 (base + 8) (by nofun)
-    have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 d_hi (base + 12) (by nofun)
+    have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 dHi (base + 12) (by nofun)
     have hcorr : cpsTriple (base + 8) (base + 16) cr
-        ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
-        ((.x5 ↦ᵣ (q0 + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2 + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
+        ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))
+        ((.x5 ↦ᵣ (q0 + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2 + dHi)) ** (.x6 ↦ᵣ dHi)) := by
       runBlock I1 I2
     have hcorr_framed := cpsTriple_frameR
       ((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
@@ -6,11 +6,11 @@
   quotient halves):
     * `divK_div128_save_split_d_spec` — 6-instruction block (SD, SD,
       SRLI, SLLI, SRLI, SD) that saves the return address and `d` to
-      scratch, and splits `d` into `d_hi` / `d_lo`.
+      scratch, and splits `d` into `dHi` / `dLo`.
     * `divK_div128_split_ulo_spec` — 4-instruction block (SRLI, SLLI,
       SRLI, SD) that splits `u_lo` into `un1` / `un0` and saves `un0`.
     * `divK_div128_step1_init_spec` — 3-instruction block (DIVU, MUL,
-      SUB) computing `q1 = u_hi / d_hi` and `rhat = u_hi - q1 * d_hi`.
+      SUB) computing `q1 = u_hi / dHi` and `rhat = u_hi - q1 * dHi`.
 
   Twentieth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -30,11 +30,11 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 Phase 1a: save x2 (return addr) and x10 (d), compute d_hi and d_lo. -/
+/-- div128 Phase 1a: save x2 (return addr) and x10 (d), compute dHi and dLo. -/
 theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
     ret_mem d_mem dlo_mem : Word) (base : Word) :
-    let d_hi := d >>> (32 : BitVec 6).toNat
-    let d_lo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := d >>> (32 : BitVec 6).toNat
+    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
@@ -49,17 +49,17 @@ theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem))
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ d_hi) ** (.x1 ↦ᵣ d_lo) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
        (sp + signExtend12 3968 ↦ₘ ret_addr) **
        (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ d_lo)) := by
-  intro d_hi d_lo cr
+       (sp + signExtend12 3952 ↦ₘ dLo)) := by
+  intro dHi dLo cr
   have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
   have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
   have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
   have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
   have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen .x12 .x1 sp d_lo dlo_mem 3952 (base + 20)
+  have I5 := sd_spec_gen .x12 .x1 sp dLo dlo_mem 3952 (base + 20)
   runBlock I0 I1 I2 I3 I4 I5
 
 /-- div128 Phase 1b: split u_lo into un1 (x11) and un0 (x5), save un0. -/
@@ -83,23 +83,23 @@ theorem divK_div128_split_ulo_spec (sp u_lo v11_old un0_mem : Word) (base : Word
   have I3 := sd_spec_gen .x12 .x5 sp un0 un0_mem 3944 (base + 12)
   runBlock I0 I1 I2 I3
 
-/-- div128 Step 1: q1 = DIVU(u_hi, d_hi), rhat = u_hi - q1 * d_hi. -/
-theorem divK_div128_step1_init_spec (u_hi d_hi v5_old v10_old : Word) (base : Word) :
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+/-- div128 Step 1: q1 = DIVU(u_hi, dHi), rhat = u_hi - q1 * dHi. -/
+theorem divK_div128_step1_init_spec (u_hi dHi v5_old v10_old : Word) (base : Word) :
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
        (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5)))
     cpsTriple base (base + 12) cr
-      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ d_hi) **
+      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ dHi) **
        (.x10 ↦ᵣ v10_old) ** (.x5 ↦ᵣ v5_old))
-      ((.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi) **
-       (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * d_hi)) := by
+      ((.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
+       (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * dHi)) := by
   intro q1 rhat cr
-  have I0 := divu_spec_gen .x10 .x7 .x6 v10_old u_hi d_hi base (by nofun)
-  have I1 := mul_spec_gen .x5 .x10 .x6 v5_old q1 d_hi (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 u_hi (q1 * d_hi) (base + 8) (by nofun)
+  have I0 := divu_spec_gen .x10 .x7 .x6 v10_old u_hi dHi base (by nofun)
+  have I1 := mul_spec_gen .x5 .x10 .x6 v5_old q1 dHi (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 u_hi (q1 * dHi) (base + 8) (by nofun)
   runBlock I0 I1 I2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -5,8 +5,8 @@
   product-check section:
     * `divK_div128_prodcheck1_merged_spec` — 8 instructions: LD + MUL +
       SLLI + OR (body) + BLTU + JAL (branch) + ADDI + ADD (correction).
-      If `rhat*2^32 + un1 < q1*d_lo`, BLTU takes the correction path
-      (`q1--`, `rhat += d_hi`); otherwise JAL skips both adjustments.
+      If `rhat*2^32 + un1 < q1*dLo`, BLTU takes the correction path
+      (`q1--`, `rhat += dHi`); otherwise JAL skips both adjustments.
       Both branches merge at `base + 32`.
 
   Twenty-fourth chunk of the `LimbSpec.lean` split tracked by issue #312.
@@ -29,14 +29,14 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 product check 1: compute q1*d_lo vs rhat*2^32+un1, conditionally correct.
+/-- div128 product check 1: compute q1*dLo vs rhat*2^32+un1, conditionally correct.
     Instrs [17]-[24]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck1_merged_spec
-    (sp q1 rhat d_hi un1 v1_old v5_old dlo : Word) (base : Word) :
+    (sp q1 rhat dHi un1 v1_old v5_old dlo : Word) (base : Word) :
     let qDlo := q1 * dlo
     let rhatUn1 := (rhat <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhatUn1 qDlo then q1 + signExtend12 4095 else q1
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + d_hi else rhat
+    let rhat' := if BitVec.ult rhatUn1 qDlo then rhat + dHi else rhat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
@@ -48,18 +48,18 @@ theorem divK_div128_prodcheck1_merged_spec
        (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
     cpsTriple base (base + 32) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
   intro qDlo rhatUn1 q1' rhat' cr
   have hbody : cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
     have I0 := ld_spec_gen .x1 .x12 sp v1_old dlo 3952 base (by nofun)
     have I1 := mul_spec_gen .x5 .x10 .x1 v5_old q1 dlo (base + 4) (by nofun)
@@ -72,20 +72,20 @@ theorem divK_div128_prodcheck1_merged_spec
   rw [ha_t, ha_f] at hbltu_raw
   have hbltu_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-     (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo))
+     (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))
     (by pcFree) hbltu_raw
   have hbltu_ext : cpsBranch (base + 16) cr
       (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-        (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
+        (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
       (base + 24)
         (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜BitVec.ult rhatUn1 qDlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-          (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
+          (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)))
       (base + 20)
         (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** ⌜¬BitVec.ult rhatUn1 qDlo⌝) **
          ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-          (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo))) :=
+          (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) :=
     fun R hR s hcr hPR hpc =>
       hbltu_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
         show cr (base + 16) = _
@@ -99,16 +99,16 @@ theorem divK_div128_prodcheck1_merged_spec
     (fun h hp => by xperm_hyp hp) hbody hbltu_ext
   by_cases hcond : BitVec.ult rhatUn1 qDlo
   · have hq : q1' = q1 + signExtend12 4095 := if_pos hcond
-    have hr : rhat' = rhat + d_hi := if_pos hcond
+    have hr : rhat' = rhat + dHi := if_pos hcond
     rw [hq, hr]
     have taken_br := cpsBranch_takenPath composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
       exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
     have I4 := addi_spec_gen_same .x10 q1 4095 (base + 24) (by nofun)
-    have I5 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat d_hi (base + 28) (by nofun)
+    have I5 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat dHi (base + 28) (by nofun)
     have hcorr : cpsTriple (base + 24) (base + 32) cr
-        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
-        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + d_hi)) ** (.x6 ↦ᵣ d_hi)) := by
+        ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))
+        ((.x10 ↦ᵣ (q1 + signExtend12 4095)) ** (.x7 ↦ᵣ (rhat + dHi)) ** (.x6 ↦ᵣ dHi)) := by
       runBlock I4 I5
     have hcorr_framed := cpsTriple_frameR
       ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ un1) **
@@ -143,23 +143,23 @@ theorem divK_div128_prodcheck1_merged_spec
     have I_jal_cr := cpsTriple_extend_code hcr_jal I_jal
     have hjal_framed := cpsTriple_frameR
       ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) **
-       (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) ** (.x6 ↦ᵣ d_hi) **
+       (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo))
       (by pcFree) I_jal_cr
     simp only [sepConj_emp_left'] at hjal_framed
     have ntaken_clean : cpsTriple base (base + 20) cr
         ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-         (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ d_hi) **
+         (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x6 ↦ᵣ dHi) **
          (sp + signExtend12 3952 ↦ₘ dlo))
         ((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo) **
          (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-         (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo)) :=
+         (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo)) :=
       cpsTriple_weaken
         (fun h hp => hp)
         (fun h hp => by
           have hp' : (((.x1 ↦ᵣ rhatUn1) ** (.x5 ↦ᵣ qDlo)) **
             ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
-             (.x6 ↦ᵣ d_hi) ** (sp + signExtend12 3952 ↦ₘ dlo))) h :=
+             (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) h :=
             sepConj_mono_left (sepConj_mono_right
               (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
           xperm_hyp hp')

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -5,7 +5,7 @@
   product-check section:
     * `divK_div128_prodcheck2_merged_spec` — 8 instructions: LD + MUL +
       SLLI + LD + OR (body) + BLTU + JAL (branch) + ADDI (correction).
-      If `rhat2*2^32 + un0 < q0*d_lo`, BLTU takes the correction path
+      If `rhat2*2^32 + un0 < q0*dLo`, BLTU takes the correction path
       (ADDI `q0--`); otherwise JAL skips the correction. Both branches
       merge at `base + 32`. Note there's only one correction instruction
       here (no rhat2 update, unlike product check 1).
@@ -30,7 +30,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 product check 2: compute q0*d_lo vs rhat2*2^32+un0, conditionally correct q0.
+/-- div128 product check 2: compute q0*dLo vs rhat2*2^32+un0, conditionally correct q0.
     Instrs [37]-[44]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck2_merged_spec
     (sp q0 rhat2 v1_old v7_old dlo un0 : Word) (base : Word) :

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -28,15 +28,15 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- div128 step 2: trial division q0, clamp, product check. Instrs [30]-[44].
-    Input: un21 in x7, d_hi in x6, dlo/un0 in memory.
+    Input: un21 in x7, dHi in x6, dlo/un0 in memory.
     Output: refined q0 in x5. -/
 theorem divK_div128_step2_spec
-    (sp un21 d_hi v1_old v5_old v11_old dlo un0 : Word) (base : Word) :
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    (sp un21 dHi v1_old v5_old v11_old dlo un0 : Word) (base : Word) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi = 0 then rhat2 else rhat2 + d_hi
+    let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let q0_dlo := q0c * dlo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
@@ -57,11 +57,11 @@ theorem divK_div128_step2_spec
       (CodeReq.union (CodeReq.singleton (base + 52) (.JAL .x0 8))
        (CodeReq.singleton (base + 56) (.ADDI .x5 .x5 4095)))))))))))))))
     cpsTriple base (base + 60) cr
-      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ d_hi) ** (.x5 ↦ᵣ v5_old) **
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5_old) **
        (.x1 ↦ᵣ v1_old) ** (.x11 ↦ᵣ v11_old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-      ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ d_hi) ** (.x5 ↦ᵣ q0') **
+      ((.x7 ↦ᵣ q0_dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
        (.x1 ↦ᵣ rhat2_un0) ** (.x11 ↦ᵣ un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
@@ -82,7 +82,7 @@ theorem divK_div128_step2_spec
       (CodeReq.union (CodeReq.singleton (base + 48) (.BLTU .x1 .x7 8))
       (CodeReq.union (CodeReq.singleton (base + 52) (.JAL .x0 8))
        (CodeReq.singleton (base + 56) (.ADDI .x5 .x5 4095))))))))))))))) := rfl
-  have h1_raw := divK_div128_step2_init_spec un21 d_hi v1_old v5_old v11_old base
+  have h1_raw := divK_div128_step2_init_spec un21 dHi v1_old v5_old v11_old base
   have h1 : cpsTriple base (base + 12) cr _ _ :=
     cpsTriple_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))
@@ -90,7 +90,7 @@ theorem divK_div128_step2_spec
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) h1
-  have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 d_hi (q0 * d_hi) (base + 12)
+  have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 dHi (q0 * dHi) (base + 12)
   have : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   have : (base + 12 : Word) + 8 = base + 20 := by bv_addr
   have : (base + 12 : Word) + 12 = base + 24 := by bv_addr
@@ -148,7 +148,7 @@ theorem divK_div128_step2_spec
                     · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
                     · simp at h)
   have h3f := cpsTriple_frameR
-    ((.x6 ↦ᵣ d_hi) ** (.x0 ↦ᵣ 0))
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0))
     (by pcFree) h3
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 h3f

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -8,9 +8,9 @@
       — single SRLI writing `hi = q >>> 32` used by the BEQ in the
       clamp-merged wrappers.
     * `divK_div128_step2_init_spec` — 3-instr DIVU/MUL/SUB computing
-      `q0 = un21 / d_hi` and `rhat2 = un21 - q0 * d_hi`.
+      `q0 = un21 / dHi` and `rhat2 = un21 - q0 * dHi`.
     * `divK_div128_prodcheck2_body_spec` — 5-instr LD/MUL/SLLI/LD/OR
-      producing `q0*d_lo` and `rhat2*2^32 + un0` for the BLTU.
+      producing `q0*dLo` and `rhat2*2^32 + un0` for the BLTU.
     * `divK_div128_correct_q0_single_spec` — single ADDI that just
       decrements q0 after the product-check-2 BLTU.
     * `divK_div128_combine_q_spec` — 2-instr SLLI/OR producing
@@ -58,26 +58,26 @@ theorem divK_div128_clamp_test_q0_spec (q0 v1_old : Word) (base : Word) :
   have I0 := srli_spec_gen .x1 .x5 v1_old q0 32 base (by nofun)
   runBlock I0
 
-/-- div128 Step 2: q0 = DIVU(un21, d_hi), rhat2 = un21 - q0 * d_hi. -/
-theorem divK_div128_step2_init_spec (un21 d_hi v1_old v5_old v11_old : Word) (base : Word) :
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+/-- div128 Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0 * dHi. -/
+theorem divK_div128_step2_init_spec (un21 dHi v1_old v5_old v11_old : Word) (base : Word) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
        (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1)))
     cpsTriple base (base + 12) cr
-      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ d_hi) **
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
        (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) ** (.x11 ↦ᵣ v11_old))
-      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ d_hi) **
-       (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * d_hi) ** (.x11 ↦ᵣ rhat2)) := by
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ q0) ** (.x1 ↦ᵣ q0 * dHi) ** (.x11 ↦ᵣ rhat2)) := by
   intro q0 rhat2 cr
-  have I0 := divu_spec_gen .x5 .x7 .x6 v5_old un21 d_hi base (by nofun)
-  have I1 := mul_spec_gen .x1 .x5 .x6 v1_old q0 d_hi (base + 4) (by nofun)
-  have I2 := sub_spec_gen .x11 .x7 .x1 un21 (q0 * d_hi) v11_old (base + 8) (by nofun)
+  have I0 := divu_spec_gen .x5 .x7 .x6 v5_old un21 dHi base (by nofun)
+  have I1 := mul_spec_gen .x1 .x5 .x6 v1_old q0 dHi (base + 4) (by nofun)
+  have I2 := sub_spec_gen .x11 .x7 .x1 un21 (q0 * dHi) v11_old (base + 8) (by nofun)
   runBlock I0 I1 I2
 
-/-- div128 product check 2: compute q0*d_lo and rhat2*2^32+un0 for comparison. -/
+/-- div128 product check 2: compute q0*dLo and rhat2*2^32+un0 for comparison. -/
 theorem divK_div128_prodcheck2_body_spec (sp q0 rhat2 v1_old v7_old dlo un0 : Word)
     (base : Word) :
     let q0_dlo := q0 * dlo

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -3,13 +3,13 @@
 
   CPS specs for the middle of the `div128` trial-division subroutine —
   the un21 computation, the product-check body shared between step 1
-  and step 2, and the two small "q-- and rhat += d_hi" correction
+  and step 2, and the two small "q-- and rhat += dHi" correction
   blocks:
     * `divK_div128_compute_un21_spec` — 5-instruction LD/SLLI/OR/MUL/SUB
-      computing `un21 = rhat*2^32 + un1 - q1*d_lo`.
+      computing `un21 = rhat*2^32 + un1 - q1*dLo`.
     * `divK_div128_prodcheck_body_spec` — 4-instruction LD/MUL/SLLI/OR
-      producing `q*d_lo` (x5) and `rhat*2^32 + un1` (x1) for BLTU.
-    * `divK_div128_correct_q1_spec` — 2-instruction q1-- / rhat += d_hi
+      producing `q*dLo` (x5) and `rhat*2^32 + un1` (x1) for BLTU.
+    * `divK_div128_correct_q1_spec` — 2-instruction q1-- / rhat += dHi
       correction on x10/x7.
     * `divK_div128_correct_q0_spec` — same shape but on x5/x11 for q0.
 
@@ -31,8 +31,8 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 un21 = rhat*2^32 + un1 - q1*d_lo.
-    Loads d_lo from scratch memory. -/
+/-- div128 un21 = rhat*2^32 + un1 - q1*dLo.
+    Loads dLo from scratch memory. -/
 theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Word) (base : Word) :
     let rhatHi := rhat <<< (32 : BitVec 6).toNat
     let rhatUn1 := rhatHi ||| un1
@@ -59,7 +59,7 @@ theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Wo
   have I4 := sub_spec_gen .x7 .x5 .x1 rhatUn1 q1Dlo rhat (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
-/-- div128 product check body: compute q*d_lo and rhat*2^32+un1 for comparison. -/
+/-- div128 product check body: compute q*dLo and rhat*2^32+un1 for comparison. -/
 theorem divK_div128_prodcheck_body_spec (sp q rhat un1 v1_old v5_old dlo : Word) (base : Word) :
     let qDlo := q * dlo
     let rhatHi := rhat <<< (32 : BitVec 6).toNat
@@ -81,34 +81,34 @@ theorem divK_div128_prodcheck_body_spec (sp q rhat un1 v1_old v5_old dlo : Word)
   have I3 := or_spec_gen_rd_eq_rs1 .x1 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
   runBlock I0 I1 I2 I3
 
-/-- div128 correction: q-- and rhat += d_hi. Generic for q1 (x10) or q0 (x5). -/
-theorem divK_div128_correct_q1_spec (q rhat d_hi : Word) (base : Word) :
+/-- div128 correction: q-- and rhat += dHi. Generic for q1 (x10) or q0 (x5). -/
+theorem divK_div128_correct_q1_spec (q rhat dHi : Word) (base : Word) :
     let q' := q + signExtend12 4095
-    let rhat' := rhat + d_hi
+    let rhat' := rhat + dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 4) (.ADD .x7 .x7 .x6))
     cpsTriple base (base + 8) cr
-      ((.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ d_hi))
-      ((.x10 ↦ᵣ q') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ d_hi)) := by
+      ((.x10 ↦ᵣ q) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))
+      ((.x10 ↦ᵣ q') ** (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi)) := by
   intro q' rhat' cr
   have I0 := addi_spec_gen_same .x10 q 4095 base (by nofun)
-  have I1 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat d_hi (base + 4) (by nofun)
+  have I1 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat dHi (base + 4) (by nofun)
   runBlock I0 I1
 
-/-- div128 correction for q0: q0-- and rhat2 += d_hi. -/
-theorem divK_div128_correct_q0_spec (q0 rhat2 d_hi : Word) (base : Word) :
+/-- div128 correction for q0: q0-- and rhat2 += dHi. -/
+theorem divK_div128_correct_q0_spec (q0 rhat2 dHi : Word) (base : Word) :
     let q0' := q0 + signExtend12 4095
-    let rhat2' := rhat2 + d_hi
+    let rhat2' := rhat2 + dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADDI .x5 .x5 4095))
        (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x6))
     cpsTriple base (base + 8) cr
-      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ d_hi))
-      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ d_hi)) := by
+      ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))
+      ((.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2') ** (.x6 ↦ᵣ dHi)) := by
   intro q0' rhat2' cr
   have I0 := addi_spec_gen_same .x5 q0 4095 base (by nofun)
-  have I1 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 d_hi (base + 4) (by nofun)
+  have I1 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 dHi (base + 4) (by nofun)
   runBlock I0 I1
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -807,28 +807,28 @@ theorem divK_trial_call_path_spec
     (ret_mem d_mem dlo_mem un0_mem : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516) :
     -- div128 intermediates (same as div128_spec)
-    let d_hi := v_top >>> (32 : BitVec 6).toNat
-    let d_lo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v_top >>> (32 : BitVec 6).toNat
+    let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -842,14 +842,14 @@ theorem divK_trial_call_path_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ un0_mem))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2_un0) **
-       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
        (.x7 ↦ᵣ q0_dlo) ** (.x10 ↦ᵣ q1') **
        (.x2 ↦ᵣ (base + 516)) ** (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v_top) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro d_hi d_lo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
   have J := jal_spec .x2 v2_old (560 : BitVec 21) (base + 512) (by nofun)
@@ -1745,28 +1745,28 @@ theorem divK_trial_call_full_spec
     let u_addr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtop_base := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v_top >>> (32 : BitVec 6).toNat
-    let d_lo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v_top >>> (32 : BitVec 6).toNat
+    let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let un1 := u_lo >>> (32 : BitVec 6).toNat
     let un0_div := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_hi d_hi
-    let rhat := u_hi - q1 * d_hi
+    let q1 := rv64_divu u_hi dHi
+    let rhat := u_hi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0_div
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -1783,7 +1783,7 @@ theorem divK_trial_call_full_spec
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ un0_mem))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2_un0) **
-       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
        (.x7 ↦ᵣ q0_dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
@@ -1791,10 +1791,10 @@ theorem divK_trial_call_full_spec
        (vtop_base + signExtend12 32 ↦ₘ v_top) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v_top) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0_div)) := by
   intro u_addr vtop_base
-        d_hi d_lo un1 un0_div q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo un1 un0_div q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q
   -- 1. Save j + trial load (base+448 → base+500)
   have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -90,28 +90,28 @@ theorem divK_trial_call_full_spec_n1
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let d_hi := v0 >>> (32 : BitVec 6).toNat
-    let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v0 >>> (32 : BitVec 6).toNat
+    let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u0 >>> (32 : BitVec 6).toNat
     let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u1 d_hi
-    let rhat := u1 - q1 * d_hi
+    let q1 := rv64_divu u1 dHi
+    let rhat := u1 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -128,7 +128,7 @@ theorem divK_trial_call_full_spec_n1
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2_un0) **
-       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ d_hi) **
+       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
        (.x7 ↦ᵣ q0_dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q_hat) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
@@ -136,10 +136,10 @@ theorem divK_trial_call_full_spec_n1
        ((sp + signExtend12 32) ↦ₘ v0) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
   have TF := divK_trial_call_full_spec sp j (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
     u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
@@ -369,28 +369,28 @@ theorem divK_loop_body_n1_call_skip_spec
     (hbltu : BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v0 >>> (32 : BitVec 6).toNat
-    let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v0 >>> (32 : BitVec 6).toNat
+    let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u0 >>> (32 : BitVec 6).toNat
     let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u1 d_hi
-    let rhat := u1 - q1 * d_hi
+    let q1 := rv64_divu u1 dHi
+    let rhat := u1 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -417,16 +417,16 @@ theorem divK_loop_body_n1_call_skip_spec
       (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
@@ -465,7 +465,7 @@ theorem divK_loop_body_n1_call_skip_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -494,7 +494,7 @@ theorem divK_loop_body_n1_call_skip_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -522,28 +522,28 @@ theorem divK_loop_body_n1_call_addback_spec
     (hbltu : BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v0 >>> (32 : BitVec 6).toNat
-    let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v0 >>> (32 : BitVec 6).toNat
+    let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u0 >>> (32 : BitVec 6).toNat
     let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u1 d_hi
-    let rhat := u1 - q1 * d_hi
+    let q1 := rv64_divu u1 dHi
+    let rhat := u1 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -575,16 +575,16 @@ theorem divK_loop_body_n1_call_addback_spec
       (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
@@ -609,7 +609,7 @@ theorem divK_loop_body_n1_call_addback_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -637,7 +637,7 @@ theorem divK_loop_body_n1_call_addback_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -275,28 +275,28 @@ theorem divK_loop_body_n2_call_skip_spec
     (hbltu : BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v1 >>> (32 : BitVec 6).toNat
-    let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v1 >>> (32 : BitVec 6).toNat
+    let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u1 >>> (32 : BitVec 6).toNat
     let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u2 d_hi
-    let rhat := u2 - q1 * d_hi
+    let q1 := rv64_divu u2 dHi
+    let rhat := u2 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -323,16 +323,16 @@ theorem divK_loop_body_n2_call_skip_spec
       (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -373,7 +373,7 @@ theorem divK_loop_body_n2_call_skip_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -402,7 +402,7 @@ theorem divK_loop_body_n2_call_skip_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -430,28 +430,28 @@ theorem divK_loop_body_n2_call_addback_spec
     (hbltu : BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v1 >>> (32 : BitVec 6).toNat
-    let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v1 >>> (32 : BitVec 6).toNat
+    let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u1 >>> (32 : BitVec 6).toNat
     let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u2 d_hi
-    let rhat := u2 - q1 * d_hi
+    let q1 := rv64_divu u2 dHi
+    let rhat := u2 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -483,16 +483,16 @@ theorem divK_loop_body_n2_call_addback_spec
       (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
@@ -520,7 +520,7 @@ theorem divK_loop_body_n2_call_addback_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -548,7 +548,7 @@ theorem divK_loop_body_n2_call_addback_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -275,28 +275,28 @@ theorem divK_loop_body_n3_call_skip_spec
     (hbltu : BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v2 >>> (32 : BitVec 6).toNat
-    let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v2 >>> (32 : BitVec 6).toNat
+    let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u2 >>> (32 : BitVec 6).toNat
     let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u3 d_hi
-    let rhat := u3 - q1 * d_hi
+    let q1 := rv64_divu u3 dHi
+    let rhat := u3 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -323,16 +323,16 @@ theorem divK_loop_body_n3_call_skip_spec
       (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -373,7 +373,7 @@ theorem divK_loop_body_n3_call_skip_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -402,7 +402,7 @@ theorem divK_loop_body_n3_call_skip_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -430,28 +430,28 @@ theorem divK_loop_body_n3_call_addback_spec
     (hbltu : BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v2 >>> (32 : BitVec 6).toNat
-    let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v2 >>> (32 : BitVec 6).toNat
+    let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u2 >>> (32 : BitVec 6).toNat
     let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u3 d_hi
-    let rhat := u3 - q1 * d_hi
+    let q1 := rv64_divu u3 dHi
+    let rhat := u3 - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -483,16 +483,16 @@ theorem divK_loop_body_n3_call_addback_spec
       (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
@@ -520,7 +520,7 @@ theorem divK_loop_body_n3_call_addback_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -548,7 +548,7 @@ theorem divK_loop_body_n3_call_addback_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -277,28 +277,28 @@ theorem divK_loop_body_n4_call_skip_spec
     (hbltu : BitVec.ult u_top v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -325,16 +325,16 @@ theorem divK_loop_body_n4_call_skip_spec
       (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
@@ -376,7 +376,7 @@ theorem divK_loop_body_n4_call_skip_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -404,7 +404,7 @@ theorem divK_loop_body_n4_call_skip_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -432,28 +432,28 @@ theorem divK_loop_body_n4_call_addback_spec
     (hbltu : BitVec.ult u_top v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -485,16 +485,16 @@ theorem divK_loop_body_n4_call_addback_spec
       (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
       (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
@@ -522,7 +522,7 @@ theorem divK_loop_body_n4_call_addback_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -550,7 +550,7 @@ theorem divK_loop_body_n4_call_addback_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -128,28 +128,28 @@ def mulsubN4_c3 (q_hat v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Word :=
 
 /-- Trial quotient from the div128 subroutine: divides u_hi:u_lo by v_top. -/
 def div128Quot (u_hi u_lo v_top : Word) : Word :=
-  let d_hi := v_top >>> (32 : BitVec 6).toNat
-  let d_lo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v_top >>> (32 : BitVec 6).toNat
+  let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u_lo >>> (32 : BitVec 6).toNat
   let div_un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u_hi d_hi
-  let rhat := u_hi - q1 * d_hi
+  let q1 := rv64_divu u_hi dHi
+  let rhat := u_hi - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi
-  let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   (q1' <<< (32 : BitVec 6).toNat) ||| q0'

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -49,26 +49,26 @@ theorem divK_loop_body_n1_call_skip_j0_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -82,7 +82,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -124,7 +124,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -172,26 +172,26 @@ theorem divK_loop_body_n1_call_skip_j1_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -205,7 +205,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -248,7 +248,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -296,26 +296,26 @@ theorem divK_loop_body_n1_call_skip_j2_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -329,7 +329,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -372,7 +372,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -420,26 +420,26 @@ theorem divK_loop_body_n1_call_skip_j3_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -453,7 +453,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -496,7 +496,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -50,26 +50,26 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -98,7 +98,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -123,7 +123,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -168,26 +168,26 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -216,7 +216,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -242,7 +242,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -287,26 +287,26 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -335,7 +335,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -361,7 +361,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -406,26 +406,26 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v0 >>> (32 : BitVec 6).toNat
-  let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v0 >>> (32 : BitVec 6).toNat
+  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
   let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 d_hi; let rhat := u1 - q1 * d_hi
+  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -454,7 +454,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -480,7 +480,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -163,26 +163,26 @@ theorem divK_loop_body_n2_call_skip_j0_spec
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates for n=2: v_top=v1, u_hi=u2, u_lo=u1
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -199,7 +199,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -246,7 +246,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -384,26 +384,26 @@ theorem divK_loop_body_n2_call_skip_j1_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -417,7 +417,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -460,7 +460,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -599,26 +599,26 @@ theorem divK_loop_body_n2_call_skip_j2_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -632,7 +632,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -675,7 +675,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -813,26 +813,26 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates for n=2
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -864,7 +864,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -893,7 +893,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -1026,26 +1026,26 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -1074,7 +1074,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1100,7 +1100,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -1232,26 +1232,26 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
-  let d_hi := v1 >>> (32 : BitVec 6).toNat
-  let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v1 >>> (32 : BitVec 6).toNat
+  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
   let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 d_hi; let rhat := u2 - q1 * d_hi
+  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -1280,7 +1280,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1306,7 +1306,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -158,26 +158,26 @@ theorem divK_loop_body_n3_call_skip_j0_spec
       (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
-  let d_hi := v2 >>> (32 : BitVec 6).toNat
-  let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v2 >>> (32 : BitVec 6).toNat
+  let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u2 >>> (32 : BitVec 6).toNat
   let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u3 d_hi; let rhat := u3 - q1 * d_hi
+  let q1 := rv64_divu u3 dHi; let rhat := u3 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -194,7 +194,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -241,7 +241,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -395,26 +395,26 @@ theorem divK_loop_body_n3_call_skip_j1_spec
       (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions
-  let d_hi := v2 >>> (32 : BitVec 6).toNat
-  let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v2 >>> (32 : BitVec 6).toNat
+  let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u2 >>> (32 : BitVec 6).toNat
   let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u3 d_hi; let rhat := u3 - q1 * d_hi
+  let q1 := rv64_divu u3 dHi; let rhat := u3 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -431,7 +431,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -479,7 +479,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -620,26 +620,26 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
       (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
-  let d_hi := v2 >>> (32 : BitVec 6).toNat
-  let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v2 >>> (32 : BitVec 6).toNat
+  let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u2 >>> (32 : BitVec 6).toNat
   let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u3 d_hi; let rhat := u3 - q1 * d_hi
+  let q1 := rv64_divu u3 dHi; let rhat := u3 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -672,7 +672,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -701,7 +701,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -843,26 +843,26 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
       (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions
-  let d_hi := v2 >>> (32 : BitVec 6).toNat
-  let d_lo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let dHi := v2 >>> (32 : BitVec 6).toNat
+  let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u2 >>> (32 : BitVec 6).toNat
   let div_un0 := (u2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u3 d_hi; let rhat := u3 - q1 * d_hi
+  let q1 := rv64_divu u3 dHi; let rhat := u3 - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-  let q_dlo := q1c * d_lo
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let q_dlo := q1c * dLo
   let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+  let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
   let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * d_lo
+  let cu_q1_dlo := q1' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 d_hi; let rhat2 := un21 - q0 * d_hi
+  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-  let q0_dlo := q0c * d_lo
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0_dlo := q0c * dLo
   let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
   let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -895,7 +895,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -925,7 +925,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -137,28 +137,28 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     (hbltu : BitVec.ult u_top v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -184,10 +184,10 @@ theorem divK_loop_body_n4_call_skip_j0_spec
       (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
 
@@ -221,7 +221,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -249,7 +249,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
@@ -377,28 +377,28 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let d_hi := v3 >>> (32 : BitVec 6).toNat
-    let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let dHi := v3 >>> (32 : BitVec 6).toNat
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu u_top dHi
+    let rhat := u_top - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + d_hi
-    let q_dlo := q1c * d_lo
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let q_dlo := q1c * dLo
     let rhat_un1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
     let q1' := if BitVec.ult rhat_un1 q_dlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + d_hi else rhatc
+    let rhat' := if BitVec.ult rhat_un1 q_dlo then rhatc + dHi else rhatc
     let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * d_lo
+    let cu_q1_dlo := q1' * dLo
     let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 d_hi
-    let rhat2 := un21 - q0 * d_hi
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + d_hi
-    let q0_dlo := q0c * d_lo
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let q0_dlo := q0c * dLo
     let rhat2_un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
@@ -424,10 +424,10 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
       (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ d_lo) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro u_base
-        d_hi d_lo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
+        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc q_dlo rhat_un1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0_dlo rhat2_un0 q0' q_hat
         q_addr hborrow
   -- Local lets matching beq_spec structure
@@ -457,7 +457,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
+    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -486,7 +486,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
-     (sp + signExtend12 3952 ↦ₘ d_lo) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -23,7 +23,7 @@
     3976(-120):            saved j (loop counter)
     3968(-128):            subroutine: saved return addr
     3960(-136):            subroutine: saved d
-    3952(-144):            subroutine: saved d_lo
+    3952(-144):            subroutine: saved dLo
     3944(-152):            subroutine: saved un0
   After: result at sp+32..sp+56, x12 = sp + 32.
 
@@ -59,40 +59,40 @@ def divK_div128 : Program :=
   -- Save return addr and d
   SD .x12 .x2 3968 ;;                         -- [0]  save return addr
   SD .x12 .x10 3960 ;;                        -- [1]  save d
-  -- Split d: d_hi = d >> 32, d_lo = (d << 32) >> 32
-  SRLI .x6 .x10 32 ;;                         -- [2]  x6 = d_hi (>= 2^31)
-  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = d_lo
-  SD .x12 .x1 3952 ;;                         -- [5]  save d_lo
+  -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
+  SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
+  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
+  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
   -- Split u_lo: un1 = u_lo >> 32, un0 = (u_lo << 32) >> 32
   SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
   SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
   SD .x12 .x5 3944 ;;                         -- [9]  save un0
-  -- Step 1: q1 = DIVU(u_hi, d_hi), rhat = u_hi - q1*d_hi
-  -- x7 = u_hi, x6 = d_hi
+  -- Step 1: q1 = DIVU(u_hi, dHi), rhat = u_hi - q1*dHi
+  -- x7 = u_hi, x6 = dHi
   single (.DIVU .x10 .x7 .x6) ;;             -- [10] x10 = q1 (use x10 since we saved d)
-  single (.MUL .x5 .x10 .x6) ;;              -- [11] x5 = q1 * d_hi
+  single (.MUL .x5 .x10 .x6) ;;              -- [11] x5 = q1 * dHi
   single (.SUB .x7 .x7 .x5) ;;               -- [12] x7 = rhat
   -- Refine q1: clamp to < 2^32
   SRLI .x5 .x10 32 ;;                         -- [13] test q1 >= 2^32
   single (.BEQ .x5 .x0 12) ;;                -- [14] skip if q1 < 2^32 → [17]
   ADDI .x10 .x10 4095 ;;                      -- [15] q1--
-  single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += d_hi
-  -- [17] Product check: q1*d_lo > rhat*2^32 + un1?
-  LD .x1 .x12 3952 ;;                         -- [17] x1 = d_lo
-  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * d_lo
+  single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
+  -- [17] Product check: q1*dLo > rhat*2^32 + un1?
+  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
+  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
   SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
   single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
   single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
   JAL .x0 12 ;;                                -- [22] skip → [25]
   ADDI .x10 .x10 4095 ;;                      -- [23] q1--
-  single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += d_hi
-  -- Compute un21 = rhat*2^32 + un1 - q1*d_lo
-  LD .x1 .x12 3952 ;;                         -- [25] d_lo
+  single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
+  -- Compute un21 = rhat*2^32 + un1 - q1*dLo
+  LD .x1 .x12 3952 ;;                         -- [25] dLo
   SLLI .x5 .x7 32 ;;                          -- [26] rhat << 32
   single (.OR .x5 .x5 .x11) ;;               -- [27] x5 = rhat*2^32 + un1
-  single (.MUL .x1 .x10 .x1) ;;              -- [28] x1 = q1 * d_lo
+  single (.MUL .x1 .x10 .x1) ;;              -- [28] x1 = q1 * dLo
   single (.SUB .x7 .x5 .x1) ;;               -- [29] x7 = un21
-  -- Step 2: q0 = DIVU(un21, d_hi), rhat2 = un21 - q0*d_hi
+  -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
   single (.DIVU .x5 .x7 .x6) ;;              -- [30] x5 = q0
   single (.MUL .x1 .x5 .x6) ;;               -- [31]
   single (.SUB .x11 .x7 .x1) ;;              -- [32] x11 = rhat2
@@ -100,10 +100,10 @@ def divK_div128 : Program :=
   SRLI .x1 .x5 32 ;;                          -- [33]
   single (.BEQ .x1 .x0 12) ;;                -- [34] skip if q0 < 2^32 → [37]
   ADDI .x5 .x5 4095 ;;                        -- [35] q0--
-  single (.ADD .x11 .x11 .x6) ;;             -- [36] rhat2 += d_hi
+  single (.ADD .x11 .x11 .x6) ;;             -- [36] rhat2 += dHi
   -- [37] Product check for q0
-  LD .x1 .x12 3952 ;;                         -- [37] d_lo
-  single (.MUL .x7 .x5 .x1) ;;               -- [38] x7 = q0 * d_lo
+  LD .x1 .x12 3952 ;;                         -- [37] dLo
+  single (.MUL .x7 .x5 .x1) ;;               -- [38] x7 = q0 * dLo
   SLLI .x1 .x11 32 ;;                         -- [39] rhat2 << 32
   LD .x11 .x12 3944 ;;                        -- [40] un0
   single (.OR .x1 .x1 .x11) ;;               -- [41] x1 = rhat2*2^32 + un0


### PR DESCRIPTION
## Summary
Broad rename of \`d_hi\` → \`dHi\` and \`d_lo\` → \`dLo\` across the entire DivMod module (25 files, 674 occurrences) — covering let-bindings, positional parameters, \`intro\` patterns, hypothesis names, and docstring references.

Files touched:
- \`LoopBody.lean\`, \`LoopBodyN{1..4}.lean\`
- \`LoopIterN{1..4}.lean\` (+ \`LoopIterN1/Call*.lean\`), \`LoopDefs/Iter.lean\`
- \`LimbSpec/Div128{Phase1,Step2,Clamp,ProdCheck1,ProdCheck2,UnProdCheck,Tail}.lean\`
- \`Compose/FullPathN4{,Beq,Loop,Shift0}.lean\`, \`Compose/{Div128,ModDiv128}.lean\`
- \`Program.lean\` (comments)

Positional callers unaffected. Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)