### PR TITLE
refactor(evm-asm): rename u_top to uTop module-wide (#189)

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -18,11 +18,11 @@ open EvmAsm.Rv64
 /-- ADD limb 0 spec (5 instructions): LD, LD, ADD, SLTU, SD.
     Computes sum = a + b (mod 2^64) and carry = (sum < b ? 1 : 0). -/
 theorem add_limb0_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 v5 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let sum := a_limb + b_limb
-    let carry := if BitVec.ult sum b_limb then (1 : Word) else 0
+    let sum := aLimb + bLimb
+    let carry := if BitVec.ult sum bLimb then (1 : Word) else 0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
@@ -31,19 +31,19 @@ theorem add_limb0_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 16) (.SD .x12 .x7 offB)))))
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ sum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carry) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ sum)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ sum) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ carry) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ sum)) := by
   runBlock
 
 /-- ADD carry limb phase 1 (4 instructions): LD, LD, ADD, SLTU.
-    Loads a_limb and b_limb, computes psum = a + b, carry1 = (psum < b ? 1 : 0). -/
+    Loads aLimb and bLimb, computes psum = a + b, carry1 = (psum < b ? 1 : 0). -/
 theorem add_limb_carry_spec_phase1 (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 carryIn v11 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 carryIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let psum := a_limb + b_limb
-    let carry1 := if BitVec.ult psum b_limb then (1 : Word) else 0
+    let psum := aLimb + bLimb
+    let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
@@ -51,16 +51,16 @@ theorem add_limb_carry_spec_phase1 (offA offB : BitVec 12)
        (CodeReq.singleton (base + 12) (.SLTU .x11 .x7 .x6))))
     cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ v11) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 /-- ADD carry limb phase 2 (4 instructions): ADD, SLTU, OR, SD.
     Takes psum, carry1, carryIn, computes result = psum + carryIn,
     carry2 = (result < carryIn ? 1 : 0), carryOut = carry1 ||| carry2. -/
 theorem add_limb_carry_spec_phase2 (offB : BitVec 12)
-    (sp psum b_limb carryIn carry1 a_limb : Word) (memA : Word) (base : Word) :
+    (sp psum bLimb carryIn carry1 aLimb : Word) (memA : Word) (base : Word) :
     let memB := sp + signExtend12 offB
     let result := psum + carryIn
     let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
@@ -71,20 +71,20 @@ theorem add_limb_carry_spec_phase2 (offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x5 .x11 .x6))
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ result)) := by
   runBlock
 
 /-- ADD carry limb spec (8 instructions): LD, LD, ADD, SLTU, ADD, SLTU, OR, SD.
     Composed from phase1 and phase2. -/
 theorem add_limb_carry_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 carryIn v11 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 carryIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let psum := a_limb + b_limb
-    let carry1 := if BitVec.ult psum b_limb then (1 : Word) else 0
+    let psum := aLimb + bLimb
+    let carry1 := if BitVec.ult psum bLimb then (1 : Word) else 0
     let result := psum + carryIn
     let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
     let carryOut := carry1 ||| carry2
@@ -99,13 +99,13 @@ theorem add_limb_carry_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 28) (.SD .x12 .x7 offB))))))))
     cpsTriple base (base + 32) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ v11) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
-  have p1 := add_limb_carry_spec_phase1 offA offB sp a_limb b_limb v7 v6 carryIn v11 base
-  have p2 := add_limb_carry_spec_phase2 offB sp (a_limb + b_limb) b_limb carryIn
-    (if BitVec.ult (a_limb + b_limb) b_limb then (1 : Word) else 0)
-    a_limb (sp + signExtend12 offA) (base + 16)
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ result)) := by
+  have p1 := add_limb_carry_spec_phase1 offA offB sp aLimb bLimb v7 v6 carryIn v11 base
+  have p2 := add_limb_carry_spec_phase2 offB sp (aLimb + bLimb) bLimb carryIn
+    (if BitVec.ult (aLimb + bLimb) bLimb then (1 : Word) else 0)
+    aLimb (sp + signExtend12 offA) (base + 16)
   runBlock p1 p2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/And/LimbSpec.lean
+++ b/EvmAsm/Evm64/And/LimbSpec.lean
@@ -18,7 +18,7 @@ open EvmAsm.Rv64
 /-- Per-limb AND spec (4 instructions: LD x7, LD x6, AND x7 x7 x6, SD x12 x7).
     Loads A[i] and B[i], computes AND, stores result at B[i]'s location. -/
 theorem and_limb_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let cr :=
@@ -28,9 +28,9 @@ theorem and_limb_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a_limb &&& b_limb)) ** (.x6 ↦ᵣ b_limb) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ (a_limb &&& b_limb))) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb &&& bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ (aLimb &&& bLimb))) := by
   runBlock
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -26,30 +26,30 @@ open EvmAsm.Rv64
 /-- LT limb 0 spec (3 instructions): LD, LD, SLTU.
     Computes initial borrow = (a < b ? 1 : 0). Does NOT modify memory. -/
 theorem lt_limb0_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 v5 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let borrow := if BitVec.ult a_limb b_limb then (1 : Word) else 0
+    let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
        (CodeReq.singleton (base + 8) (.SLTU .x5 .x7 .x6)))
     cpsTriple base (base + 12) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ a_limb) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ borrow) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ aLimb) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 /-- LT carry limb spec (6 instructions): LD, LD, SLTU, SUB, SLTU, OR.
     Propagates borrow without storing result. Memory is NOT modified. -/
 theorem lt_limb_carry_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 borrowIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let borrow1 := if BitVec.ult a_limb b_limb then (1 : Word) else 0
-    let temp := a_limb - b_limb
-    let borrow2 := if BitVec.ult temp borrow_in then (1 : Word) else 0
+    let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+    let temp := aLimb - bLimb
+    let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
     let borrowOut := borrow1 ||| borrow2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -59,10 +59,10 @@ theorem lt_limb_carry_spec (offA offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 16) (.SLTU .x6 .x7 .x5))
        (CodeReq.singleton (base + 20) (.OR .x5 .x11 .x6))))))
     cpsTriple base (base + 24) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrow_in) ** (.x11 ↦ᵣ v11) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ v11) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -236,7 +236,7 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
     - `q0..q3` at `sp + signExtend12 4088/4080/4072/4064` — accumulated quotient digits
     - `u0..u4` at `sp + signExtend12 4056/4048/4040/4032/4024` — normalized dividend
     - `u5..u7` at `sp + signExtend12 4016/4008/4000` — overflow/scratch
-    - `shiftMem` at `sp + signExtend12 3992`, `n_mem` at `sp + signExtend12 3984`
+    - `shiftMem` at `sp + signExtend12 3992`, `nMem` at `sp + signExtend12 3984`
     - `jMem` at `sp + signExtend12 3976`
 
     This is the precondition shape — specific starting values for every cell.
@@ -245,7 +245,7 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
     with fifteen `↦ₘ` lines at every call site. -/
 @[irreducible]
 def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem : Word) : Assertion :=
+    shiftMem nMem jMem : Word) : Assertion :=
   ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
   ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
   ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -253,16 +253,16 @@ def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
   ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
   ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-  ((sp + signExtend12 3984) ↦ₘ n_mem) **
+  ((sp + signExtend12 3984) ↦ₘ nMem) **
   ((sp + signExtend12 3976) ↦ₘ jMem)
 
 /-- Unfold `divScratchValues` into its 15 underlying memory atoms. The bundle
     is `@[irreducible]`, so `unfold` won't see through it — this named rewrite
     is the supported way in at call sites (parallel to `divScratchOwn_unfold`). -/
 theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem : Word) :
+    shiftMem nMem jMem : Word) :
     divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem n_mem jMem =
+        shiftMem nMem jMem =
     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -270,7 +270,7 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem) **
+     ((sp + signExtend12 3984) ↦ₘ nMem) **
      ((sp + signExtend12 3976) ↦ₘ jMem)) := by
   delta divScratchValues; rfl
 
@@ -281,7 +281,7 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     composition where scratch atoms are scattered across the unfolded
     `fullDivN4MaxSkipPost` post. -/
 theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem : Word) (Q : Assertion) :
+    shiftMem nMem jMem : Word) (Q : Assertion) :
     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -289,10 +289,10 @@ theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem) **
+     ((sp + signExtend12 3984) ↦ₘ nMem) **
      ((sp + signExtend12 3976) ↦ₘ jMem) ** Q) =
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem n_mem jMem ** Q) := by
+      shiftMem nMem jMem ** Q) := by
   rw [divScratchValues_unfold]
   iterate 14 rw [sepConj_assoc']
 
@@ -346,16 +346,16 @@ theorem divScratchOwn_unfold_right (sp : Word) (Q : Assertion) :
   rw [divScratchOwn_unfold]
 
 theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem : Word) :
+    shiftMem nMem jMem : Word) :
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem n_mem jMem).pcFree := by
+      shiftMem nMem jMem).pcFree := by
   unfold divScratchValues; pcFree
 
-instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem n_mem jMem) :=
+        shiftMem nMem jMem) :=
   ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem⟩
+    shiftMem nMem jMem⟩
 
 /-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
     through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
@@ -369,34 +369,34 @@ instance pcFreeInst_divScratchOwn (sp : Word) :
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
 theorem divScratchValues_implies_divScratchOwn
-    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     ∀ h, divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem n_mem jMem h → divScratchOwn sp h := by
+        shiftMem nMem jMem h → divScratchOwn sp h := by
   unfold divScratchValues divScratchOwn
   -- Weaken each of the 15 memIs cells to memOwn, left to right.
   iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
   exact memIs_implies_memOwn _ _
 
 /-- Postcondition for the shift≠0 path from entry to loop setup.
-    Encapsulates the shift/anti_shift computation, normalized b'[0..3],
+    Encapsulates the shift/antiShift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.
     Marked @[irreducible] so xperm treats this as 1 opaque atom. -/
 @[irreducible]
-def loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+def loopSetupPost (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n_val) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ nVal) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
   (.x0 ↦ᵣ (0 : Word)) **
-  (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - n_val) **
+  (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -407,26 +407,26 @@ def loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
   ((sp + signExtend12 4024) ↦ₘ u4) **
   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ nVal) **
   ((sp + signExtend12 3992) ↦ₘ shift)
 
 /-- Unfold the opaque loopSetupPost back to its expanded form. -/
-theorem loopSetupPost_unfold (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 =
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+theorem loopSetupPost_unfold (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 =
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n_val) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
+    (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ nVal) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
     (.x0 ↦ᵣ (0 : Word)) **
-    (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
-    (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - n_val) **
+    (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
+    (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - nVal) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -437,35 +437,35 @@ theorem loopSetupPost_unfold (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
     ((sp + signExtend12 4024) ↦ₘ u4) **
     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ nVal) **
     ((sp + signExtend12 3992) ↦ₘ shift) := by
   delta loopSetupPost; rfl
 
 /-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_loopSetupPost (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
+theorem pcFree_loopSetupPost (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
   rw [loopSetupPost_unfold]; pcFree
 
 instance pcFreeInst_loopSetupPost
-    (sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    Assertion.PCFree (loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_loopSetupPost sp n_val shift a0 a1 a2 a3 b0 b1 b2 b3⟩
+    (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3) :=
+  ⟨pcFree_loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3⟩
 
 -- ============================================================================
 -- Postcondition bundles for denorm + epilogue paths
 -- ============================================================================
 
 /-- Postcondition for DIV denorm + epilogue (shift ≠ 0).
-    Encapsulates anti_shift and denormalized u'[0..3]. -/
+    Encapsulates antiShift and denormalized u'[0..3]. -/
 @[irreducible]
 def denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) : Assertion :=
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
   let u3' := u3 >>> (shift.toNat % 64)
   (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
-  (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
+  (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
   ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
   ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
   ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -475,13 +475,13 @@ def denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) : Assertion :=
 
 theorem denormDivPost_unfold (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
     denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3 =
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
     (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q0) ** (.x6 ↦ᵣ q1) ** (.x7 ↦ᵣ q2) **
-    (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
+    (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ q3) **
     ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
     ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
     ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
@@ -500,16 +500,16 @@ instance pcFreeInst_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
   ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
 
 /-- Postcondition for MOD denorm + epilogue (shift ≠ 0).
-    Encapsulates anti_shift and denormalized u'[0..3]. -/
+    Encapsulates antiShift and denormalized u'[0..3]. -/
 @[irreducible]
 def denormModPost (sp shift u0 u1 u2 u3 : Word) : Assertion :=
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
   let u3' := u3 >>> (shift.toNat % 64)
   (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
-  (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
+  (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
   ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
   ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
   ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
@@ -517,13 +517,13 @@ def denormModPost (sp shift u0 u1 u2 u3 : Word) : Assertion :=
 
 theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
     denormModPost sp shift u0 u1 u2 u3 =
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
     (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ u0') ** (.x6 ↦ᵣ u1') ** (.x7 ↦ᵣ u2') **
-    (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
+    (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ u3') **
     ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
     ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3') **
     ((sp + 32) ↦ₘ u0') ** ((sp + 40) ↦ₘ u1') **
@@ -544,52 +544,52 @@ instance pcFreeInst_denormModPost (sp shift u0 u1 u2 u3 : Word) :
 -- ============================================================================
 
 /-- Postcondition after PhaseAB + CLZ + PhaseC2(ntaken) + NormB.
-    Encapsulates shift, anti_shift, and normalized b'[0..3]. -/
+    Encapsulates shift, antiShift, and normalized b'[0..3]. -/
 @[irreducible]
-def normBPost (sp n_val shift b0 b1 b2 b3 : Word) : Assertion :=
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+def normBPost (sp nVal shift b0 b1 b2 b3 : Word) : Assertion :=
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-  (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-  (.x2 ↦ᵣ anti_shift) **
+  (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+  (.x2 ↦ᵣ antiShift) **
   ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
   ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
   ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ nVal) **
   ((sp + signExtend12 3992) ↦ₘ shift)
 
-theorem normBPost_unfold (sp n_val shift b0 b1 b2 b3 : Word) :
-    normBPost sp n_val shift b0 b1 b2 b3 =
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+theorem normBPost_unfold (sp nVal shift b0 b1 b2 b3 : Word) :
+    normBPost sp nVal shift b0 b1 b2 b3 =
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
     (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
-    (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-    (.x2 ↦ᵣ anti_shift) **
+    (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+    (.x2 ↦ᵣ antiShift) **
     ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
     ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3') **
     ((sp + signExtend12 4088) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
-    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ n_val) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ nVal) **
     ((sp + signExtend12 3992) ↦ₘ shift) := by
   delta normBPost; rfl
 
 /-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
-    (normBPost sp n_val shift b0 b1 b2 b3).pcFree := by
+theorem pcFree_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
+    (normBPost sp nVal shift b0 b1 b2 b3).pcFree := by
   rw [normBPost_unfold]; pcFree
 
-instance pcFreeInst_normBPost (sp n_val shift b0 b1 b2 b3 : Word) :
-    Assertion.PCFree (normBPost sp n_val shift b0 b1 b2 b3) :=
-  ⟨pcFree_normBPost sp n_val shift b0 b1 b2 b3⟩
+instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
+    Assertion.PCFree (normBPost sp nVal shift b0 b1 b2 b3) :=
+  ⟨pcFree_normBPost sp nVal shift b0 b1 b2 b3⟩
 
 -- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -50,21 +50,21 @@ private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
 
 -- ============================================================================
 -- div128_spec: compose 5 block specs into single subroutine theorem.
--- Entry: base+1072, Exit: ret_addr (via JALR), CodeReq: sharedDivModCode base.
+-- Entry: base+1072, Exit: retAddr (via JALR), CodeReq: sharedDivModCode base.
 -- ============================================================================
 
-theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
+theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1_old v6_old v11_old : Word)
-    (ret_mem d_mem dlo_mem un0_mem : Word)
-    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
+    (retMem dMem dloMem un0Mem : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     -- Phase 1 intermediates
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     -- Step 1 intermediates
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + dHi
@@ -87,22 +87,22 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + div128Off) ret_addr (sharedDivModCode base)
+    cpsTriple (base + div128Off) retAddr (sharedDivModCode base)
       (-- Precondition: caller registers + scratch memory
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
        (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x11 ↦ᵣ v11_old) **
        (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ q1') **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
        (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0Dlo) **
        (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ ret_addr) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
@@ -110,10 +110,10 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
-  -- Saves ret/d, splits d and u_lo into halves.
+  -- Saves ret/d, splits d and uLo into halves.
   -- ================================================================
-  have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-    ret_mem d_mem dlo_mem un0_mem (base + div128Off)
+  have hph1 := divK_div128_phase1_spec sp retAddr d uLo uHi v1_old v6_old v11_old
+    retMem dMem dloMem un0Mem (base + div128Off)
   rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
   -- Extend phase1 cr to sharedDivModCode
   have hph1e := cpsTriple_extend_code (hmono := by
@@ -137,7 +137,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Block 2: Step 1 (base+1112 → base+1172)
   -- Trial division q1, clamp, product check.
   -- ================================================================
-  have hst1 := divK_div128_step1_spec sp u_hi dHi un1 dLo un0 d dLo
+  have hst1 := divK_div128_step1_spec sp uHi dHi un1 dLo un0 d dLo
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
@@ -159,7 +159,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
   have hst1f := cpsTriple_frameR
-    ((.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
+    ((.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hst1e
   -- Compose phase1 → step1
@@ -182,7 +182,7 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
     ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
+     (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
   -- Compose (phase1→step1) → compute_un21
@@ -217,19 +217,19 @@ theorem div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
-    ((.x10 ↦ᵣ q1') ** (.x2 ↦ᵣ ret_addr) **
-     (sp + signExtend12 3968 ↦ₘ ret_addr) ** (sp + signExtend12 3960 ↦ₘ d))
+    ((.x10 ↦ᵣ q1') ** (.x2 ↦ᵣ retAddr) **
+     (sp + signExtend12 3968 ↦ₘ retAddr) ** (sp + signExtend12 3960 ↦ₘ d))
     (by pcFree) hst2e
   -- Compose (→step1→compute_un21) → step2
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
-  -- Block 5: End (base+1252 → ret_addr via JALR)
+  -- Block 5: End (base+1252 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
-  -- Params: q1=q1'(x10), q0=q0'(x5), v2_old=ret_addr(x2),
-  --         v11_old=un0(x11), ret_addr(mem[3968])
+  -- Params: q1=q1'(x10), q0=q0'(x5), v2_old=retAddr(x2),
+  --         v11_old=un0(x11), retAddr(mem[3968])
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' ret_addr un0 ret_addr
+  have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub base 45 _ _ (by decide) (by bv_addr) (by decide))

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -87,22 +87,22 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
     base+908+8 → base+908+100 (23 instructions: ADDI+SUB + 3×merge + last).
     Used when shift≠0. The BEQ and LD are handled separately. -/
 theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 916) (base + epilogueOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
        ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
-  intro anti_shift u0' u1' u2' u3'
-  -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute anti_shift
+  intro antiShift u0' u1' u2' u3'
+  -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
   have haddi := addi_x0_spec_gen .x2 v2 0 (base + 916) (by nofun)
   rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
@@ -136,7 +136,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
   have h_anti := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
-  have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 924)
+  have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + 924)
   rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
@@ -151,7 +151,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
-    u0' (u1 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 948)
+    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + 948)
   rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
@@ -166,7 +166,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
-    u1' (u2 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 972)
+    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + 972)
   rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode base a i
@@ -188,7 +188,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frameR
-    ((.x7 ↦ᵣ (u3 <<< (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
      ((sp + signExtend12 4040) ↦ₘ u2'))
     (by pcFree) hle

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -29,7 +29,7 @@ open EvmAsm.Rv64.AddrNorm (se13_96)
     base → base+212. After CLZ, x6 = shift count, x5 = shifted leading limb. -/
 theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (divCode base)
@@ -40,7 +40,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -51,7 +51,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word))) := by
   -- Phase AB(n=4): base → base+116
   have hAB := evm_div_phaseAB_n4_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   -- CLZ: base+116 → base+212, needs x5=b3 (leading limb), x6=b1, x7=b2
   have hCLZ := divK_clz_spec b3 b1 b2 base
   -- Frame CLZ with x12, x10, and all memory atoms
@@ -80,7 +80,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
     base → base+312. b[0..3] normalized in-place. -/
 theorem evm_div_n4_to_normB_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -92,14 +92,14 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   -- Frame AB+CLZ with x2 and shiftMem (not touched by AB or CLZ)
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -126,7 +126,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
     (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   -- Frame NormB with x10, x0, and non-b[] memory
   have hNBf := cpsTriple_frameR
@@ -154,7 +154,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     base → base+448. Normalizes b[] and a[], sets up loop parameters. -/
 theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -172,23 +172,23 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=4) + CLZ + PhaseC2 + NormB (base → base+312)
   have hNormB := evm_div_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem hbnz hb3nz hshift_nz
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
 
   -- Frame NormB result with a[], u[] scratch, x1
   have hNormBf := cpsTriple_frameR
@@ -201,7 +201,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     (by pcFree) hNormB
   -- Step 2: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   -- Frame NormA with x0, b[], scratch q/u5-7/n/shift
@@ -224,10 +224,10 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
   have hLS := divK_loopSetup_ntaken_spec sp (4 : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
-  -- Frame LoopSetup with everything except x5, x1, x0 + n_mem
+  -- Frame LoopSetup with everything except x5, x1, x0 + nMem
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -259,7 +259,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
@@ -277,7 +277,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -297,7 +297,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1)) := by
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   -- Frame AB+CLZ with x2, x1, a[], u[0..4], shiftMem
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -408,10 +408,10 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
       (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) := by
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
   let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+916 → base+1008)
   have hDenorm := divK_denorm_body_spec sp u0 u1 u2 u3 v2 v5 v7 shift base
@@ -426,13 +426,13 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
      ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
     (by pcFree) hDenorm
   -- Step 2: DIV epilogue (base+1008 → base+1068)
-  -- After denorm: x5=u3', x6=shift, x7=(u3<<<anti_shift%64), x10=v10
+  -- After denorm: x5=u3', x6=shift, x7=(u3<<<antiShift%64), x10=v10
   have hEpi := divK_div_epilogue_spec sp base q0 q1 q2 q3
-    u3' shift (u3 <<< (anti_shift.toNat % 64)) v10 m0 m8 m16 m24
+    u3' shift (u3 <<< (antiShift.toNat % 64)) v10 m0 m8 m16 m24
 
   -- Frame epilogue with x2, x0, u'[]
   have hEpiF := cpsTriple_frameR
-    ((.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
      ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3'))
     (by pcFree) hEpi
@@ -462,10 +462,10 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
        ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
        ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
       (denormModPost sp shift u0 u1 u2 u3) := by
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
   let u3' := u3 >>> (shift.toNat % 64)
   -- Step 1: Denorm body (base+916 → base+1008, modCode)
   have hDenorm := mod_denorm_body_spec sp u0 u1 u2 u3 v2 v5 v7 shift base
@@ -478,14 +478,14 @@ theorem evm_mod_denorm_epilogue_spec (sp base : Word)
      ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
     (by pcFree) hDenorm
   -- Step 2: MOD epilogue (base+1008 → base+1068, modCode)
-  -- After denorm: x5=u3', x6=shift, x7=(u3<<<anti_shift%64), x10=v10
+  -- After denorm: x5=u3', x6=shift, x7=(u3<<<antiShift%64), x10=v10
   -- Epilogue loads u'[] from 4056..4032 (the denormalized values)
   have hEpi := divK_mod_epilogue_spec sp base u0' u1' u2' u3'
-    u3' shift (u3 <<< (anti_shift.toNat % 64)) v10 m0 m8 m16 m24
+    u3' shift (u3 <<< (antiShift.toNat % 64)) v10 m0 m8 m16 m24
 
   -- Frame epilogue with x2, x0
   have hEpiF := cpsTriple_frameR
-    ((.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)))
+    ((.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)))
     (by pcFree) hEpi
   -- Compose denorm → epilogue
   have hFull := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b0, x6 = shift = clzResult(b0).1. -/
 theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
     cpsTriple base (base + phaseC2Off) (divCode base)
@@ -35,7 +35,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -51,11 +51,11 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=1 (includes b0 in assertion, no framing needed)
   have hB := evm_div_phaseB_n1_spec sp base b0 b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2z hb1z
   have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hB
@@ -85,7 +85,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
@@ -103,23 +103,23 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=1) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n1_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1z
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -155,7 +155,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
     (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -175,7 +175,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -196,8 +196,8 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -226,7 +226,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
@@ -244,7 +244,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (1 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -264,7 +264,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) := by
   -- Step 1: PhaseAB(n=1) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n1_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1z
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -22,7 +22,7 @@ open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 
 -- ============================================================================
 -- Address normalization lemmas for n=1 preloop+loop composition
--- Maps u_base(j)/qAddr(j) relative offsets to flat sp+signExtend12 offsets.
+-- Maps uBase(j)/qAddr(j) relative offsets to flat sp+signExtend12 offsets.
 -- signExtend12/<<</>> → concrete values via simp, then bv_omega.
 -- bv_addr only handles (a+k1)+k2=a+k3; these involve subtraction and shifts,
 -- so bv_omega is required. Pattern matches FullPathN2Loop.lean.
@@ -31,12 +31,12 @@ open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 /-- signExtend12(4) - 1 = 3, for x1 register in loopSetupPost at n=1. -/
 theorem x1_val_n1 : signExtend12 (4 : BitVec 12) - (1 : Word) = (3 : Word) := by decide
 
--- u_base(3) = sp + se(4056) - 24.  Offsets map to flat addresses:
--- u_base(3)+0     = sp+se(4032)  [u0 at iteration j=3]
--- u_base(3)-8     = sp+se(4024)  [u1]
--- u_base(3)-16    = sp+se(4016)  [u2]
--- u_base(3)-24    = sp+se(4008)  [u3]
--- u_base(3)-32    = sp+se(4000)  [uTop]
+-- uBase(3) = sp + se(4056) - 24.  Offsets map to flat addresses:
+-- uBase(3)+0     = sp+se(4032)  [u0 at iteration j=3]
+-- uBase(3)-8     = sp+se(4024)  [u1]
+-- uBase(3)-16    = sp+se(4016)  [u2]
+-- uBase(3)-24    = sp+se(4008)  [u3]
+-- uBase(3)-32    = sp+se(4000)  [uTop]
 
 theorem n1_ub3_off0 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
@@ -59,9 +59,9 @@ theorem n1_ub3_off4064 (sp : Word) :
     sp + signExtend12 4000 := by
   divmod_addr
 
--- u_base(2)+0 = sp+se(4040), already covered by n2_ub2_off0 (same addresses)
--- u_base(1)+0 = sp+se(4048), already covered by n3_ub1_off0
--- u_base(0)+0 = sp+se(4056), already covered by n3_ub0_off0
+-- uBase(2)+0 = sp+se(4040), already covered by n2_ub2_off0 (same addresses)
+-- uBase(1)+0 = sp+se(4048), already covered by n3_ub1_off0
+-- uBase(0)+0 = sp+se(4056), already covered by n3_ub0_off0
 
 -- qAddr(j) = sp + se(4088) - j<<<3
 theorem n1_qa3 (sp : Word) :
@@ -75,21 +75,21 @@ theorem n1_qa3 (sp : Word) :
 -- loopExitPostN1 at j=0: concrete address specialization
 -- ============================================================================
 
-/-- Specialize `loopExitPostN1` at `j=0`: all u_base/qAddr offsets become
+/-- Specialize `loopExitPostN1` at `j=0`: all uBase/qAddr offsets become
     flat `sp + signExtend12 K` addresses. Uses the shared u_base_off*_j0 lemmas. -/
-theorem loopExitPostN1_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
+theorem loopExitPostN1_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
-    loopExitPostN1 sp (0 : Word) q_f c3 un0_f un1_f un2_f un3_f u4_f v0 v1 v2 v3 =
+    loopExitPostN1 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
-     (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0_f) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1_f) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2_f) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3_f) **
-     ((sp + signExtend12 4024) ↦ₘ u4_f) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0F) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1F) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2F) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3F) **
+     ((sp + signExtend12 4024) ↦ₘ u4F) **
      ((sp + signExtend12 4088) ↦ₘ q_f)) := by
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
@@ -107,7 +107,7 @@ theorem divK_loop_n1_unified_divCode (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
@@ -143,15 +143,15 @@ theorem divK_loop_n1_unified_divCode (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) :=
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n1_unified_spec bltu_3 bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -36,7 +36,7 @@ theorem x1_val_n1 : signExtend12 (4 : BitVec 12) - (1 : Word) = (3 : Word) := by
 -- u_base(3)-8     = sp+se(4024)  [u1]
 -- u_base(3)-16    = sp+se(4016)  [u2]
 -- u_base(3)-24    = sp+se(4008)  [u3]
--- u_base(3)-32    = sp+se(4000)  [u_top]
+-- u_base(3)-32    = sp+se(4000)  [uTop]
 
 theorem n1_ub3_off0 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
@@ -104,52 +104,52 @@ theorem loopExitPostN1_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
 /-- Lift the unified n=1 4-iteration  loop spec from sharedDivModCode to divCode. -/
 theorem divK_loop_n1_unified_divCode (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
-    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n1_unified_spec bltu_3 bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_2 u0_orig_1 u0_orig_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -28,62 +28,62 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 -- ============================================================================
 
 /-- j=3 trial condition for n=1 (double-addback): `bltu_3 = BitVec.ult u_hi_norm v_top_norm`
-    where `shift = clz(b0)`, `u_hi_norm = a3 >>> anti_shift`,
+    where `shift = clz(b0)`, `u_hi_norm = a3 >>> antiShift`,
     `v_top_norm = b0 <<< shift`. -/
 def isTrialN1_j3 (bltu_3 : Bool) (a3 b0 : Word) : Prop :=
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   bltu_3 = BitVec.ult
-    (a3 >>> (anti_shift.toNat % 64))
+    (a3 >>> (antiShift.toNat % 64))
     (b0 <<< (shift.toNat % 64))
 
 /-- j=2 trial condition for n=1 (double-addback), dependent on j=3 path (bltu_3).
     Checks the BLTU condition after the j=3 iteration result. -/
 def isTrialN1_j2 (bltu_3 bltu_2 : Bool) (a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
   bltu_2 = BitVec.ult
-    (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+    (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
     v0'
 
 /-- j=1 trial condition for n=1 (double-addback), dependent on j=3 and j=2 paths. -/
 def isTrialN1_j1 (bltu_3 bltu_2 bltu_1 : Bool) (a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r3 := iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r3 := iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
   bltu_1 = BitVec.ult
-    (iterN1 bltu_2 v0' v1' v2' v3' u2_s r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1).2.1
+    (iterN1 bltu_2 v0' v1' v2' v3' u2S r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1).2.1
     v0'
 
 /-- j=0 trial condition for n=1 (double-addback), dependent on j=3, j=2, and j=1 paths. -/
 def isTrialN1_j0 (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r3 := iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
-  let r2 := iterN1 bltu_2 v0' v1' v2' v3' u2_s r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r3 := iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+  let r2 := iterN1 bltu_2 v0' v1' v2' v3' u2S r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
   bltu_0 = BitVec.ult
-    (iterN1 bltu_1 v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1).2.1
+    (iterN1 bltu_1 v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1).2.1
     v0'
 
 -- ============================================================================
@@ -96,21 +96,21 @@ def isTrialN1_j0 (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 :
 @[irreducible]
 def preloopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
   loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base
-    v0' v1' v2' v3' u3_s (a3 >>> (anti_shift.toNat % 64)) (0 : Word) (0 : Word) (0 : Word)
-    u2_s u1_s u0_s
-    ret_mem d_mem dlo_mem scratch_un0 **
+    v0' v1' v2' v3' u3S (a3 >>> (antiShift.toNat % 64)) (0 : Word) (0 : Word) (0 : Word)
+    u2S u1S u0S
+    retMem dMem dloMem scratch_un0 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)
@@ -123,57 +123,57 @@ def preloopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     Separates the loop application from the composition for heartbeat budgeting. -/
 private theorem evm_div_n1_loop_unified_inst
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
-    (shift anti_shift v0' v1' v2' v3' u0_s u1_s u2_s u3_s u4_s : Word)
+    (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11_old jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u4_s v0')
     (hbltu_2 : bltu_2 = BitVec.ult
-      (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1 v0')
+      (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1 v0')
     (hbltu_1 : bltu_1 = BitVec.ult
-      (iterN1 bltu_2 v0' v1' v2' v3' u2_s
-        (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
-        (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
-        (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
-        (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.1
+      (iterN1 bltu_2 v0' v1' v2' v3' u2S
+        (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+        (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
+        (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
+        (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.1
       v0')
     (hbltu_0 : bltu_0 = BitVec.ult
-      (iterN1 bltu_1 v0' v1' v2' v3' u1_s
-        (iterN1 bltu_2 v0' v1' v2' v3' u2_s
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.1
-        (iterN1 bltu_2 v0' v1' v2' v3' u2_s
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
-        (iterN1 bltu_2 v0' v1' v2' v3' u2_s
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.2.1
-        (iterN1 bltu_2 v0' v1' v2' v3' u2_s
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
-          (iterN1 bltu_3 v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.2.2.1).2.1
+      (iterN1 bltu_1 v0' v1' v2' v3' u1S
+        (iterN1 bltu_2 v0' v1' v2' v3' u2S
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.1
+        (iterN1 bltu_2 v0' v1' v2' v3' u2S
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+        (iterN1 bltu_2 v0' v1' v2' v3' u2S
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.2.1
+        (iterN1 bltu_2 v0' v1' v2' v3' u2S
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.1
+          (iterN1 bltu_3 v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)).2.2.2.2.1).2.2.2.2.1).2.1
       v0')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN1PreWithScratch sp jMem (1 : Word) shift u0_s v10_val v11_old anti_shift
-        v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
-        u2_s u1_s u0_s (0 : Word) (0 : Word) (0 : Word) (0 : Word)
-        ret_mem d_mem dlo_mem scratch_un0)
+      (loopN1PreWithScratch sp jMem (1 : Word) shift u0S v10_val v11_old antiShift
+        v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+        u2S u1S u0S (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base
-        v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
-        u2_s u1_s u0_s ret_mem d_mem dlo_mem scratch_un0) :=
+        v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+        u2S u1S u0S retMem dMem dloMem scratch_un0) :=
   divK_loop_n1_unified_divCode bltu_3 bltu_2 bltu_1 bltu_0
-    sp jMem (1 : Word) shift u0_s v10_val v11_old anti_shift
-    v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
-    u2_s u1_s u0_s (0 : Word) (0 : Word) (0 : Word) (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    sp jMem (1 : Word) shift u0S v10_val v11_old antiShift
+    v0' v1' v2' v3' u3S u4_s (0 : Word) (0 : Word) (0 : Word)
+    u2S u1S u0S (0 : Word) (0 : Word) (0 : Word) (0 : Word)
+    retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -192,8 +192,8 @@ private theorem evm_div_n1_loop_unified_inst
 theorem evm_div_n1_preloop_loop_unified_spec
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0)
@@ -221,28 +221,28 @@ theorem evm_div_n1_preloop_loop_unified_spec
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (preloopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n1_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3z hb2z hb1z hshift_nz
 
 
   -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+904 (unified da, with explicit normalized values)
@@ -259,7 +259,7 @@ theorem evm_div_n1_preloop_loop_unified_spec
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
     v11_old jMem
-    ret_mem d_mem dlo_mem scratch_un0 halign
+    retMem dMem dloMem scratch_un0 halign
     hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
   -- Frame loop with a[], shiftMem (no spare q/u for n=1)
   have hLoopF := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b1, x6 = shift = clzResult(b1).1. -/
 theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (divCode base)
@@ -35,7 +35,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -51,11 +51,11 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=3
   have hB := evm_div_phaseB_n2_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2z hb1nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -88,7 +88,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
@@ -106,23 +106,23 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=2) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n2_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -158,7 +158,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
     (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -178,7 +178,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -199,8 +199,8 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -229,7 +229,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
@@ -247,7 +247,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -267,7 +267,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) := by
   -- Step 1: PhaseAB(n=2) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n2_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -33,19 +33,19 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 @[irreducible]
 def fullDivN2_FFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -64,8 +64,8 @@ def fullDivN2_FFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FFT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -92,34 +92,34 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_FFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1') v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false false true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -166,19 +166,19 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_FTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -197,8 +197,8 @@ def fullDivN2_FTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FTF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -225,34 +225,34 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_FTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false true false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -299,19 +299,19 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_FTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -330,8 +330,8 @@ def fullDivN2_FTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FTT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -358,34 +358,34 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_FTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1') v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false true true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -432,19 +432,19 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_TFF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -459,12 +459,12 @@ def fullDivN2_TFF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1') **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
-  (sp + signExtend12 3944 ↦ₘ div128Un0 u3_s)
+  (sp + signExtend12 3944 ↦ₘ div128Un0 u3S)
 
 theorem evm_div_n2_full_TFF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -491,34 +491,34 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_TFF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true false false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -540,7 +540,7 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1') **
      (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
-     (sp + signExtend12 3944 ↦ₘ div128Un0 u3_s))
+     (sp + signExtend12 3944 ↦ₘ div128Un0 u3S))
     (by pcFree) hB
   have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
@@ -565,19 +565,19 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_TFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -596,8 +596,8 @@ def fullDivN2_TFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TFT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -624,34 +624,34 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_TFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1') v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true false true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -698,19 +698,19 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_TTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -729,8 +729,8 @@ def fullDivN2_TTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TTF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -757,34 +757,34 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_TTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true true false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
@@ -831,19 +831,19 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
 @[irreducible]
 def fullDivN2_TTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -862,8 +862,8 @@ def fullDivN2_TTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TTT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -890,34 +890,34 @@ theorem evm_div_n2_full_TTT_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2_TTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Call v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Call v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Call v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Call v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Call v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Call v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1') v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true true true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   have hB := evm_div_preamble_denorm_epilogue_spec sp base

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -30,21 +30,21 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
     Same as `fullDivN2AllMaxPost` but uses `iterN2Max` (with addback branching). -/
 @[irreducible]
 def fullDivN2AllMaxPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -56,9 +56,9 @@ def fullDivN2AllMaxPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
   (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 -- ============================================================================
@@ -69,8 +69,8 @@ def fullDivN2AllMaxPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     Composes pre-loop + three-iteration loop + denorm + epilogue. -/
 theorem evm_div_n2_full_all_max_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -97,36 +97,36 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2AllMaxPost sp a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        retMem dMem dloMem scratch_un0) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2Max v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2Max v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2Max v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2Max v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2Max v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2Max v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   let c3_0 := (mulsubN4 (signExtend12 4095 : Word) v0' v1' v2' v3'
-    u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    u0S r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n2_preloop_loop_unified_spec false false false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   -- 2. Post-loop: base+904 → base+1068
@@ -147,9 +147,9 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
      (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hB
   -- 3. Compose A + B
@@ -178,21 +178,21 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
 @[irreducible]
 def fullDivN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-  let r1 := iterN2 bltu_1 v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
-  let r0 := iterN2 bltu_0 v0' v1' v2' v3' u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+  let r1 := iterN2 bltu_1 v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+  let r0 := iterN2 bltu_0 v0' v1' v2' v3' u0S r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
   denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 r0.1 r1.1 r2.1 (0 : Word) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -207,9 +207,9 @@ def fullDivN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
   -- Scratch cells: bltu_0=true → j=0 call scratch; bltu_0=false → from previous iterations
   match bltu_2, bltu_1, bltu_0 with
   | false, false, false =>
-    (sp + signExtend12 3968 ↦ₘ ret_mem) **
-    (sp + signExtend12 3960 ↦ₘ d_mem) **
-    (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
   | false, false, true  =>
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
@@ -230,7 +230,7 @@ def fullDivN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ v1') **
     (sp + signExtend12 3952 ↦ₘ div128DLo v1') **
-    (sp + signExtend12 3944 ↦ₘ div128Un0 u3_s)
+    (sp + signExtend12 3944 ↦ₘ div128Un0 u3S)
   | true,  false, true  =>
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ v1') **
@@ -256,8 +256,8 @@ def fullDivN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     Dispatches to per-case  lemmas via postcondition bridge. -/
 theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -284,91 +284,91 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (fullDivN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        retMem dMem dloMem scratch_un0) := by
   cases bltu_2 <;> cases bltu_1 <;> cases bltu_0 <;>
     simp only [isTrialN2_j2, isTrialN2_j1, isTrialN2_j0,
                iterN2_false, iterN2_true]
       at hbltu_2 hbltu_1 hbltu_0
   · have h_eq : fullDivN2UnifiedPost false false false sp base a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0 =
-      fullDivN2AllMaxPost sp a0 a1 a2 a3 b0 b1 b2 b3 ret_mem d_mem dlo_mem scratch_un0 := by
+        retMem dMem dloMem scratch_un0 =
+      fullDivN2AllMaxPost sp a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 := by
       delta fullDivN2UnifiedPost fullDivN2AllMaxPost; rfl
     rw [h_eq]; exact evm_div_n2_full_all_max_spec sp base
       a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-      q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-      ret_mem d_mem dlo_mem scratch_un0
+      q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+      retMem dMem dloMem scratch_un0
       hbnz hb3z hb2z hb1nz hshift_nz halign
       hbltu_2 hbltu_1 hbltu_0 hcarry2
   all_goals (
     first
     | (have h_eq : fullDivN2UnifiedPost false false true sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_FFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FFT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FFT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost false true false sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_FTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FTF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FTF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost false true true sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_FTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FTT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FTT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost true false false sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TFF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_TFF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TFF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TFF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost true false true sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_TFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TFT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TFT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost true true false sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_TTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TTF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TTF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2)
     | (have h_eq : fullDivN2UnifiedPost true true true sp base a0 a1 a2 a3 b0 b1 b2 b3
-          ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
+          retMem dMem dloMem scratch_un0 = fullDivN2_TTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TTT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TTT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-          ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+          retMem dMem dloMem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
           hbltu_2 hbltu_1 hbltu_0 hcarry2))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -22,7 +22,7 @@ open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 
 -- ============================================================================
 -- Address normalization lemmas for n=2 preloop+loop composition
--- Maps u_base(j)/qAddr(j) relative offsets to flat sp+signExtend12 offsets.
+-- Maps uBase(j)/qAddr(j) relative offsets to flat sp+signExtend12 offsets.
 -- signExtend12/<<</>> → concrete values via simp, then bv_omega.
 -- bv_addr only handles (a+k1)+k2=a+k3; these involve subtraction and shifts,
 -- so bv_omega is required. Pattern matches FullPathN3Loop.lean:69.
@@ -31,12 +31,12 @@ open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_3 word_shl3_0)
 /-- signExtend12(4) - 2 = 2, for x1 register in loopSetupPost at n=2. -/
 theorem x1_val_n2 : signExtend12 (4 : BitVec 12) - (2 : Word) = (2 : Word) := by decide
 
--- u_base(2) = sp + se(4056) - 16.  Offsets map to flat addresses:
--- u_base(2)+0     = sp+se(4040)  [u0 at iteration j=2]
--- u_base(2)-8     = sp+se(4032)  [u1]
--- u_base(2)-16    = sp+se(4024)  [u2]
--- u_base(2)-24    = sp+se(4016)  [u3]
--- u_base(2)-32    = sp+se(4008)  [uTop]
+-- uBase(2) = sp + se(4056) - 16.  Offsets map to flat addresses:
+-- uBase(2)+0     = sp+se(4040)  [u0 at iteration j=2]
+-- uBase(2)-8     = sp+se(4032)  [u1]
+-- uBase(2)-16    = sp+se(4024)  [u2]
+-- uBase(2)-24    = sp+se(4016)  [u3]
+-- uBase(2)-32    = sp+se(4008)  [uTop]
 
 theorem n2_ub2_off0 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
@@ -59,8 +59,8 @@ theorem n2_ub2_off4064 (sp : Word) :
     sp + signExtend12 4008 := by
   divmod_addr
 
--- u_base(1)+0 = sp+se(4048), already covered by n3_ub1_off0 (same addresses)
--- u_base(0)+0 = sp+se(4056), already covered by n3_ub0_off0
+-- uBase(1)+0 = sp+se(4048), already covered by n3_ub1_off0 (same addresses)
+-- uBase(0)+0 = sp+se(4056), already covered by n3_ub0_off0
 
 -- qAddr(j) = sp + se(4088) - j<<<3
 theorem n2_qa2 (sp : Word) :
@@ -73,21 +73,21 @@ theorem n2_qa2 (sp : Word) :
 -- loopExitPostN2 at j=0: concrete address specialization
 -- ============================================================================
 
-/-- Specialize `loopExitPostN2` at `j=0`: all u_base/qAddr offsets become
+/-- Specialize `loopExitPostN2` at `j=0`: all uBase/qAddr offsets become
     flat `sp + signExtend12 K` addresses. Uses the shared u_base_off*_j0 lemmas. -/
-theorem loopExitPostN2_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
+theorem loopExitPostN2_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
-    loopExitPostN2 sp (0 : Word) q_f c3 un0_f un1_f un2_f un3_f u4_f v0 v1 v2 v3 =
+    loopExitPostN2 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
-     (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0_f) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1_f) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2_f) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3_f) **
-     ((sp + signExtend12 4024) ↦ₘ u4_f) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0F) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1F) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2F) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3F) **
+     ((sp + signExtend12 4024) ↦ₘ u4F) **
      ((sp + signExtend12 4088) ↦ₘ q_f)) := by
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
@@ -105,7 +105,7 @@ theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
@@ -120,14 +120,14 @@ theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) :=
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n2_unified_spec bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
 
 
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -36,7 +36,7 @@ theorem x1_val_n2 : signExtend12 (4 : BitVec 12) - (2 : Word) = (2 : Word) := by
 -- u_base(2)-8     = sp+se(4032)  [u1]
 -- u_base(2)-16    = sp+se(4024)  [u2]
 -- u_base(2)-24    = sp+se(4016)  [u3]
--- u_base(2)-32    = sp+se(4008)  [u_top]
+-- u_base(2)-32    = sp+se(4008)  [uTop]
 
 theorem n2_ub2_off0 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
@@ -102,31 +102,31 @@ theorem loopExitPostN2_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
 /-- Lift the unified n=2 3-iteration  loop spec from sharedDivModCode to divCode. -/
 theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1)
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n2_unified_spec bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_1 u0_orig_0 q2_old q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -31,42 +31,42 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
     since the first iteration doesn't use `iterN2`. -/
 def isTrialN2_j2 (bltu_2 : Bool) (a3 b0 b1 : Word) : Prop :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   bltu_2 = BitVec.ult
-    (a3 >>> (anti_shift.toNat % 64))
-    ((b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64)))
+    (a3 >>> (antiShift.toNat % 64))
+    ((b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)))
 
 /-- j=1 trial condition for n=2 (double-addback), dependent on j=2 path (bltu_2).
     Checks the BLTU condition after the j=2 iteration result using `iterN2`. -/
 def isTrialN2_j1 (bltu_2 bltu_1 : Bool) (a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
   bltu_1 = BitVec.ult
-    (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.1
+    (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
     v1'
 
 /-- j=0 trial condition for n=2 (double-addback), dependent on j=2 and j=1 paths. -/
 def isTrialN2_j0 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
-  let r2 := iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
+  let r2 := iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
   bltu_0 = BitVec.ult
-    (iterN2 bltu_1 v0' v1' v2' v3' u1_s r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1).2.2.1
+    (iterN2 bltu_1 v0' v1' v2' v3' u1S r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1).2.2.1
     v1'
 
 -- ============================================================================
@@ -79,21 +79,21 @@ def isTrialN2_j0 (bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) 
 @[irreducible]
 def preloopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
   loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base
-    v0' v1' v2' v3' u2_s u3_s (a3 >>> (anti_shift.toNat % 64)) (0 : Word) (0 : Word)
-    u1_s u0_s
-    ret_mem d_mem dlo_mem scratch_un0 **
+    v0' v1' v2' v3' u2S u3S (a3 >>> (antiShift.toNat % 64)) (0 : Word) (0 : Word)
+    u1S u0S
+    retMem dMem dloMem scratch_un0 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
@@ -108,34 +108,34 @@ def preloopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     Separates the loop application from the composition for heartbeat budgeting. -/
 private theorem evm_div_n2_loop_unified_inst
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
-    (shift anti_shift v0' v1' v2' v3' u0_s u1_s u2_s u3_s u4_s : Word)
+    (shift antiShift v0' v1' v2' v3' u0S u1S u2S u3S u4_s : Word)
     (v10_val v11_old jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u4_s v1')
     (hbltu_1 : bltu_1 = BitVec.ult
-      (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.1 v1')
+      (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1 v1')
     (hbltu_0 : bltu_0 = BitVec.ult
-      (iterN2 bltu_1 v0' v1' v2' v3' u1_s
-        (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.1
-        (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.1
-        (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.2.1
-        (iterN2 bltu_2 v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
+      (iterN2 bltu_1 v0' v1' v2' v3' u1S
+        (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.1
+        (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.1
+        (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.1
+        (iterN2 bltu_2 v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)).2.2.2.2.1).2.2.1
       v1')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN2PreWithScratch sp jMem (2 : Word) shift u0_s v10_val v11_old anti_shift
-        v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-        u1_s u0_s (0 : Word) (0 : Word) (0 : Word)
-        ret_mem d_mem dlo_mem scratch_un0)
+      (loopN2PreWithScratch sp jMem (2 : Word) shift u0S v10_val v11_old antiShift
+        v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+        u1S u0S (0 : Word) (0 : Word) (0 : Word)
+        retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base
-        v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-        u1_s u0_s ret_mem d_mem dlo_mem scratch_un0) :=
+        v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+        u1S u0S retMem dMem dloMem scratch_un0) :=
   divK_loop_n2_unified_divCode bltu_2 bltu_1 bltu_0
-    sp jMem (2 : Word) shift u0_s v10_val v11_old anti_shift
-    v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
-    u1_s u0_s (0 : Word) (0 : Word) (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    sp jMem (2 : Word) shift u0S v10_val v11_old antiShift
+    v0' v1' v2' v3' u2S u3S u4_s (0 : Word) (0 : Word)
+    u1S u0S (0 : Word) (0 : Word) (0 : Word)
+    retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -153,8 +153,8 @@ private theorem evm_div_n2_loop_unified_inst
 theorem evm_div_n2_preloop_loop_unified_spec
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0)
@@ -181,28 +181,28 @@ theorem evm_div_n2_preloop_loop_unified_spec
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (preloopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n2_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3z hb2z hb1nz hshift_nz
 
 
   -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+904 (unified da, with explicit normalized values)
@@ -219,7 +219,7 @@ theorem evm_div_n2_preloop_loop_unified_spec
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))
     v11_old jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    retMem dMem dloMem scratch_un0
 
     halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b2, x6 = shift = clzResult(b2).1. -/
 theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (divCode base)
@@ -35,7 +35,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -51,11 +51,11 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=3
   have hB := evm_div_phaseB_n3_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -88,7 +88,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
@@ -106,23 +106,23 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b2).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=3) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n3_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -158,7 +158,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := divK_normB_full_spec sp b0 b1 b2 b3
     (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -178,7 +178,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := divK_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -199,8 +199,8 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -229,7 +229,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
@@ -247,7 +247,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -267,7 +267,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) := by
   -- Step 1: PhaseAB(n=3) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n3_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -67,22 +67,22 @@ theorem n3_qa0 (sp : Word) :
 /-- Lift the unified n=3 2-iteration  loop spec from sharedDivModCode to divCode. -/
 theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
-    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
         ret_mem d_mem dlo_mem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n3_unified_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_1 hbltu_0 hcarry2)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -67,8 +67,8 @@ theorem n3_qa0 (sp : Word) :
 /-- Lift the unified n=3 2-iteration  loop spec from sharedDivModCode to divCode. -/
 theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
@@ -76,13 +76,13 @@ theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-        ret_mem d_mem dlo_mem scratch_un0) :=
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) :=
   cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_n3_unified_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_1 hbltu_0 hcarry2)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -25,26 +25,26 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
     since the first iteration doesn't use `iterN3`. -/
 def isTrialN3_j1 (bltu : Bool) (a3 b1 b2 : Word) : Prop :=
   let shift := (clzResult b2).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   bltu = BitVec.ult
-    (a3 >>> (anti_shift.toNat % 64))
-    ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64)))
+    (a3 >>> (antiShift.toNat % 64))
+    ((b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)))
 
 /-- j=0 trial condition for n=3 (double-addback), dependent on j=1 path (bltu_1).
     Checks the BLTU condition after the j=1 iteration result using `iterN3`. -/
 def isTrialN3_j0 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b2).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u4_s := a3 >>> (anti_shift.toNat % 64)
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u4_s := a3 >>> (antiShift.toNat % 64)
   bltu_0 = BitVec.ult
-    (iterN3 bltu_1 v0' v1' v2' v3' u1_s u2_s u3_s u4_s (0 : Word)).2.2.2.1
+    (iterN3 bltu_1 v0' v1' v2' v3' u1S u2S u3S u4_s (0 : Word)).2.2.2.1
     v2'
 
 -- ============================================================================
@@ -57,20 +57,20 @@ def isTrialN3_j0 (bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop 
 @[irreducible]
 def preloopN3UnifiedPost (bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let shift := (clzResult b2).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   let v0' := b0 <<< (shift.toNat % 64)
-  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
-  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u0_s := a0 <<< (shift.toNat % 64)
-  let u1_s := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
-  let u2_s := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u3_s := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let v1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let v2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let v3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u0S := a0 <<< (shift.toNat % 64)
+  let u1S := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u2S := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u3S := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
   loopN3UnifiedPost bltu_1 bltu_0 sp base
-    v0' v1' v2' v3' u1_s u2_s u3_s (a3 >>> (anti_shift.toNat % 64)) (0 : Word) u0_s
-    ret_mem d_mem dlo_mem scratch_un0 **
+    v0' v1' v2' v3' u1S u2S u3S (a3 >>> (antiShift.toNat % 64)) (0 : Word) u0S
+    retMem dMem dloMem scratch_un0 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
@@ -87,25 +87,25 @@ def preloopN3UnifiedPost (bltu_1 bltu_0 : Bool)
     Separates the loop application from the composition for heartbeat budgeting. -/
 private theorem evm_div_n3_loop_unified_inst
     (bltu_1 bltu_0 : Bool) (sp base : Word)
-    (shift anti_shift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
+    (shift antiShift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
     (v10_old v11_old jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
     (hbltu_0 : bltu_0 = BitVec.ult
       (iterN3 bltu_1 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
     (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN3PreWithScratch sp jMem (3 : Word) shift u0 v10_old v11_old anti_shift
+      (loopN3PreWithScratch sp jMem (3 : Word) shift u0 v10_old v11_old antiShift
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN3UnifiedPost bltu_1 bltu_0 sp base
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
-        ret_mem d_mem dlo_mem scratch_un0) :=
+        retMem dMem dloMem scratch_un0) :=
   divK_loop_n3_unified_divCode bltu_1 bltu_0
-    sp jMem (3 : Word) shift u0 v10_old v11_old anti_shift
+    sp jMem (3 : Word) shift u0 v10_old v11_old antiShift
     b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    retMem dMem dloMem scratch_un0 base halign
     hbltu_1 hbltu_0 hcarry2
 
 -- ============================================================================
@@ -118,8 +118,8 @@ private theorem evm_div_n3_loop_unified_inst
     Composes preloop (base→base+448) with unified loop (base+448→base+908). -/
 theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0)
@@ -145,26 +145,26 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       ((sp + signExtend12 3968) ↦ₘ ret_mem) **
-       ((sp + signExtend12 3960) ↦ₘ d_mem) **
-       ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
        ((sp + signExtend12 3944) ↦ₘ scratch_un0))
       (preloopN3UnifiedPost bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        retMem dMem dloMem scratch_un0) := by
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n3_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3z hb2nz hshift_nz
   -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
      (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   -- 2. Loop: base+448 → base+908 (unified da, with explicit normalized values)
@@ -181,7 +181,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))
     v11_old jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    retMem dMem dloMem scratch_un0
     halign
     hbltu_1 hbltu_0 hcarry2
   -- Frame loop with a[], spare q[2..3], spare u[6..7], shiftMem

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -35,15 +35,15 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 @[irreducible]
 def preloopMaxSkipPostN4 (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095) b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -59,26 +59,26 @@ def preloopMaxSkipPostN4 (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 /-- Max trial quotient condition at n=4: u4 ≥ normalized b3 (BLTU not taken). -/
 def isMaxTrialN4 (a3 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
   ¬BitVec.ult u4 b3'
 
 /-- Skip addback condition at n=4 with max trial quotient: borrow = 0. -/
 def isSkipBorrowN4Max (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  (if BitVec.ult u4 (mulsubN4_c3 q_hat b0' b1' b2' b3' u0 u1 u2 u3)
+  let qHat : Word := signExtend12 4095
+  (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
    then (1 : Word) else 0) = (0 : Word)
 
 -- ============================================================================
@@ -90,8 +90,8 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (hbltu : ¬BitVec.ult uTop v3) :
-    let q_hat : Word := signExtend12 4095
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    let qHat : Word := signExtend12 4095
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -105,8 +105,8 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro q_hat hborrow
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro qHat hborrow
   have raw := divK_loop_body_n4_max_skip_j0_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
 
@@ -123,7 +123,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
 /-- n=4 pre-loop + max+skip loop body: base → base+904 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -144,26 +144,26 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isMaxTrialN4 at hbltu
   unfold isSkipBorrowN4Max at hborrow
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_nz
 
 
@@ -171,7 +171,7 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_skip_j0_norm sp base
-    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11_old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
 
     hbltu
@@ -206,21 +206,21 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
 theorem preloopMaxSkipPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    let q_hat : Word := signExtend12 4095
-    let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+    let qHat : Word := signExtend12 4095
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
-     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ q_hat) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ ms.1) **
@@ -228,7 +228,7 @@ theorem preloopMaxSkipPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
      ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
      ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
      ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
-     ((sp + signExtend12 4088) ↦ₘ q_hat)) **
+     ((sp + signExtend12 4088) ↦ₘ qHat)) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
@@ -251,28 +251,28 @@ theorem preloopMaxSkipPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 @[irreducible]
 def fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
-  denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q_hat 0 0 0 **
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 qHat 0 0 0 **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-  ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+  ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat)
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
 
 /-- Named unfold for `fullDivN4MaxSkipPost`. Restores access to the
     underlying sepConj structure once the `@[irreducible]` attribute
@@ -281,28 +281,28 @@ def fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 theorem fullDivN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
     (let shift := (clzResult b3).1
-     let anti_shift := signExtend12 (0 : BitVec 12) - shift
-     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+     let antiShift := signExtend12 (0 : BitVec 12) - shift
+     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
      let b0' := b0 <<< (shift.toNat % 64)
-     let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+     let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
      let u0 := a0 <<< (shift.toNat % 64)
-     let q_hat : Word := signExtend12 4095
-     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
-     denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q_hat 0 0 0 **
+     let qHat : Word := signExtend12 4095
+     let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+     denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 qHat 0 0 0 **
      ((sp + signExtend12 3992) ↦ₘ shift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat)) := by
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)) := by
   delta fullDivN4MaxSkipPost; rfl
 
 /-- `fullDivN4MaxSkipPost` is pc-free: all its atoms (inside the
@@ -328,7 +328,7 @@ instance pcFreeInst_fullDivN4MaxSkipPost
     `fullDivN4MaxSkipPost` but wraps `denormModPost` instead of
     `denormDivPost`: the `sp+32..sp+56` output slot holds the
     *denormalized* remainder limbs (MOD result), while the scratch
-    cells at `sp+4088..sp+4064` still carry the raw `q_hat / 0 / 0 / 0`
+    cells at `sp+4088..sp+4064` still carry the raw `qHat / 0 / 0 / 0`
     trial-quotient values from the loop-body phase.
 
     Scaffolding for the forthcoming `evm_mod_n4_full_max_skip_spec`.
@@ -338,60 +338,60 @@ instance pcFreeInst_fullDivN4MaxSkipPost
 @[irreducible]
 def fullModN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   denormModPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
-  ((sp + signExtend12 4088) ↦ₘ q_hat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4088) ↦ₘ qHat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-  ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+  ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
   ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat)
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)
 
 /-- Named unfold for `fullModN4MaxSkipPost`. Mirror of
     `fullDivN4MaxSkipPost_unfold`. -/
 theorem fullModN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
     (let shift := (clzResult b3).1
-     let anti_shift := signExtend12 (0 : BitVec 12) - shift
-     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+     let antiShift := signExtend12 (0 : BitVec 12) - shift
+     let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+     let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+     let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
      let b0' := b0 <<< (shift.toNat % 64)
-     let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+     let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
      let u0 := a0 <<< (shift.toNat % 64)
-     let q_hat : Word := signExtend12 4095
-     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+     let qHat : Word := signExtend12 4095
+     let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
      denormModPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
-     ((sp + signExtend12 4088) ↦ₘ q_hat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4088) ↦ₘ qHat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat)) := by
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat)) := by
   delta fullModN4MaxSkipPost; rfl
 
 /-- `fullModN4MaxSkipPost` is pc-free. Mirror of
@@ -410,7 +410,7 @@ instance pcFreeInst_fullModN4MaxSkipPost
     Composes pre-loop + loop body + denorm + epilogue. -/
 theorem evm_div_n4_full_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -431,26 +431,26 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_max_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
     hbnz hb3nz hshift_nz
 
 
@@ -459,20 +459,20 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
     ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 shift
     ms.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
-    ms.2.2.2.2 q_hat 0 0 0
+    ms.2.2.2.2 qHat 0 0 0
     b0' b1' b2' b3'
     hshift_nz
   -- Frame post-loop with remainder atoms
   have hBF := cpsTriple_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat))
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTriple_seq_perm_same_cr
@@ -494,56 +494,56 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
 /-- Call path condition: u4 < b3' (BLTU taken, use div128). -/
 def isCallTrialN4 (a3 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let u4 := a3 >>> (anti_shift.toNat % 64)
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
   BitVec.ult u4 b3'
 
 /-- Skip addback condition at n=4 with call trial quotient. -/
 def isSkipBorrowN4Call (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
-  (if BitVec.ult u4 (mulsubN4_c3 q_hat b0' b1' b2' b3' u0 u1 u2 u3)
+  let qHat := div128Quot u4 u3 b3'
+  (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
    then (1 : Word) else 0) = (0 : Word)
 
 /-- Addback condition at n=4 with call trial quotient. -/
 def isAddbackBorrowN4Call (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
-  (if BitVec.ult u4 (mulsubN4_c3 q_hat b0' b1' b2' b3' u0 u1 u2 u3)
+  let qHat := div128Quot u4 u3 b3'
+  (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
    then (1 : Word) else 0) ≠ (0 : Word)
 
 /-- Loop body n=4, call+skip, j=0 with sp-relative addresses. -/
 theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3) :
-    let q_hat := div128Quot uTop u3 v3
+    let qHat := div128Quot uTop u3 v3
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -557,18 +557,18 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro q_hat dLo div_un0 hborrow
+  intro qHat dLo div_un0 hborrow
   have raw := divK_loop_body_n4_call_skip_j0_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base halign hbltu
   have raw' := raw hborrow
   simp only [se12_32, se12_40, se12_48, se12_56,
              u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
@@ -583,20 +583,20 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
 @[irreducible]
 def preloopCallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  loopBodyN4SkipPost sp (0 : Word) q_hat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
+  loopBodyN4SkipPost sp (0 : Word) qHat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -615,23 +615,23 @@ def preloopCallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    let q_hat := div128Quot u4 u3 b3'
+    let qHat := div128Quot u4 u3 b3'
     let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
-     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ q_hat) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ ms.1) **
@@ -639,7 +639,7 @@ theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
      ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
      ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
      ((sp + signExtend12 4024) ↦ₘ u4 - ms.2.2.2.2) **
-     ((sp + signExtend12 4088) ↦ₘ q_hat)) **
+     ((sp + signExtend12 4088) ↦ₘ qHat)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ b3') **
     (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -659,8 +659,8 @@ theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 /-- n=4 pre-loop + call+skip loop body: base → base+904 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -682,40 +682,40 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isSkipBorrowN4Call at hborrow
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
-    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11_old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0 halign
+    retMem dMem dloMem scratch_un0 halign
 
     hbltu
   intro_lets at hLoop
@@ -746,21 +746,21 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
 @[irreducible]
 def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
-  denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q_hat 0 0 0 **
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+  denormDivPost sp shift ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 qHat 0 0 0 **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -770,7 +770,7 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -779,8 +779,8 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+skip). -/
 theorem evm_div_n4_full_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -802,41 +802,41 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (fullDivN4CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_call_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3nz hshift_nz halign
     hbltu hborrow
   -- 2. Post-loop: base+904 → base+1068
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
     ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 shift
     ms.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
-    ms.2.2.2.2 q_hat 0 0 0
+    ms.2.2.2.2 qHat 0 0 0
     b0' b1' b2' b3'
     hshift_nz
   have hBF := cpsTriple_frameR
@@ -848,7 +848,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ b3') **
      (sp + signExtend12 3952 ↦ₘ dLo) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -88,10 +88,10 @@ def isSkipBorrowN4Max (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 /-- Loop body n=4, max+skip, j=0 with sp-relative addresses in precondition. -/
 theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (hbltu : ¬BitVec.ult u_top v3) :
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
+    (hbltu : ¬BitVec.ult uTop v3) :
     let q_hat : Word := signExtend12 4095
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -103,12 +103,12 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro q_hat hborrow
   have raw := divK_loop_body_n4_max_skip_j0_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
 
     hbltu hborrow
   simp only [se12_32, se12_40, se12_48, se12_56,
@@ -536,14 +536,14 @@ def isAddbackBorrowN4Call (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 /-- Loop body n=4, call+skip, j=0 with sp-relative addresses. -/
 theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3) :
-    let q_hat := div128Quot u_top u3 v3
+    (hbltu : BitVec.ult uTop v3) :
+    let q_hat := div128Quot uTop u3 v3
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -555,20 +555,20 @@ theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro q_hat d_lo div_un0 hborrow
   have raw := divK_loop_body_n4_call_skip_j0_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu
   have raw' := raw hborrow
   simp only [se12_32, se12_40, se12_48, se12_56,
              u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -41,8 +41,8 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
     (hv_q : isValidDwordAccess (sp + signExtend12 4088) = true)
     (hbltu : ¬BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let q_hat : Word := signExtend12 4095
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    let qHat : Word := signExtend12 4095
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -56,8 +56,8 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro q_hat hborrow
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro qHat hborrow
   rw [← se12_32] at hv_v0; rw [← se12_40] at
   rw [← se12_48] at hv_v2; rw [← se12_56] at
   rw [← u_base_off0_j0] at hv_u0; rw [← u_base_off4088_j0] at
@@ -76,7 +76,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
 theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
     (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
@@ -99,10 +99,10 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     (hv_q : isValidDwordAccess (sp + signExtend12 4088) = true)
     (hbltu : BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let q_hat := div128Quot uTop u3 v3
+    let qHat := div128Quot uTop u3 v3
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -116,23 +116,23 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro q_hat dLo div_un0 hborrow
+  intro qHat dLo div_un0 hborrow
   rw [← se12_32] at hv_v0; rw [← se12_40] at
   rw [← se12_48] at hv_v2; rw [← se12_56] at
   rw [← u_base_off0_j0] at hv_u0; rw [← u_base_off4088_j0] at
   rw [← u_base_off4080_j0] at hv_u2; rw [← u_base_off4072_j0] at
   rw [← u_base_off4064_j0] at hv_u4; rw [← q_addr_j0] at
   have raw := divK_loop_body_n4_call_addback_j0_beq_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
     hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
     hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu hcarry2_nz
   have raw' := raw hborrow
@@ -150,15 +150,15 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
 @[irreducible]
 def preloopMaxAddbackBeqPostN4 (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   loopBodyN4AddbackBeqPost sp (0 : Word) (signExtend12 4095) b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -174,22 +174,22 @@ def preloopMaxAddbackBeqPostN4 (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Double-addback carry2≠0 condition at n=4 with max trial quotient (expressed over a/b). -/
 def isAddbackCarry2NzN4MaxAb (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   isAddbackCarry2NzN4Max b0' b1' b2' b3' u0 u1 u2 u3 u4
 
 /-- n=4 pre-loop + max+addback BEQ loop body: base → base+908 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -229,7 +229,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxAddbackBeqPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -237,15 +237,15 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
   unfold isAddbackBorrowN4Max at hborrow
   unfold isAddbackCarry2NzN4MaxAb at hcarry2_nz
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
   have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
@@ -253,7 +253,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
   have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_nz
 
 
@@ -261,7 +261,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_addback_j0_beq_norm sp base
-    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11_old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
 
     hbltu hcarry2_nz
@@ -298,20 +298,20 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
 @[irreducible]
 def preloopCallAddbackBeqPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  loopBodyN4AddbackBeqPost sp (0 : Word) q_hat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat b0' b1' b2' b3' u0 u1 u2 u3 u4 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3') **
   (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -329,23 +329,23 @@ def preloopCallAddbackBeqPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
 /-- Double-addback carry2≠0 condition at n=4 with call trial quotient (expressed over a/b). -/
 def isAddbackCarry2NzN4CallAb (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   isAddbackCarry2NzN4Call b0' b1' b2' b3' u0 u1 u2 u3 u4
 
 /-- n=4 pre-loop + call+addback BEQ loop body: base → base+908 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
     (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
@@ -386,24 +386,24 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isCallTrialN4 at hbltu
   unfold isAddbackBorrowN4Call at hborrow
   unfold isAddbackCarry2NzN4CallAb at hcarry2_nz
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
   have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
@@ -411,19 +411,19 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
   have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm sp base
-    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11_old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0
+    retMem dMem dloMem scratch_un0
     hv_j hv_n hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
 
     hbltu hcarry2_nz
@@ -455,39 +455,39 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
 theorem preloopMaxAddbackBeqPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopMaxAddbackBeqPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    let q_hat : Word := signExtend12 4095
-    let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+    let qHat : Word := signExtend12 4095
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
     let c3 := ms.2.2.2.2
     let u4_new := u4 - c3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-    let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-                 else q_hat + signExtend12 4095
-    let un0_out := if carry = 0 then ab'.1 else ab.1
-    let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-    let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-    let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+    let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+                 else qHat + signExtend12 4095
+    let un0Out := if carry = 0 then ab'.1 else ab.1
+    let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+    let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+    let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_out) **
-     (.x2 ↦ᵣ un3_out) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ un3Out) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ un0_out) **
-     ((sp + 40) ↦ₘ b1') ** ((sp + signExtend12 4048) ↦ₘ un1_out) **
-     ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ un2_out) **
-     ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ un3_out) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ un0Out) **
+     ((sp + 40) ↦ₘ b1') ** ((sp + signExtend12 4048) ↦ₘ un1Out) **
+     ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ un2Out) **
+     ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ un3Out) **
      ((sp + signExtend12 4024) ↦ₘ u4_out) **
      ((sp + signExtend12 4088) ↦ₘ q_out)) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -511,30 +511,30 @@ theorem preloopMaxAddbackBeqPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 @[irreducible]
 def fullDivN4MaxAddbackBeqPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   let c3 := ms.2.2.2.2
-  let u4_new := (a3 >>> (anti_shift.toNat % 64)) - c3
+  let u4_new := (a3 >>> (antiShift.toNat % 64)) - c3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  denormDivPost sp shift un0_out un1_out un2_out un3_out q_out 0 0 0 **
+  denormDivPost sp shift un0Out un1Out un2Out un3Out q_out 0 0 0 **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -549,7 +549,7 @@ def fullDivN4MaxAddbackBeqPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, max+addback BEQ). -/
 theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -589,44 +589,44 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullDivN4MaxAddbackBeqPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   let c3 := ms.2.2.2.2
-  let u4_new := (a3 >>> (anti_shift.toNat % 64)) - c3
+  let u4_new := (a3 >>> (antiShift.toNat % 64)) - c3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   have hA := evm_div_n4_preloop_max_addback_beq_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
     hbnz hb3nz hshift_nz
 
 
     hbltu hcarry2_nz hborrow
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
-    un0_out un1_out un2_out un3_out shift
-    un3_out (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    un0Out un1Out un2Out un3Out shift
+    un3Out (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
     c3 q_out 0 0 0
     b0' b1' b2' b3'
     hshift_nz
@@ -658,41 +658,41 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
 theorem preloopCallAddbackBeqPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    let q_hat := div128Quot u4 u3 b3'
+    let qHat := div128Quot u4 u3 b3'
     let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
     let c3 := ms.2.2.2.2
     let u4_new := u4 - c3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-    let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-                 else q_hat + signExtend12 4095
-    let un0_out := if carry = 0 then ab'.1 else ab.1
-    let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-    let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-    let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+    let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+                 else qHat + signExtend12 4095
+    let un0Out := if carry = 0 then ab'.1 else ab.1
+    let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+    let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+    let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_out) **
-     (.x2 ↦ᵣ un3_out) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ un3Out) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ un0_out) **
-     ((sp + 40) ↦ₘ b1') ** ((sp + signExtend12 4048) ↦ₘ un1_out) **
-     ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ un2_out) **
-     ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ un3_out) **
+     ((sp + 32) ↦ₘ b0') ** ((sp + signExtend12 4056) ↦ₘ un0Out) **
+     ((sp + 40) ↦ₘ b1') ** ((sp + signExtend12 4048) ↦ₘ un1Out) **
+     ((sp + 48) ↦ₘ b2') ** ((sp + signExtend12 4040) ↦ₘ un2Out) **
+     ((sp + 56) ↦ₘ b3') ** ((sp + signExtend12 4032) ↦ₘ un3Out) **
      ((sp + signExtend12 4024) ↦ₘ u4_out) **
      ((sp + signExtend12 4088) ↦ₘ q_out)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
@@ -715,33 +715,33 @@ theorem preloopCallAddbackBeqPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
 @[irreducible]
 def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let u4_new := u4 - c3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  denormDivPost sp shift un0_out un1_out un2_out un3_out q_out 0 0 0 **
+  denormDivPost sp shift un0Out un1Out un2Out un3Out q_out 0 0 0 **
   ((sp + signExtend12 3992) ↦ₘ shift) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -760,8 +760,8 @@ def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+addback BEQ). -/
 theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
     (hv_q0 : isValidDwordAccess (sp + signExtend12 4088) = true)
@@ -802,51 +802,51 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (fullDivN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat := div128Quot u4 u3 b3'
+  let qHat := div128Quot u4 u3 b3'
   let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0
-    ((a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64)))
-    ((a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64)))
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0
+    ((a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)))
+    ((a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)))
     u3
   let c3 := ms.2.2.2.2
   let u4_new := u4 - c3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   have hA := evm_div_n4_preloop_call_addback_beq_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3nz hshift_nz
 
 
     hv_uhi hv_ulo hv_vtop halign
     hbltu hcarry2_nz hborrow
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
-    un0_out un1_out un2_out un3_out shift
-    un3_out (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    un0Out un1Out un2Out un3Out shift
+    un3Out (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
     c3 q_out 0 0 0
     b0' b1' b2' b3'
     hshift_nz

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -23,7 +23,7 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 /-- Loop body n=4, max+addback (BEQ double-addback), j=0 with sp-relative addresses. -/
 theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
     (hv_uhi : isValidDwordAccess (sp + signExtend12 4056 - (0 + (4 : Word)) <<< (3 : BitVec 6).toNat) = true)
@@ -39,10 +39,10 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
     (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
     (hv_q : isValidDwordAccess (sp + signExtend12 4088) = true)
-    (hbltu : ¬BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let q_hat : Word := signExtend12 4095
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -54,9 +54,9 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro q_hat hborrow
   rw [← se12_32] at hv_v0; rw [← se12_40] at
   rw [← se12_48] at hv_v2; rw [← se12_56] at
@@ -64,7 +64,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
   rw [← u_base_off4080_j0] at hv_u2; rw [← u_base_off4072_j0] at
   rw [← u_base_off4064_j0] at hv_u4; rw [← q_addr_j0] at
   have raw := divK_loop_body_n4_max_addback_j0_beq_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
 
     hv_v3 hv_u3 hv_u4 hv_q hbltu hcarry2_nz hborrow
   simp only [se12_32, se12_40, se12_48, se12_56,
@@ -75,7 +75,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_norm (sp base : Word)
 /-- Loop body n=4, call+addback (BEQ double-addback), j=0 with sp-relative addresses. -/
 theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hv_j : isValidDwordAccess (sp + signExtend12 3976) = true)
     (hv_n1 : isValidDwordAccess (sp + signExtend12 3984) = true)
@@ -97,12 +97,12 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
     (hv_u3 : isValidDwordAccess (sp + signExtend12 4032) = true)
     (hv_u4 : isValidDwordAccess (sp + signExtend12 4024) = true)
     (hv_q : isValidDwordAccess (sp + signExtend12 4088) = true)
-    (hbltu : BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let q_hat := div128Quot u_top u3 v3
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let q_hat := div128Quot uTop u3 v3
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -114,13 +114,13 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -132,7 +132,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
   rw [← u_base_off4080_j0] at hv_u2; rw [← u_base_off4072_j0] at
   rw [← u_base_off4064_j0] at hv_u4; rw [← q_addr_j0] at
   have raw := divK_loop_body_n4_call_addback_j0_beq_divCode sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
     hv_j hv_n1 hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
     hv_v0 hv_u0 hv_v1 hv_u1 hv_v2 hv_u2 hv_v3 hv_u3 hv_u4 hv_q hbltu hcarry2_nz
   have raw' := raw hborrow

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -53,19 +53,19 @@ theorem q_addr_j0 (sp : Word) :
 -- ============================================================================
 
 /-- At j=0, loopExitPostN4 normalizes to sp-relative addresses. -/
-theorem loopExitPostN4_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
+theorem loopExitPostN4_j0_eq (sp q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
-    loopExitPostN4 sp (0 : Word) q_f c3 un0_f un1_f un2_f un3_f u4_f v0 v1 v2 v3 =
+    loopExitPostN4 sp (0 : Word) q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
      (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
-     (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0_f) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1_f) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2_f) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3_f) **
-     ((sp + signExtend12 4024) ↦ₘ u4_f) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ un0F) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ un1F) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ un2F) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ un3F) **
+     ((sp + signExtend12 4024) ↦ₘ u4F) **
      ((sp + signExtend12 4088) ↦ₘ q_f)) := by
   simp only [loopExitPost_unfold]
   rw [u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
@@ -82,49 +82,49 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hborrow)
 
 /-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_modCode` /
     `_divCode` code-extended loop-body specs. Wraps the 21-atom sepConj
-    chain that the `let u_base / qAddr` bindings make awkward in the
+    chain that the `let uBase / qAddr` bindings make awkward in the
     raw statement. Marked `@[irreducible]` so the `let`-bound offsets
     don't pollute callers' types. -/
 @[irreducible]
 def loopBodyN4SkipJ0Pre
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
   (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
   (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
   (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-  ((u_base + signExtend12 4064) ↦ₘ uTop) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+  ((uBase + signExtend12 4064) ↦ₘ uTop) **
   (qAddr ↦ₘ q_old)
 
 /-- Named unfold for `loopBodyN4SkipJ0Pre`. -/
@@ -133,18 +133,18 @@ theorem loopBodyN4SkipJ0Pre_unfold
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word) :
     loopBodyN4SkipJ0Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old =
-    (let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    (let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
      let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
      (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
      (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
      (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
      (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old)) := by
   delta loopBodyN4SkipJ0Pre; rfl
 
@@ -177,7 +177,7 @@ theorem divK_loop_body_n4_max_skip_j0_modCode
 
 /-- Max_skip j=0 loop body against modCode with sp-relative addresses in the
     precondition. Mirror of the DIV `divK_loop_body_n4_max_skip_j0_norm`
-    with `divCode → modCode`. `q_hat = signExtend12 4095` is inlined so no
+    with `divCode → modCode`. `qHat = signExtend12 4095` is inlined so no
     `let` bindings appear in the statement. -/
 theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
@@ -218,11 +218,11 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
 theorem divK_loop_body_n4_call_skip_j0_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -248,37 +248,37 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign hbltu hborrow)
 
 -- ============================================================================
@@ -292,24 +292,24 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_max_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hcarry2_nz hborrow)
@@ -318,12 +318,12 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
 theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -349,37 +349,37 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign hbltu hcarry2_nz hborrow)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -79,13 +79,13 @@ theorem loopExitPostN4_j0_eq (sp q_f c3 un0_f un1_f un2_f un3_f u4_f
 /-- Extend max_skip j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_max_skip_j0_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3) :
+    (hbltu : ¬BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -96,13 +96,13 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hborrow)
 
 /-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_modCode` /
     `_divCode` code-extended loop-body specs. Wraps the 21-atom sepConj
@@ -112,7 +112,7 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
 @[irreducible]
 def loopBodyN4SkipJ0Pre
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word) : Assertion :=
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word) : Assertion :=
   let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -124,15 +124,15 @@ def loopBodyN4SkipJ0Pre
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-  ((u_base + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base + signExtend12 4064) ↦ₘ uTop) **
   (q_addr ↦ₘ q_old)
 
 /-- Named unfold for `loopBodyN4SkipJ0Pre`. -/
 theorem loopBodyN4SkipJ0Pre_unfold
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word) :
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word) :
     loopBodyN4SkipJ0Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old =
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old =
     (let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
      let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
      (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -144,7 +144,7 @@ theorem loopBodyN4SkipJ0Pre_unfold
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old)) := by
   delta loopBodyN4SkipJ0Pre; rfl
 
@@ -156,20 +156,20 @@ theorem loopBodyN4SkipJ0Pre_unfold
     appear in the statement. -/
 theorem divK_loop_body_n4_max_skip_j0_modCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3)
-    (hborrow : (if BitVec.ult u_top
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4SkipJ0Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old)
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old)
       (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
     (divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hborrow)
   refine cpsTriple_weaken ?_ (fun _ hq => hq) h
   intro _ hp
   rw [loopBodyN4SkipJ0Pre_unfold] at hp
@@ -181,9 +181,9 @@ theorem divK_loop_body_n4_max_skip_j0_modCode
     `let` bindings appear in the statement. -/
 theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
     (j_old v5_old v6_old v7_old v10_old v11_old v2_old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (hbltu : ¬BitVec.ult u_top v3)
-    (hborrow : (if BitVec.ult u_top
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
@@ -196,12 +196,12 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
        ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u_top) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
        ((sp + signExtend12 4088) ↦ₘ q_old))
       (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   have raw := divK_loop_body_n4_max_skip_j0_modCode sp j_old v5_old v6_old v7_old
-    v10_old v11_old v2_old v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hborrow
+    v10_old v11_old v2_old v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hborrow
   refine cpsTriple_weaken ?_ (fun _ hq => hq) raw
   intro _ hp
   rw [loopBodyN4SkipJ0Pre_unfold]
@@ -217,19 +217,19 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
 /-- Extend call_skip j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_call_skip_j0_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3) :
+    (hbltu : BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -250,7 +250,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -261,13 +261,13 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -278,7 +278,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
         q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign hbltu hborrow)
 
 -- ============================================================================
@@ -288,14 +288,14 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
 /-- Extend max_addback (BEQ double-addback) j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_max_addback_j0_beq_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -306,31 +306,31 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_max_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz hborrow)
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu hcarry2_nz hborrow)
 
 /-- Extend call_addback (BEQ double-addback) j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -351,7 +351,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     let q0' := if BitVec.ult rhat2_un0 q0_dlo then q0c + signExtend12 4095 else q0c
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -362,13 +362,13 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -379,7 +379,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
         q_addr hborrow
   exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
     (divK_loop_body_n4_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign hbltu hcarry2_nz hborrow)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -33,8 +33,8 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 /-- Skip addback condition at n=4 with shift=0 call path: borrow = 0. -/
 def isSkipBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
-  let q_hat := div128Quot (0 : Word) a3 b3
-  (if BitVec.ult (0 : Word) (mulsubN4_c3 q_hat b0 b1 b2 b3 a0 a1 a2 a3)
+  let qHat := div128Quot (0 : Word) a3 b3
+  (if BitVec.ult (0 : Word) (mulsubN4_c3 qHat b0 b1 b2 b3 a0 a1 a2 a3)
    then (1 : Word) else 0) = (0 : Word)
 
 -- ============================================================================
@@ -45,10 +45,10 @@ def isSkipBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
     Uses unnormalized b[] and a[] directly (no shift). -/
 @[irreducible]
 def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
-  let q_hat := div128Quot (0 : Word) a3 b3
+  let qHat := div128Quot (0 : Word) a3 b3
   let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  loopBodyN4SkipPost sp (0 : Word) q_hat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
+  loopBodyN4SkipPost sp (0 : Word) qHat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -71,8 +71,8 @@ def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
 /-- n=4 pre-loop + call+skip loop body: base → base+904 (shift = 0). -/
 theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0)
@@ -93,25 +93,25 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isSkipBorrowN4Shift0 at hborrow
   -- Pre-loop: base → base+448 (shift=0)
   have hPre := evm_div_n4_shift0_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_z
 
 
-  -- Frame preloop with x11, jMem, ret_mem, d_mem, dlo_mem, scratch_un0
+  -- Frame preloop with x11, jMem, retMem, dMem, dloMem, scratch_un0
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   -- Loop body: base+448 → base+904, call+skip with v=b, u=a, uTop=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
@@ -119,7 +119,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     jMem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
     v11_old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
     b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
-    ret_mem d_mem dlo_mem scratch_un0 halign
+    retMem dMem dloMem scratch_un0 halign
 
     hbltu
   intro_lets at hLoop
@@ -153,13 +153,13 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
 /-- Unfold preloopShift0CallSkipPostN4 to expanded sp-relative form. -/
 theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
-    let q_hat := div128Quot (0 : Word) a3 b3
+    let qHat := div128Quot (0 : Word) a3 b3
     let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+    let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ signExtend12 4095) **
      (.x5 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ sp + signExtend12 4056) **
-     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ q_hat) **
+     (.x7 ↦ᵣ sp + signExtend12 4088) ** (.x10 ↦ᵣ ms.2.2.2.2) ** (.x11 ↦ᵣ qHat) **
      (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      ((sp + 32) ↦ₘ b0) ** ((sp + signExtend12 4056) ↦ₘ ms.1) **
@@ -167,7 +167,7 @@ theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
      ((sp + 48) ↦ₘ b2) ** ((sp + signExtend12 4040) ↦ₘ ms.2.2.1) **
      ((sp + 56) ↦ₘ b3) ** ((sp + signExtend12 4032) ↦ₘ ms.2.2.2.1) **
      ((sp + signExtend12 4024) ↦ₘ (0 : Word) - ms.2.2.2.2) **
-     ((sp + signExtend12 4088) ↦ₘ q_hat)) **
+     ((sp + signExtend12 4088) ↦ₘ qHat)) **
     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
     (sp + signExtend12 3960 ↦ₘ b3) **
     (sp + signExtend12 3952 ↦ₘ dLo) **
@@ -192,15 +192,15 @@ theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Wo
     No denormalization needed since shift=0. -/
 @[irreducible]
 def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
-  let q_hat := div128Quot (0 : Word) a3 b3
-  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
-  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ q_hat) **
+  let qHat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
+  (.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ qHat) **
   (.x6 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ (0 : Word)) **
   (.x2 ↦ᵣ ms.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ (0 : Word)) **
   ((sp + signExtend12 3992) ↦ₘ (0 : Word)) **
-  ((sp + signExtend12 4088) ↦ₘ q_hat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4088) ↦ₘ qHat) ** ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
   ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
-  ((sp + 32) ↦ₘ q_hat) ** ((sp + 40) ↦ₘ (0 : Word)) **
+  ((sp + 32) ↦ₘ qHat) ** ((sp + 40) ↦ₘ (0 : Word)) **
   ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
   ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
   ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -214,7 +214,7 @@ def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
   ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
   (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
   (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ b3) **
   (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **
@@ -228,8 +228,8 @@ def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
     Composes pre-loop + loop body + shift=0 epilogue. -/
 theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0)
@@ -247,25 +247,25 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (fullDivN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
-  let q_hat := div128Quot (0 : Word) a3 b3
-  let ms := mulsubN4 q_hat b0 b1 b2 b3 a0 a1 a2 a3
+  let qHat := div128Quot (0 : Word) a3 b3
+  let ms := mulsubN4 qHat b0 b1 b2 b3 a0 a1 a2 a3
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_shift0_call_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
-    ret_mem d_mem dlo_mem scratch_un0
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
     hbnz hb3nz hshift_z halign hborrow
   -- 2. Post-loop: base+904 → base+1068 (shift=0 epilogue)
   have hB := evm_div_shift0_epilogue_spec sp base
     ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (0 : Word)
     ms.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
     ms.2.2.2.2
-    q_hat 0 0 0
+    qHat 0 0 0
     b0 b1 b2 b3
     rfl
   -- Frame post-loop with remaining atoms
@@ -282,7 +282,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ b3) **
      (sp + signExtend12 3952 ↦ₘ (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -113,7 +113,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
      (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
-  -- Loop body: base+448 → base+904, call+skip with v=b, u=a, u_top=0
+  -- Loop body: base+448 → base+904, call+skip with v=b, u=a, uTop=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
   have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
     j_mem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -49,21 +49,21 @@ private theorem d128_sub_mod (base : Word) (k : Nat) (addr : Word) (instr : Inst
 
 -- ============================================================================
 -- mod_div128_spec: compose 5 block specs into single subroutine theorem.
--- Entry: base+1072, Exit: ret_addr (via JALR), CodeReq: modCode base.
+-- Entry: base+1072, Exit: retAddr (via JALR), CodeReq: modCode base.
 -- ============================================================================
 
-theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
+theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1_old v6_old v11_old : Word)
-    (ret_mem d_mem dlo_mem un0_mem : Word)
-    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
+    (retMem dMem dloMem un0Mem : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     -- Phase 1 intermediates
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     -- Step 1 intermediates
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + dHi
@@ -86,22 +86,22 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    cpsTriple (base + div128Off) ret_addr (modCode base)
+    cpsTriple (base + div128Off) retAddr (modCode base)
       (-- Precondition: caller registers + scratch memory
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
        (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x11 ↦ᵣ v11_old) **
        (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ q1') **
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
        (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0Dlo) **
        (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ ret_addr) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
@@ -109,10 +109,10 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
-  -- Saves ret/d, splits d and u_lo into halves.
+  -- Saves ret/d, splits d and uLo into halves.
   -- ================================================================
-  have hph1 := divK_div128_phase1_spec sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-    ret_mem d_mem dlo_mem un0_mem (base + div128Off)
+  have hph1 := divK_div128_phase1_spec sp retAddr d uLo uHi v1_old v6_old v11_old
+    retMem dMem dloMem un0Mem (base + div128Off)
   rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
   -- Extend phase1 cr to modCode
   have hph1e := cpsTriple_extend_code (hmono := by
@@ -136,7 +136,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Block 2: Step 1 (base+1112 → base+1172)
   -- Trial division q1, clamp, product check.
   -- ================================================================
-  have hst1 := divK_div128_step1_spec sp u_hi dHi un1 dLo un0 d dLo
+  have hst1 := divK_div128_step1_spec sp uHi dHi un1 dLo un0 d dLo
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
@@ -158,7 +158,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
   have hst1f := cpsTriple_frameR
-    ((.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
+    ((.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hst1e
   -- Compose phase1 → step1
@@ -181,7 +181,7 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
     ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr) **
+     (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0))
     (by pcFree) hcue
   -- Compose (phase1→step1) → compute_un21
@@ -213,17 +213,17 @@ theorem mod_div128_spec (sp ret_addr d u_lo u_hi : Word) (base : Word)
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
-    ((.x10 ↦ᵣ q1') ** (.x2 ↦ᵣ ret_addr) **
-     (sp + signExtend12 3968 ↦ₘ ret_addr) ** (sp + signExtend12 3960 ↦ₘ d))
+    ((.x10 ↦ᵣ q1') ** (.x2 ↦ᵣ retAddr) **
+     (sp + signExtend12 3968 ↦ₘ retAddr) ** (sp + signExtend12 3960 ↦ₘ d))
     (by pcFree) hst2e
   -- Compose (→step1→compute_un21) → step2
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
-  -- Block 5: End (base+1252 → ret_addr via JALR)
+  -- Block 5: End (base+1252 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' ret_addr un0 ret_addr
+  have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub_mod base 45 _ _ (by decide) (by bv_addr) (by decide))

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -32,22 +32,22 @@ private theorem divK_denorm_code_sub_modCode (base : Word) :
     Used when shift≠0. The BEQ and LD are handled separately.
     Mirror of divK_denorm_body_spec from Epilogue.lean with modCode. -/
 theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word) :
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (anti_shift.toNat % 64))
-    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (anti_shift.toNat % 64))
-    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
+    let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
+    let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
     cpsTriple (base + 916) (base + epilogueOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
        ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
-  intro anti_shift u0' u1' u2' u3'
-  -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute anti_shift
+  intro antiShift u0' u1' u2' u3'
+  -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
   have haddi := addi_x0_spec_gen .x2 v2 0 (base + 916) (by nofun)
   rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
   have haddie := cpsTriple_extend_code (hmono := fun a i h =>
@@ -81,7 +81,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
   have h_anti := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
-  have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift anti_shift (base + 924)
+  have hm0 := divK_denorm_merge_spec 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + 924)
   rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
   have hm0e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
@@ -96,7 +96,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec 4048 4040 sp u1 u2
-    u0' (u1 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 948)
+    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + 948)
   rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
@@ -111,7 +111,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec 4040 4032 sp u2 u3
-    u1' (u2 <<< (anti_shift.toNat % 64)) shift anti_shift (base + 972)
+    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + 972)
   rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode base a i
@@ -133,7 +133,7 @@ theorem mod_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Word
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frameR
-    ((.x7 ↦ᵣ (u3 <<< (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) ** (.x0 ↦ᵣ (0 : Word)) **
+    ((.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
      ((sp + signExtend12 4040) ↦ₘ u2'))
     (by pcFree) hle

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64
     base → base+116. Zeroes q[], u5..u7, stores n=4, loads b[1..3]. -/
 theorem evm_mod_phaseAB_n4_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
     cpsTriple base (base + clzOff) (modCode base)
@@ -37,7 +37,7 @@ theorem evm_mod_phaseAB_n4_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b3) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 32) ↦ₘ b0) **
@@ -52,10 +52,10 @@ theorem evm_mod_phaseAB_n4_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   have hB := evm_mod_phaseB_n4_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -75,7 +75,7 @@ theorem evm_mod_phaseAB_n4_spec (sp base : Word)
     base → base+212. After CLZ, x6 = shift count, x5 = shifted leading limb. -/
 theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (modCode base)
@@ -86,7 +86,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -96,7 +96,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
        ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
        ((sp + signExtend12 4000) ↦ₘ (0 : Word)) ** ((sp + signExtend12 3984) ↦ₘ (4 : Word))) := by
   have hAB := evm_mod_phaseAB_n4_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   have hCLZ := mod_clz_spec b3 b1 b2 base
   have hCLZf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
@@ -122,7 +122,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
     base → base+312. b[0..3] normalized in-place. -/
 theorem evm_mod_n4_to_normB_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -134,13 +134,13 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
   have hABCLZ := evm_mod_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
      ((sp + signExtend12 3992) ↦ₘ shiftMem))
@@ -163,7 +163,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
   -- NormB
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
     (clzResult b3).2 ((clzResult b3).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -188,7 +188,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     base → base+448. Normalizes b[] and a[], sets up loop parameters. -/
 theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -206,23 +206,23 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: Through NormB (base → base+312)
   have hNormB := evm_mod_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem hbnz hb3nz hshift_nz
+    q0 q1 q2 q3 u5 u6 u7 nMem shiftMem hbnz hb3nz hshift_nz
 
   have hNormBf := cpsTriple_frameR
     ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -234,7 +234,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     (by pcFree) hNormB
   -- Step 2: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -255,8 +255,8 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -285,7 +285,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
@@ -303,7 +303,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -323,7 +323,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1)) := by
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3nz
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b0, x6 = shift = clzResult(b0).1. -/
 theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
     cpsTriple base (base + phaseC2Off) (modCode base)
@@ -37,7 +37,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -53,11 +53,11 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=1 (includes b0 in assertion, no framing needed)
   have hB := evm_mod_phaseB_n1_spec sp base b0 b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2z hb1z
   have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hB
@@ -87,7 +87,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
@@ -105,23 +105,23 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b0).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=1) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n1_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1z
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -157,7 +157,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
     (clzResult b0).2 ((clzResult b0).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -177,7 +177,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -198,8 +198,8 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -228,7 +228,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
@@ -246,7 +246,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (1 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -266,7 +266,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b0).1)) := by
   -- Step 1: PhaseAB(n=1) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n1_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1z
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1z
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b1, x6 = shift = clzResult(b1).1. -/
 theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (modCode base)
@@ -37,7 +37,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -53,11 +53,11 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=2
   have hB := evm_mod_phaseB_n2_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2z hb1nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -90,7 +90,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
@@ -108,23 +108,23 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=2) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n2_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -160,7 +160,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
     (clzResult b1).2 ((clzResult b1).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -180,7 +180,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -201,8 +201,8 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -231,7 +231,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
@@ -249,7 +249,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -269,7 +269,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b1).1)) := by
   -- Step 1: PhaseAB(n=2) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n2_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2z hb1nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2z hb1nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64
     base → base+212. CLZ on b2, x6 = shift = clzResult(b2).1. -/
 theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
     cpsTriple base (base + phaseC2Off) (modCode base)
@@ -37,7 +37,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -53,11 +53,11 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   -- Phase B n=3
   have hB := evm_mod_phaseB_n3_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3z hb2nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -90,7 +90,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
@@ -108,23 +108,23 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b2).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=3) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n3_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -160,7 +160,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
   -- Step 3: NormB (base+228 → base+312)
   have hNB := mod_normB_full_spec sp b0 b1 b2 b3
     (clzResult b2).2 ((clzResult b2).2 >>> (63 : Nat))
-    shift anti_shift base
+    shift antiShift base
   intro_lets at hNB
   have hNBf := cpsTriple_frameR
     ((.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -180,7 +180,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) hABC2 hNBf
   -- Step 4: NormA (base+312 → base+432)
   have hNormA := mod_normA_full_spec sp a0 a1 a2 a3
-    b0' (b0 >>> (anti_shift.toNat % 64)) b3 shift anti_shift
+    b0' (b0 >>> (antiShift.toNat % 64)) b3 shift antiShift
     u0_old u1_old u2_old u3_old u4_old base
   intro_lets at hNormA
   have hNormAf := cpsTriple_frameR
@@ -201,8 +201,8 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (signExtend12 (4 : BitVec 12) - (4 : Word)) u1 base
     (by decide)
   have hLSf := cpsTriple_frameR
-    ((.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+     (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ u0) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
@@ -231,7 +231,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
@@ -249,7 +249,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -269,7 +269,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 3992) ↦ₘ (clzResult b2).1)) := by
   -- Step 1: PhaseAB(n=3) + CLZ (base → base+212)
   have hABCLZ := evm_mod_phaseAB_n3_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3z hb2nz
+    q0 q1 q2 q3 u5 u6 u7 nMem hbnz hb3z hb2nz
 
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
     and the DIV/MOD-specific loopSetup/loop-body theorems swapped. -/
 theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -47,32 +47,32 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isMaxTrialN4 at hbltu
   unfold isSkipBorrowN4Max at hborrow
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (anti_shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_mod_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem
     hbnz hb3nz hshift_nz
   have hPreF := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_skip_j0_norm_modCode sp base
-    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11_old antiShift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     hbltu hborrow
   have hLoopF := cpsTriple_frameR
@@ -106,7 +106,7 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
     `modCode` and the MOD-specific post-loop composer. -/
 theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -127,26 +127,26 @@ theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
-  let anti_shift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
   let b0' := b0 <<< (shift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   -- 1. Pre-loop + loop body: base → base+denormOff
   have hA := evm_mod_n4_preloop_max_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 nMem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   -- 2. Post-loop: base+denormOff → base+nopOff (modCode)
   have hB := evm_mod_preamble_denorm_epilogue_spec sp base
@@ -157,19 +157,19 @@ theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
     hshift_nz
   -- Frame post-loop with remainder atoms (4 q cells, a-atoms, zeros, x1, x11)
   have hBF := cpsTriple_frameR
-    (((sp + signExtend12 4088) ↦ₘ q_hat) **
+    (((sp + signExtend12 4088) ↦ₘ qHat) **
      ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (anti_shift.toNat % 64)) - ms.2.2.2.2) **
+     ((sp + signExtend12 4024) ↦ₘ (a3 >>> (antiShift.toNat % 64)) - ms.2.2.2.2) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_hat))
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ qHat))
     (by pcFree) hB
   -- 3. Compose A + B
   have hFull := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -41,7 +41,7 @@ private theorem beq_shift_sub_modCode (base : Word) :
 
 -- `se13_172` → use `se13_172` from `Compose/Base.lean`.
 
-/-- Phase C2 body (base+212 -> base+224): store shift, compute anti_shift.
+/-- Phase C2 body (base+212 -> base+224): store shift, compute antiShift.
     Extends to modCode. Uses first 3 instructions of phaseC2. -/
 private theorem mod_phaseC2_body_modCode (sp shift v2 shiftMem : Word) (base : Word) :
     cpsTriple (base + phaseC2Off) (base + 224) (modCode base)
@@ -129,21 +129,21 @@ private theorem divK_normB_code_sub_modCode (base : Word) :
 
 /-- NormB first half: merge1 (b[3] with b[2]) + merge2 (b[2] with b[1]).
     base+228 -> base+276 (12 instructions). MOD mirror. -/
-private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
     cpsTriple (base + normBOff) (base + 276) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2'
   -- Merge 1: b[3] with b[2] (base+228 -> base+252)
-  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + normBOff)
+  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift antiShift (base + normBOff)
   simp only [se12_56, se12_48] at hm1
   rw [show (base + normBOff : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -156,8 +156,8 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
     (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1))
     (by pcFree) hm1e
   -- Merge 2: b[2] with b[1] (base+252 -> base+276)
-  have hm2 := divK_normB_merge_spec 48 40 sp b2 b1 b3' (b2 >>> (anti_shift.toNat % 64))
-    shift anti_shift (base + 252)
+  have hm2 := divK_normB_merge_spec 48 40 sp b2 b1 b3' (b2 >>> (antiShift.toNat % 64))
+    shift antiShift (base + 252)
   simp only [se12_48, se12_40] at hm2
   rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -177,22 +177,22 @@ private theorem mod_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (
 
 /-- NormB second half: merge3 (b[1] with b[0]) + last (b[0] shift).
     base+276 -> base+312 (9 instructions). MOD mirror. -/
-private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base : Word) :
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift antiShift : Word) (base : Word) :
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple (base + 276) (base + normAOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b1' b0'
   -- Merge 3: b[1] with b[0] (base+276 -> base+300)
   have hm3 := divK_normB_merge_spec 40 32 sp b1 b0
-    b2' (b1 >>> (anti_shift.toNat % 64)) shift anti_shift (base + 276)
+    b2' (b1 >>> (antiShift.toNat % 64)) shift antiShift (base + 276)
   simp only [se12_40, se12_32] at hm3
   rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -213,7 +213,7 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
         (divK_normB_last_prog 32) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frameR
-    ((.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hle
   have h34 := cpsTriple_seq_perm_same_cr
@@ -226,23 +226,23 @@ private theorem mod_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base
 /-- Full NormB for modCode: normalize divisor b[0..3] in place by left-shifting.
     base+228 -> base+312 (21 instructions).
     MOD mirror of divK_normB_full_spec. -/
-theorem mod_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+theorem mod_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple (base + normBOff) (base + normAOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2' b1' b0'
-  have h1 := mod_normB_half1 sp b0 b1 b2 b3 v5 v7 shift anti_shift base
-  have h2 := mod_normB_half2 sp b0 b1 b2' b3' shift anti_shift base
+  have h1 := mod_normB_half1 sp b0 b1 b2 b3 v5 v7 shift antiShift base
+  have h2 := mod_normB_half2 sp b0 b1 b2' b3' shift antiShift base
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -34,23 +34,23 @@ private theorem divK_normA_code_sub_modCode (base : Word) :
 /-- Full NormA for modCode: normalize dividend a[0..3] -> u[0..4] and jump to loopSetup.
     base+312 -> base+432 (21 instructions including JAL).
     MOD mirror of divK_normA_full_spec. -/
-theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
+theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0_old u1_old u2_old u3_old u4_old : Word) (base : Word) :
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     cpsTriple (base + normAOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
        ((sp + signExtend12 4056) ↦ₘ u0_old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -58,7 +58,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
        ((sp + signExtend12 4056) ↦ₘ u0)) := by
   intro u4 u3 u2 u1 u0
   -- Top: LD a[3], SRL->u[4], SD u[4] (base+312 -> base+324)
-  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + normAOff)
+  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 antiShift u4_old (base + normAOff)
   simp only [signExtend12_24] at htop
   rw [show (base + normAOff : Word) + 12 = base + 324 from by bv_addr] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
@@ -75,7 +75,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) htope
   -- MergeA 1: u[3] = (a[3]<<<shift) | (a[2]>>>anti) (base+324 -> base+344)
-  have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift anti_shift u3_old (base + 324)
+  have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift antiShift u3_old (base + 324)
   simp only [signExtend12_16] at hma1
   rw [show (base + 324 : Word) + 20 = base + 344 from by bv_addr] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -92,8 +92,8 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) htopef hma1ef
   -- MergeB: u[2] = (a[2]<<<shift) | (a[1]>>>anti) (base+344 -> base+364)
-  have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (anti_shift.toNat % 64))
-    shift anti_shift u2_old (base + 344)
+  have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (antiShift.toNat % 64))
+    shift antiShift u2_old (base + 344)
   simp only [signExtend12_8] at hmb
   rw [show (base + 344 : Word) + 20 = base + 364 from by bv_addr] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
@@ -109,8 +109,8 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hmbef
   -- MergeA 2: u[1] = (a[1]<<<shift) | (a[0]>>>anti) (base+364 -> base+384)
-  have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (anti_shift.toNat % 64))
-    shift anti_shift u1_old (base + 364)
+  have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (antiShift.toNat % 64))
+    shift antiShift u1_old (base + 364)
   simp only [signExtend12_0] at hma2
   rw [show (base + 364 : Word) + 20 = base + 384 from by bv_addr] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -134,7 +134,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
         (divK_normA_last_prog 4056) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
   have hlastef := cpsTriple_frameR
-    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -157,8 +157,8 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
   let postAll := (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) **
-    (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+    (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -114,7 +114,7 @@ theorem mod_phB_sp24_32 (sp : Word) :
     init1 → init2 → ADDI x5=4 → BNE(taken, b[3]≠0) → tail. -/
 theorem evm_mod_phaseB_n4_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3nz : b3 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -124,7 +124,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b3) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -140,7 +140,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- Step 2: init2 (base+60 → base+68) — load b[1], b[2]
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -163,7 +163,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   have hbne := cpsTriple_extend_code (bne_x10_singleton_sub_modCode base) hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]
-  have htail_raw := divK_phaseB_tail_spec sp (4 : Word) b3 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (4 : Word) b3 nMem (base + 96)
   simp only [mod_phB_t_20, mod_phB_sp24_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw
   seqFrame hinit1fhinit2haddihbne htail
@@ -249,7 +249,7 @@ theorem addi_x5_1_sub_modCode (base : Word) :
 -- signExtend13 constants for cascade branches: `signExtend13_{8,16}` now live
 -- in `Compose/Base.lean` (shared with PhaseAB). `se12_*` come from AddrNorm.
 
--- nm1_x8 = (n + signExtend12 4095) <<< 3 for each n value
+-- nm1X8 = (n + signExtend12 4095) <<< 3 for each n value
 theorem mod_divK_phaseB_n3_nm1_x8 :
     ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
   decide

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -21,7 +21,7 @@ open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se12_32)
     Exit at base+116. x5 = b[1] (leading limb), n = 2. -/
 theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -31,7 +31,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -47,7 +47,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -60,7 +60,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -75,7 +75,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -95,7 +95,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -110,7 +110,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -130,7 +130,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
@@ -145,7 +145,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi2
   have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
@@ -165,12 +165,12 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne2
   have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 nMem (base + 96)
   simp only [mod_phB_t_20, mod_divK_phaseB_n2_nm1_x8, se12_32,
     mod_phB_sp8_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw
@@ -201,7 +201,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     Note: b[0] must be in precondition since the tail loads from sp+32. -/
 theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -211,7 +211,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -227,7 +227,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -240,7 +240,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -255,7 +255,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -275,7 +275,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -290,7 +290,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -310,7 +310,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
@@ -325,7 +325,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi2
   have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
@@ -345,7 +345,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne2
   have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
@@ -360,12 +360,12 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi3
   have h123456789 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 nMem (base + 96)
   simp only [mod_phB_t_20, mod_divK_phaseB_n1_nm1_x8, se12_32,
     mod_phB_sp0_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -20,7 +20,7 @@ open EvmAsm.Rv64.AddrNorm (se13_16 se13_24 se12_32)
     Exit at base+116 (start of CLZ). x5 = b[2] (leading limb), n = 3. -/
 theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -30,7 +30,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -46,7 +46,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -59,7 +59,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -74,7 +74,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -94,7 +94,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -109,7 +109,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -129,12 +129,12 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 nMem (base + 96)
   simp only [mod_phB_t_20, mod_divK_phaseB_n3_nm1_x8, se12_32,
     mod_phB_sp16_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_modCode base) htail_raw

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -35,7 +35,7 @@ private theorem beq_shift_sub_divCode (base : Word) :
 
 -- `se13_172` moved to `Compose/Base.lean` (shared with ModNorm).
 
-/-- Phase C2 body (base+212 → base+224): store shift, compute anti_shift.
+/-- Phase C2 body (base+212 → base+224): store shift, compute antiShift.
     Extends to divCode. Uses first 3 instructions of phaseC2. -/
 private theorem divK_phaseC2_body_divCode (sp shift v2 shiftMem : Word) (base : Word) :
     cpsTriple (base + phaseC2Off) (base + 224) (divCode base)
@@ -48,7 +48,7 @@ private theorem divK_phaseC2_body_divCode (sp shift v2 shiftMem : Word) (base : 
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_divCode base) hbody
 
 /-- Phase C2 when shift ≠ 0: falls through to normB at base+228.
-    Stores shift to scratch, computes anti_shift = -shift. -/
+    Stores shift to scratch, computes antiShift = -shift. -/
 theorem divK_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
     cpsTriple (base + phaseC2Off) (base + normBOff) (divCode base)
@@ -78,7 +78,7 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
     hC2
 
 /-- Phase C2 when shift = 0: branches to copyAU at base+396.
-    Stores shift (=0) to scratch, computes anti_shift = 0. -/
+    Stores shift (=0) to scratch, computes antiShift = 0. -/
 theorem divK_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_z : shift = 0) :
     cpsTriple (base + phaseC2Off) (base + copyAUOff) (divCode base)
@@ -123,21 +123,21 @@ private theorem divK_normB_code_sub_divCode (base : Word) :
 
 /-- NormB first half: merge1 (b[3] with b[2]) + merge2 (b[2] with b[1]).
     base+228 → base+276 (12 instructions). -/
-private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
+private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
     cpsTriple (base + normBOff) (base + 276) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2'
   -- Merge 1: b[3] with b[2] (base+228 → base+252)
-  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift anti_shift (base + normBOff)
+  have hm1 := divK_normB_merge_spec 56 48 sp b3 b2 v5 v7 shift antiShift (base + normBOff)
   simp only [se12_56, se12_48] at hm1
   rw [show (base + normBOff : Word) + 24 = base + 252 from by bv_addr] at hm1
   have hm1e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -150,8 +150,8 @@ private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) 
     (((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1))
     (by pcFree) hm1e
   -- Merge 2: b[2] with b[1] (base+252 → base+276)
-  have hm2 := divK_normB_merge_spec 48 40 sp b2 b1 b3' (b2 >>> (anti_shift.toNat % 64))
-    shift anti_shift (base + 252)
+  have hm2 := divK_normB_merge_spec 48 40 sp b2 b1 b3' (b2 >>> (antiShift.toNat % 64))
+    shift antiShift (base + 252)
   simp only [se12_48, se12_40] at hm2
   rw [show (base + 252 : Word) + 24 = base + 276 from by bv_addr] at hm2
   have hm2e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -171,22 +171,22 @@ private theorem divK_normB_half1 (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) 
 
 /-- NormB second half: merge3 (b[1] with b[0]) + last (b[0] shift).
     base+276 → base+312 (9 instructions). -/
-private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (base : Word) :
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift antiShift : Word) (base : Word) :
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple (base + 276) (base + normAOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2') ** (.x7 ↦ᵣ (b1 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b1' b0'
   -- Merge 3: b[1] with b[0] (base+276 → base+300)
   have hm3 := divK_normB_merge_spec 40 32 sp b1 b0
-    b2' (b1 >>> (anti_shift.toNat % 64)) shift anti_shift (base + 276)
+    b2' (b1 >>> (antiShift.toNat % 64)) shift antiShift (base + 276)
   simp only [se12_40, se12_32] at hm3
   rw [show (base + 276 : Word) + 24 = base + 300 from by bv_addr] at hm3
   have hm3e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -207,7 +207,7 @@ private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (bas
         (divK_normB_last_prog 32) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTriple_frameR
-    ((.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 40) ↦ₘ b1') ** ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3'))
     (by pcFree) hle
   have h34 := cpsTriple_seq_perm_same_cr
@@ -219,25 +219,25 @@ private theorem divK_normB_half2 (sp b0 b1 b2' b3' shift anti_shift : Word) (bas
 
 /-- Full NormB: normalize divisor b[0..3] in place by left-shifting.
     base+228 → base+312 (21 instructions).
-    Pre: x12=sp, x6=shift, x2=anti_shift, b[0..3] at sp+32..56.
-    Post: b[i] normalized, x5=b[0]<<<shift, x7=b[0]>>>anti_shift. -/
-theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift anti_shift : Word) (base : Word) :
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    Pre: x12=sp, x6=shift, x2=antiShift, b[0..3] at sp+32..56.
+    Post: b[i] normalized, x5=b[0]<<<shift, x7=b[0]>>>antiShift. -/
+theorem divK_normB_full_spec (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word) (base : Word) :
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
     cpsTriple (base + normBOff) (base + normAOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0') ** (.x7 ↦ᵣ (b0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 32) ↦ₘ b0') ** ((sp + 40) ↦ₘ b1') **
        ((sp + 48) ↦ₘ b2') ** ((sp + 56) ↦ₘ b3')) := by
   intro b3' b2' b1' b0'
-  have h1 := divK_normB_half1 sp b0 b1 b2 b3 v5 v7 shift anti_shift base
-  have h2 := divK_normB_half2 sp b0 b1 b2' b3' shift anti_shift base
+  have h1 := divK_normB_half1 sp b0 b1 b2 b3 v5 v7 shift antiShift base
+  have h2 := divK_normB_half2 sp b0 b1 b2' b3' shift antiShift base
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -32,24 +32,24 @@ open EvmAsm.Rv64.AddrNorm (se13_464 se21_40 bv64_4mul_3)
 
 /-- Full NormA: normalize dividend a[0..3] → u[0..4] and jump to loopSetup.
     base+312 → base+432 (21 instructions including JAL).
-    u[4] = a[3]>>>anti_shift, u[3..0] = merged shifted limbs. -/
-theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
+    u[4] = a[3]>>>antiShift, u[3..0] = merged shifted limbs. -/
+theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     (u0_old u1_old u2_old u3_old u4_old : Word) (base : Word) :
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     cpsTriple (base + normAOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ u4_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
        ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
        ((sp + signExtend12 4056) ↦ₘ u0_old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -57,7 +57,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
        ((sp + signExtend12 4056) ↦ₘ u0)) := by
   intro u4 u3 u2 u1 u0
   -- Top: LD a[3], SRL→u[4], SD u[4] (base+312 → base+324)
-  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 anti_shift u4_old (base + normAOff)
+  have htop := divK_normA_top_spec 24 4024 sp a3 v5 v7 antiShift u4_old (base + normAOff)
   simp only [se12_24] at htop
   rw [show (base + normAOff : Word) + 12 = base + 324 from by bv_addr] at htop
   have htope := cpsTriple_extend_code (hmono := fun a i h =>
@@ -74,7 +74,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old))
     (by pcFree) htope
   -- MergeA 1: u[3] = (a[3]<<<shift) | (a[2]>>>anti) (base+324 → base+344)
-  have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift anti_shift u3_old (base + 324)
+  have hma1 := divK_normA_mergeA_spec 16 4032 sp a3 a2 u4 v10 shift antiShift u3_old (base + 324)
   simp only [se12_16] at hma1
   rw [show (base + 324 : Word) + 20 = base + 344 from by bv_addr] at hma1
   have hma1e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -91,8 +91,8 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) htopef hma1ef
   -- MergeB: u[2] = (a[2]<<<shift) | (a[1]>>>anti) (base+344 → base+364)
-  have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (anti_shift.toNat % 64))
-    shift anti_shift u2_old (base + 344)
+  have hmb := divK_normA_mergeB_spec 8 4040 sp a2 a1 u3 (a2 >>> (antiShift.toNat % 64))
+    shift antiShift u2_old (base + 344)
   simp only [se12_8] at hmb
   rw [show (base + 344 : Word) + 20 = base + 364 from by bv_addr] at hmb
   have hmbe := cpsTriple_extend_code (hmono := fun a i h =>
@@ -108,8 +108,8 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hmbef
   -- MergeA 2: u[1] = (a[1]<<<shift) | (a[0]>>>anti) (base+364 → base+384)
-  have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (anti_shift.toNat % 64))
-    shift anti_shift u1_old (base + 364)
+  have hma2 := divK_normA_mergeA_spec 0 4048 sp a1 a0 u2 (a1 >>> (antiShift.toNat % 64))
+    shift antiShift u1_old (base + 364)
   simp only [se12_0] at hma2
   rw [show (base + 364 : Word) + 20 = base + 384 from by bv_addr] at hma2
   have hma2e := cpsTriple_extend_code (hmono := fun a i h =>
@@ -133,7 +133,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
         (divK_normA_last_prog 4056) 18
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hlast
   have hlastef := cpsTriple_frameR
-    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) ** (.x2 ↦ᵣ anti_shift) **
+    ((.x5 ↦ᵣ u1) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) ** (.x2 ↦ᵣ antiShift) **
      ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
@@ -156,8 +156,8 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift anti_shift : Word)
         exact hlookup) a i h)) hjal
   -- Frame JAL with everything, then strip empAssertion via consequence
   let postAll := (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) **
-    (.x10 ↦ᵣ (a0 >>> (anti_shift.toNat % 64))) **
-    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+    (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
+    (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
     ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
     ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -133,7 +133,7 @@ private theorem divK_phaseB_tail_code_sub_divCode (base : Word) :
 -- and `Rv64/Instructions.lean` respectively — call sites use the shared names
 -- (`signExtend13_24`, `signExtend13_1020`, `signExtend12_4`) directly.
 
--- Phase B tail address: nm1_x8 = (4 + signExtend12 4095) <<< 3 = 24
+-- Phase B tail address: nm1X8 = (4 + signExtend12 4095) <<< 3 = 24
 private theorem divK_phaseB_n4_nm1_x8 :
     ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (24 : Word) := by
   decide
@@ -265,7 +265,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
     Exit at base+116 (start of CLZ). x5 = b[3] (leading limb), x6 = b[1], x7 = b[2], n = 4. -/
 theorem evm_div_phaseB_n4_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3nz : b3 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -275,7 +275,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b3) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -291,7 +291,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- Step 2: init2 (base+60 → base+68) — load b[1], b[2]
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -314,7 +314,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   have hbne := cpsTriple_extend_code (bne_x10_singleton_sub_divCode base) hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]
-  have htail_raw := divK_phaseB_tail_spec sp (4 : Word) b3 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (4 : Word) b3 nMem (base + 96)
   simp only [phB_t_20, divK_phaseB_n4_nm1_x8, signExtend12_32, phB_sp24_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_divCode base) htail_raw
   seqFrame hinit1fhinit2haddihbne htail
@@ -334,7 +334,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
     Pre/postcondition shapes reflect frame structure from composition. -/
 theorem evm_div_phaseAB_n4_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
     cpsTriple base (base + clzOff) (divCode base)
@@ -345,7 +345,7 @@ theorem evm_div_phaseAB_n4_spec (sp base : Word)
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b3) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 32) ↦ₘ b0) **
@@ -360,10 +360,10 @@ theorem evm_div_phaseAB_n4_spec (sp base : Word)
      ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
-     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hA
   have hB := evm_div_phaseB_n4_spec sp base b1 b2 b3
-    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 n_mem
+    (b0 ||| b1 ||| b2 ||| b3) v6 v7 q0 q1 q2 q3 u5 u6 u7 nMem
     hb3nz
   have hBf := cpsTriple_frameR
     (((sp + 32) ↦ₘ b0))
@@ -452,7 +452,7 @@ private theorem addi_x5_1_sub_divCode (base : Word) :
 -- `divK_se12_{1,2,3}` removed: use `signExtend12_{1,2,3}` from Rv64/Instructions.lean.
 -- `signExtend13_{8,16}` moved to `Compose/Base.lean` (shared with MOD side).
 
--- nm1_x8 = (n + signExtend12 4095) <<< 3 for each n value
+-- nm1X8 = (n + signExtend12 4095) <<< 3 for each n value
 private theorem divK_phaseB_n3_nm1_x8 :
     ((3 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat = (16 : Word) := by
   decide
@@ -485,7 +485,7 @@ private theorem phB_sp0_32 (sp : Word) : (sp + (0 : Word) + (32 : Word)) = sp + 
     Exit at base+116 (start of CLZ). x5 = b[2] (leading limb), n = 3. -/
 theorem evm_div_phaseB_n3_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -495,7 +495,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b2) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -511,7 +511,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -524,7 +524,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -539,7 +539,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -559,7 +559,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -574,7 +574,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -594,12 +594,12 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (3 : Word) b2 nMem (base + 96)
   simp only [phB_t_20, divK_phaseB_n3_nm1_x8, signExtend12_32, phB_sp16_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_divCode base) htail_raw
   have htailf := cpsTriple_frameR
@@ -628,7 +628,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
     Exit at base+116. x5 = b[1] (leading limb), n = 2. -/
 theorem evm_div_phaseB_n2_spec (sp base : Word)
     (b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -638,7 +638,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b1) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -654,7 +654,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -667,7 +667,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -682,7 +682,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -702,7 +702,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -717,7 +717,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -737,7 +737,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
@@ -752,7 +752,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi2
   have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
@@ -772,12 +772,12 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne2
   have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (2 : Word) b1 nMem (base + 96)
   simp only [phB_t_20, divK_phaseB_n2_nm1_x8, signExtend12_32, phB_sp8_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_divCode base) htail_raw
   have htailf := cpsTriple_frameR
@@ -807,7 +807,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
     Note: b[0] must be in precondition since the tail loads from sp+32. -/
 theorem evm_div_phaseB_n1_spec (sp base : Word)
     (b0 b1 b2 b3 : Word) (v5 v6 v7 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0) :
     cpsTriple (base + phaseBOff) (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -817,7 +817,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem))
+       ((sp + signExtend12 3984) ↦ₘ nMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
@@ -833,7 +833,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hinit1f := cpsTriple_frameR
     ((.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
   have hinit2_raw := divK_phaseB_init2_spec sp (base + 60) b1 b2 v6 v7
@@ -846,7 +846,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit2
   have h12 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
@@ -861,7 +861,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi0
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 haddi0f
@@ -881,7 +881,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne0
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne0f
@@ -896,7 +896,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi1
   have h12345 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
@@ -916,7 +916,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne1
   have h123456 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
@@ -931,7 +931,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi2
   have h1234567 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
@@ -951,7 +951,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hbne2
   have h12345678 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
@@ -966,12 +966,12 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
      ((sp + signExtend12 4072) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4016) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
      ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 3984) ↦ₘ n_mem))
+     ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) haddi3
   have h123456789 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 n_mem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec sp (1 : Word) b0 nMem (base + 96)
   simp only [phB_t_20, divK_phaseB_n1_nm1_x8, signExtend12_32, phB_sp0_32] at htail_raw
   have htail := cpsTriple_extend_code (divK_phaseB_tail_code_sub_divCode base) htail_raw
   have htailf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
@@ -2,7 +2,7 @@
   EvmAsm.Evm64.DivMod.LimbSpec.AddBack
 
   CPS specs for one limb of the Knuth Algorithm D "add-back" correction,
-  which un-does the mul-sub when `q_hat` over-shot by 1:
+  which un-does the mul-sub when `qHat` over-shot by 1:
     * `divK_addback_partA_spec` — 5 instructions (LD, LD, ADD, SLTU, ADD):
       load v[i] and u[j+i], form `uPlusCarry = u_i + carryIn`, its
       SLTU `carry1`, and `uNew = uPlusCarry + v_i`.
@@ -30,7 +30,7 @@ open EvmAsm.Rv64
 
 /-- Add-back Part A: LD v[i], LD u[j+i], ADD carry, SLTU carry1, ADD v[i].
     5 instructions. Produces sum (x2) and carry1 (x7). -/
-theorem divK_addback_partA_spec (sp u_base carryIn v5_old v2_old v_i u_i : Word)
+theorem divK_addback_partA_spec (sp uBase carryIn v5_old v2_old v_i u_i : Word)
     (v_off : BitVec 12) (u_off : BitVec 12) (base : Word) :
     let uPlusCarry := u_i + carryIn
     let carry1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
@@ -42,17 +42,17 @@ theorem divK_addback_partA_spec (sp u_base carryIn v5_old v2_old v_i u_i : Word)
       (CodeReq.union (CodeReq.singleton (base + 12) (.SLTU .x7 .x2 .x7))
        (CodeReq.singleton (base + 16) (.ADD .x2 .x2 .x5)))))
     cpsTriple base (base + 20) cr
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryIn) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry1) **
+       ((uBase + signExtend12 u_off) ↦ₘ u_i))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry1) **
        (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ u_i)) := by
   intro uPlusCarry carry1 uNew cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
-  have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
+  have I1 := ld_spec_gen .x2 .x6 uBase v2_old u_i u_off (base + 4) (by nofun)
   have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carryIn (base + 8) (by nofun)
   have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carryIn (base + 12) (by nofun)
   have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 uPlusCarry v_i (base + 16) (by nofun)
@@ -60,7 +60,7 @@ theorem divK_addback_partA_spec (sp u_base carryIn v5_old v2_old v_i u_i : Word)
 
 /-- Add-back Part B: SLTU carry2, OR carryOut, SD uNew.
     3 instructions. Produces carryOut (x7) and stores uNew. -/
-theorem divK_addback_partB_spec (u_base carry1 v_i uNew u_i : Word)
+theorem divK_addback_partB_spec (uBase carry1 v_i uNew u_i : Word)
     (u_off : BitVec 12) (base : Word) :
     let carry2 := if BitVec.ult uNew v_i then (1 : Word) else 0
     let carryOut := carry1 ||| carry2
@@ -69,16 +69,16 @@ theorem divK_addback_partB_spec (u_base carry1 v_i uNew u_i : Word)
       (CodeReq.union (CodeReq.singleton (base + 4) (.OR .x7 .x7 .x5))
        (CodeReq.singleton (base + 8) (.SD .x6 .x2 u_off)))
     cpsTriple base (base + 12) cr
-      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry1) **
+      ((.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry1) **
        (.x5 ↦ᵣ v_i) ** (.x2 ↦ᵣ uNew) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryOut) **
+       ((uBase + signExtend12 u_off) ↦ₘ u_i))
+      ((.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carryOut) **
        (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ uNew) **
-       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ uNew)) := by
   intro carry2 carryOut cr
   have I0 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 uNew v_i base (by nofun)
   have I1 := or_spec_gen_rd_eq_rs1 .x7 .x5 carry1 carry2 (base + 4) (by nofun)
-  have I2 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 8)
+  have I2 := sd_spec_gen .x6 .x2 uBase uNew u_i u_off (base + 8)
   runBlock I0 I1 I2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -5,7 +5,7 @@
   step:
     * `divK_addback_final_spec` — 4 instructions (LD, ADD, SD, ADDI)
       that add the final carry to `u[j+4]` after the add-back corrections
-      and decrement `q_hat`.
+      and decrement `qHat`.
     * `divK_loop_control_spec` — 2-instruction `cpsBranch` (ADDI + BGE)
       that decrements `j` and branches back to the top of the loop while
       `j ≥ 0`.
@@ -29,25 +29,25 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Add-back finalization after limb corrections. -/
-theorem divK_addback_final_spec (u_base carry q_hat v5_old uTop : Word)
+theorem divK_addback_final_spec (uBase carry qHat v5_old uTop : Word)
     (u_off : BitVec 12) (base : Word) :
     let uNew := uTop + carry
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x5 .x5 .x7))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SD .x6 .x5 u_off))
        (CodeReq.singleton (base + 12) (.ADDI .x11 .x11 4095))))
     cpsTriple base (base + 16) cr
-      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ v5_old) ** (u_base + signExtend12 u_off ↦ₘ uTop))
-      ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat') **
-       (.x5 ↦ᵣ uNew) ** (u_base + signExtend12 u_off ↦ₘ uNew)) := by
-  intro uNew q_hat' cr
-  have I0 := ld_spec_gen .x5 .x6 u_base v5_old uTop u_off base (by nofun)
+      ((.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ v5_old) ** (uBase + signExtend12 u_off ↦ₘ uTop))
+      ((.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ qHat') **
+       (.x5 ↦ᵣ uNew) ** (uBase + signExtend12 u_off ↦ₘ uNew)) := by
+  intro uNew qHat' cr
+  have I0 := ld_spec_gen .x5 .x6 uBase v5_old uTop u_off base (by nofun)
   have I1 := add_spec_gen_rd_eq_rs1 .x5 .x7 uTop carry (base + 4) (by nofun)
-  have I2 := sd_spec_gen .x6 .x5 u_base uNew uTop u_off (base + 8)
-  have I3 := addi_spec_gen_same .x11 q_hat 4095 (base + 12) (by nofun)
+  have I2 := sd_spec_gen .x6 .x5 uBase uNew uTop u_off (base + 8)
+  have I3 := addi_spec_gen_same .x11 qHat 4095 (base + 12) (by nofun)
   runBlock I0 I1 I2 I3
 
 /-- Loop control: decrement j and branch back if j >= 0. -/

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -29,9 +29,9 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Add-back finalization after limb corrections. -/
-theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
+theorem divK_addback_final_spec (u_base carry q_hat v5_old uTop : Word)
     (u_off : BitVec 12) (base : Word) :
-    let uNew := u_top + carry
+    let uNew := uTop + carry
     let q_hat' := q_hat + signExtend12 4095
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
@@ -40,13 +40,13 @@ theorem divK_addback_final_spec (u_base carry q_hat v5_old u_top : Word)
        (CodeReq.singleton (base + 12) (.ADDI .x11 .x11 4095))))
     cpsTriple base (base + 16) cr
       ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ v5_old) ** (u_base + signExtend12 u_off ↦ₘ u_top))
+       (.x5 ↦ᵣ v5_old) ** (u_base + signExtend12 u_off ↦ₘ uTop))
       ((.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry) ** (.x11 ↦ᵣ q_hat') **
        (.x5 ↦ᵣ uNew) ** (u_base + signExtend12 u_off ↦ₘ uNew)) := by
   intro uNew q_hat' cr
-  have I0 := ld_spec_gen .x5 .x6 u_base v5_old u_top u_off base (by nofun)
-  have I1 := add_spec_gen_rd_eq_rs1 .x5 .x7 u_top carry (base + 4) (by nofun)
-  have I2 := sd_spec_gen .x6 .x5 u_base uNew u_top u_off (base + 8)
+  have I0 := ld_spec_gen .x5 .x6 u_base v5_old uTop u_off base (by nofun)
+  have I1 := add_spec_gen_rd_eq_rs1 .x5 .x7 uTop carry (base + 4) (by nofun)
+  have I2 := sd_spec_gen .x6 .x5 u_base uNew uTop u_off (base + 8)
   have I3 := addi_spec_gen_same .x11 q_hat 4095 (base + 12) (by nofun)
   runBlock I0 I1 I2 I3
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Denorm.lean
@@ -4,8 +4,8 @@
   Per-limb CPS specs for the Knuth Algorithm D denormalize phase:
     * `divK_denorm_merge_prog` / `divK_denorm_merge_code` / `divK_denorm_merge_spec`
       — 6-instruction merge: LD curr, LD next, SRL curr>>shift,
-        SLL next<<anti_shift, OR, SD curr. Computes
-        `result = (curr >>> shift) ||| (next <<< anti_shift)`.
+        SLL next<<antiShift, OR, SD curr. Computes
+        `result = (curr >>> shift) ||| (next <<< antiShift)`.
     * `divK_denorm_last_prog` / `divK_denorm_last_code` / `divK_denorm_last_spec`
       — 3-instruction last-limb: LD, SRL, SD. Computes `val >>> shift`.
 
@@ -39,30 +39,30 @@ abbrev divK_denorm_merge_code (curr_off next_off : BitVec 12) (base : Word) : Co
   CodeReq.ofProg base (divK_denorm_merge_prog curr_off next_off)
 
 /-- Denorm merge limb (6 instructions): LD curr, LD next, SRL, SLL, OR, SD.
-    Computes result = (curr >>> shift) ||| (next <<< anti_shift) and stores to curr_off.
-    x6 = shift, x2 = anti_shift. -/
+    Computes result = (curr >>> shift) ||| (next <<< antiShift) and stores to curr_off.
+    x6 = shift, x2 = antiShift. -/
 theorem divK_denorm_merge_spec (curr_off next_off : BitVec 12)
-    (sp curr next v5 v7 shift anti_shift : Word) (base : Word) :
+    (sp curr next v5 v7 shift antiShift : Word) (base : Word) :
     let shiftedCurr := curr >>> (shift.toNat % 64)
-    let shiftedNext := next <<< (anti_shift.toNat % 64)
+    let shiftedNext := next <<< (antiShift.toNat % 64)
     let result := shiftedCurr ||| shiftedNext
     let cr := divK_denorm_merge_code curr_off next_off base
     cpsTriple base (base + 24) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 curr_off) ↦ₘ curr) **
        ((sp + signExtend12 next_off) ↦ₘ next))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedNext) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 curr_off) ↦ₘ result) **
        ((sp + signExtend12 next_off) ↦ₘ next)) := by
   intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 curr curr_off base (by nofun)
   have I1 := ld_spec_gen .x7 .x12 sp v7 next next_off (base + 4) (by nofun)
   have I2 := srl_spec_gen_rd_eq_rs1 .x5 .x6 curr shift (base + 8) (by nofun)
-  have I3 := sll_spec_gen_rd_eq_rs1 .x7 .x2 next anti_shift (base + 12) (by nofun)
+  have I3 := sll_spec_gen_rd_eq_rs1 .x7 .x2 next antiShift (base + 12) (by nofun)
   have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shiftedCurr shiftedNext (base + 16) (by nofun)
   have I5 := sd_spec_gen .x12 .x5 sp result curr curr_off (base + 20)
   runBlock I0 I1 I2 I3 I4 I5

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Phase1.lean
@@ -8,9 +8,9 @@
       SRLI, SLLI, SRLI, SD) that saves the return address and `d` to
       scratch, and splits `d` into `dHi` / `dLo`.
     * `divK_div128_split_ulo_spec` — 4-instruction block (SRLI, SLLI,
-      SRLI, SD) that splits `u_lo` into `un1` / `un0` and saves `un0`.
+      SRLI, SD) that splits `uLo` into `un1` / `un0` and saves `un0`.
     * `divK_div128_step1_init_spec` — 3-instruction block (DIVU, MUL,
-      SUB) computing `q1 = u_hi / dHi` and `rhat = u_hi - q1 * dHi`.
+      SUB) computing `q1 = uHi / dHi` and `rhat = uHi - q1 * dHi`.
 
   Twentieth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -31,8 +31,8 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- div128 Phase 1a: save x2 (return addr) and x10 (d), compute dHi and dLo. -/
-theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
-    ret_mem d_mem dlo_mem : Word) (base : Word) :
+theorem divK_div128_save_split_d_spec (sp retAddr d v1_old v6_old
+    retMem dMem dloMem : Word) (base : Word) :
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let cr :=
@@ -43,63 +43,63 @@ theorem divK_div128_save_split_d_spec (sp ret_addr d v1_old v6_old
       (CodeReq.union (CodeReq.singleton (base + 16) (.SRLI .x1 .x1 32))
        (CodeReq.singleton (base + 20) (.SD .x12 .x1 3952))))))
     cpsTriple base (base + 24) cr
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem))
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem))
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) **
-       (sp + signExtend12 3968 ↦ₘ ret_addr) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo)) := by
   intro dHi dLo cr
-  have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
-  have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
+  have I0 := sd_spec_gen .x12 .x2 sp retAddr retMem 3968 base
+  have I1 := sd_spec_gen .x12 .x10 sp d dMem 3960 (base + 4)
   have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
   have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
   have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen .x12 .x1 sp dLo dlo_mem 3952 (base + 20)
+  have I5 := sd_spec_gen .x12 .x1 sp dLo dloMem 3952 (base + 20)
   runBlock I0 I1 I2 I3 I4 I5
 
-/-- div128 Phase 1b: split u_lo into un1 (x11) and un0 (x5), save un0. -/
-theorem divK_div128_split_ulo_spec (sp u_lo v11_old un0_mem : Word) (base : Word) :
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+/-- div128 Phase 1b: split uLo into un1 (x11) and un0 (x5), save un0. -/
+theorem divK_div128_split_ulo_spec (sp uLo v11_old un0Mem : Word) (base : Word) :
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SRLI .x11 .x5 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x5 32))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SRLI .x5 .x5 32))
        (CodeReq.singleton (base + 12) (.SD .x12 .x5 3944))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u_lo) ** (.x11 ↦ᵣ v11_old) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ uLo) ** (.x11 ↦ᵣ v11_old) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ un0) ** (.x11 ↦ᵣ un1) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro un1 un0 cr
-  have I0 := srli_spec_gen .x11 .x5 v11_old u_lo 32 base (by nofun)
-  have I1 := slli_spec_gen_same .x5 u_lo 32 (base + 4) (by nofun)
-  have I2 := srli_spec_gen_same .x5 (u_lo <<< (32 : BitVec 6).toNat) 32 (base + 8) (by nofun)
-  have I3 := sd_spec_gen .x12 .x5 sp un0 un0_mem 3944 (base + 12)
+  have I0 := srli_spec_gen .x11 .x5 v11_old uLo 32 base (by nofun)
+  have I1 := slli_spec_gen_same .x5 uLo 32 (base + 4) (by nofun)
+  have I2 := srli_spec_gen_same .x5 (uLo <<< (32 : BitVec 6).toNat) 32 (base + 8) (by nofun)
+  have I3 := sd_spec_gen .x12 .x5 sp un0 un0Mem 3944 (base + 12)
   runBlock I0 I1 I2 I3
 
-/-- div128 Step 1: q1 = DIVU(u_hi, dHi), rhat = u_hi - q1 * dHi. -/
-theorem divK_div128_step1_init_spec (u_hi dHi v5_old v10_old : Word) (base : Word) :
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+/-- div128 Step 1: q1 = DIVU(uHi, dHi), rhat = uHi - q1 * dHi. -/
+theorem divK_div128_step1_init_spec (uHi dHi v5_old v10_old : Word) (base : Word) :
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
        (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5)))
     cpsTriple base (base + 12) cr
-      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ dHi) **
+      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) **
        (.x10 ↦ᵣ v10_old) ** (.x5 ↦ᵣ v5_old))
       ((.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi) **
        (.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q1 * dHi)) := by
   intro q1 rhat cr
-  have I0 := divu_spec_gen .x10 .x7 .x6 v10_old u_hi dHi base (by nofun)
+  have I0 := divu_spec_gen .x10 .x7 .x6 v10_old uHi dHi base (by nofun)
   have I1 := mul_spec_gen .x5 .x10 .x6 v5_old q1 dHi (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 u_hi (q1 * dHi) (base + 8) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 uHi (q1 * dHi) (base + 8) (by nofun)
   runBlock I0 I1 I2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128PhaseEnd.lean
@@ -6,10 +6,10 @@
     * `divK_div128_phase1_spec` — Instrs [0]-[9], 10 instructions:
       SD+SD+SRLI+SLLI+SRLI+SD (save_split_d) followed by
       SRLI+SLLI+SRLI+SD (split_ulo). Saves the return address and `d`,
-      splits `d` into `dHi`/`dLo`, splits `u_lo` into `un1`/`un0`.
+      splits `d` into `dHi`/`dLo`, splits `uLo` into `un1`/`un0`.
     * `divK_div128_end_spec` — Instrs [45]-[48], 4 instructions:
       SLLI+OR (combine_q → `q = q1<<32 | q0`) followed by LD+JALR
-      (restore return addr and jump back). Exits at `ret_addr`.
+      (restore return addr and jump back). Exits at `retAddr`.
 
   Twenty-seventh chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -29,16 +29,16 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 Phase 1: save return addr/d, split d and u_lo. Instrs [0]-[9].
-    Input: x12=sp, x2=ret_addr, x10=d, x5=u_lo, x7=u_hi.
-    Output: x6=dHi, x11=un1, x5=un0 (saved), x7=u_hi (unchanged). -/
+/-- div128 Phase 1: save return addr/d, split d and uLo. Instrs [0]-[9].
+    Input: x12=sp, x2=retAddr, x10=d, x5=uLo, x7=uHi.
+    Output: x6=dHi, x11=un1, x5=un0 (saved), x7=uHi (unchanged). -/
 theorem divK_div128_phase1_spec
-    (sp ret_addr d u_lo u_hi v1_old v6_old v11_old
-     ret_mem d_mem dlo_mem un0_mem : Word) (base : Word) :
+    (sp retAddr d uLo uHi v1_old v6_old v11_old
+     retMem dMem dloMem un0Mem : Word) (base : Word) :
     let dHi := d >>> (32 : BitVec 6).toNat
     let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SD .x12 .x2 3968))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SD .x12 .x10 3960))
@@ -51,55 +51,55 @@ theorem divK_div128_phase1_spec
       (CodeReq.union (CodeReq.singleton (base + 32) (.SRLI .x5 .x5 32))
        (CodeReq.singleton (base + 36) (.SD .x12 .x5 3944))))))))))
     cpsTriple base (base + 40) cr
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
-       (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ u_lo) **
-       (.x11 ↦ᵣ v11_old) ** (.x7 ↦ᵣ u_hi) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (.x10 ↦ᵣ d) **
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x6 ↦ᵣ v6_old) ** (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ uLo) **
+       (.x11 ↦ᵣ v11_old) ** (.x7 ↦ᵣ uHi) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ dLo) ** (.x5 ↦ᵣ un0) **
-       (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ u_hi) **
-       (sp + signExtend12 3968 ↦ₘ ret_addr) **
+       (.x11 ↦ᵣ un1) ** (.x7 ↦ᵣ uHi) **
+       (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro dHi dLo un1 un0 cr
-  have I0 := sd_spec_gen .x12 .x2 sp ret_addr ret_mem 3968 base
-  have I1 := sd_spec_gen .x12 .x10 sp d d_mem 3960 (base + 4)
+  have I0 := sd_spec_gen .x12 .x2 sp retAddr retMem 3968 base
+  have I1 := sd_spec_gen .x12 .x10 sp d dMem 3960 (base + 4)
   have I2 := srli_spec_gen .x6 .x10 v6_old d 32 (base + 8) (by nofun)
   have I3 := slli_spec_gen .x1 .x10 v1_old d 32 (base + 12) (by nofun)
   have I4 := srli_spec_gen_same .x1 (d <<< (32 : BitVec 6).toNat) 32 (base + 16) (by nofun)
-  have I5 := sd_spec_gen .x12 .x1 sp dLo dlo_mem 3952 (base + 20)
-  have I6 := srli_spec_gen .x11 .x5 v11_old u_lo 32 (base + 24) (by nofun)
-  have I7 := slli_spec_gen_same .x5 u_lo 32 (base + 28) (by nofun)
-  have I8 := srli_spec_gen_same .x5 (u_lo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)
-  have I9 := sd_spec_gen .x12 .x5 sp un0 un0_mem 3944 (base + 36)
+  have I5 := sd_spec_gen .x12 .x1 sp dLo dloMem 3952 (base + 20)
+  have I6 := srli_spec_gen .x11 .x5 v11_old uLo 32 (base + 24) (by nofun)
+  have I7 := slli_spec_gen_same .x5 uLo 32 (base + 28) (by nofun)
+  have I8 := srli_spec_gen_same .x5 (uLo <<< (32 : BitVec 6).toNat) 32 (base + 32) (by nofun)
+  have I9 := sd_spec_gen .x12 .x5 sp un0 un0Mem 3944 (base + 36)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9
 
 /-- div128 end phase: combine q1,q0 into q, restore return addr, return.
-    Instrs [45]-[48]. Exit to ret_addr. -/
+    Instrs [45]-[48]. Exit to retAddr. -/
 theorem divK_div128_end_spec
-    (sp q1 q0 v2_old v11_old ret_addr : Word) (base : Word)
-    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
-    let q1_hi := q1 <<< (32 : BitVec 6).toNat
-    let q := q1_hi ||| q0
+    (sp q1 q0 v2_old v11_old retAddr : Word) (base : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
+    let q1Hi := q1 <<< (32 : BitVec 6).toNat
+    let q := q1Hi ||| q0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x11 .x10 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.OR .x11 .x11 .x5))
       (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x2 .x12 3968))
        (CodeReq.singleton (base + 12) (.JALR .x0 .x2 0))))
-    cpsTriple base ret_addr cr
+    cpsTriple base retAddr cr
       ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ v11_old) **
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ ret_addr))
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ retAddr))
       ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q) **
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr)) := by
-  intro q1_hi q cr
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr)) := by
+  intro q1Hi q cr
   have I0 := slli_spec_gen .x11 .x10 v11_old q1 32 base (by nofun)
-  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1_hi q0 (base + 4) (by nofun)
-  have I2 := ld_spec_gen .x2 .x12 sp v2_old ret_addr 3968 (base + 8) (by nofun)
-  have I3 := jalr_x0_spec_gen .x2 ret_addr 0 (base + 12)
+  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1Hi q0 (base + 4) (by nofun)
+  have I2 := ld_spec_gen .x2 .x12 sp v2_old retAddr 3968 (base + 8) (by nofun)
+  have I3 := jalr_x0_spec_gen .x2 retAddr 0 (base + 12)
   rw [halign] at I3
   runBlock I0 I1 I2 I3
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -28,12 +28,12 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- div128 step 1: trial division q1, clamp, product check. Instrs [10]-[24].
-    Input: u_hi in x7, dHi in x6, un1 in x11, dlo in memory.
+    Input: uHi in x7, dHi in x6, un1 in x11, dlo in memory.
     Output: refined q1 in x10, refined rhat in x7. -/
 theorem divK_div128_step1_spec
-    (sp u_hi dHi un1 v1_old v5_old v10_old dlo : Word) (base : Word) :
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+    (sp uHi dHi un1 v1_old v5_old v10_old dlo : Word) (base : Word) :
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let hi := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi = 0 then rhat else rhat + dHi
@@ -58,7 +58,7 @@ theorem divK_div128_step1_spec
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6)))))))))))))))
     cpsTriple base (base + 60) cr
-      ((.x7 ↦ᵣ u_hi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10_old) **
+      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10_old) **
        (.x5 ↦ᵣ v5_old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1_old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
       ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
@@ -81,7 +81,7 @@ theorem divK_div128_step1_spec
       (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))))))))))))))) := rfl
-  have h1_raw := divK_div128_step1_init_spec u_hi dHi v5_old v10_old base
+  have h1_raw := divK_div128_step1_init_spec uHi dHi v5_old v10_old base
   have h1 : cpsTriple base (base + 12) cr _ _ :=
     cpsTriple_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -117,31 +117,31 @@ theorem divK_div128_correct_q0_single_spec (q0 : Word) (base : Word) :
 
 /-- div128 combine: x11 = q1<<32 | q0. -/
 theorem divK_div128_combine_q_spec (q1 q0 v11_old : Word) (base : Word) :
-    let q1_hi := q1 <<< (32 : BitVec 6).toNat
-    let q := q1_hi ||| q0
+    let q1Hi := q1 <<< (32 : BitVec 6).toNat
+    let q := q1Hi ||| q0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x11 .x10 32))
        (CodeReq.singleton (base + 4) (.OR .x11 .x11 .x5))
     cpsTriple base (base + 8) cr
       ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ v11_old))
       ((.x10 ↦ᵣ q1) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ q)) := by
-  intro q1_hi q cr
+  intro q1Hi q cr
   have I0 := slli_spec_gen .x11 .x10 v11_old q1 32 base (by nofun)
-  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1_hi q0 (base + 4) (by nofun)
+  have I1 := or_spec_gen_rd_eq_rs1 .x11 .x5 q1Hi q0 (base + 4) (by nofun)
   runBlock I0 I1
 
 /-- div128 restore and return: load return addr, JALR x0 x2 0. -/
-theorem divK_div128_restore_return_spec (sp v2_old ret_addr : Word) (base : Word)
-    (halign : (ret_addr + signExtend12 0) &&& ~~~1 = ret_addr) :
+theorem divK_div128_restore_return_spec (sp v2_old retAddr : Word) (base : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x2 .x12 3968))
        (CodeReq.singleton (base + 4) (.JALR .x0 .x2 0))
-    cpsTriple base ret_addr cr
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ ret_addr))
-      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ ret_addr) ** (sp + signExtend12 3968 ↦ₘ ret_addr)) := by
+    cpsTriple base retAddr cr
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ v2_old) ** (sp + signExtend12 3968 ↦ₘ retAddr))
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr)) := by
   intro cr
-  have I0 := ld_spec_gen .x2 .x12 sp v2_old ret_addr 3968 base (by nofun)
-  have I1 := jalr_x0_spec_gen .x2 ret_addr 0 (base + 4)
+  have I0 := ld_spec_gen .x2 .x12 sp v2_old retAddr 3968 base (by nofun)
+  have I1 := jalr_x0_spec_gen .x2 retAddr 0 (base + 4)
   rw [halign] at I1
   runBlock I0 I1
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128UnProdCheck.lean
@@ -33,10 +33,10 @@ open EvmAsm.Rv64
 
 /-- div128 un21 = rhat*2^32 + un1 - q1*dLo.
     Loads dLo from scratch memory. -/
-theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Word) (base : Word) :
+theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dloMem : Word) (base : Word) :
     let rhatHi := rhat <<< (32 : BitVec 6).toNat
     let rhatUn1 := rhatHi ||| un1
-    let q1Dlo := q1 * dlo_mem
+    let q1Dlo := q1 * dloMem
     let un21 := rhatUn1 - q1Dlo
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
@@ -47,15 +47,15 @@ theorem divK_div128_compute_un21_spec (sp q1 rhat un1 v1_old v5_old dlo_mem : Wo
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) **
        (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5_old) ** (.x1 ↦ᵣ v1_old) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem))
+       (sp + signExtend12 3952 ↦ₘ dloMem))
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ un21) **
        (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ rhatUn1) ** (.x1 ↦ᵣ q1Dlo) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem)) := by
+       (sp + signExtend12 3952 ↦ₘ dloMem)) := by
   intro rhatHi rhatUn1 q1Dlo un21 cr
-  have I0 := ld_spec_gen .x1 .x12 sp v1_old dlo_mem 3952 base (by nofun)
+  have I0 := ld_spec_gen .x1 .x12 sp v1_old dloMem 3952 base (by nofun)
   have I1 := slli_spec_gen .x5 .x7 v5_old rhat 32 (base + 4) (by nofun)
   have I2 := or_spec_gen_rd_eq_rs1 .x5 .x11 rhatHi un1 (base + 8) (by nofun)
-  have I3 := mul_spec_gen_rd_eq_rs2 .x1 .x10 q1 dlo_mem (base + 12) (by nofun)
+  have I3 := mul_spec_gen_rd_eq_rs2 .x1 .x10 q1 dloMem (base + 12) (by nofun)
   have I4 := sub_spec_gen .x7 .x5 .x1 rhatUn1 q1Dlo rhat (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -2,7 +2,7 @@
   EvmAsm.Evm64.DivMod.LimbSpec.LoopSetup
 
   CPS specs for the Knuth Algorithm D main-loop setup:
-    * `divK_loopSetup_code` — `CodeReq.ofProg base (divK_loopSetup blt_off)`.
+    * `divK_loopSetup_code` — `CodeReq.ofProg base (divK_loopSetup bltOff)`.
     * `divK_loopSetup_body_spec` — 3-instruction body (LD n, ADDI x1 = 4,
       SUB x1 = 4 - n).
     * `divK_loopSetup_spec` — full `cpsBranch` wrapping body + BLT that
@@ -26,14 +26,14 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-abbrev divK_loopSetup_code (blt_off : BitVec 13) (base : Word) : CodeReq :=
-  CodeReq.ofProg base (divK_loopSetup blt_off)
+abbrev divK_loopSetup_code (bltOff : BitVec 13) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (divK_loopSetup bltOff)
 
 /-- Loop setup body: load n, compute m = 4 - n. 3 straight-line instructions.
     Uses signExtend12 4 directly to match addi_x0_spec_gen + sub_spec_gen output. -/
 theorem divK_loopSetup_body_spec (sp n v1 v5 : Word)
-    (blt_off : BitVec 13) (base : Word) :
-    let cr := divK_loopSetup_code blt_off base
+    (bltOff : BitVec 13) (base : Word) :
+    let cr := divK_loopSetup_code bltOff base
     cpsTriple base (base + 12) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -53,9 +53,9 @@ theorem divK_loopSetup_body_spec (sp n v1 v5 : Word)
     Taken: m < 0 (n > 4, impossible in practice but handled).
     Not taken: m >= 0, proceed to loop. -/
 theorem divK_loopSetup_spec (sp n v1 v5 : Word)
-    (blt_off : BitVec 13) (base : Word) :
+    (bltOff : BitVec 13) (base : Word) :
     let m := signExtend12 (4 : BitVec 12) - n
-    let cr := divK_loopSetup_code blt_off base
+    let cr := divK_loopSetup_code bltOff base
     let post :=
       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** (.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)) **
       ((sp + signExtend12 3984) ↦ₘ n)
@@ -64,17 +64,17 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x1 ↦ᵣ v1) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3984) ↦ₘ n))
       -- Taken: m < 0 (signed)
-      ((base + 12) + signExtend13 blt_off) post
+      ((base + 12) + signExtend13 bltOff) post
       -- Not taken: m >= 0
       (base + 16) post := by
   intro m cr post
-  have hbody := divK_loopSetup_body_spec sp n v1 v5 blt_off base
-  have hblt_raw := blt_spec_gen .x1 .x0 blt_off m (0 : Word) (base + 12)
+  have hbody := divK_loopSetup_body_spec sp n v1 v5 bltOff base
+  have hblt_raw := blt_spec_gen .x1 .x0 bltOff m (0 : Word) (base + 12)
   have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   rw [ha1] at hblt_raw
   have hblt : cpsBranch (base + 12) _
       ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
-      ((base + 12) + signExtend13 blt_off)
+      ((base + 12) + signExtend13 bltOff)
         ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word)))
       (base + 16)
         ((.x1 ↦ᵣ m) ** (.x0 ↦ᵣ (0 : Word))) :=
@@ -95,10 +95,10 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
     · next heq =>
       rw [beq_iff_eq] at heq; subst heq
       simp only [Option.some.injEq] at h; subst h
-      show divK_loopSetup_code blt_off base (base + 12) = _
-      have hlen : (divK_loopSetup blt_off).length = 4 := by
+      show divK_loopSetup_code bltOff base (base + 12) = _
+      have hlen : (divK_loopSetup bltOff).length = 4 := by
         unfold divK_loopSetup LD ADDI single seq; rfl
-      exact CodeReq.ofProg_lookup base (divK_loopSetup blt_off) 3
+      exact CodeReq.ofProg_lookup base (divK_loopSetup bltOff) 3
         (by omega) (by omega)
     · simp at h) hblt_framed
   have composed := cpsTriple_seq_cpsBranch_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
@@ -63,7 +63,7 @@ theorem divK_mulsub_partA_spec (sp qHat carryIn v5_old v7_old v_i : Word)
 
 /-- Mul-sub limb Part B: LD u[j+i], SLTU, SUB, ADD, SD.
     5 instructions. Produces carryOut (x10) and stores uNew. -/
-theorem divK_mulsub_partB_spec (u_base partialCarry prodHi fullSub v2_old u_i : Word)
+theorem divK_mulsub_partB_spec (uBase partialCarry prodHi fullSub v2_old u_i : Word)
     (u_off : BitVec 12) (base : Word) :
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     let uNew := u_i - fullSub
@@ -75,18 +75,18 @@ theorem divK_mulsub_partB_spec (u_base partialCarry prodHi fullSub v2_old u_i : 
       (CodeReq.union (CodeReq.singleton (base + 12) (.ADD .x10 .x10 .x5))
        (CodeReq.singleton (base + 16) (.SD .x6 .x2 u_off)))))
     cpsTriple base (base + 20) cr
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ partialCarry) **
+      ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ partialCarry) **
        (.x5 ↦ᵣ prodHi) ** (.x7 ↦ᵣ fullSub) ** (.x2 ↦ᵣ v2_old) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryOut) **
+       ((uBase + signExtend12 u_off) ↦ₘ u_i))
+      ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ carryOut) **
        (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) ** (.x2 ↦ᵣ uNew) **
-       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ uNew)) := by
   intro borrowSub uNew carryOut cr
-  have I0 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off base (by nofun)
+  have I0 := ld_spec_gen .x2 .x6 uBase v2_old u_i u_off base (by nofun)
   have I1 := sltu_spec_gen .x5 .x2 .x7 prodHi u_i fullSub (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i fullSub (base + 8) (by nofun)
   have I3 := add_spec_gen_rd_eq_rs1 .x10 .x5 partialCarry borrowSub (base + 12) (by nofun)
-  have I4 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 16)
+  have I4 := sd_spec_gen .x6 .x2 uBase uNew u_i u_off (base + 16)
   runBlock I0 I1 I2 I3 I4
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
@@ -32,7 +32,7 @@ open EvmAsm.Rv64
     Input: qHat (x11), carryIn (x10), v[i] and u[j+i] in memory.
     Output: carryOut (x10), uNew stored. -/
 theorem divK_mulsub_limb_spec
-    (sp u_base qHat carryIn v5_old v7_old v2_old v_i u_i : Word)
+    (sp uBase qHat carryIn v5_old v7_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
     let prodLo := qHat * v_i
     let prodHi := rv64_mulhu qHat v_i
@@ -56,15 +56,15 @@ theorem divK_mulsub_limb_spec
        (CodeReq.singleton (base + 40) (.SD .x6 .x2 u_off)))))))))))
     cpsTriple base (base + 44) cr
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryIn) **
-       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
+       (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i))
+       ((uBase + signExtend12 u_off) ↦ₘ u_i))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryOut) **
-       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) **
+       (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ borrowSub) ** (.x7 ↦ᵣ fullSub) **
        (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ uNew)) := by
   intro prodLo prodHi fullSub borrowAdd partialCarry borrowSub uNew carryOut cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := mul_spec_gen .x7 .x11 .x5 v7_old qHat v_i (base + 4) (by nofun)
@@ -72,18 +72,18 @@ theorem divK_mulsub_limb_spec
   have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carryIn (base + 12) (by nofun)
   have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carryIn (base + 16) (by nofun)
   have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrowAdd prodHi (base + 20) (by nofun)
-  have I6 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 24) (by nofun)
+  have I6 := ld_spec_gen .x2 .x6 uBase v2_old u_i u_off (base + 24) (by nofun)
   have I7 := sltu_spec_gen .x5 .x2 .x7 prodHi u_i fullSub (base + 28) (by nofun)
   have I8 := sub_spec_gen_rd_eq_rs1 .x2 .x7 u_i fullSub (base + 32) (by nofun)
   have I9 := add_spec_gen_rd_eq_rs1 .x10 .x5 partialCarry borrowSub (base + 36) (by nofun)
-  have I10 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 40)
+  have I10 := sd_spec_gen .x6 .x2 uBase uNew u_i u_off (base + 40)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10
 
 /-- Add-back full limb: partA (5 instrs) + partB (3 instrs) = 8 instructions.
     Input: carryIn (x7), v[i] and u[j+i] in memory.
     Output: carryOut (x7), uNew stored. -/
 theorem divK_addback_limb_spec
-    (sp u_base carryIn v5_old v2_old v_i u_i : Word)
+    (sp uBase carryIn v5_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
     let uPlusCarry := u_i + carryIn
     let carry1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
@@ -100,23 +100,23 @@ theorem divK_addback_limb_spec
       (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x7 .x7 .x5))
        (CodeReq.singleton (base + 28) (.SD .x6 .x2 u_off))))))))
     cpsTriple base (base + 32) cr
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryIn) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_i))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryOut) **
+       ((uBase + signExtend12 u_off) ↦ₘ u_i))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ carryOut) **
        (.x5 ↦ᵣ carry2) ** (.x2 ↦ᵣ uNew) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
-       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ uNew)) := by
   intro uPlusCarry carry1 uNew carry2 carryOut cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
-  have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
+  have I1 := ld_spec_gen .x2 .x6 uBase v2_old u_i u_off (base + 4) (by nofun)
   have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carryIn (base + 8) (by nofun)
   have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carryIn (base + 12) (by nofun)
   have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 uPlusCarry v_i (base + 16) (by nofun)
   have I5 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 uNew v_i (base + 20) (by nofun)
   have I6 := or_spec_gen_rd_eq_rs1 .x7 .x5 carry1 carry2 (base + 24) (by nofun)
-  have I7 := sd_spec_gen .x6 .x2 u_base uNew u_i u_off (base + 28)
+  have I7 := sd_spec_gen .x6 .x2 uBase uNew u_i u_off (base + 28)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubSetup.lean
@@ -4,7 +4,7 @@
   CPS specs for the small setup/save/init blocks around the mul-sub and
   add-back inner loops of the Knuth Algorithm D step:
     * `divK_mulsub_setup_spec` — 5 instructions (LD, SLLI, ADDI, SUB,
-      ADDI) that restore `j` from scratch, compute `u_base = sp - 8*j`,
+      ADDI) that restore `j` from scratch, compute `uBase = sp - 8*j`,
       and zero the carry.
     * `divK_save_j_spec` — single SD storing `j` back to scratch.
     * `divK_addback_init_spec` — single ADDI zeroing the add-back carry.
@@ -27,12 +27,12 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- Mul-sub setup: restore j from scratch, compute u_base, zero carry. -/
+/-- Mul-sub setup: restore j from scratch, compute uBase, zero carry. -/
 theorem divK_mulsub_setup_spec (sp qHat j v1_old v5_old v6_old v10_old : Word)
     (base : Word) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
+    let jX8 := j <<< (3 : BitVec 6).toNat
     let sp_m40 := sp + signExtend12 4056
-    let u_base := sp_m40 - j_x8
+    let uBase := sp_m40 - jX8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3976))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLLI .x5 .x1 3))
@@ -45,14 +45,14 @@ theorem divK_mulsub_setup_spec (sp qHat j v1_old v5_old v6_old v10_old : Word)
        (.x10 ↦ᵣ v10_old) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ j_x8) ** (.x6 ↦ᵣ u_base) **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ jX8) ** (.x6 ↦ᵣ uBase) **
        (.x10 ↦ᵣ signExtend12 0) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j)) := by
-  intro j_x8 sp_m40 u_base cr
+  intro jX8 sp_m40 uBase cr
   have I0 := ld_spec_gen .x1 .x12 sp v1_old j 3976 base (by nofun)
   have I1 := slli_spec_gen .x5 .x1 v5_old j 3 (base + 4) (by nofun)
   have I2 := addi_spec_gen .x6 .x12 v6_old sp 4056 (base + 8) (by nofun)
-  have I3 := sub_spec_gen_rd_eq_rs1 .x6 .x5 sp_m40 j_x8 (base + 12) (by nofun)
+  have I3 := sub_spec_gen_rd_eq_rs1 .x6 .x5 sp_m40 jX8 (base + 12) (by nofun)
   have I4 := addi_x0_spec_gen .x10 v10_old 0 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormA.lean
@@ -3,9 +3,9 @@
 
   Per-limb CPS specs for the Knuth Algorithm D normalize-a phase:
     * `divK_normA_top_*` — 3-instruction top: LD, SRL, SD.
-      Computes `u[4] = a[3] >>> anti_shift` (overflow bits from top limb).
+      Computes `u[4] = a[3] >>> antiShift` (overflow bits from top limb).
     * `divK_normA_mergeA_*` — 5-instruction merge, x5 holds current limb.
-      Computes `(current <<< shift) ||| (next >>> anti_shift)`; used for u[3]/u[1].
+      Computes `(current <<< shift) ||| (next >>> antiShift)`; used for u[3]/u[1].
     * `divK_normA_mergeB_*` — 5-instruction merge, x7 holds current limb.
       Same shape as mergeA with registers swapped; used for u[2].
     * `divK_normA_last_*` — 2-instruction last: SLL, SD.
@@ -36,23 +36,23 @@ abbrev divK_normA_top_code (src_off dst_off : BitVec 12) (base : Word) : CodeReq
   CodeReq.ofProg base (divK_normA_top_prog src_off dst_off)
 
 /-- NormA top: LD a[3], SRL to x7, SD u[4]. 3 instructions.
-    Computes u[4] = a[3] >>> anti_shift (overflow bits from top limb). -/
+    Computes u[4] = a[3] >>> antiShift (overflow bits from top limb). -/
 theorem divK_normA_top_spec (src_off dst_off : BitVec 12)
-    (sp val v5 v7 anti_shift dst_old : Word) (base : Word) :
-    let result := val >>> (anti_shift.toNat % 64)
+    (sp val v5 v7 antiShift dst_old : Word) (base : Word) :
+    let result := val >>> (antiShift.toNat % 64)
     let cr := divK_normA_top_code src_off dst_off base
     cpsTriple base (base + 12) cr
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ anti_shift) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 src_off) ↦ₘ val) **
        ((sp + signExtend12 dst_off) ↦ₘ dst_old))
       (
-       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ val) ** (.x7 ↦ᵣ result) ** (.x2 ↦ᵣ anti_shift) **
+       (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ val) ** (.x7 ↦ᵣ result) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 src_off) ↦ₘ val) **
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
   intro result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 val src_off base (by nofun)
-  have I1 := srl_spec_gen .x7 .x5 .x2 v7 val anti_shift (base + 4) (by nofun)
+  have I1 := srl_spec_gen .x7 .x5 .x2 v7 val antiShift (base + 4) (by nofun)
   have I2 := sd_spec_gen .x12 .x7 sp result dst_old dst_off (base + 8)
   runBlock I0 I1 I2
 
@@ -64,29 +64,29 @@ abbrev divK_normA_mergeA_code (next_off dst_off : BitVec 12) (base : Word) : Cod
   CodeReq.ofProg base (divK_normA_mergeA_prog next_off dst_off)
 
 /-- NormA merge type A (5 instructions): x5 holds current limb.
-    LD next into x7, SLL x5 by shift, SRL x10 from x7 by anti_shift, OR into x5, SD.
+    LD next into x7, SLL x5 by shift, SRL x10 from x7 by antiShift, OR into x5, SD.
     Used for u[3] and u[1] computation. -/
 theorem divK_normA_mergeA_spec (next_off dst_off : BitVec 12)
-    (sp current next v7 v10 shift anti_shift dst_old : Word) (base : Word) :
+    (sp current next v7 v10 shift antiShift dst_old : Word) (base : Word) :
     let shiftedCurr := current <<< (shift.toNat % 64)
-    let shiftedNext := next >>> (anti_shift.toNat % 64)
+    let shiftedNext := next >>> (antiShift.toNat % 64)
     let result := shiftedCurr ||| shiftedNext
     let cr := divK_normA_mergeA_code next_off dst_off base
     cpsTriple base (base + 20) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ current) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ dst_old))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ next) ** (.x10 ↦ᵣ shiftedNext) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
   intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x7 .x12 sp v7 next next_off base (by nofun)
   have I1 := sll_spec_gen_rd_eq_rs1 .x5 .x6 current shift (base + 4) (by nofun)
-  have I2 := srl_spec_gen .x10 .x7 .x2 v10 next anti_shift (base + 8) (by nofun)
+  have I2 := srl_spec_gen .x10 .x7 .x2 v10 next antiShift (base + 8) (by nofun)
   have I3 := or_spec_gen_rd_eq_rs1 .x5 .x10 shiftedCurr shiftedNext (base + 12) (by nofun)
   have I4 := sd_spec_gen .x12 .x5 sp result dst_old dst_off (base + 16)
   runBlock I0 I1 I2 I3 I4
@@ -99,29 +99,29 @@ abbrev divK_normA_mergeB_code (next_off dst_off : BitVec 12) (base : Word) : Cod
   CodeReq.ofProg base (divK_normA_mergeB_prog next_off dst_off)
 
 /-- NormA merge type B (5 instructions): x7 holds current limb.
-    LD next into x5, SLL x7 by shift, SRL x10 from x5 by anti_shift, OR into x7, SD.
+    LD next into x5, SLL x7 by shift, SRL x10 from x5 by antiShift, OR into x7, SD.
     Used for u[2] computation. -/
 theorem divK_normA_mergeB_spec (next_off dst_off : BitVec 12)
-    (sp current next v5 v10 shift anti_shift dst_old : Word) (base : Word) :
+    (sp current next v5 v10 shift antiShift dst_old : Word) (base : Word) :
     let shiftedCurr := current <<< (shift.toNat % 64)
-    let shiftedNext := next >>> (anti_shift.toNat % 64)
+    let shiftedNext := next >>> (antiShift.toNat % 64)
     let result := shiftedCurr ||| shiftedNext
     let cr := divK_normA_mergeB_code next_off dst_off base
     cpsTriple base (base + 20) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ current) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ dst_old))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ next) ** (.x7 ↦ᵣ result) ** (.x10 ↦ᵣ shiftedNext) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 next_off) ↦ₘ next) **
        ((sp + signExtend12 dst_off) ↦ₘ result)) := by
   intro shiftedCurr shiftedNext result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 next next_off base (by nofun)
   have I1 := sll_spec_gen_rd_eq_rs1 .x7 .x6 current shift (base + 4) (by nofun)
-  have I2 := srl_spec_gen .x10 .x5 .x2 v10 next anti_shift (base + 8) (by nofun)
+  have I2 := srl_spec_gen .x10 .x5 .x2 v10 next antiShift (base + 8) (by nofun)
   have I3 := or_spec_gen_rd_eq_rs1 .x7 .x10 shiftedCurr shiftedNext (base + 12) (by nofun)
   have I4 := sd_spec_gen .x12 .x7 sp result dst_old dst_off (base + 16)
   runBlock I0 I1 I2 I3 I4

--- a/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/NormB.lean
@@ -4,8 +4,8 @@
   Per-limb CPS specs for the Knuth Algorithm D normalize-b phase:
     * `divK_normB_merge_prog` / `divK_normB_merge_code` / `divK_normB_merge_spec`
       — 6-instruction merge: LD high, LD low, SLL high<<shift,
-        SRL low>>anti_shift, OR, SD high. Computes
-        `result = (high <<< shift) ||| (low >>> anti_shift)`.
+        SRL low>>antiShift, OR, SD high. Computes
+        `result = (high <<< shift) ||| (low >>> antiShift)`.
     * `divK_normB_last_prog` / `divK_normB_last_code` / `divK_normB_last_spec`
       — 3-instruction last-limb: LD, SLL, SD. Computes `val <<< shift`.
 
@@ -39,30 +39,30 @@ abbrev divK_normB_merge_code (high_off low_off : BitVec 12) (base : Word) : Code
   CodeReq.ofProg base (divK_normB_merge_prog high_off low_off)
 
 /-- NormB merge limb (6 instructions): LD high, LD low, SLL, SRL, OR, SD.
-    Computes result = (high <<< shift) ||| (low >>> anti_shift) and stores to high_off.
-    x6 = shift, x2 = anti_shift (= 64 - shift as unsigned). -/
+    Computes result = (high <<< shift) ||| (low >>> antiShift) and stores to high_off.
+    x6 = shift, x2 = antiShift (= 64 - shift as unsigned). -/
 theorem divK_normB_merge_spec (high_off low_off : BitVec 12)
-    (sp high low v5 v7 shift anti_shift : Word) (base : Word) :
+    (sp high low v5 v7 shift antiShift : Word) (base : Word) :
     let shiftedHigh := high <<< (shift.toNat % 64)
-    let shiftedLow := low >>> (anti_shift.toNat % 64)
+    let shiftedLow := low >>> (antiShift.toNat % 64)
     let result := shiftedHigh ||| shiftedLow
     let cr := divK_normB_merge_code high_off low_off base
     cpsTriple base (base + 24) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 high_off) ↦ₘ high) **
        ((sp + signExtend12 low_off) ↦ₘ low))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x7 ↦ᵣ shiftedLow) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ anti_shift) **
+       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + signExtend12 high_off) ↦ₘ result) **
        ((sp + signExtend12 low_off) ↦ₘ low)) := by
   intro shiftedHigh shiftedLow result cr
   have I0 := ld_spec_gen .x5 .x12 sp v5 high high_off base (by nofun)
   have I1 := ld_spec_gen .x7 .x12 sp v7 low low_off (base + 4) (by nofun)
   have I2 := sll_spec_gen_rd_eq_rs1 .x5 .x6 high shift (base + 8) (by nofun)
-  have I3 := srl_spec_gen_rd_eq_rs1 .x7 .x2 low anti_shift (base + 12) (by nofun)
+  have I3 := srl_spec_gen_rd_eq_rs1 .x7 .x2 low antiShift (base + 12) (by nofun)
   have I4 := or_spec_gen_rd_eq_rs1 .x5 .x7 shiftedHigh shiftedLow (base + 16) (by nofun)
   have I5 := sd_spec_gen .x12 .x5 sp result high high_off (base + 20)
   runBlock I0 I1 I2 I3 I4 I5

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -2,12 +2,12 @@
   EvmAsm.Evm64.DivMod.LimbSpec.PhaseBCascade
 
   CPS spec for a single step of the Knuth Algorithm D phase-B cascade —
-  the repeating `ADDI x5 = n_val; BNE rx x0 → end` pattern that computes
+  the repeating `ADDI x5 = nVal; BNE rx x0 → end` pattern that computes
   `n` (the index of the highest non-zero limb of the divisor):
     * `divK_phaseB_cascade_step_code` — a 2-instruction `CodeReq.union`
       of the ADDI and the BNE.
     * `divK_phaseB_cascade_step_spec` — full `cpsBranch` spec: in either
-      branch `x5 = n_val`; the taken branch jumps when `rx ≠ 0`.
+      branch `x5 = nVal`; the taken branch jumps when `rx ≠ 0`.
 
   Eleventh chunk of the `LimbSpec.lean` split tracked by issue #312. The
   consumer surface is unchanged: `LimbSpec.lean` re-exports this file so
@@ -27,18 +27,18 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-abbrev divK_phaseB_cascade_step_code (n_val : BitVec 12) (rx : Reg) (bne_off : BitVec 13)
+abbrev divK_phaseB_cascade_step_code (nVal : BitVec 12) (rx : Reg) (bne_off : BitVec 13)
     (base : Word) : CodeReq :=
-  CodeReq.union (CodeReq.singleton base (.ADDI .x5 .x0 n_val))
+  CodeReq.union (CodeReq.singleton base (.ADDI .x5 .x0 nVal))
    (CodeReq.singleton (base + 4) (.BNE rx .x0 bne_off))
 
-/-- Single cascade step: load n_val into x5, then BNE on rx vs x0.
-    Taken: rx ≠ 0 (limb is nonzero), branch to target with x5 = n_val.
-    Not taken: rx = 0, fall through with x5 = n_val. -/
-theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 : Word)
+/-- Single cascade step: load nVal into x5, then BNE on rx vs x0.
+    Taken: rx ≠ 0 (limb is nonzero), branch to target with x5 = nVal.
+    Not taken: rx = 0, fall through with x5 = nVal. -/
+theorem divK_phaseB_cascade_step_spec (nVal : BitVec 12) (rx : Reg) (check v5 : Word)
     (bne_off : BitVec 13) (base : Word) :
-    let n := (0 : Word) + signExtend12 n_val
-    let cr := divK_phaseB_cascade_step_code n_val rx bne_off base
+    let n := (0 : Word) + signExtend12 nVal
+    let cr := divK_phaseB_cascade_step_code nVal rx bne_off base
     let post :=
       (.x5 ↦ᵣ n) ** (.x0 ↦ᵣ (0 : Word)) ** (rx ↦ᵣ check)
     cpsBranch base cr
@@ -52,7 +52,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
   have hbody : cpsTriple base (base + 4) cr
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (rx ↦ᵣ check))
       ((.x5 ↦ᵣ n) ** (.x0 ↦ᵣ (0 : Word)) ** (rx ↦ᵣ check)) := by
-    have I0 := addi_spec_gen .x5 .x0 v5 (0 : Word) n_val base (by nofun)
+    have I0 := addi_spec_gen .x5 .x0 v5 (0 : Word) nVal base (by nofun)
     runBlock I0
   -- 2. BNE at base + 4, drop pure facts
   have hbne_raw := bne_spec_gen rx .x0 bne_off check (0 : Word) (base + 4)
@@ -82,7 +82,7 @@ theorem divK_phaseB_cascade_step_spec (n_val : BitVec 12) (rx : Reg) (check v5 :
     · next heq =>
       rw [beq_iff_eq] at heq; subst heq
       simp only [Option.some.injEq] at h; subst h
-      show divK_phaseB_cascade_step_code n_val rx bne_off base (base + 4) = _
+      show divK_phaseB_cascade_step_code nVal rx bne_off base (base + 4) = _
       simp only [divK_phaseB_cascade_step_code, CodeReq.union, CodeReq.singleton]
       have h0 : ¬(base + 4 = base) := by bv_omega
       simp only [beq_iff_eq, h0, ↓reduceIte]

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
@@ -29,25 +29,25 @@ abbrev divK_phaseB_tail_code (base : Word) : CodeReq :=
 
 /-- Phase B tail: store n to scratch, compute sp + (n-1)*8, load b[n-1].
     x5 = n on entry. On exit, x5 = leading limb b[n-1]. -/
-theorem divK_phaseB_tail_spec (sp n leading_limb n_mem : Word) (base : Word) :
+theorem divK_phaseB_tail_spec (sp n leading_limb nMem : Word) (base : Word) :
     let nm1 := n + signExtend12 4095
-    let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-    let addrLead := sp + nm1_x8
+    let nm1X8 := nm1 <<< (3 : BitVec 6).toNat
+    let addrLead := sp + nm1X8
     let cr := divK_phaseB_tail_code base
     cpsTriple base (base + 20) cr
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((addrLead + signExtend12 32) ↦ₘ leading_limb))
       (
        (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ leading_limb) **
        ((sp + signExtend12 3984) ↦ₘ n) **
        ((addrLead + signExtend12 32) ↦ₘ leading_limb)) := by
-  intro nm1 nm1_x8 addrLead cr
-  have I0 := sd_spec_gen .x12 .x5 sp n n_mem 3984 base
+  intro nm1 nm1X8 addrLead cr
+  have I0 := sd_spec_gen .x12 .x5 sp n nMem 3984 base
   have I1 := addi_spec_gen_same .x5 n 4095 (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x5 nm1 3 (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs2 .x5 .x12 sp nm1_x8 (base + 12) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs2 .x5 .x12 sp nm1X8 (base + 12) (by nofun)
   have I4 := ld_spec_gen_same .x5 addrLead leading_limb 32 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -51,10 +51,10 @@ theorem divK_phaseC2_body_spec (sp shift v2 shiftMem : Word)
     (signExtend12 (0 : BitVec 12)) shift (base + 8) (by nofun)
   runBlock I0 I1 I2
 
-/-- Phase C2: store shift, compute anti_shift, BEQ if shift=0.
+/-- Phase C2: store shift, compute antiShift, BEQ if shift=0.
     Taken: shift = 0, skip normalization.
     Not taken: shift ≠ 0, proceed to normalize.
-    anti_shift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
+    antiShift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
 theorem divK_phaseC2_spec (sp shift v2 shiftMem : Word)
     (shift0_off : BitVec 13) (base : Word) :
     let cr := divK_phaseC2_code shift0_off base

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -9,7 +9,7 @@
     * `divK_store_qj_addr_spec` — 3 instructions (SLLI, ADDI, SUB) that
       compute `qAddr = sp + 4088 - 8*j` into x7.
     * `divK_store_qj_write_spec` — 1-instruction SD that actually
-      writes `q_hat` at `qAddr`.
+      writes `qHat` at `qAddr`.
 
   Sixteenth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -33,7 +33,7 @@ open EvmAsm.Rv64
 
 /-- Subtract carry from u[j+4].
     4 instructions: LD, SLTU, SUB, SD. Produces borrow (x7). -/
-theorem divK_sub_carry_spec (u_base carryIn v5_old v7_old uTop : Word)
+theorem divK_sub_carry_spec (uBase carryIn v5_old v7_old uTop : Word)
     (u_off : BitVec 12) (base : Word) :
     let borrow := if BitVec.ult uTop carryIn then (1 : Word) else 0
     let uNew := uTop - carryIn
@@ -43,26 +43,26 @@ theorem divK_sub_carry_spec (u_base carryIn v5_old v7_old uTop : Word)
       (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x5 .x5 .x10))
        (CodeReq.singleton (base + 12) (.SD .x6 .x5 u_off))))
     cpsTriple base (base + 16) cr
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryIn) **
+      ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
-       ((u_base + signExtend12 u_off) ↦ₘ uTop))
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryIn) **
+       ((uBase + signExtend12 u_off) ↦ₘ uTop))
+      ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ uNew) ** (.x7 ↦ᵣ borrow) **
-       ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
+       ((uBase + signExtend12 u_off) ↦ₘ uNew)) := by
   intro borrow uNew cr
-  have I0 := ld_spec_gen .x5 .x6 u_base v5_old uTop u_off base (by nofun)
+  have I0 := ld_spec_gen .x5 .x6 uBase v5_old uTop u_off base (by nofun)
   have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old uTop carryIn (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 uTop carryIn (base + 8) (by nofun)
-  have I3 := sd_spec_gen .x6 .x5 u_base uNew uTop u_off (base + 12)
+  have I3 := sd_spec_gen .x6 .x5 uBase uNew uTop u_off (base + 12)
   runBlock I0 I1 I2 I3
 
-/-- Store q[j]: compute &q[j] = sp+4088 - j*8, store q_hat.
+/-- Store q[j]: compute &q[j] = sp+4088 - j*8, store qHat.
     First 3 instructions compute qAddr. Then SD stores. Split into 3+1. -/
 theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
     (base : Word) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
+    let jX8 := j <<< (3 : BitVec 6).toNat
     let sp_m8 := sp + signExtend12 4088
-    let qAddr := sp_m8 - j_x8
+    let qAddr := sp_m8 - jX8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
@@ -71,22 +71,22 @@ theorem divK_store_qj_addr_spec (sp j v5_old v7_old : Word)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr)) := by
-  intro j_x8 sp_m8 qAddr cr
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr)) := by
+  intro jX8 sp_m8 qAddr cr
   have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 sp_m8 j_x8 (base + 8) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 sp_m8 jX8 (base + 8) (by nofun)
   runBlock I0 I1 I2
 
-/-- Store q[j]: SD q_hat at qAddr. 1 instruction. -/
-theorem divK_store_qj_write_spec (qAddr q_hat q_old : Word) (base : Word) :
+/-- Store q[j]: SD qHat at qAddr. 1 instruction. -/
+theorem divK_store_qj_write_spec (qAddr qHat q_old : Word) (base : Word) :
     let cr := CodeReq.singleton base (.SD .x7 .x11 0)
     cpsTriple base (base + 4) cr
-      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ q_hat) ** (qAddr ↦ₘ q_old))
-      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ q_hat) ** (qAddr ↦ₘ q_hat)) := by
+      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ qHat) ** (qAddr ↦ₘ q_old))
+      ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ qHat) ** (qAddr ↦ₘ qHat)) := by
   intro cr
   have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
-  have I0 := sd_spec_gen .x7 .x11 qAddr q_hat q_old 0 base
+  have I0 := sd_spec_gen .x7 .x11 qAddr qHat q_old 0 base
   rw [haddr] at I0
   runBlock I0
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -33,10 +33,10 @@ open EvmAsm.Rv64
 
 /-- Subtract carry from u[j+4].
     4 instructions: LD, SLTU, SUB, SD. Produces borrow (x7). -/
-theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
+theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old uTop : Word)
     (u_off : BitVec 12) (base : Word) :
-    let borrow := if BitVec.ult u_top carry_in then (1 : Word) else 0
-    let uNew := u_top - carry_in
+    let borrow := if BitVec.ult uTop carry_in then (1 : Word) else 0
+    let uNew := uTop - carry_in
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLTU .x7 .x5 .x10))
@@ -45,15 +45,15 @@ theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
     cpsTriple base (base + 16) cr
       ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_in) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
-       ((u_base + signExtend12 u_off) ↦ₘ u_top))
+       ((u_base + signExtend12 u_off) ↦ₘ uTop))
       ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_in) **
        (.x5 ↦ᵣ uNew) ** (.x7 ↦ᵣ borrow) **
        ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
   intro borrow uNew cr
-  have I0 := ld_spec_gen .x5 .x6 u_base v5_old u_top u_off base (by nofun)
-  have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old u_top carry_in (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 u_top carry_in (base + 8) (by nofun)
-  have I3 := sd_spec_gen .x6 .x5 u_base uNew u_top u_off (base + 12)
+  have I0 := ld_spec_gen .x5 .x6 u_base v5_old uTop u_off base (by nofun)
+  have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old uTop carry_in (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 uTop carry_in (base + 8) (by nofun)
+  have I3 := sd_spec_gen .x6 .x5 u_base uNew uTop u_off (base + 12)
   runBlock I0 I1 I2 I3
 
 /-- Store q[j]: compute &q[j] = sp+4088 - j*8, store q_hat.

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -8,9 +8,9 @@
     * `divK_trial_load_u_spec` — 7-instruction block loading the high
       two limbs of `u[j..]` into x7/x5 at `uAddr = sp + 4056 - (j+n)*8`.
     * `divK_trial_load_vtop_spec` — 5-instruction block loading
-      `v_top = b[n-1]` and leaving its address in x6.
+      `vTop = b[n-1]` and leaving its address in x6.
     * `divK_trial_max_spec` — 2-instruction MAX path (ADDI x11, JAL)
-      that clamps q_hat to MAX64 and jumps past the div128 call.
+      that clamps qHat to MAX64 and jumps past the div128 call.
 
   Nineteenth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -53,15 +53,15 @@ theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
     hbeq
 
-/-- Load u_hi = u[j+n] and u_lo = u[j+n-1] for trial quotient estimation.
+/-- Load uHi = u[j+n] and uLo = u[j+n-1] for trial quotient estimation.
     uAddr = sp + signExtend12 4056 - (j + n) <<< 3.
-    u_hi = mem[uAddr], u_lo = mem[uAddr + 8]. -/
-theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
+    uHi = mem[uAddr], uLo = mem[uAddr + 8]. -/
+theorem divK_trial_load_u_spec (sp j n v5_old v7_old uHi uLo : Word)
     (base : Word) :
     let jpn := j + n
-    let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
+    let jpnX8 := jpn <<< (3 : BitVec 6).toNat
     let u0_base := sp + signExtend12 4056
-    let uAddr := u0_base - jpn_x8
+    let uAddr := u0_base - jpnX8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 3984))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADD .x7 .x1 .x5))
@@ -74,31 +74,31 @@ theorem divK_trial_load_u_spec (sp j n v5_old v7_old u_hi u_lo : Word)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo))
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x7 ↦ᵣ u_hi) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo)) := by
-  intro jpn jpn_x8 u0_base uAddr cr
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo)) := by
+  intro jpn jpnX8 u0_base uAddr cr
   have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
   have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
-  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
-  have I5 := ld_spec_gen .x7 .x5 uAddr jpn_x8 u_hi 0 (base + 20) (by nofun)
+  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpnX8 (base + 16) (by nofun)
+  have I5 := ld_spec_gen .x7 .x5 uAddr jpnX8 uHi 0 (base + 20) (by nofun)
   rw [haddr0] at I5
-  have I6 := ld_spec_gen_same .x5 uAddr u_lo 8 (base + 24) (by nofun)
+  have I6 := ld_spec_gen_same .x5 uAddr uLo 8 (base + 24) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5 I6
 
-/-- Load v_top = b[n-1] for trial quotient estimation.
+/-- Load vTop = b[n-1] for trial quotient estimation.
     vtop_addr = sp + (n + signExtend12 4095) <<< 3.
-    v_top = mem[vtop_addr + 32]. -/
-theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
+    vTop = mem[vtop_addr + 32]. -/
+theorem divK_trial_load_vtop_spec (sp n v6_old v10_old vTop : Word)
     (base : Word) :
     let nm1 := n + signExtend12 4095
-    let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
-    let vtopBase := sp + nm1_x8
+    let nm1X8 := nm1 <<< (3 : BitVec 6).toNat
+    let vtopBase := sp + nm1X8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x6 .x12 3984))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x6 .x6 4095))
@@ -107,18 +107,18 @@ theorem divK_trial_load_vtop_spec (sp n v6_old v10_old v_top : Word)
        (CodeReq.singleton (base + 16) (.LD .x10 .x6 32)))))
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6_old) ** (.x10 ↦ᵣ v10_old) **
-       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ v_top))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ v_top) **
-       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
-  intro nm1 nm1_x8 vtopBase cr
+       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ vTop))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ vtopBase) ** (.x10 ↦ᵣ vTop) **
+       (sp + signExtend12 3984 ↦ₘ n) ** (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
+  intro nm1 nm1X8 vtopBase cr
   have I0 := ld_spec_gen .x6 .x12 sp v6_old n 3984 base (by nofun)
   have I1 := addi_spec_gen_same .x6 n 4095 (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x6 nm1 3 (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 12) (by nofun)
-  have I4 := ld_spec_gen .x10 .x6 vtopBase v10_old v_top 32 (base + 16) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1X8 (base + 12) (by nofun)
+  have I4 := ld_spec_gen .x10 .x6 vtopBase v10_old vTop 32 (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 
-/-- Trial quotient MAX path: set q_hat = MAX64, jump over div128 call. -/
+/-- Trial quotient MAX path: set qHat = MAX64, jump over div128 call. -/
 theorem divK_trial_max_spec (v11_old : Word) (base : Word) :
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADDI .x11 .x0 4095))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -3,11 +3,11 @@
 
   Two straight-line composition specs for the Knuth loop body:
     * `divK_trial_load_spec` — 12-instruction composition (trial_load_u
-      + trial_load_vtop) that fetches `u_hi`, `u_lo`, and `v_top` from
+      + trial_load_vtop) that fetches `uHi`, `uLo`, and `vTop` from
       memory in preparation for the trial-quotient estimation.
     * `divK_store_qj_spec` — 4-instruction composition (store_qj_addr
       + store_qj_write) that computes `qAddr = sp + 4088 - 8*j` and
-      stores `q_hat` there.
+      stores `qHat` there.
 
   Twenty-eighth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -29,11 +29,11 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- Trial quotient load: fetch u_hi, u_lo, v_top from memory.
+/-- Trial quotient load: fetch uHi, uLo, vTop from memory.
     Instrs [1]-[12] of loop body.
-    Output: x7 = u_hi, x5 = u_lo, x10 = v_top, x6 = vtopBase. -/
+    Output: x7 = uHi, x5 = uLo, x10 = vTop, x6 = vtopBase. -/
 theorem divK_trial_load_spec
-    (sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
+    (sp j n v5_old v6_old v7_old v10_old uHi uLo vTop : Word)
     (base : Word) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -55,60 +55,60 @@ theorem divK_trial_load_spec
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
-       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
   intro uAddr vtopBase cr
   let jpn := j + n
-  let jpn_x8 := jpn <<< (3 : BitVec 6).toNat
+  let jpnX8 := jpn <<< (3 : BitVec 6).toNat
   let u0_base := sp + signExtend12 4056
   have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
   have I0 := ld_spec_gen .x5 .x12 sp v5_old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7_old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
   have I3 := addi_spec_gen .x5 .x12 n sp 4056 (base + 12) (by nofun)
-  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpn_x8 (base + 16) (by nofun)
-  have I5 := ld_spec_gen .x7 .x5 uAddr jpn_x8 u_hi 0 (base + 20) (by nofun)
+  have I4 := sub_spec_gen_rd_eq_rs1 .x5 .x7 u0_base jpnX8 (base + 16) (by nofun)
+  have I5 := ld_spec_gen .x7 .x5 uAddr jpnX8 uHi 0 (base + 20) (by nofun)
   rw [haddr0] at I5
-  have I6 := ld_spec_gen_same .x5 uAddr u_lo 8 (base + 24) (by nofun)
+  have I6 := ld_spec_gen_same .x5 uAddr uLo 8 (base + 24) (by nofun)
   let nm1 := n + signExtend12 4095
-  let nm1_x8 := nm1 <<< (3 : BitVec 6).toNat
+  let nm1X8 := nm1 <<< (3 : BitVec 6).toNat
   have I7 := ld_spec_gen .x6 .x12 sp v6_old n 3984 (base + 28) (by nofun)
   have I8 := addi_spec_gen_same .x6 n 4095 (base + 32) (by nofun)
   have I9 := slli_spec_gen_same .x6 nm1 3 (base + 36) (by nofun)
-  have I10 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1_x8 (base + 40) (by nofun)
-  have I11 := ld_spec_gen .x10 .x6 vtopBase v10_old v_top 32 (base + 44) (by nofun)
+  have I10 := add_spec_gen_rd_eq_rs2 .x6 .x12 sp nm1X8 (base + 40) (by nofun)
+  have I11 := ld_spec_gen .x10 .x6 vtopBase v10_old vTop 32 (base + 44) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10 I11
 
-/-- Store q[j]: compute address and store q_hat. 4 instructions.
+/-- Store q[j]: compute address and store qHat. 4 instructions.
     qAddr = sp + 4088 - j*8. -/
-theorem divK_store_qj_spec (sp j q_hat v5_old v7_old q_old : Word)
+theorem divK_store_qj_spec (sp j qHat v5_old v7_old q_old : Word)
     (base : Word) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j_x8
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLLI .x5 .x1 3))
       (CodeReq.union (CodeReq.singleton (base + 4) (.ADDI .x7 .x12 4088))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
        (CodeReq.singleton (base + 12) (.SD .x7 .x11 0))))
     cpsTriple base (base + 16) cr
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) **
-       (qAddr ↦ₘ q_hat)) := by
-  intro j_x8 qAddr cr
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat)) := by
+  intro jX8 qAddr cr
   have I0 := slli_spec_gen .x5 .x1 v5_old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7_old sp 4088 (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) j_x8 (base + 8) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) jX8 (base + 8) (by nofun)
   have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
-  have I3 := sd_spec_gen .x7 .x11 qAddr q_hat q_old 0 (base + 12)
+  have I3 := sd_spec_gen .x7 .x11 qAddr qHat q_old 0 (base + 12)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3
 

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -66,16 +66,16 @@ private theorem lb_ms_end (base : Word) : (base + 668 : Word) + 44 = base + 712 
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-/-- Multiply-subtract all 4 limbs: u[j+k] -= q_hat * v[k] for k=0..3 with carry chain.
+/-- Multiply-subtract all 4 limbs: u[j+k] -= qHat * v[k] for k=0..3 with carry chain.
     44 instructions, loop body indices [22]-[65].
     Entry: base+536, Exit: base+712, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_4limbs_spec
-    (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     (v5_init v7_init v2_init : Word)
     (base : Word) :
     -- Limb 0 intermediates
-    let p0_lo := q_hat * v0
-    let p0_hi := rv64_mulhu q_hat v0
+    let p0_lo := qHat * v0
+    let p0_hi := rv64_mulhu qHat v0
     let fs0 := p0_lo + (signExtend12 0 : Word)
     let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
     let pc0 := ba0 + p0_hi
@@ -83,8 +83,8 @@ theorem divK_mulsub_4limbs_spec
     let un0 := u0 - fs0
     let c0 := pc0 + bs0
     -- Limb 1 intermediates
-    let p1_lo := q_hat * v1
-    let p1_hi := rv64_mulhu q_hat v1
+    let p1_lo := qHat * v1
+    let p1_hi := rv64_mulhu qHat v1
     let fs1 := p1_lo + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let pc1 := ba1 + p1_hi
@@ -92,8 +92,8 @@ theorem divK_mulsub_4limbs_spec
     let un1 := u1 - fs1
     let c1 := pc1 + bs1
     -- Limb 2 intermediates
-    let p2_lo := q_hat * v2
-    let p2_hi := rv64_mulhu q_hat v2
+    let p2_lo := qHat * v2
+    let p2_hi := rv64_mulhu qHat v2
     let fs2 := p2_lo + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let pc2 := ba2 + p2_hi
@@ -101,8 +101,8 @@ theorem divK_mulsub_4limbs_spec
     let un2 := u2 - fs2
     let c2 := pc2 + bs2
     -- Limb 3 intermediates
-    let p3_lo := q_hat * v3
-    let p3_hi := rv64_mulhu q_hat v3
+    let p3_lo := qHat * v3
+    let p3_hi := rv64_mulhu qHat v3
     let fs3 := p3_lo + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let pc3 := ba3 + p3_hi
@@ -110,26 +110,26 @@ theorem divK_mulsub_4limbs_spec
     let un3 := u3 - fs3
     let c3 := pc3 + bs3
     cpsTriple (base + 536) (base + 712) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ (signExtend12 0 : Word)) **
-       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ v5_init) ** (.x7 ↦ᵣ v7_init) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ (signExtend12 0 : Word)) **
+       (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ v5_init) ** (.x7 ↦ᵣ v7_init) **
        (.x2 ↦ᵣ v2_init) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) ** (.x10 ↦ᵣ c3) **
-       (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ bs3) ** (.x7 ↦ᵣ fs3) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ c3) **
+       (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ bs3) ** (.x7 ↦ᵣ fs3) **
        (.x2 ↦ᵣ un3) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3)) := by
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3)) := by
   intro p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
         p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
         p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3
   -- Limb 0: instrs [22]-[32] at base+536
-  have L0 := divK_mulsub_limb_spec sp u_base q_hat (signExtend12 0 : Word)
+  have L0 := divK_mulsub_limb_spec sp uBase qHat (signExtend12 0 : Word)
     v5_init v7_init v2_init v0 u0 32 0 (base + 536)
 
   rw [lb_ms1] at L0
@@ -147,7 +147,7 @@ theorem divK_mulsub_4limbs_spec
       (lb_sub base 32 _ _ (by decide) (by bv_addr) (by decide))))))))))))
     L0
   -- Limb 1: instrs [33]-[43] at base+580
-  have L1 := divK_mulsub_limb_spec sp u_base q_hat c0
+  have L1 := divK_mulsub_limb_spec sp uBase qHat c0
     bs0 fs0 un0 v1 u1 40 4088 (base + 580)
 
   rw [lb_ms2] at L1
@@ -166,14 +166,14 @@ theorem divK_mulsub_4limbs_spec
     L1
   -- Frame L0 with memory for limbs 1-3 (so seqFrame can find L1's precondition atoms)
   have L0f := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3))
     (by pcFree) L0e
   -- Compose L0 + L1
   seqFrame L0f L1e
   -- Limb 2: instrs [44]-[54] at base+624
-  have L2 := divK_mulsub_limb_spec sp u_base q_hat c1
+  have L2 := divK_mulsub_limb_spec sp uBase qHat c1
     bs1 fs1 un1 v2 u2 48 4080 (base + 624)
 
   rw [lb_ms3] at L2
@@ -193,7 +193,7 @@ theorem divK_mulsub_4limbs_spec
   -- Compose (L0+L1) + L2
   seqFrame L0fL1e L2e
   -- Limb 3: instrs [55]-[65] at base+668
-  have L3 := divK_mulsub_limb_spec sp u_base q_hat c2
+  have L3 := divK_mulsub_limb_spec sp uBase qHat c2
     bs2 fs2 un2 v3 u3 56 4072 (base + 668)
 
   rw [lb_ms_end] at L3
@@ -234,11 +234,11 @@ private theorem lb_ab3_end (base : Word) : (base + 832 : Word) + 32 = base + 864
 private theorem lb_abf_end (base : Word) : (base + 864 : Word) + 16 = base + 880 := by bv_addr
 
 set_option maxRecDepth 4096 in
-/-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + q_hat--.
+/-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + qHat--.
     37 instructions, loop body indices [71]-[107].
     Entry: base+732, Exit: base+880, CodeReq: sharedDivModCode base. -/
 theorem divK_addback_full_spec
-    (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v7_init v5_init v2_init : Word)
     (base : Word) :
     -- Limb 0 addback intermediates
@@ -265,29 +265,29 @@ theorem divK_addback_full_spec
     let aun3 := upc3 + v3
     let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
     let aco3 := ac1_3 ||| ac2_3
-    -- Final: u4 + carry, q_hat--
+    -- Final: u4 + carry, qHat--
     let aun4 := u4 + aco3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     cpsTriple (base + 732) (base + 880) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ v7_init) **
-       (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ aco3) **
-       (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4)) := by
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ aco3) **
+       (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4)) := by
   intro upc0 ac1_0 aun0 ac2_0 aco0
         upc1 ac1_1 aun1 ac2_1 aco1
         upc2 ac1_2 aun2 ac2_2 aco2
         upc3 ac1_3 aun3 ac2_3 aco3
-        aun4 q_hat'
+        aun4 qHat'
   -- Init: instr [71] at base+732
   have I := divK_addback_init_spec v7_init (base + 732)
   rw [lb_ab0] at I
@@ -295,16 +295,16 @@ theorem divK_addback_full_spec
     exact lb_sub base 71 _ _ (by decide) (by bv_addr) (by decide)) I
   -- Frame init with all addback state
   have If := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x11 ↦ᵣ q_hat) **
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x11 ↦ᵣ qHat) **
      (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4))
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
     (by pcFree) Ie
   -- Limb 0: instrs [72]-[79] at base+736
-  have A0 := divK_addback_limb_spec sp u_base (signExtend12 0 : Word)
+  have A0 := divK_addback_limb_spec sp uBase (signExtend12 0 : Word)
     v5_init v2_init v0 u0 32 0 (base + 736)
   rw [lb_ab0_end] at A0
   have A0e := cpsTriple_extend_code (hmono := by
@@ -320,7 +320,7 @@ theorem divK_addback_full_spec
   -- Compose init + limb 0
   seqFrame If A0e
   -- Limb 1: instrs [80]-[87] at base+768
-  have A1 := divK_addback_limb_spec sp u_base aco0
+  have A1 := divK_addback_limb_spec sp uBase aco0
     ac2_0 aun0 v1 u1 40 4088 (base + 768)
   rw [lb_ab1_end] at A1
   have A1e := cpsTriple_extend_code (hmono := by
@@ -335,7 +335,7 @@ theorem divK_addback_full_spec
     A1
   seqFrame IfA0e A1e
   -- Limb 2: instrs [88]-[95] at base+800
-  have A2 := divK_addback_limb_spec sp u_base aco1
+  have A2 := divK_addback_limb_spec sp uBase aco1
     ac2_1 aun1 v2 u2 48 4080 (base + 800)
   rw [lb_ab2_end] at A2
   have A2e := cpsTriple_extend_code (hmono := by
@@ -350,7 +350,7 @@ theorem divK_addback_full_spec
     A2
   seqFrame IfA0eA1e A2e
   -- Limb 3: instrs [96]-[103] at base+832
-  have A3 := divK_addback_limb_spec sp u_base aco2
+  have A3 := divK_addback_limb_spec sp uBase aco2
     ac2_2 aun2 v3 u3 56 4072 (base + 832)
   rw [lb_ab3_end] at A3
   have A3e := cpsTriple_extend_code (hmono := by
@@ -365,7 +365,7 @@ theorem divK_addback_full_spec
     A3
   seqFrame IfA0eA1eA2e A3e
   -- Final: instrs [104]-[107] at base+864
-  have AF := divK_addback_final_spec u_base aco3 q_hat ac2_3 u4 4064 (base + 864)
+  have AF := divK_addback_final_spec uBase aco3 qHat ac2_3 u4 4064 (base + 864)
   rw [lb_abf_end] at AF
   have AFe := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub base 104 _ _ (by decide) (by bv_addr) (by decide))
@@ -396,37 +396,37 @@ set_option maxRecDepth 4096 in
     53 instructions, loop body indices [17]-[69].
     Entry: base+516, Exit: base+728, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_full_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- Mulsub intermediates (same as mulsub_4limbs_spec)
-    let p0_lo := q_hat * v0
-    let p0_hi := rv64_mulhu q_hat v0
+    let p0_lo := qHat * v0
+    let p0_hi := rv64_mulhu qHat v0
     let fs0 := p0_lo + (signExtend12 0 : Word)
     let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
     let pc0 := ba0 + p0_hi
     let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
     let un0 := u0 - fs0
     let c0 := pc0 + bs0
-    let p1_lo := q_hat * v1
-    let p1_hi := rv64_mulhu q_hat v1
+    let p1_lo := qHat * v1
+    let p1_hi := rv64_mulhu qHat v1
     let fs1 := p1_lo + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let pc1 := ba1 + p1_hi
     let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
     let un1 := u1 - fs1
     let c1 := pc1 + bs1
-    let p2_lo := q_hat * v2
-    let p2_hi := rv64_mulhu q_hat v2
+    let p2_lo := qHat * v2
+    let p2_hi := rv64_mulhu qHat v2
     let fs2 := p2_lo + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let pc2 := ba2 + p2_hi
     let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
     let un2 := u2 - fs2
     let c2 := pc2 + bs2
-    let p3_lo := q_hat * v3
-    let p3_hi := rv64_mulhu q_hat v3
+    let p3_lo := qHat * v3
+    let p3_hi := rv64_mulhu qHat v3
     let fs3 := p3_lo + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let pc3 := ba3 + p3_hi
@@ -437,34 +437,34 @@ theorem divK_mulsub_full_spec
     let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
     let u4_new := uTop - c3
     cpsTriple (base + 516) (base + 728) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ u_base) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4_new)) := by
-  intro u_base
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
+  intro uBase
         p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
         p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
         p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3
         borrow u4_new
   -- 1. Mulsub setup: instrs [17]-[21] at base+516
-  have S := divK_mulsub_setup_spec sp q_hat j v1_old v5_old v6_old v10_old (base + 516)
+  have S := divK_mulsub_setup_spec sp qHat j v1_old v5_old v6_old v10_old (base + 516)
   rw [lb_ms_setup] at S
   have Se := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
@@ -475,20 +475,20 @@ theorem divK_mulsub_full_spec
   -- Frame setup with all memory + x7/x2 for mulsub
   have Sf := cpsTriple_frameR
     ((.x7 ↦ᵣ v7_old) ** (.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ uTop))
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ uTop))
     (by pcFree) Se
   -- 2. Mulsub 4 limbs: instrs [22]-[65] at base+536
-  have M := divK_mulsub_4limbs_spec sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  have M := divK_mulsub_4limbs_spec sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3
     (j <<< (3 : BitVec 6).toNat) v7_old v2_old base
   intro_lets at M
   -- Compose setup + mulsub
   seqFrame Sf M
   -- 3. Sub-carry: instrs [66]-[69] at base+712
-  have SC := divK_sub_carry_spec u_base c3 bs3 fs3 uTop 4064 (base + 712)
+  have SC := divK_sub_carry_spec uBase c3 bs3 fs3 uTop 4064 (base + 712)
   rw [lb_sc] at SC
   have SCe := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub base 66 _ _ (by decide) (by bv_addr) (by decide))
@@ -521,23 +521,23 @@ private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 7
 /-- Correction skip: when borrow=0, BEQ taken → jump to base+884. No addback.
     1 instruction. All registers and memory unchanged. -/
 theorem divK_correction_skip_spec
-    (sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5_old v2_old : Word) (base : Word) :
     cpsTriple (base + 728) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4)) := by
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4)) := by
   -- BEQ x7 x0 156 at base+728 with x7=0, x0=0
   have hbeq := beq_spec_gen .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + 728)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
@@ -558,13 +558,13 @@ theorem divK_correction_skip_spec
       skip
   -- Frame with all other state and permute
   have skip_framed := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) **
-     (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4))
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
     (by pcFree) skip_clean
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -577,9 +577,9 @@ theorem divK_correction_skip_spec
 -- ============================================================================
 
 /-- Correction with addback: when borrow≠0, BEQ not-taken → addback_full.
-    38 instructions. Modifies u values and decrements q_hat. -/
+    38 instructions. Modifies u values and decrements qHat. -/
 theorem divK_correction_addback_spec
-    (sp u_base borrow q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5_old v2_old : Word) (base : Word)
     (hb : borrow ≠ (0 : Word)) :
     -- Addback intermediates
@@ -604,24 +604,24 @@ theorem divK_correction_addback_spec
     let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4 + aco3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     cpsTriple (base + 728) (base + 880) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ borrow) **
-       (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ aco3) **
-       (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4)) := by
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ aco3) **
+       (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4)) := by
   intro upc0 ac1_0 aun0 ac2_0 aco0 upc1 ac1_1 aun1 ac2_1 aco1
-        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 q_hat'
+        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 qHat'
   -- BEQ x7 x0 156 at base+728
   have hbeq := beq_spec_gen .x7 .x0 (156 : BitVec 13) borrow 0 (base + 728)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
@@ -642,16 +642,16 @@ theorem divK_correction_addback_spec
       ntaken
   -- Frame ntaken with all addback state
   have ntaken_framed := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) **
-     (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4))
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4))
     (by pcFree) ntaken_clean
   -- Compose with addback_full (base+732 → base+880)
-  have AB := divK_addback_full_spec sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4
+  have AB := divK_addback_full_spec sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
     borrow v5_old v2_old base
   dsimp only [] at AB
   seqFrame ntaken_framed AB
@@ -663,28 +663,28 @@ theorem divK_correction_addback_spec
 /-- Variant of correction_addback_spec with addbackN4/addbackN4_carry in postcondition.
     Same proof via cpsTriple_consequence (definitional equality). -/
 theorem divK_correction_addback_named_spec
-    (sp u_base borrow q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
+    (sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5_old v2_old : Word) (base : Word)
     (hb : borrow ≠ (0 : Word)) :
     let ab := addbackN4 u0 u1 u2 u3 u4 v0 v1 v2 v3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     cpsTriple (base + 728) (base + 880) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ borrow) **
-       (.x11 ↦ᵣ q_hat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ addbackN4_carry u0 u1 u2 u3 v0 v1 v2 v3) **
-       (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x2 ↦ᵣ ab.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ ab.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ ab.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ ab.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
-       ((u_base + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
-  intro ab q_hat'
-  exact divK_correction_addback_spec sp u_base borrow q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
+       (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ addbackN4_carry u0 u1 u2 u3 v0 v1 v2 v3) **
+       (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x2 ↦ᵣ ab.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab.1) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab.2.1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab.2.2.1) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
+       ((uBase + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
+  intro ab qHat'
+  exact divK_correction_addback_spec sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
     v5_old v2_old base hb
 
 -- ============================================================================
@@ -695,11 +695,11 @@ theorem divK_correction_addback_named_spec
 private theorem lb_save_j (base : Word) : (base + loopBodyOff : Word) + 4 = base + 452 := by bv_addr
 private theorem lb_trial_load (base : Word) : (base + 452 : Word) + 48 = base + 500 := by bv_addr
 
-/-- Save j + trial load: save j to memory, then load u_hi, u_lo, v_top for trial quotient.
+/-- Save j + trial load: save j to memory, then load uHi, uLo, vTop for trial quotient.
     13 instructions, loop body indices [0]-[12].
     Entry: base+448, Exit: base+500, CodeReq: sharedDivModCode base. -/
 theorem divK_save_trial_load_spec
-    (sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top : Word)
+    (sp j n j_old v5_old v6_old v7_old v10_old uHi uLo vTop : Word)
     (base : Word) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -709,15 +709,15 @@ theorem divK_save_trial_load_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
        (sp + signExtend12 3976 ↦ₘ j_old) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
-       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (sp + signExtend12 3976 ↦ₘ j) **
        (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
   intro uAddr vtopBase
   -- 1. Save j: instr [0] at base+448
   have SJ := divK_save_j_spec sp j j_old (base + loopBodyOff)
@@ -729,11 +729,11 @@ theorem divK_save_trial_load_spec
     ((.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
      (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) **
      (sp + signExtend12 3984 ↦ₘ n) **
-     (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-     (vtopBase + signExtend12 32 ↦ₘ v_top))
+     (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+     (vtopBase + signExtend12 32 ↦ₘ vTop))
     (by pcFree) SJe
   -- 2. Trial load: instrs [1]-[12] at base+452
-  have TL := divK_trial_load_spec sp j n v5_old v6_old v7_old v10_old u_hi u_lo v_top
+  have TL := divK_trial_load_spec sp j n v5_old v6_old v7_old v10_old uHi uLo vTop
     (base + 452)
   dsimp only [] at TL
   rw [lb_trial_load] at TL
@@ -760,10 +760,10 @@ theorem divK_save_trial_load_spec
 
 -- ============================================================================
 -- Section 8: Trial quotient BLTU branch + div128/max composition
--- After trial_load (base+500): x7=u_hi, x10=v_top, x5=u_lo.
+-- After trial_load (base+500): x7=uHi, x10=vTop, x5=uLo.
 -- BLTU x7 x10 12 at base+500:
---   Taken (u_hi < v_top) → base+512: JAL x2 560 → div128 → base+516, x11=q
---   Not-taken (u_hi >= v_top) → base+504: ADDI x11 x0 4095 + JAL x0 8 → base+516
+--   Taken (uHi < vTop) → base+512: JAL x2 560 → div128 → base+516, x11=q
+--   Not-taken (uHi >= vTop) → base+504: ADDI x11 x0 4095 + JAL x0 8 → base+516
 -- ============================================================================
 
 -- Address normalization for trial quotient
@@ -776,11 +776,11 @@ private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21
 private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_addr
 
 -- ============================================================================
--- Section 8a: Trial quotient NOT-TAKEN path (u_hi >= v_top)
+-- Section 8a: Trial quotient NOT-TAKEN path (uHi >= vTop)
 -- Instrs [14]-[15] at base+504: ADDI x11 x0 4095 + JAL x0 8 → base+516.
 -- ============================================================================
 
-/-- Trial quotient MAX path: q_hat = MAX64, skip div128 call.
+/-- Trial quotient MAX path: qHat = MAX64, skip div128 call.
     2 instructions at base+504. Entry: base+504, Exit: base+516. -/
 private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
     cpsTriple (base + 504) (base + 516) (sharedDivModCode base)
@@ -794,25 +794,25 @@ private theorem divK_trial_max_extended (v11_old : Word) (base : Word) :
       (lb_sub base 15 _ _ (by decide) (by bv_addr) (by decide))) TM
 
 -- ============================================================================
--- Section 8b: Trial quotient TAKEN path (u_hi < v_top)
+-- Section 8b: Trial quotient TAKEN path (uHi < vTop)
 -- Instr [16] JAL x2 560 at base+512 → div128 at base+1072 → returns to base+516.
 -- ============================================================================
 
 /-- Trial call path: JAL x2 560 (instr [16]) + div128 subroutine.
     Entry: base+512, Exit: base+516, CodeReq: sharedDivModCode base.
-    Computes q_hat = div128(u_hi, u_lo, v_top). -/
+    Computes qHat = div128(uHi, uLo, vTop). -/
 theorem divK_trial_call_path_spec
-    (sp j u_lo u_hi v_top vtopBase : Word) (base : Word)
+    (sp j uLo uHi vTop vtopBase : Word) (base : Word)
     (v2_old v11_old : Word)
-    (ret_mem d_mem dlo_mem un0_mem : Word)
+    (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516) :
     -- div128 intermediates (same as div128_spec)
-    let dHi := v_top >>> (32 : BitVec 6).toNat
-    let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+    let dHi := vTop >>> (32 : BitVec 6).toNat
+    let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + dHi
@@ -834,19 +834,19 @@ theorem divK_trial_call_path_spec
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
-       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
        (.x2 ↦ᵣ v2_old) ** (.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
        (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') **
        (.x2 ↦ᵣ (base + 516)) ** (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ v_top) **
+       (sp + signExtend12 3960 ↦ₘ vTop) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
@@ -857,20 +857,20 @@ theorem divK_trial_call_path_spec
   have Je := cpsTriple_extend_code (hmono :=
     lb_sub base 16 _ _ (by decide) (by bv_addr) (by decide)) J
   -- 2. div128 subroutine: base+1072 → base+516
-  have D := div128_spec sp (base + 516) v_top u_lo u_hi base
-    j vtopBase v11_old ret_mem d_mem dlo_mem un0_mem
+  have D := div128_spec sp (base + 516) vTop uLo uHi base
+    j vtopBase v11_old retMem dMem dloMem un0Mem
     halign
   dsimp only [] at D
   -- 3. Frame JAL with all registers/memory for div128
   have Jf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-     (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
-     (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) **
+     (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+     (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
      (.x11 ↦ᵣ v11_old) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-     (sp + signExtend12 3944 ↦ₘ un0_mem))
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) Je
   -- 4. Compose JAL + div128
   have full := cpsTriple_seq_perm_same_cr
@@ -927,7 +927,7 @@ private theorem lb_beq_back_taken (base : Word) :
     Entry: base+880 (after first addback), x7 = 0.
     Exit: base+884 (store entry), with double-addback results. -/
 theorem divK_double_addback_beq_spec
-    (sp u_base q_hat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
+    (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
     (base : Word)
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
     -- Second addback intermediates (same chain as addbackN4 applied to first addback results)
@@ -952,24 +952,24 @@ theorem divK_double_addback_beq_spec
     let ac2_3' := if BitVec.ult aun3' v3 then (1 : Word) else 0
     let aco3' := ac1_3' ||| ac2_3'
     let aun4' := aun4 + aco3'
-    let q_hat'' := q_hat' + signExtend12 4095
+    let qHat'' := qHat' + signExtend12 4095
     cpsTriple (base + 880) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ aco3') **
-       (.x11 ↦ᵣ q_hat'') ** (.x5 ↦ᵣ aun4') ** (.x2 ↦ᵣ aun3') ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0') **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1') **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2') **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3') **
-       ((u_base + signExtend12 4064) ↦ₘ aun4')) := by
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ aco3') **
+       (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ aun4') ** (.x2 ↦ᵣ aun3') ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0') **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1') **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2') **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3') **
+       ((uBase + signExtend12 4064) ↦ₘ aun4')) := by
   intro upc0' ac1_0' aun0' ac2_0' aco0' upc1' ac1_1' aun1' ac2_1' aco1'
-        upc2' ac1_2' aun2' ac2_2' aco2' upc3' ac1_3' aun3' ac2_3' aco3' aun4' q_hat''
+        upc2' ac1_2' aun2' ac2_2' aco2' upc3' ac1_3' aun3' ac2_3' aco3' aun4' qHat''
   -- 1. BEQ at [108] taken (carry = 0, x7 = 0 = x0) → base+732
   have hbeq := beq_spec_gen .x7 .x0 (8044 : BitVec 13) (0 : Word) 0 (base + 880)
   rw [lb_beq_back_taken, lb_beq_back_ntaken] at hbeq
@@ -986,7 +986,7 @@ theorem divK_double_addback_beq_spec
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
     beq_taken
   -- 2. Second addback (base+732 → base+880)
-  have AB2 := divK_addback_full_spec sp u_base q_hat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
+  have AB2 := divK_addback_full_spec sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
     (0 : Word) aun4 aun3 base
 
   intro_lets at AB2
@@ -999,26 +999,26 @@ theorem divK_double_addback_beq_spec
   -- 4. Compose: BEQ taken (→732) + addback2 (732→880) + BEQ ntaken (880→884)
   -- Frame BEQ with addback atoms
   have beq_f := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) **
-     (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-     ((u_base + signExtend12 4064) ↦ₘ aun4))
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+     ((uBase + signExtend12 4064) ↦ₘ aun4))
     (by pcFree) beq_taken'
   -- Compose BEQ → addback2
   have beq_ab2 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) beq_f AB2
   -- Frame BEQ passthrough with addback2 postcondition atoms
   have BPTf := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) **
-     (.x11 ↦ᵣ q_hat'') ** (.x5 ↦ᵣ aun4') ** (.x2 ↦ᵣ aun3') **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0') **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1') **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2') **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3') **
-     ((u_base + signExtend12 4064) ↦ₘ aun4'))
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
+     (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ aun4') ** (.x2 ↦ᵣ aun3') **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0') **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1') **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2') **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3') **
+     ((uBase + signExtend12 4064) ↦ₘ aun4'))
     (by pcFree) BPT
   -- Compose (BEQ+addback2) → BEQ passthrough
   have full := cpsTriple_seq_perm_same_cr
@@ -1030,29 +1030,29 @@ theorem divK_double_addback_beq_spec
 
 /-- Named variant of double_addback_beq_spec with addbackN4 projections in postcondition. -/
 theorem divK_double_addback_beq_named_spec
-    (sp u_base q_hat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
+    (sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4 : Word)
     (base : Word)
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
     let ab' := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
-    let q_hat'' := q_hat' + signExtend12 4095
+    let qHat'' := qHat' + signExtend12 4095
     cpsTriple (base + 880) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ q_hat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
+       (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4))
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3) **
-       (.x11 ↦ᵣ q_hat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ ab'.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ ab'.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ ab'.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
-       ((u_base + signExtend12 4064) ↦ₘ ab'.2.2.2.2)) := by
-  intro ab' q_hat''
-  exact divK_double_addback_beq_spec sp u_base q_hat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
+       (.x11 ↦ᵣ qHat'') ** (.x5 ↦ᵣ ab'.2.2.2.2) ** (.x2 ↦ᵣ ab'.2.2.2.1) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab'.1) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab'.2.1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab'.2.2.1) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab'.2.2.2.1) **
+       ((uBase + signExtend12 4064) ↦ₘ ab'.2.2.2.2)) := by
+  intro ab' qHat''
+  exact divK_double_addback_beq_spec sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
     base hcarry2_nz
 
 /-- Double-addback BEQ check + store q[j] + loop control.
@@ -1062,26 +1062,26 @@ theorem divK_double_addback_beq_named_spec
     Entry: base+880. Taken exit: base+448 (loop back). Not-taken exit: base+908 (exit loop).
     CodeReq: sharedDivModCode base. -/
 theorem divK_store_loop_spec
-    (sp j q_hat v5_old v7_old q_old : Word)
+    (sp j qHat v5_old v7_old q_old : Word)
     (base : Word) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j_x8
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
     let j' := j + signExtend12 4095
     cpsBranch (base + 884) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ q_old))
       (base + loopBodyOff)
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
-       (qAddr ↦ₘ q_hat))
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat))
       (base + denormOff)
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
-       (qAddr ↦ₘ q_hat)) := by
-  intro j_x8 qAddr j'
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat)) := by
+  intro jX8 qAddr j'
   -- 1. Store q[j]: instrs [109]-[112] at base+884
-  have SQ := divK_store_qj_spec sp j q_hat v5_old v7_old q_old (base + 884)
+  have SQ := divK_store_qj_spec sp j qHat v5_old v7_old q_old (base + 884)
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
@@ -1098,32 +1098,32 @@ theorem divK_store_loop_spec
       (lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide))) LC
   -- 3. Add x0 to store_qj via frame, then reshape via consequence
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat)) :=
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
   -- 4. Frame loop_control with store_qj postcondition atoms, then reshape
   have LCp : cpsBranch (base + 900) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat))
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat))
       (base + loopBodyOff)
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat))
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat))
       (base + denormOff)
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat)) :=
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsBranch_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsBranch_frameR
-        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-         (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) **
-         (qAddr ↦ₘ q_hat))
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+         (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+         (qAddr ↦ₘ qHat))
         (by pcFree) LCe)
   -- 5. Compose store_qj(+x0) → loop_control(reshaped)
   exact cpsTriple_seq_cpsBranch_perm_same_cr
@@ -1141,20 +1141,20 @@ private theorem j0_slt_zero :
 /-- Store q[0] + loop exit at j=0. Since j' = -1 < 0, BGE is not taken,
     so this is a cpsTriple (not cpsBranch) to base+908. -/
 theorem divK_store_loop_j0_spec
-    (sp q_hat v5_old v7_old q_old : Word)
+    (sp qHat v5_old v7_old q_old : Word)
     (base : Word) :
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     let j' := (0 : Word) + signExtend12 4095
     cpsTriple (base + 884) (base + denormOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
-       (qAddr ↦ₘ q_hat)) := by
+       (qAddr ↦ₘ qHat)) := by
   intro qAddr j'
   -- 1. Store q[j]: instrs [109]-[112] at base+884
-  have SQ := divK_store_qj_spec sp (0 : Word) q_hat v5_old v7_old q_old (base + 884)
+  have SQ := divK_store_qj_spec sp (0 : Word) qHat v5_old v7_old q_old (base + 884)
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
@@ -1188,11 +1188,11 @@ theorem divK_store_loop_j0_spec
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
-       (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat)) :=
+       (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -1205,9 +1205,9 @@ theorem divK_store_loop_j0_spec
     (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
   -- Frame with remaining atoms
   have addi_bge_framed := cpsTriple_frameR
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ (0 : Word) <<< (3 : BitVec 6).toNat) ** (.x7 ↦ᵣ qAddr) **
-       (qAddr ↦ₘ q_hat))
+       (qAddr ↦ₘ qHat))
       (by pcFree) addi_bge
   -- 7. Compose: store_qj → (ADDI → BGE exit)
   have full := cpsTriple_seq_perm_same_cr
@@ -1225,22 +1225,22 @@ theorem divK_store_loop_j0_spec
 /-- Store q[j] + loop back at j > 0. Since j' = j-1 ≥ 0 (signed), BGE is taken,
     so this is a cpsTriple (not cpsBranch) to base+448. -/
 theorem divK_store_loop_jgt0_spec
-    (sp j q_hat v5_old v7_old q_old : Word)
+    (sp j qHat v5_old v7_old q_old : Word)
     (base : Word)
     (hj_pos : BitVec.slt (j + signExtend12 4095) 0 = false) :
-    let j_x8 := j <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - j_x8
+    let jX8 := j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - jX8
     let j' := j + signExtend12 4095
     cpsTriple (base + 884) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
-       (qAddr ↦ₘ q_hat)) := by
-  intro j_x8 qAddr j'
+      ((.x1 ↦ᵣ j') ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) **
+       (qAddr ↦ₘ qHat)) := by
+  intro jX8 qAddr j'
   -- 1. Store q[j]: instrs [109]-[112] at base+884
-  have SQ := divK_store_qj_spec sp j q_hat v5_old v7_old q_old (base + 884)
+  have SQ := divK_store_qj_spec sp j qHat v5_old v7_old q_old (base + 884)
   dsimp only [] at SQ
   rw [lb_sqj] at SQ
   have SQe := cpsTriple_extend_code (hmono := by
@@ -1274,10 +1274,10 @@ theorem divK_store_loop_jgt0_spec
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_old))
-      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ q_hat)) :=
+      ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -1290,9 +1290,9 @@ theorem divK_store_loop_jgt0_spec
     (fun h hp => by xperm_hyp hp) haddi_x0 hbge_exit
   -- Frame with remaining atoms
   have addi_bge_framed := cpsTriple_frameR
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x5 ↦ᵣ j_x8) ** (.x7 ↦ᵣ qAddr) **
-       (qAddr ↦ₘ q_hat))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) **
+       (qAddr ↦ₘ qHat))
       (by pcFree) addi_bge
   -- 7. Compose: store_qj → (ADDI → BGE exit)
   have full := cpsTriple_seq_perm_same_cr
@@ -1311,30 +1311,30 @@ theorem divK_store_loop_jgt0_spec
     Takes borrow as explicit parameter to avoid let-binding expansion issues.
     Entry: base+516, Exit: base+880, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_skip_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- Mulsub intermediates
-    let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+    let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
     let fs0 := p0_lo + (signExtend12 0 : Word)
     let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
     let pc0 := ba0 + p0_hi
     let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
     let un0 := u0 - fs0; let c0 := pc0 + bs0
-    let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+    let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
     let fs1 := p1_lo + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let pc1 := ba1 + p1_hi
     let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
     let un1 := u1 - fs1; let c1 := pc1 + bs1
-    let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+    let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
     let fs2 := p2_lo + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let pc2 := ba2 + p2_hi
     let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
     let un2 := u2 - fs2; let c2 := pc2 + bs2
-    let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+    let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
     let fs3 := p3_lo + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let pc3 := ba3 + p3_hi
@@ -1344,41 +1344,41 @@ theorem divK_mulsub_correction_skip_spec
     -- Hypothesis: mulsub borrow = 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ u_base) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-       ((u_base + signExtend12 4064) ↦ₘ u4_new)) := by
-  intro u_base
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+       ((uBase + signExtend12 4064) ↦ₘ u4_new)) := by
+  intro uBase
         p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
         p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
         p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3 u4_new
         hborrow
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MS := divK_mulsub_full_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
   -- 2. Rewrite borrow to 0 in mulsub postcondition
   rw [hborrow] at MS
   -- 3. Correction skip (base+728 → base+884)
-  have CS := divK_correction_skip_spec sp u_base q_hat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
+  have CS := divK_correction_skip_spec sp uBase qHat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
     u4_new un3 base
   -- 4. Compose mulsub(borrow=0) + correction_skip
   seqFrame MS CS
@@ -1395,30 +1395,30 @@ theorem divK_mulsub_correction_skip_spec
     Entry: base+516, Exit: base+880 (before BEQ at [108]).
     CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_addback_880_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- Mulsub intermediates (same as in addback spec)
-    let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+    let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
     let fs0 := p0_lo + (signExtend12 0 : Word)
     let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
     let pc0 := ba0 + p0_hi
     let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
     let un0 := u0 - fs0; let c0 := pc0 + bs0
-    let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+    let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
     let fs1 := p1_lo + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let pc1 := ba1 + p1_hi
     let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
     let un1 := u1 - fs1; let c1 := pc1 + bs1
-    let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+    let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
     let fs2 := p2_lo + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let pc2 := ba2 + p2_hi
     let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
     let un2 := u2 - fs2; let c2 := pc2 + bs2
-    let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+    let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
     let fs3 := p3_lo + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let pc3 := ba3 + p3_hi
@@ -1447,47 +1447,47 @@ theorem divK_mulsub_correction_addback_880_spec
     let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4_new + aco3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 880) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ u_base) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4)) := by
-  intro u_base
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4)) := by
+  intro uBase
         p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
         p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
         p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3 u4_new
         upc0 ac1_0 aun0 ac2_0 aco0 upc1 ac1_1 aun1 ac2_1 aco1
-        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 q_hat'
+        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 qHat'
         hborrow
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MS := divK_mulsub_full_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
   -- 2. Correction addback (base+728 → base+880) with borrow ≠ 0
-  have CA := divK_correction_addback_spec sp u_base
+  have CA := divK_correction_addback_spec sp uBase
     (if BitVec.ult uTop c3 then (1 : Word) else 0)
-    q_hat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
+    qHat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
     u4_new un3 base hborrow
 
   dsimp only [] at CA
@@ -1501,39 +1501,39 @@ theorem divK_mulsub_correction_addback_880_spec
 /-- Mulsub + correction addback (→880), named postcondition variant.
     Uses addbackN4/addbackN4_carry in postcondition for rewritability. -/
 theorem divK_mulsub_correction_addback_named_880_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let c3 := ms.2.2.2.2
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 880) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ u_base) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ab.2.2.2.1) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ ab.1) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ ab.2.1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ ab.2.2.1) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
-       ((u_base + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
-  intro u_base ms c3 ab q_hat' hborrow
-  exact (divK_mulsub_correction_addback_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ ab.1) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ ab.2.1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ ab.2.2.1) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
+       ((uBase + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
+  intro uBase ms c3 ab qHat' hborrow
+  exact (divK_mulsub_correction_addback_880_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base) hborrow
 
 set_option maxRecDepth 4096 in
@@ -1541,30 +1541,30 @@ set_option maxRecDepth 4096 in
     run addback, then BEQ falls through (carry ≠ 0).
     Entry: base+516, Exit: base+884, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_addback_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- Mulsub intermediates
-    let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+    let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
     let fs0 := p0_lo + (signExtend12 0 : Word)
     let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
     let pc0 := ba0 + p0_hi
     let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
     let un0 := u0 - fs0; let c0 := pc0 + bs0
-    let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+    let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
     let fs1 := p1_lo + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let pc1 := ba1 + p1_hi
     let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
     let un1 := u1 - fs1; let c1 := pc1 + bs1
-    let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+    let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
     let fs2 := p2_lo + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let pc2 := ba2 + p2_hi
     let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
     let un2 := u2 - fs2; let c2 := pc2 + bs2
-    let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+    let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
     let fs3 := p3_lo + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let pc3 := ba3 + p3_hi
@@ -1593,49 +1593,49 @@ theorem divK_mulsub_correction_addback_spec
     let ac2_3 := if BitVec.ult aun3 v3 then (1 : Word) else 0
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4_new + aco3
-    let q_hat' := q_hat + signExtend12 4095
+    let qHat' := qHat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     -- Hypothesis: addback carry ≠ 0 (single addback sufficient)
     aco3 ≠ 0 →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ u_base) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-       ((u_base + signExtend12 4064) ↦ₘ aun4)) := by
-  intro u_base
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+       ((uBase + signExtend12 4064) ↦ₘ aun4)) := by
+  intro uBase
         p0_lo p0_hi fs0 ba0 pc0 bs0 un0 c0
         p1_lo p1_hi fs1 ba1 pc1 bs1 un1 c1
         p2_lo p2_hi fs2 ba2 pc2 bs2 un2 c2
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3 u4_new
         upc0 ac1_0 aun0 ac2_0 aco0 upc1 ac1_1 aun1 ac2_1 aco1
-        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 q_hat'
+        upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 qHat'
         hborrow hcarry
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MS := divK_mulsub_full_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
   -- 2. Correction addback (base+728 → base+880) with borrow ≠ 0
-  have CA := divK_correction_addback_spec sp u_base
+  have CA := divK_correction_addback_spec sp uBase
     (if BitVec.ult uTop c3 then (1 : Word) else 0)
-    q_hat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
+    qHat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
     u4_new un3 base hborrow
 
   dsimp only [] at CA
@@ -1645,15 +1645,15 @@ theorem divK_mulsub_correction_addback_spec
   seqFrame MS CA
   -- 5. Frame BEQ with remaining atoms and compose (880→884)
   have BEQf := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
-     (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ u_base) **
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat') **
+     (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ uBase) **
      (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ aun0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ aun1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ aun2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ aun3) **
-     ((u_base + signExtend12 4064) ↦ₘ aun4))
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ aun1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ aun2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ aun3) **
+     ((uBase + signExtend12 4064) ↦ₘ aun4))
     (by pcFree) BEQ
   have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) MSCA BEQf
@@ -1670,12 +1670,12 @@ theorem divK_mulsub_correction_addback_spec
 
 set_option maxRecDepth 4096 in
 /-- Trial quotient max path: save j + load + BLTU not-taken + trial_max.
-    When u_hi >= v_top, sets q_hat = MAX64 without calling div128.
+    When uHi >= vTop, sets qHat = MAX64 without calling div128.
     Entry: base+448, Exit: base+516, CodeReq: sharedDivModCode base. -/
 theorem divK_trial_max_full_spec
-    (sp j n j_old v5_old v6_old v7_old v10_old v11_old u_hi u_lo v_top : Word)
+    (sp j n j_old v5_old v6_old v7_old v10_old v11_old uHi uLo vTop : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_hi v_top) :
+    (hbltu : ¬BitVec.ult uHi vTop) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
@@ -1684,26 +1684,26 @@ theorem divK_trial_max_full_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top))
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
-       (.x5 ↦ᵣ u_lo) ** (.x6 ↦ᵣ vtopBase) **
-       (.x7 ↦ᵣ u_hi) ** (.x10 ↦ᵣ v_top) ** (.x11 ↦ᵣ signExtend12 4095) **
+       (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
+       (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top)) := by
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop)) := by
   intro uAddr vtopBase
   -- 1. Save j + trial load (base+448 → base+500)
-  have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top
+  have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old uHi uLo vTop
     base
   dsimp only [] at STL
   -- 2. BLTU x7 x10 12 at base+500
-  have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) u_hi v_top (base + 500)
+  have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) uHi vTop (base + 500)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranch_extend_code (hmono :=
     lb_sub base 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw
-  -- Eliminate taken path (⌜BitVec.ult u_hi v_top⌝ contradicts hbltu)
+  -- Eliminate taken path (⌜BitVec.ult uHi vTop⌝ contradicts hbltu)
   have ntaken := cpsBranch_ntakenPath hbltu_ext (fun hp hQt => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
     exact hbltu hpure)
@@ -1728,29 +1728,29 @@ theorem divK_trial_max_full_spec
 
 -- ============================================================================
 -- Section 11b: Trial quotient call path (BLTU taken): save + load + BLTU + JAL + div128
--- When u_hi < v_top, calls div128 to compute the trial quotient.
+-- When uHi < vTop, calls div128 to compute the trial quotient.
 -- Entry: base+448, Exit: base+516, CodeReq: sharedDivModCode base.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
 /-- Trial quotient call path: save j + load + BLTU taken + JAL + div128.
-    When u_hi < v_top, computes q_hat = div128(u_hi, u_lo, v_top).
+    When uHi < vTop, computes qHat = div128(uHi, uLo, vTop).
     Entry: base+448, Exit: base+516, CodeReq: sharedDivModCode base. -/
 theorem divK_trial_call_full_spec
-    (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old u_hi u_lo v_top : Word)
-    (ret_mem d_mem dlo_mem un0_mem : Word)
+    (sp j n j_old v5_old v6_old v7_old v10_old v11_old v2_old uHi uLo vTop : Word)
+    (retMem dMem dloMem un0Mem : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_hi v_top) :
+    (hbltu : BitVec.ult uHi vTop) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
-    let dHi := v_top >>> (32 : BitVec 6).toNat
-    let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := u_lo >>> (32 : BitVec 6).toNat
-    let un0_div := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_hi dHi
-    let rhat := u_hi - q1 * dHi
+    let dHi := vTop >>> (32 : BitVec 6).toNat
+    let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let un1 := uLo >>> (32 : BitVec 6).toNat
+    let un0Div := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + dHi
@@ -1767,7 +1767,7 @@ theorem divK_trial_call_full_spec
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0_div
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
@@ -1776,36 +1776,36 @@ theorem divK_trial_call_full_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ un0_mem))
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
        (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ u_hi) ** ((uAddr + 8) ↦ₘ u_lo) **
-       (vtopBase + signExtend12 32 ↦ₘ v_top) **
+       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+       (vtopBase + signExtend12 32 ↦ₘ vTop) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ v_top) **
+       (sp + signExtend12 3960 ↦ₘ vTop) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ un0_div)) := by
+       (sp + signExtend12 3944 ↦ₘ un0Div)) := by
   intro uAddr vtopBase
-        dHi dLo un1 un0_div q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
+        dHi dLo un1 un0Div q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
   -- 1. Save j + trial load (base+448 → base+500)
-  have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old u_hi u_lo v_top
+  have STL := divK_save_trial_load_spec sp j n j_old v5_old v6_old v7_old v10_old uHi uLo vTop
     base
   dsimp only [] at STL
   -- 2. BLTU x7 x10 12 at base+500
-  have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) u_hi v_top (base + 500)
+  have hbltu_raw := bltu_spec_gen .x7 .x10 (12 : BitVec 13) uHi vTop (base + 500)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranch_extend_code (hmono :=
     lb_sub base 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw
-  -- Eliminate ntaken path (⌜¬BitVec.ult u_hi v_top⌝ contradicts hbltu)
+  -- Eliminate ntaken path (⌜¬BitVec.ult uHi vTop⌝ contradicts hbltu)
   have taken := cpsBranch_takenPath hbltu_ext (fun hp hQf => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
     exact hpure hbltu)
@@ -1815,17 +1815,17 @@ theorem divK_trial_call_full_spec
     (fun h hp => sepConj_mono_right
       (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp) taken
   -- 3. Trial call path (base+512 → base+516)
-  have TCP := divK_trial_call_path_spec sp j u_lo u_hi v_top vtopBase base
-    v2_old v11_old ret_mem d_mem dlo_mem un0_mem
+  have TCP := divK_trial_call_path_spec sp j uLo uHi vTop vtopBase base
+    v2_old v11_old retMem dMem dloMem un0Mem
     halign
   dsimp only [] at TCP
   -- 4. Frame save_trial_load with x2, x11, x0, scratch memory
   have STLf := cpsTriple_frameR
     ((.x11 ↦ᵣ v11_old) ** (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) **
-     (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-     (sp + signExtend12 3944 ↦ₘ un0_mem))
+     (sp + signExtend12 3968 ↦ₘ retMem) **
+     (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) **
+     (sp + signExtend12 3944 ↦ₘ un0Mem))
     (by pcFree) STL
   -- 5. Compose save_trial_load + BLTU taken
   seqFrame STLf taken_clean
@@ -1849,23 +1849,23 @@ theorem divK_trial_call_full_spec
     - carry = 0 (double addback): BEQ takes backward branch, second addback, then falls through
     Entry: base+516, Exit: base+884. -/
 theorem divK_mulsub_correction_addback_beq_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let c3 := ms.2.2.2.2
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
     -- Double-addback results (only used when carry = 0)
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
     -- Final values depend on carry
-    let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-                 else q_hat + signExtend12 4095
-    let un0_out := if carry = 0 then ab'.1 else ab.1
-    let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-    let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-    let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+    let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+                 else qHat + signExtend12 4095
+    let un0Out := if carry = 0 then ab'.1 else ab.1
+    let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+    let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+    let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
     let carryOut := if carry = 0 then
         addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -1875,30 +1875,30 @@ theorem divK_mulsub_correction_addback_beq_spec
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x2 ↦ᵣ v2_old) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop))
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
-       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ u_base) **
-       (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+       (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ uBase) **
+       (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-       ((u_base + signExtend12 4064) ↦ₘ u4_out)) := by
-  intro u_base ms c3 carry ab ab' q_out un0_out un1_out un2_out un3_out u4_out carryOut
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+       ((uBase + signExtend12 4064) ↦ₘ u4_out)) := by
+  intro uBase ms c3 carry ab ab' q_out un0Out un1Out un2Out un3Out u4_out carryOut
         hcarry2_nz hborrow
   -- 1. Mulsub + first addback (base+516 → base+880)
-  have MCA := divK_mulsub_correction_addback_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   intro_lets at MCA
@@ -1906,24 +1906,24 @@ theorem divK_mulsub_correction_addback_beq_spec
   -- 2. Case split on carry
   by_cases hcarry : carry = 0
   · -- carry = 0: double addback path
-    have hq : q_out = q_hat + signExtend12 4095 + signExtend12 4095 := if_pos hcarry
-    have h0 : un0_out = ab'.1 := if_pos hcarry
-    have h1 : un1_out = ab'.2.1 := if_pos hcarry
-    have h2 : un2_out = ab'.2.2.1 := if_pos hcarry
-    have h3 : un3_out = ab'.2.2.2.1 := if_pos hcarry
+    have hq : q_out = qHat + signExtend12 4095 + signExtend12 4095 := if_pos hcarry
+    have h0 : un0Out = ab'.1 := if_pos hcarry
+    have h1 : un1Out = ab'.2.1 := if_pos hcarry
+    have h2 : un2Out = ab'.2.2.1 := if_pos hcarry
+    have h3 : un3Out = ab'.2.2.2.1 := if_pos hcarry
     have h4 : u4_out = ab'.2.2.2.2 := if_pos hcarry
     have hc : carryOut = addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 := if_pos hcarry
     rw [hq, h0, h1, h2, h3, h4, hc]
     -- Use named 880 spec (→880 with addbackN4_carry in postcondition)
-    have MCA_N := (divK_mulsub_correction_addback_named_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    have MCA_N := (divK_mulsub_correction_addback_named_880_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
       v1_old v5_old v6_old v7_old v10_old v2_old base) hborrow
     -- Rewrite carry to 0
     rw [show addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = (0 : Word) from hcarry] at MCA_N
     -- Use named DA spec (880→884 with addbackN4 projections in postcondition)
     have hcarry2 : addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 :=
       hcarry2_nz hcarry
-    have DA := divK_double_addback_beq_named_spec sp u_base
-      (q_hat + signExtend12 4095) v0 v1 v2 v3
+    have DA := divK_double_addback_beq_named_spec sp uBase
+      (qHat + signExtend12 4095) v0 v1 v2 v3
       ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
       base hcarry2
     -- Frame DA with extra atoms from MCA_N postcondition
@@ -1939,11 +1939,11 @@ theorem divK_mulsub_correction_addback_beq_spec
       (fun h hp => by xperm_hyp hp)
       full
   · -- carry ≠ 0: single addback path (BEQ passthrough)
-    have hq : q_out = q_hat + signExtend12 4095 := if_neg hcarry
-    have h0 : un0_out = ab.1 := if_neg hcarry
-    have h1 : un1_out = ab.2.1 := if_neg hcarry
-    have h2 : un2_out = ab.2.2.1 := if_neg hcarry
-    have h3 : un3_out = ab.2.2.2.1 := if_neg hcarry
+    have hq : q_out = qHat + signExtend12 4095 := if_neg hcarry
+    have h0 : un0Out = ab.1 := if_neg hcarry
+    have h1 : un1Out = ab.2.1 := if_neg hcarry
+    have h2 : un2Out = ab.2.2.1 := if_neg hcarry
+    have h3 : un3Out = ab.2.2.2.1 := if_neg hcarry
     have h4 : u4_out = ab.2.2.2.2 := if_neg hcarry
     have hc : carryOut = carry := if_neg hcarry
     rw [hq, h0, h1, h2, h3, h4, hc]

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -396,7 +396,7 @@ set_option maxRecDepth 4096 in
     53 instructions, loop body indices [17]-[69].
     Entry: base+516, Exit: base+728, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_full_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -434,8 +434,8 @@ theorem divK_mulsub_full_spec
     let un3 := u3 - fs3
     let c3 := pc3 + bs3
     -- Sub-carry intermediates
-    let borrow := if BitVec.ult u_top c3 then (1 : Word) else 0
-    let u4_new := u_top - c3
+    let borrow := if BitVec.ult uTop c3 then (1 : Word) else 0
+    let u4_new := uTop - c3
     cpsTriple (base + 516) (base + 728) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -446,7 +446,7 @@ theorem divK_mulsub_full_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ borrow) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -479,7 +479,7 @@ theorem divK_mulsub_full_spec
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((u_base + signExtend12 4064) ↦ₘ u_top))
+     ((u_base + signExtend12 4064) ↦ₘ uTop))
     (by pcFree) Se
   -- 2. Mulsub 4 limbs: instrs [22]-[65] at base+536
   have M := divK_mulsub_4limbs_spec sp u_base q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -488,7 +488,7 @@ theorem divK_mulsub_full_spec
   -- Compose setup + mulsub
   seqFrame Sf M
   -- 3. Sub-carry: instrs [66]-[69] at base+712
-  have SC := divK_sub_carry_spec u_base c3 bs3 fs3 u_top 4064 (base + 712)
+  have SC := divK_sub_carry_spec u_base c3 bs3 fs3 uTop 4064 (base + 712)
   rw [lb_sc] at SC
   have SCe := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub base 66 _ _ (by decide) (by bv_addr) (by decide))
@@ -1311,7 +1311,7 @@ theorem divK_store_loop_jgt0_spec
     Takes borrow as explicit parameter to avoid let-binding expansion issues.
     Entry: base+516, Exit: base+880, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_skip_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -1340,9 +1340,9 @@ theorem divK_mulsub_correction_skip_spec
     let pc3 := ba3 + p3_hi
     let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
     let un3 := u3 - fs3; let c3 := pc3 + bs3
-    let u4_new := u_top - c3
+    let u4_new := uTop - c3
     -- Hypothesis: mulsub borrow = 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -1353,7 +1353,7 @@ theorem divK_mulsub_correction_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_new) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
@@ -1371,7 +1371,7 @@ theorem divK_mulsub_correction_skip_spec
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3 u4_new
         hborrow
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
@@ -1395,7 +1395,7 @@ theorem divK_mulsub_correction_skip_spec
     Entry: base+516, Exit: base+880 (before BEQ at [108]).
     CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_addback_880_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -1424,7 +1424,7 @@ theorem divK_mulsub_correction_addback_880_spec
     let pc3 := ba3 + p3_hi
     let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
     let un3 := u3 - fs3; let c3 := pc3 + bs3
-    let u4_new := u_top - c3
+    let u4_new := uTop - c3
     -- Addback intermediates
     let upc0 := un0 + (signExtend12 0 : Word)
     let ac1_0 := if BitVec.ult upc0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -1449,7 +1449,7 @@ theorem divK_mulsub_correction_addback_880_spec
     let aun4 := u4_new + aco3
     let q_hat' := q_hat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 880) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -1460,7 +1460,7 @@ theorem divK_mulsub_correction_addback_880_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
@@ -1480,13 +1480,13 @@ theorem divK_mulsub_correction_addback_880_spec
         upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 q_hat'
         hborrow
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
   -- 2. Correction addback (base+728 → base+880) with borrow ≠ 0
   have CA := divK_correction_addback_spec sp u_base
-    (if BitVec.ult u_top c3 then (1 : Word) else 0)
+    (if BitVec.ult uTop c3 then (1 : Word) else 0)
     q_hat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
     u4_new un3 base hborrow
 
@@ -1501,16 +1501,16 @@ theorem divK_mulsub_correction_addback_880_spec
 /-- Mulsub + correction addback (→880), named postcondition variant.
     Uses addbackN4/addbackN4_carry in postcondition for rewritability. -/
 theorem divK_mulsub_correction_addback_named_880_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
     let c3 := ms.2.2.2.2
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
     let q_hat' := q_hat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 880) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -1521,7 +1521,7 @@ theorem divK_mulsub_correction_addback_named_880_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ ab.2.2.2.2) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ ab.2.2.2.1) **
@@ -1533,7 +1533,7 @@ theorem divK_mulsub_correction_addback_named_880_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ ab.2.2.2.1) **
        ((u_base + signExtend12 4064) ↦ₘ ab.2.2.2.2)) := by
   intro u_base ms c3 ab q_hat' hborrow
-  exact (divK_mulsub_correction_addback_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  exact (divK_mulsub_correction_addback_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base) hborrow
 
 set_option maxRecDepth 4096 in
@@ -1541,7 +1541,7 @@ set_option maxRecDepth 4096 in
     run addback, then BEQ falls through (carry ≠ 0).
     Entry: base+516, Exit: base+884, CodeReq: sharedDivModCode base. -/
 theorem divK_mulsub_correction_addback_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
@@ -1570,7 +1570,7 @@ theorem divK_mulsub_correction_addback_spec
     let pc3 := ba3 + p3_hi
     let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
     let un3 := u3 - fs3; let c3 := pc3 + bs3
-    let u4_new := u_top - c3
+    let u4_new := uTop - c3
     -- Addback intermediates
     let upc0 := un0 + (signExtend12 0 : Word)
     let ac1_0 := if BitVec.ult upc0 (signExtend12 0 : Word) then (1 : Word) else 0
@@ -1595,7 +1595,7 @@ theorem divK_mulsub_correction_addback_spec
     let aun4 := u4_new + aco3
     let q_hat' := q_hat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     -- Hypothesis: addback carry ≠ 0 (single addback sufficient)
     aco3 ≠ 0 →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
@@ -1608,7 +1608,7 @@ theorem divK_mulsub_correction_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat') **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ aun4) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ aco3) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ aun3) **
@@ -1628,13 +1628,13 @@ theorem divK_mulsub_correction_addback_spec
         upc2 ac1_2 aun2 ac2_2 aco2 upc3 ac1_3 aun3 ac2_3 aco3 aun4 q_hat'
         hborrow hcarry
   -- 1. Mulsub full (base+516 → base+728)
-  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MS := divK_mulsub_full_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   dsimp only [] at MS hborrow
   -- 2. Correction addback (base+728 → base+880) with borrow ≠ 0
   have CA := divK_correction_addback_spec sp u_base
-    (if BitVec.ult u_top c3 then (1 : Word) else 0)
+    (if BitVec.ult uTop c3 then (1 : Word) else 0)
     q_hat v0 v1 v2 v3 un0 un1 un2 un3 u4_new
     u4_new un3 base hborrow
 
@@ -1849,14 +1849,14 @@ theorem divK_trial_call_full_spec
     - carry = 0 (double addback): BEQ takes backward branch, second addback, then falls through
     Entry: base+516, Exit: base+884. -/
 theorem divK_mulsub_correction_addback_beq_spec
-    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
+    (sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1_old v5_old v6_old v7_old v10_old v2_old : Word)
     (base : Word) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
     let c3 := ms.2.2.2.2
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
     -- Double-addback results (only used when carry = 0)
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
     -- Final values depend on carry
@@ -1873,7 +1873,7 @@ theorem divK_mulsub_correction_addback_beq_spec
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (carry = 0 → addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top c3 then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + 516) (base + 884) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_hat) **
        (.x1 ↦ᵣ v1_old) ** (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -1884,7 +1884,7 @@ theorem divK_mulsub_correction_addback_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top))
+       ((u_base + signExtend12 4064) ↦ₘ uTop))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ u_base) **
        (.x7 ↦ᵣ carry_out) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
@@ -1898,7 +1898,7 @@ theorem divK_mulsub_correction_addback_beq_spec
   intro u_base ms c3 carry ab ab' q_out un0_out un1_out un2_out un3_out u4_out carry_out
         hcarry2_nz hborrow
   -- 1. Mulsub + first addback (base+516 → base+880)
-  have MCA := divK_mulsub_correction_addback_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     v1_old v5_old v6_old v7_old v10_old v2_old base
 
   intro_lets at MCA
@@ -1915,7 +1915,7 @@ theorem divK_mulsub_correction_addback_beq_spec
     have hc : carry_out = addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 := if_pos hcarry
     rw [hq, h0, h1, h2, h3, h4, hc]
     -- Use named 880 spec (→880 with addbackN4_carry in postcondition)
-    have MCA_N := (divK_mulsub_correction_addback_named_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    have MCA_N := (divK_mulsub_correction_addback_named_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
       v1_old v5_old v6_old v7_old v10_old v2_old base) hborrow
     -- Rewrite carry to 0
     rw [show addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = (0 : Word) from hcarry] at MCA_N

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -5,13 +5,13 @@
   Eliminates the uAddr/window-cell and vtop/v0 overlaps in the generic spec.
 
   For n=1, three address overlaps exist:
-  1. uAddr = u_base + signExtend12 4088  (both refer to u[j+1])
-  2. uAddr + 8 = u_base + signExtend12 0  (both refer to u[j+0])
+  1. uAddr = uBase + signExtend12 4088  (both refer to u[j+1])
+  2. uAddr + 8 = uBase + signExtend12 0  (both refer to u[j+0])
   3. vtopBase + signExtend12 32 = sp + signExtend12 32  (both refer to v[0])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting uAddr and vtopBase to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical uBase-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,13 +29,13 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=1 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=1: uAddr = u_base + signExtend12 4088 -/
+/-- For n=1: uAddr = uBase + signExtend12 4088 -/
 theorem u_addr_eq_n1 (sp j : Word) :
     sp + signExtend12 4056 - (j + (1 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- For n=1: (u_base + signExtend12 4088) + 8 = u_base + signExtend12 0 -/
+/-- For n=1: (uBase + signExtend12 4088) + 8 = uBase + signExtend12 0 -/
 theorem u_addr8_eq_n1 (sp j : Word) :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0 := by
@@ -48,7 +48,7 @@ theorem vtop_eq_v0_n1 (sp : Word) :
   divmod_addr
 
 -- ============================================================================
--- Trial wrappers for n=1 with addresses rewritten to canonical u_base-relative form
+-- Trial wrappers for n=1 with addresses rewritten to canonical uBase-relative form
 -- ============================================================================
 
 /-- Trial max full spec specialized for n=1, with addresses rewritten. -/
@@ -56,7 +56,7 @@ theorem divK_trial_max_full_spec_n1
     (sp j j_old v5_old v6_old v7_old v10_old v11_old u1 u0 v0 : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -64,16 +64,16 @@ theorem divK_trial_max_full_spec_n1
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ u0) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ u1) ** (.x10 ↦ᵣ v0) ** (.x11 ↦ᵣ signExtend12 4095) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0)) := by
-  intro u_base vtopBase
+  intro uBase vtopBase
   have TF := divK_trial_max_full_spec sp j (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
@@ -85,11 +85,11 @@ theorem divK_trial_max_full_spec_n1
 /-- Trial call full spec specialized for n=1, with addresses rewritten. -/
 theorem divK_trial_call_full_spec_n1
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old u1 u0 v0 : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let dHi := v0 >>> (32 : BitVec 6).toNat
     let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -114,35 +114,35 @@ theorem divK_trial_call_full_spec_n1
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q_hat) **
+       (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ qHat) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((u_base + signExtend12 4088) ↦ₘ u1) ** ((u_base + signExtend12 0) ↦ₘ u0) **
+       ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
        ((sp + signExtend12 32) ↦ₘ v0) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
   have TF := divK_trial_call_full_spec sp j (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp j] at TF
@@ -156,54 +156,54 @@ theorem divK_trial_call_full_spec_n1
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ skip) for n=1.
-    No overlapping cells: u_hi=u1, u_lo=u0, v_top=v0.
+    No overlapping cells: uHi=u1, uLo=u0, vTop=v0.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (base + loopBodyOff) (loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   -- Expand mulsub computation locally for intermediate steps
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -218,34 +218,34 @@ theorem divK_loop_body_n1_max_skip_spec
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells that DON'T overlap
-  --    (u_base+4088 ↦ₘ u1, u_base+0 ↦ₘ u0, sp+32 ↦ₘ v0 are already in TF)
+  --    (uBase+4088 ↦ₘ u1, uBase+0 ↦ₘ u0, sp+32 ↦ₘ v0 are already in TF)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
@@ -263,48 +263,48 @@ theorem divK_loop_body_n1_max_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ addback) for n=1.
-    No overlapping cells: u_hi=u1, u_lo=u0, v_top=v0.
+    No overlapping cells: uHi=u1, uLo=u0, vTop=v0.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr ms ab hcarry2_nz hborrow
+      (base + loopBodyOff) (loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -315,7 +315,7 @@ theorem divK_loop_body_n1_max_addback_spec
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
@@ -326,22 +326,22 @@ theorem divK_loop_body_n1_max_addback_spec
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose
@@ -358,16 +358,16 @@ theorem divK_loop_body_n1_max_addback_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ skip) for n=1.
-    No overlapping cells: u_hi=u1, u_lo=u0, v_top=v0.
+    No overlapping cells: uHi=u1, uLo=u0, vTop=v0.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v0 >>> (32 : BitVec 6).toNat
     let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -393,63 +393,63 @@ theorem divK_loop_body_n1_call_skip_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
   -- Expand mulsub computation locally for intermediate steps
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -460,37 +460,37 @@ theorem divK_loop_body_n1_call_skip_spec
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full for n=1 (base+448 → base+516)
   have TF := divK_trial_call_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (trial_call includes scratch memory, so don't add those to frame)
-  --    For n=1: u_base+4088 ↦ u1, u_base+0 ↦ u0, sp+32 ↦ v0 are in the trial
+  --    For n=1: uBase+4088 ↦ u1, uBase+0 ↦ u0, sp+32 ↦ v0 are in the trial
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -511,16 +511,16 @@ theorem divK_loop_body_n1_call_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ addback) for n=1.
-    No overlapping cells: u_hi=u1, u_lo=u0, v_top=v0.
+    No overlapping cells: uHi=u1, uLo=u0, vTop=v0.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v0 >>> (32 : BitVec 6).toNat
     let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -546,57 +546,57 @@ theorem divK_loop_body_n1_call_addback_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -604,12 +604,12 @@ theorem divK_loop_body_n1_call_addback_spec
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full for n=1 (base+448 → base+516)
   have TF := divK_trial_call_full_spec_n1 sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -618,22 +618,22 @@ theorem divK_loop_body_n1_call_addback_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -661,19 +661,19 @@ def loopBodyPostN1
     (x2v x10v x11v : Word)
     (un0v un1v un2v un3v u4v qv : Word)
     (retv dv dlov sunv : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
   (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3v) **
+  ((uBase + signExtend12 4064) ↦ₘ u4v) **
   (qAddr ↦ₘ qv) **
   (sp + signExtend12 3968 ↦ₘ retv) **
   (sp + signExtend12 3960 ↦ₘ dv) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -160,14 +160,14 @@ theorem divK_trial_call_full_spec_n1
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -178,10 +178,10 @@ theorem divK_loop_body_n1_max_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -209,7 +209,7 @@ theorem divK_loop_body_n1_max_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   -- Abbreviation for vtop_base (register value, not a memory address)
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -218,7 +218,7 @@ theorem divK_loop_body_n1_max_skip_spec
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCS
@@ -232,7 +232,7 @@ theorem divK_loop_body_n1_max_skip_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -267,19 +267,19 @@ theorem divK_loop_body_n1_max_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -290,10 +290,10 @@ theorem divK_loop_body_n1_max_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -315,7 +315,7 @@ theorem divK_loop_body_n1_max_addback_spec
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCA
@@ -328,7 +328,7 @@ theorem divK_loop_body_n1_max_addback_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
@@ -362,7 +362,7 @@ theorem divK_loop_body_n1_max_addback_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -396,7 +396,7 @@ theorem divK_loop_body_n1_call_skip_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -407,20 +407,20 @@ theorem divK_loop_body_n1_call_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -455,7 +455,7 @@ theorem divK_loop_body_n1_call_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full for n=1 (base+448 → base+516)
@@ -464,7 +464,7 @@ theorem divK_loop_body_n1_call_skip_spec
     halign hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -477,7 +477,7 @@ theorem divK_loop_body_n1_call_skip_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -515,7 +515,7 @@ theorem divK_loop_body_n1_call_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n1_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -549,12 +549,12 @@ theorem divK_loop_body_n1_call_addback_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -565,20 +565,20 @@ theorem divK_loop_body_n1_call_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -608,7 +608,7 @@ theorem divK_loop_body_n1_call_addback_spec
     halign hbltu
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -620,7 +620,7 @@ theorem divK_loop_body_n1_call_addback_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -5,13 +5,13 @@
   Eliminates the uAddr/window-cell and vtop/v1 overlaps in the generic spec.
 
   For n=2, three address overlaps exist:
-  1. uAddr = u_base + signExtend12 4080  (both refer to u[j+2])
-  2. uAddr + 8 = u_base + signExtend12 4088  (both refer to u[j+1])
+  1. uAddr = uBase + signExtend12 4080  (both refer to u[j+2])
+  2. uAddr + 8 = uBase + signExtend12 4088  (both refer to u[j+1])
   3. vtopBase + signExtend12 32 = sp + signExtend12 40  (both refer to v[1])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting uAddr and vtopBase to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical uBase-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,13 +29,13 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=2 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=2: uAddr = u_base + signExtend12 4080 -/
+/-- For n=2: uAddr = uBase + signExtend12 4080 -/
 theorem u_addr_eq_n2 (sp j : Word) :
     sp + signExtend12 4056 - (j + (2 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- For n=2: (u_base + signExtend12 4080) + 8 = u_base + signExtend12 4088 -/
+/-- For n=2: (uBase + signExtend12 4080) + 8 = uBase + signExtend12 4088 -/
 theorem u_addr8_eq_n2 (sp j : Word) :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
@@ -53,54 +53,54 @@ theorem vtop_eq_v1_n2 (sp : Word) :
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ skip) for n=2.
-    No overlapping cells: u_hi=u2, u_lo=u1, v_top=v1.
+    No overlapping cells: uHi=u2, uLo=u1, vTop=v1.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (base + loopBodyOff) (loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   -- Expand mulsub computation locally for intermediate steps
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -110,45 +110,45 @@ theorem divK_loop_body_n2_max_skip_spec
   let j' := j + signExtend12 4095
   -- Abbreviation for vtopBase (register value, not a memory address)
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  -- 1. Trial max full (base+448 → base+516), instantiated with n=2, u_hi=u2, u_lo=u1, v_top=v1
+  -- 1. Trial max full (base+448 → base+516), instantiated with n=2, uHi=u2, uLo=u1, vTop=v1
   have TF := divK_trial_max_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite uAddr → u_base + signExtend12 4080, and (uAddr+8) → u_base + signExtend12 4088
+  -- Rewrite uAddr → uBase + signExtend12 4080, and (uAddr+8) → uBase + signExtend12 4088
   rw [u_addr_eq_n2 sp j] at TF
   rw [u_addr8_eq_n2 sp j] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 40
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells that DON'T overlap
-  --    (u_base+4080 ↦ₘ u2, u_base+4088 ↦ₘ u1, sp+40 ↦ₘ v1 are already in TF)
+  --    (uBase+4080 ↦ₘ u2, uBase+4088 ↦ₘ u1, sp+40 ↦ₘ v1 are already in TF)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
@@ -166,48 +166,48 @@ theorem divK_loop_body_n2_max_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ addback) for n=2.
-    No overlapping cells: u_hi=u2, u_lo=u1, v_top=v1.
+    No overlapping cells: uHi=u2, uLo=u1, vTop=v1.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr ms ab hcarry2_nz hborrow
+      (base + loopBodyOff) (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -221,7 +221,7 @@ theorem divK_loop_body_n2_max_addback_spec
   rw [u_addr8_eq_n2 sp j] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
@@ -232,22 +232,22 @@ theorem divK_loop_body_n2_max_addback_spec
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose
@@ -264,16 +264,16 @@ theorem divK_loop_body_n2_max_addback_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ skip) for n=2.
-    No overlapping cells: u_hi=u2, u_lo=u1, v_top=v1.
+    No overlapping cells: uHi=u2, uLo=u1, vTop=v1.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v1 >>> (32 : BitVec 6).toNat
     let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -299,62 +299,62 @@ theorem divK_loop_body_n2_call_skip_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -365,7 +365,7 @@ theorem divK_loop_body_n2_call_skip_spec
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp j] at TF
@@ -373,32 +373,32 @@ theorem divK_loop_body_n2_call_skip_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (trial_call includes scratch memory, so don't add those to frame)
-  --    For n=2: u_base+4080 ↦ u2, u_base+4088 ↦ u1, sp+40 ↦ v1 are in the trial
+  --    For n=2: uBase+4080 ↦ u2, uBase+4088 ↦ u1, sp+40 ↦ v1 are in the trial
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -419,16 +419,16 @@ theorem divK_loop_body_n2_call_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ addback) for n=2.
-    No overlapping cells: u_hi=u2, u_lo=u1, v_top=v1.
+    No overlapping cells: uHi=u2, uLo=u1, vTop=v1.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v1 >>> (32 : BitVec 6).toNat
     let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -454,57 +454,57 @@ theorem divK_loop_body_n2_call_addback_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -512,7 +512,7 @@ theorem divK_loop_body_n2_call_addback_spec
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp j] at TF
@@ -520,7 +520,7 @@ theorem divK_loop_body_n2_call_addback_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -529,22 +529,22 @@ theorem divK_loop_body_n2_call_addback_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -572,19 +572,19 @@ def loopBodyPostN2
     (x2v x10v x11v : Word)
     (un0v un1v un2v un3v u4v qv : Word)
     (retv dv dlov sunv : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
   (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3v) **
+  ((uBase + signExtend12 4064) ↦ₘ u4v) **
   (qAddr ↦ₘ qv) **
   (sp + signExtend12 3968 ↦ₘ retv) **
   (sp + signExtend12 3960 ↦ₘ dv) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -57,14 +57,14 @@ theorem vtop_eq_v1_n2 (sp : Word) :
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -75,10 +75,10 @@ theorem divK_loop_body_n2_max_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -106,7 +106,7 @@ theorem divK_loop_body_n2_max_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   -- Abbreviation for vtop_base (register value, not a memory address)
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -121,7 +121,7 @@ theorem divK_loop_body_n2_max_skip_spec
   -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 40
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCS
@@ -135,7 +135,7 @@ theorem divK_loop_body_n2_max_skip_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -170,19 +170,19 @@ theorem divK_loop_body_n2_max_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -193,10 +193,10 @@ theorem divK_loop_body_n2_max_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -221,7 +221,7 @@ theorem divK_loop_body_n2_max_addback_spec
   rw [u_addr8_eq_n2 sp j] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCA
@@ -234,7 +234,7 @@ theorem divK_loop_body_n2_max_addback_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
@@ -268,7 +268,7 @@ theorem divK_loop_body_n2_max_addback_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -302,7 +302,7 @@ theorem divK_loop_body_n2_call_skip_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -313,20 +313,20 @@ theorem divK_loop_body_n2_call_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -360,7 +360,7 @@ theorem divK_loop_body_n2_call_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
@@ -372,7 +372,7 @@ theorem divK_loop_body_n2_call_skip_spec
   rw [u_addr8_eq_n2 sp j] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -385,7 +385,7 @@ theorem divK_loop_body_n2_call_skip_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -423,7 +423,7 @@ theorem divK_loop_body_n2_call_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n2_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -457,12 +457,12 @@ theorem divK_loop_body_n2_call_addback_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -473,20 +473,20 @@ theorem divK_loop_body_n2_call_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v1) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -519,7 +519,7 @@ theorem divK_loop_body_n2_call_addback_spec
   rw [u_addr8_eq_n2 sp j] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -531,7 +531,7 @@ theorem divK_loop_body_n2_call_addback_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -5,13 +5,13 @@
   Eliminates the uAddr/window-cell and vtop/v2 overlaps in the generic spec.
 
   For n=3, three address overlaps exist:
-  1. uAddr = u_base + signExtend12 4072  (both refer to u[j+3])
-  2. uAddr + 8 = u_base + signExtend12 4080  (both refer to u[j+2])
+  1. uAddr = uBase + signExtend12 4072  (both refer to u[j+3])
+  2. uAddr + 8 = uBase + signExtend12 4080  (both refer to u[j+2])
   3. vtopBase + signExtend12 32 = sp + signExtend12 48  (both refer to v[2])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting uAddr and vtopBase to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical uBase-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,13 +29,13 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=3 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=3: uAddr = u_base + signExtend12 4072 -/
+/-- For n=3: uAddr = uBase + signExtend12 4072 -/
 theorem u_addr_eq_n3 (sp j : Word) :
     sp + signExtend12 4056 - (j + (3 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- For n=3: (u_base + signExtend12 4072) + 8 = u_base + signExtend12 4080 -/
+/-- For n=3: (uBase + signExtend12 4072) + 8 = uBase + signExtend12 4080 -/
 theorem u_addr8_eq_n3 (sp j : Word) :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
@@ -53,53 +53,53 @@ theorem vtop_eq_v2_n3 (sp : Word) :
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ skip) for n=3.
-    No overlapping cells: u_hi=u3, u_lo=u2, v_top=v2.
+    No overlapping cells: uHi=u3, uLo=u2, vTop=v2.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (base + loopBodyOff) (loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -109,45 +109,45 @@ theorem divK_loop_body_n3_max_skip_spec
   let j' := j + signExtend12 4095
   -- Abbreviation for vtopBase (register value, not a memory address)
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  -- 1. Trial max full (base+448 → base+516), instantiated with n=3, u_hi=u3, u_lo=u2, v_top=v2
+  -- 1. Trial max full (base+448 → base+516), instantiated with n=3, uHi=u3, uLo=u2, vTop=v2
   have TF := divK_trial_max_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u3 u2 v2 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite uAddr → u_base + signExtend12 4072, and (uAddr+8) → u_base + signExtend12 4080
+  -- Rewrite uAddr → uBase + signExtend12 4072, and (uAddr+8) → uBase + signExtend12 4080
   rw [u_addr_eq_n3 sp j] at TF
   rw [u_addr8_eq_n3 sp j] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 48
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells that DON'T overlap
-  --    (u_base+4072 ↦ₘ u3, u_base+4080 ↦ₘ u2, sp+48 ↦ₘ v2 are already in TF)
+  --    (uBase+4072 ↦ₘ u3, uBase+4080 ↦ₘ u2, sp+48 ↦ₘ v2 are already in TF)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
@@ -165,48 +165,48 @@ theorem divK_loop_body_n3_max_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ addback) for n=3.
-    No overlapping cells: u_hi=u3, u_lo=u2, v_top=v2.
+    No overlapping cells: uHi=u3, uLo=u2, vTop=v2.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr ms ab hcarry2_nz hborrow
+      (base + loopBodyOff) (loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -221,7 +221,7 @@ theorem divK_loop_body_n3_max_addback_spec
   rw [u_addr8_eq_n3 sp j] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
@@ -232,22 +232,22 @@ theorem divK_loop_body_n3_max_addback_spec
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose
@@ -264,16 +264,16 @@ theorem divK_loop_body_n3_max_addback_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ skip) for n=3.
-    No overlapping cells: u_hi=u3, u_lo=u2, v_top=v2.
+    No overlapping cells: uHi=u3, uLo=u2, vTop=v2.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v2 >>> (32 : BitVec 6).toNat
     let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -299,62 +299,62 @@ theorem divK_loop_body_n3_call_skip_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -365,7 +365,7 @@ theorem divK_loop_body_n3_call_skip_spec
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp j] at TF
@@ -373,32 +373,32 @@ theorem divK_loop_body_n3_call_skip_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (trial_call includes scratch memory, so don't add those to frame)
-  --    For n=3: u_base+4072 ↦ u3, u_base+4080 ↦ u2, sp+48 ↦ v2 are in the trial
+  --    For n=3: uBase+4072 ↦ u3, uBase+4080 ↦ u2, sp+48 ↦ v2 are in the trial
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
@@ -419,16 +419,16 @@ theorem divK_loop_body_n3_call_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ addback) for n=3.
-    No overlapping cells: u_hi=u3, u_lo=u2, v_top=v2.
+    No overlapping cells: uHi=u3, uLo=u2, vTop=v2.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v2 >>> (32 : BitVec 6).toNat
     let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -454,57 +454,57 @@ theorem divK_loop_body_n3_call_addback_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -512,7 +512,7 @@ theorem divK_loop_body_n3_call_addback_spec
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp j] at TF
@@ -520,7 +520,7 @@ theorem divK_loop_body_n3_call_addback_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -529,22 +529,22 @@ theorem divK_loop_body_n3_call_addback_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
@@ -572,19 +572,19 @@ def loopBodyPostN3
     (x2v x10v x11v : Word)
     (un0v un1v un2v un3v u4v qv : Word)
     (retv dv dlov sunv : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
   (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3v) **
+  ((uBase + signExtend12 4064) ↦ₘ u4v) **
   (qAddr ↦ₘ qv) **
   (sp + signExtend12 3968 ↦ₘ retv) **
   (sp + signExtend12 3960 ↦ₘ dv) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -57,14 +57,14 @@ theorem vtop_eq_v2_n3 (sp : Word) :
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -75,10 +75,10 @@ theorem divK_loop_body_n3_max_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -105,7 +105,7 @@ theorem divK_loop_body_n3_max_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   -- Abbreviation for vtop_base (register value, not a memory address)
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -120,7 +120,7 @@ theorem divK_loop_body_n3_max_skip_spec
   -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 48
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCS
@@ -134,7 +134,7 @@ theorem divK_loop_body_n3_max_skip_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -169,19 +169,19 @@ theorem divK_loop_body_n3_max_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -192,10 +192,10 @@ theorem divK_loop_body_n3_max_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -221,7 +221,7 @@ theorem divK_loop_body_n3_max_addback_spec
   rw [u_addr8_eq_n3 sp j] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCA
@@ -234,7 +234,7 @@ theorem divK_loop_body_n3_max_addback_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
@@ -268,7 +268,7 @@ theorem divK_loop_body_n3_max_addback_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -302,7 +302,7 @@ theorem divK_loop_body_n3_call_skip_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -313,20 +313,20 @@ theorem divK_loop_body_n3_call_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -360,7 +360,7 @@ theorem divK_loop_body_n3_call_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
@@ -372,7 +372,7 @@ theorem divK_loop_body_n3_call_skip_spec
   rw [u_addr8_eq_n3 sp j] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -385,7 +385,7 @@ theorem divK_loop_body_n3_call_skip_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -423,7 +423,7 @@ theorem divK_loop_body_n3_call_skip_spec
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n3_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -457,12 +457,12 @@ theorem divK_loop_body_n3_call_addback_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -473,20 +473,20 @@ theorem divK_loop_body_n3_call_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v2) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -519,7 +519,7 @@ theorem divK_loop_body_n3_call_addback_spec
   rw [u_addr8_eq_n3 sp j] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -531,7 +531,7 @@ theorem divK_loop_body_n3_call_addback_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -5,13 +5,13 @@
   Eliminates the uAddr/window-cell and vtop/v3 overlaps in the generic spec.
 
   For n=4, three address overlaps exist:
-  1. uAddr = u_base + signExtend12 4064  (both refer to u[j+4])
-  2. uAddr + 8 = u_base + signExtend12 4072  (both refer to u[j+3])
+  1. uAddr = uBase + signExtend12 4064  (both refer to u[j+4])
+  2. uAddr + 8 = uBase + signExtend12 4072  (both refer to u[j+3])
   3. vtopBase + signExtend12 32 = sp + signExtend12 56  (both refer to v[3])
 
   This file eliminates these overlaps by:
   - Expanding the trial spec's let-bindings via dsimp
-  - Rewriting uAddr and vtopBase to canonical u_base-relative form
+  - Rewriting uAddr and vtopBase to canonical uBase-relative form
   - Framing only with cells NOT already in the trial spec
   - Composing without cell duplication in any separating conjunction
 -/
@@ -29,13 +29,13 @@ open EvmAsm.Rv64
 -- Address rewriting lemmas for n=4 (no let-bindings, suitable for rw)
 -- ============================================================================
 
-/-- For n=4: uAddr = u_base + signExtend12 4064 -/
+/-- For n=4: uAddr = uBase + signExtend12 4064 -/
 theorem u_addr_eq_n4 (sp j : Word) :
     sp + signExtend12 4056 - (j + (4 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
 
-/-- For n=4: (u_base + signExtend12 4064) + 8 = u_base + signExtend12 4072 -/
+/-- For n=4: (uBase + signExtend12 4064) + 8 = uBase + signExtend12 4072 -/
 theorem u_addr8_eq_n4 (sp j : Word) :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4064) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
@@ -53,55 +53,55 @@ theorem vtop_eq_v3_n4 (sp : Word) :
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ skip) for n=4.
-    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
+    No overlapping cells: uHi=uTop, uLo=u3, vTop=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (base + loopBodyOff) (loopBodyN4SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN4SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   -- Expand mulsub computation locally for intermediate steps
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   -- Extract individual components matching the old let-chain names
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -111,45 +111,45 @@ theorem divK_loop_body_n4_max_skip_spec
   let j' := j + signExtend12 4095
   -- Abbreviation for vtopBase (register value, not a memory address)
   let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  -- 1. Trial max full (base+448 → base+516), instantiated with n=4, u_hi=uTop, u_lo=u3, v_top=v3
+  -- 1. Trial max full (base+448 → base+516), instantiated with n=4, uHi=uTop, uLo=u3, vTop=v3
   have TF := divK_trial_max_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     uTop u3 v3 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
-  -- Rewrite uAddr → u_base + signExtend12 4064, and (uAddr+8) → u_base + signExtend12 4072
+  -- Rewrite uAddr → uBase + signExtend12 4064, and (uAddr+8) → uBase + signExtend12 4072
   rw [u_addr_eq_n4 sp j] at TF
   rw [u_addr8_eq_n4 sp j] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 56
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u3 vtopBase uTop v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells that DON'T overlap
-  --    (u_base+4064 ↦ₘ uTop, u_base+4072 ↦ₘ u3, sp+56 ↦ₘ v3 are already in TF)
+  --    (uBase+4064 ↦ₘ uTop, uBase+4072 ↦ₘ u3, sp+56 ↦ₘ v3 are already in TF)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop with remaining atoms
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
@@ -167,48 +167,48 @@ theorem divK_loop_body_n4_max_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ addback) for n=4.
-    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
+    No overlapping cells: uHi=uTop, uLo=u3, vTop=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-      (base + denormOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr ms ab hcarry2_nz hborrow
+      (base + loopBodyOff) (loopBodyN4AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN4AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -223,7 +223,7 @@ theorem divK_loop_body_n4_max_addback_spec
   rw [u_addr8_eq_n4 sp j] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u3 vtopBase uTop v3 v2_old base
 
   intro_lets at MCA
@@ -234,22 +234,22 @@ theorem divK_loop_body_n4_max_addback_spec
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose
@@ -266,16 +266,16 @@ theorem divK_loop_body_n4_max_addback_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ skip) for n=4.
-    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
+    No overlapping cells: uHi=uTop, uLo=u3, vTop=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -301,63 +301,63 @@ theorem divK_loop_body_n4_call_skip_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
   -- Expand mulsub computation locally for intermediate steps
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -368,7 +368,7 @@ theorem divK_loop_body_n4_call_skip_spec
   let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp j] at TF
@@ -376,31 +376,31 @@ theorem divK_loop_body_n4_call_skip_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_spec sp j qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (trial_call includes scratch memory, so don't add those to frame)
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
@@ -421,16 +421,16 @@ theorem divK_loop_body_n4_call_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ addback) for n=4.
-    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
+    No overlapping cells: uHi=uTop, uLo=u3, vTop=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -456,57 +456,57 @@ theorem divK_loop_body_n4_call_addback_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -514,7 +514,7 @@ theorem divK_loop_body_n4_call_addback_spec
   let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp j] at TF
@@ -522,7 +522,7 @@ theorem divK_loop_body_n4_call_addback_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -531,22 +531,22 @@ theorem divK_loop_body_n4_call_addback_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop
   have SLf := cpsBranch_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ j) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
@@ -575,19 +575,19 @@ def loopBodyPostN4
     (x2v x10v x11v : Word)
     (un0v un1v un2v un3v u4v qv : Word)
     (retv dv dlov sunv : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
   (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ x10v) ** (.x11 ↦ᵣ x11v) **
   (.x2 ↦ᵣ x2v) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0v) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1v) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2v) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3v) **
-  ((u_base + signExtend12 4064) ↦ₘ u4v) **
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0v) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1v) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2v) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3v) **
+  ((uBase + signExtend12 4064) ↦ₘ u4v) **
   (qAddr ↦ₘ qv) **
   (sp + signExtend12 3968 ↦ₘ retv) **
   (sp + signExtend12 3960 ↦ₘ dv) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -53,18 +53,18 @@ theorem vtop_eq_v3_n4 (sp : Word) :
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ skip) for n=4.
-    No overlapping cells: u_hi=u_top, u_lo=u3, v_top=v3.
+    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_max_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3) :
+    (hbltu : ¬BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -75,10 +75,10 @@ theorem divK_loop_body_n4_max_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
@@ -107,13 +107,13 @@ theorem divK_loop_body_n4_max_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   -- Abbreviation for vtop_base (register value, not a memory address)
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  -- 1. Trial max full (base+448 → base+516), instantiated with n=4, u_hi=u_top, u_lo=u3, v_top=v3
+  -- 1. Trial max full (base+448 → base+516), instantiated with n=4, u_hi=uTop, u_lo=u3, v_top=v3
   have TF := divK_trial_max_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
-    u_top u3 v3 base hbltu
+    uTop u3 v3 base hbltu
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
   -- Rewrite u_addr → u_base + signExtend12 4064, and (u_addr+8) → u_base + signExtend12 4072
@@ -122,8 +122,8 @@ theorem divK_loop_body_n4_max_skip_spec
   -- Rewrite vtop_base + signExtend12 32 → sp + signExtend12 56
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u3 vtop_base u_top v3 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u3 vtop_base uTop v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -131,7 +131,7 @@ theorem divK_loop_body_n4_max_skip_spec
   have SL := divK_store_loop_spec sp j q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells that DON'T overlap
-  --    (u_base+4064 ↦ₘ u_top, u_base+4072 ↦ₘ u3, sp+56 ↦ₘ v3 are already in TF)
+  --    (u_base+4064 ↦ₘ uTop, u_base+4072 ↦ₘ u3, sp+56 ↦ₘ v3 are already in TF)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
@@ -167,23 +167,23 @@ theorem divK_loop_body_n4_max_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU ntaken + BEQ addback) for n=4.
-    No overlapping cells: u_hi=u_top, u_lo=u3, v_top=v3.
+    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_max_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3) :
+    (hbltu : ¬BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -194,10 +194,10 @@ theorem divK_loop_body_n4_max_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (base + loopBodyOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-      (base + denormOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (base + loopBodyOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+      (base + denormOff) (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr ms ab hcarry2_nz hborrow
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
@@ -217,14 +217,14 @@ theorem divK_loop_body_n4_max_addback_spec
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
-    u_top u3 v3 base hbltu
+    uTop u3 v3 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp j] at TF
   rw [u_addr8_eq_n4 sp j] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    j u3 vtop_base u_top v3 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u3 vtop_base uTop v3 v2_old base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
@@ -266,23 +266,23 @@ theorem divK_loop_body_n4_max_addback_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ skip) for n=4.
-    No overlapping cells: u_hi=u_top, u_lo=u3, v_top=v3.
+    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_call_skip_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3) :
+    (hbltu : BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -304,7 +304,7 @@ theorem divK_loop_body_n4_call_skip_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -315,20 +315,20 @@ theorem divK_loop_body_n4_call_skip_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -363,19 +363,19 @@ theorem divK_loop_body_n4_call_skip_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let j' := j + signExtend12 4095
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp j] at TF
   rw [u_addr8_eq_n4 sp j] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -421,23 +421,23 @@ theorem divK_loop_body_n4_call_skip_spec
 -- ============================================================================
 
 /-- Full loop body (BLTU taken + BEQ addback) for n=4.
-    No overlapping cells: u_hi=u_top, u_lo=u3, v_top=v3.
+    No overlapping cells: u_hi=uTop, u_lo=u3, v_top=v3.
     Entry: base+448, cpsBranch to base+448/904. -/
 theorem divK_loop_body_n4_call_addback_spec
     (sp j j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3) :
+    (hbltu : BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -459,12 +459,12 @@ theorem divK_loop_body_n4_call_addback_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
     (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0) →
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsBranch (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -475,20 +475,20 @@ theorem divK_loop_body_n4_call_addback_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (base + loopBodyOff)
-      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
        (sp + signExtend12 3944 ↦ₘ div_un0))
       (base + denormOff)
-      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -514,14 +514,14 @@ theorem divK_loop_body_n4_call_addback_spec
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp j (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp j] at TF
   rw [u_addr8_eq_n4 sp j] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA

--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -27,30 +27,30 @@ open EvmAsm.Rv64
 -- ============================================================================
 -- Address equality lemmas for j=3 output → j=2 input transition
 --
--- j=3 postcondition uses u_base(3) = sp + signExtend12(4056) - 24
--- j=2 precondition uses u_base(2) = sp + signExtend12(4056) - 16
--- The overlap: u_base(3) + offset_k = u_base(2) + offset_{k-1}
+-- j=3 postcondition uses uBase(3) = sp + signExtend12(4056) - 24
+-- j=2 precondition uses uBase(2) = sp + signExtend12(4056) - 16
+-- The overlap: uBase(3) + offset_k = uBase(2) + offset_{k-1}
 -- ============================================================================
 
-/-- j=3 un0 at u_base(3)+0 = j=2 u1 at u_base(2)-8 -/
+/-- j=3 un0 at uBase(3)+0 = j=2 u1 at uBase(2)-8 -/
 theorem u_n1_j3_0_eq_j2_4088 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- j=3 un1 at u_base(3)-8 = j=2 u2 at u_base(2)-16 -/
+/-- j=3 un1 at uBase(3)-8 = j=2 u2 at uBase(2)-16 -/
 theorem u_n1_j3_4088_eq_j2_4080 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- j=3 un2 at u_base(3)-16 = j=2 u3 at u_base(2)-24 -/
+/-- j=3 un2 at uBase(3)-16 = j=2 u3 at uBase(2)-24 -/
 theorem u_n1_j3_4080_eq_j2_4072 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=3 un3 at u_base(3)+4072 = j=2 uTop at u_base(2)+4064 -/
+/-- j=3 un3 at uBase(3)+4072 = j=2 uTop at uBase(2)+4064 -/
 theorem u_n1_j3_4072_eq_j2_4064 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -59,29 +59,29 @@ theorem u_n1_j3_4072_eq_j2_4064 (sp : Word) :
 -- ============================================================================
 -- Address equality lemmas for j=2 output → j=1 input transition
 --
--- j=2 postcondition uses u_base(2) = sp + signExtend12(4056) - 16
--- j=1 precondition uses u_base(1) = sp + signExtend12(4056) - 8
+-- j=2 postcondition uses uBase(2) = sp + signExtend12(4056) - 16
+-- j=1 precondition uses uBase(1) = sp + signExtend12(4056) - 8
 -- ============================================================================
 
-/-- j=2 un0 at u_base(2)+0 = j=1 u1 at u_base(1)-8 -/
+/-- j=2 un0 at uBase(2)+0 = j=1 u1 at uBase(1)-8 -/
 theorem u_n1_j2_0_eq_j1_4088 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- j=2 un1 at u_base(2)-8 = j=1 u2 at u_base(1)-16 -/
+/-- j=2 un1 at uBase(2)-8 = j=1 u2 at uBase(1)-16 -/
 theorem u_n1_j2_4088_eq_j1_4080 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- j=2 un2 at u_base(2)-16 = j=1 u3 at u_base(1)-24 -/
+/-- j=2 un2 at uBase(2)-16 = j=1 u3 at uBase(1)-24 -/
 theorem u_n1_j2_4080_eq_j1_4072 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=2 un3 at u_base(2)+4072 = j=1 uTop at u_base(1)+4064 -/
+/-- j=2 un3 at uBase(2)+4072 = j=1 uTop at uBase(1)+4064 -/
 theorem u_n1_j2_4072_eq_j1_4064 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -90,29 +90,29 @@ theorem u_n1_j2_4072_eq_j1_4064 (sp : Word) :
 -- ============================================================================
 -- Address equality lemmas for j=1 output → j=0 input transition
 --
--- j=1 postcondition uses u_base(1) = sp + signExtend12(4056) - 8
--- j=0 precondition uses u_base(0) = sp + signExtend12(4056) - 0
+-- j=1 postcondition uses uBase(1) = sp + signExtend12(4056) - 8
+-- j=0 precondition uses uBase(0) = sp + signExtend12(4056) - 0
 -- ============================================================================
 
-/-- j=1 un0 at u_base(1)+0 = j=0 u1 at u_base(0)-8 -/
+/-- j=1 un0 at uBase(1)+0 = j=0 u1 at uBase(0)-8 -/
 theorem u_n1_j1_0_eq_j0_4088 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- j=1 un1 at u_base(1)-8 = j=0 u2 at u_base(0)-16 -/
+/-- j=1 un1 at uBase(1)-8 = j=0 u2 at uBase(0)-16 -/
 theorem u_n1_j1_4088_eq_j0_4080 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- j=1 un2 at u_base(1)-16 = j=0 u3 at u_base(0)-24 -/
+/-- j=1 un2 at uBase(1)-16 = j=0 u3 at uBase(0)-24 -/
 theorem u_n1_j1_4080_eq_j0_4072 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=1 un3 at u_base(1)+4072 = j=0 uTop at u_base(0)+4064 -/
+/-- j=1 un3 at uBase(1)+4072 = j=0 uTop at uBase(0)+4064 -/
 theorem u_n1_j1_4072_eq_j0_4064 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -135,7 +135,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
@@ -143,14 +143,14 @@ theorem divK_loop_body_n1_max_unified_j3_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN1Max sp (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -183,7 +183,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -191,14 +191,14 @@ theorem divK_loop_body_n1_max_unified_j2_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN1Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -231,7 +231,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -239,14 +239,14 @@ theorem divK_loop_body_n1_max_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN1Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -282,7 +282,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -290,14 +290,14 @@ theorem divK_loop_body_n1_max_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN1Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -333,12 +333,12 @@ theorem divK_loop_body_n1_max_unified_j0_spec
 theorem divK_loop_body_n1_call_unified_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
@@ -346,24 +346,24 @@ theorem divK_loop_body_n1_call_unified_j3_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN1Call sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J3 := divK_loop_body_n1_call_addback_j3_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -376,7 +376,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J3 := divK_loop_body_n1_call_skip_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J3
@@ -390,12 +390,12 @@ theorem divK_loop_body_n1_call_unified_j3_spec
 theorem divK_loop_body_n1_call_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -403,24 +403,24 @@ theorem divK_loop_body_n1_call_unified_j2_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN1Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J2 := divK_loop_body_n1_call_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -433,7 +433,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J2 := divK_loop_body_n1_call_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J2
@@ -447,12 +447,12 @@ theorem divK_loop_body_n1_call_unified_j2_spec
 theorem divK_loop_body_n1_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -460,24 +460,24 @@ theorem divK_loop_body_n1_call_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN1Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n1_call_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -490,7 +490,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n1_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -505,12 +505,12 @@ theorem divK_loop_body_n1_call_unified_j1_spec
 theorem divK_loop_body_n1_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -518,24 +518,24 @@ theorem divK_loop_body_n1_call_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN1Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n1_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -548,7 +548,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n1_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0

--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -50,7 +50,7 @@ theorem u_n1_j3_4080_eq_j2_4072 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=3 un3 at u_base(3)+4072 = j=2 u_top at u_base(2)+4064 -/
+/-- j=3 un3 at u_base(3)+4072 = j=2 uTop at u_base(2)+4064 -/
 theorem u_n1_j3_4072_eq_j2_4064 (sp : Word) :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -81,7 +81,7 @@ theorem u_n1_j2_4080_eq_j1_4072 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=2 un3 at u_base(2)+4072 = j=1 u_top at u_base(1)+4064 -/
+/-- j=2 un3 at u_base(2)+4072 = j=1 uTop at u_base(1)+4064 -/
 theorem u_n1_j2_4072_eq_j1_4064 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -112,7 +112,7 @@ theorem u_n1_j1_4080_eq_j0_4072 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=1 un3 at u_base(1)+4072 = j=0 u_top at u_base(0)+4064 -/
+/-- j=1 un3 at u_base(1)+4072 = j=0 uTop at u_base(0)+4064 -/
 theorem u_n1_j1_4072_eq_j0_4064 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -131,10 +131,10 @@ theorem u_n1_j1_4072_eq_j0_4064 (sp : Word) :
 /-- Unified j=3 max-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_max_unified_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -147,16 +147,16 @@ theorem divK_loop_body_n1_max_unified_j3_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN1Max sp (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Max sp (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J3 := divK_loop_body_n1_max_addback_j3_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
       hcarry2_nz
     intro_lets at J3
     exact cpsTriple_weaken
@@ -165,10 +165,10 @@ theorem divK_loop_body_n1_max_unified_j3_spec
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J3 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J3 := divK_loop_body_n1_max_skip_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
     intro_lets at J3
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -179,10 +179,10 @@ theorem divK_loop_body_n1_max_unified_j3_spec
 /-- Unified j=2 max-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_max_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -195,16 +195,16 @@ theorem divK_loop_body_n1_max_unified_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN1Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n1_max_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
       hcarry2_nz
     intro_lets at J2
     exact cpsTriple_weaken
@@ -213,10 +213,10 @@ theorem divK_loop_body_n1_max_unified_j2_spec
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J2 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J2 := divK_loop_body_n1_max_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
     intro_lets at J2
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -227,10 +227,10 @@ theorem divK_loop_body_n1_max_unified_j2_spec
 /-- Unified j=1 max-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_max_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -243,16 +243,16 @@ theorem divK_loop_body_n1_max_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN1Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n1_max_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
       hcarry2_nz
     intro_lets at J1
@@ -262,10 +262,10 @@ theorem divK_loop_body_n1_max_unified_j1_spec
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J1 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J1 := divK_loop_body_n1_max_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J1
     exact cpsTriple_weaken
@@ -278,10 +278,10 @@ theorem divK_loop_body_n1_max_unified_j1_spec
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n1_max_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -294,16 +294,16 @@ theorem divK_loop_body_n1_max_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN1Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J0 := divK_loop_body_n1_max_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
       hcarry2_nz
     intro_lets at J0
@@ -313,10 +313,10 @@ theorem divK_loop_body_n1_max_unified_j0_spec
         rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J0 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J0 := divK_loop_body_n1_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J0
     exact cpsTriple_weaken
@@ -332,12 +332,12 @@ theorem divK_loop_body_n1_max_unified_j0_spec
 /-- Unified j=3 call-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_call_unified_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -350,20 +350,20 @@ theorem divK_loop_body_n1_call_unified_j3_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN1Call sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Call sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J3 := divK_loop_body_n1_call_addback_j3_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -374,9 +374,9 @@ theorem divK_loop_body_n1_call_unified_j3_spec
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J3
   · -- skip path
-    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J3 := divK_loop_body_n1_call_skip_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J3
@@ -389,12 +389,12 @@ theorem divK_loop_body_n1_call_unified_j3_spec
 /-- Unified j=2 call-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_call_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -407,20 +407,20 @@ theorem divK_loop_body_n1_call_unified_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN1Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J2 := divK_loop_body_n1_call_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -431,9 +431,9 @@ theorem divK_loop_body_n1_call_unified_j2_spec
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J2
   · -- skip path
-    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J2 := divK_loop_body_n1_call_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J2
@@ -446,12 +446,12 @@ theorem divK_loop_body_n1_call_unified_j2_spec
 /-- Unified j=1 call-path  spec: uses _beq spec for addback, _skip for skip. -/
 theorem divK_loop_body_n1_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -464,20 +464,20 @@ theorem divK_loop_body_n1_call_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN1Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n1_call_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -488,9 +488,9 @@ theorem divK_loop_body_n1_call_unified_j1_spec
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J1
   · -- skip path
-    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n1_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -504,12 +504,12 @@ theorem divK_loop_body_n1_call_unified_j1_spec
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n1_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -522,20 +522,20 @@ theorem divK_loop_body_n1_call_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN1Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN1Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path
-    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n1_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -546,9 +546,9 @@ theorem divK_loop_body_n1_call_unified_j0_spec
         rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J0
   · -- skip path
-    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n1_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -27,30 +27,30 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 -- ============================================================================
 -- Address equality lemmas for j=2 output → j=1 input transition
 --
--- j=2 postcondition uses u_base(2) = sp + signExtend12(4056) - 16
--- j=1 precondition uses u_base(1) = sp + signExtend12(4056) - 8
--- The overlap: u_base(2) + offset_k = u_base(1) + offset_{k-1}
+-- j=2 postcondition uses uBase(2) = sp + signExtend12(4056) - 16
+-- j=1 precondition uses uBase(1) = sp + signExtend12(4056) - 8
+-- The overlap: uBase(2) + offset_k = uBase(1) + offset_{k-1}
 -- ============================================================================
 
-/-- j=2 un0 at u_base(2)+0 = j=1 u1 at u_base(1)-8 -/
+/-- j=2 un0 at uBase(2)+0 = j=1 u1 at uBase(1)-8 -/
 theorem u_j2_0_eq_j1_4088 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- j=2 un1 at u_base(2)-8 = j=1 u2 at u_base(1)-16 -/
+/-- j=2 un1 at uBase(2)-8 = j=1 u2 at uBase(1)-16 -/
 theorem u_j2_4088_eq_j1_4080 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- j=2 un2 at u_base(2)-16 = j=1 u3 at u_base(1)-24 -/
+/-- j=2 un2 at uBase(2)-16 = j=1 u3 at uBase(1)-24 -/
 theorem u_j2_4080_eq_j1_4072 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=2 un3 at u_base(2)-24 = j=1 uTop at u_base(1)-32 -/
+/-- j=2 un3 at uBase(2)-24 = j=1 uTop at uBase(1)-32 -/
 theorem u_j2_4072_eq_j1_4064 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -69,7 +69,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -77,14 +77,14 @@ theorem divK_loop_body_n2_max_unified_j2_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -118,7 +118,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -126,14 +126,14 @@ theorem divK_loop_body_n2_max_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -168,7 +168,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -176,14 +176,14 @@ theorem divK_loop_body_n2_max_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -220,12 +220,12 @@ theorem divK_loop_body_n2_max_unified_j0_spec
 theorem divK_loop_body_n2_call_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -233,24 +233,24 @@ theorem divK_loop_body_n2_call_unified_j2_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN2Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_call_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -263,7 +263,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J2 := divK_loop_body_n2_call_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J2
@@ -277,12 +277,12 @@ theorem divK_loop_body_n2_call_unified_j2_spec
 theorem divK_loop_body_n2_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -290,24 +290,24 @@ theorem divK_loop_body_n2_call_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_call_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -320,7 +320,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n2_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -335,12 +335,12 @@ theorem divK_loop_body_n2_call_unified_j1_spec
 theorem divK_loop_body_n2_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -348,24 +348,24 @@ theorem divK_loop_body_n2_call_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n2_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign hbltu hborrow
       hcarry2_nz
     intro_lets at J0
@@ -377,7 +377,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n2_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0
@@ -394,15 +394,15 @@ theorem divK_loop_body_n2_call_unified_j0_spec
 
 theorem divK_loop_n2_max_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
     (base : Word)
     (hbltu_1 : ¬BitVec.ult u2 v1)
     (hbltu_0 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
-      (loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old)
+      (loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -414,9 +414,9 @@ theorem divK_loop_n2_max_max_spec
     hbltu_1
     (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0  iteration spec (inputs from j=1 via iterN2Max)
   have J0 := divK_loop_body_n2_max_unified_j0_spec sp (1 : Word)
@@ -425,7 +425,7 @@ theorem divK_loop_n2_max_max_spec
     ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -433,7 +433,7 @@ theorem divK_loop_n2_max_max_spec
     q0_old base
 
     hbltu_0
-    (hcarry2 (signExtend12 4095) u0_orig
+    (hcarry2 (signExtend12 4095) u0Orig
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -469,8 +469,8 @@ theorem divK_loop_n2_max_max_spec
 
 theorem divK_loop_n2_call_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : BitVec.ult u2 v1)
@@ -478,9 +478,9 @@ theorem divK_loop_n2_call_call_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -488,12 +488,12 @@ theorem divK_loop_n2_call_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  iteration spec
   have J1 := divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu_1
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base halign hbltu_1
     (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0 call  iteration spec (inputs from j=1 via iterN2Call)
   have J0 := divK_loop_body_n2_call_unified_j0_spec sp (1 : Word)
@@ -502,7 +502,7 @@ theorem divK_loop_n2_call_call_spec
     ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -514,7 +514,7 @@ theorem divK_loop_n2_call_call_spec
     hbltu_0
     (hcarry2 (div128Quot (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
                           (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
-      u0_orig
+      u0Orig
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -552,8 +552,8 @@ theorem divK_loop_n2_call_call_spec
 
 theorem divK_loop_n2_max_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 max (BLTU not taken), j=0 call (BLTU taken)
@@ -562,9 +562,9 @@ theorem divK_loop_n2_max_call_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -576,11 +576,11 @@ theorem divK_loop_n2_max_call_spec
     hbltu_1
     (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig, q0_old, AND scratch cells (max doesn't touch scratch)
+  -- Frame j=1 with u0Orig, q0_old, AND scratch cells (max doesn't touch scratch)
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) J1
   -- 3. j=0 call  spec (inputs from j=1 via iterN2Max, scratch from frame)
   have J0 := divK_loop_body_n2_call_unified_j0_spec sp (1 : Word)
@@ -589,20 +589,20 @@ theorem divK_loop_n2_max_call_spec
     ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
     (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
-    ret_mem d_mem dlo_mem scratch_un0
+    retMem dMem dloMem scratch_un0
     base
     halign
 
     hbltu_0
     (hcarry2 (div128Quot (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
                           (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
-      u0_orig
+      u0Orig
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -640,8 +640,8 @@ theorem divK_loop_n2_max_call_spec
 
 theorem divK_loop_n2_call_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 call (BLTU taken), j=0 max (BLTU not taken)
@@ -650,9 +650,9 @@ theorem divK_loop_n2_call_max_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -660,14 +660,14 @@ theorem divK_loop_n2_call_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  spec (with scratch cells)
   have J1 := divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base
     halign
     hbltu_1
     (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0 max  spec (inputs from j=1 via iterN2Call)
   have J0 := divK_loop_body_n2_max_unified_j0_spec sp (1 : Word)
@@ -676,7 +676,7 @@ theorem divK_loop_n2_call_max_spec
     ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -684,7 +684,7 @@ theorem divK_loop_n2_call_max_spec
     q0_old base
 
     hbltu_0
-    (hcarry2 (signExtend12 4095) u0_orig
+    (hcarry2 (signExtend12 4095) u0Orig
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -50,7 +50,7 @@ theorem u_j2_4080_eq_j1_4072 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=2 un3 at u_base(2)-24 = j=1 u_top at u_base(1)-32 -/
+/-- j=2 un3 at u_base(2)-24 = j=1 uTop at u_base(1)-32 -/
 theorem u_j2_4072_eq_j1_4064 (sp : Word) :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -65,10 +65,10 @@ theorem u_j2_4072_eq_j1_4064 (sp : Word) :
     Produces loopIterPostN2Max which uses AddbackBeqPost/SkipPost. -/
 theorem divK_loop_body_n2_max_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -81,16 +81,16 @@ theorem divK_loop_body_n2_max_unified_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Max sp (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_max_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
       hcarry2_nz
     intro_lets at J2
     exact cpsTriple_weaken
@@ -99,10 +99,10 @@ theorem divK_loop_body_n2_max_unified_j2_spec
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J2 hborrow)
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J2 := divK_loop_body_n2_max_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
     intro_lets at J2
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -114,10 +114,10 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     Produces loopIterPostN2Max which uses AddbackBeqPost/SkipPost. -/
 theorem divK_loop_body_n2_max_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -130,16 +130,16 @@ theorem divK_loop_body_n2_max_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_max_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base hbltu
       hcarry2_nz
     intro_lets at J1
     exact cpsTriple_weaken
@@ -148,10 +148,10 @@ theorem divK_loop_body_n2_max_unified_j1_spec
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J1 hborrow)
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J1 := divK_loop_body_n2_max_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J1
     exact cpsTriple_weaken
@@ -164,10 +164,10 @@ theorem divK_loop_body_n2_max_unified_j1_spec
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+908. -/
 theorem divK_loop_body_n2_max_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -180,16 +180,16 @@ theorem divK_loop_body_n2_max_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J0 := divK_loop_body_n2_max_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
       hcarry2_nz
     intro_lets at J0
@@ -199,10 +199,10 @@ theorem divK_loop_body_n2_max_unified_j0_spec
         rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J0 hborrow)
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J0 := divK_loop_body_n2_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J0
     exact cpsTriple_weaken
@@ -219,12 +219,12 @@ theorem divK_loop_body_n2_max_unified_j0_spec
 /-- Unified  j=2 call-path spec: handles both skip and addback internally. -/
 theorem divK_loop_body_n2_call_unified_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -237,20 +237,20 @@ theorem divK_loop_body_n2_call_unified_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN2Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Call sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J2 := divK_loop_body_n2_call_addback_j2_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -261,9 +261,9 @@ theorem divK_loop_body_n2_call_unified_j2_spec
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J2
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J2 := divK_loop_body_n2_call_skip_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J2
@@ -276,12 +276,12 @@ theorem divK_loop_body_n2_call_unified_j2_spec
 /-- Unified  j=1 call-path spec: handles both skip and addback internally. -/
 theorem divK_loop_body_n2_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -294,20 +294,20 @@ theorem divK_loop_body_n2_call_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n2_call_addback_j1_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
       hcarry2_nz
@@ -318,9 +318,9 @@ theorem divK_loop_body_n2_call_unified_j1_spec
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J1
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n2_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -334,12 +334,12 @@ theorem divK_loop_body_n2_call_unified_j1_spec
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+908. -/
 theorem divK_loop_body_n2_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -352,20 +352,20 @@ theorem divK_loop_body_n2_call_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n2_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign hbltu hborrow
       hcarry2_nz
     intro_lets at J0
@@ -375,9 +375,9 @@ theorem divK_loop_body_n2_call_unified_j0_spec
         rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J0
   · -- skip path: use existing skip spec (unchanged)
-    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n2_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0
@@ -394,15 +394,15 @@ theorem divK_loop_body_n2_call_unified_j0_spec
 
 theorem divK_loop_n2_max_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (base : Word)
     (hbltu_1 : ¬BitVec.ult u2 v1)
-    (hbltu_0 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_0 : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
-      (loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
+      (loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -410,9 +410,9 @@ theorem divK_loop_n2_max_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1  iteration spec
   have J1 := divK_loop_body_n2_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -422,27 +422,27 @@ theorem divK_loop_n2_max_max_spec
   have J0 := divK_loop_body_n2_max_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old base
 
     hbltu_0
     (hcarry2 (signExtend12 4095) u0_orig
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -469,18 +469,18 @@ theorem divK_loop_n2_max_max_spec
 
 theorem divK_loop_n2_call_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : BitVec.ult u2 v1)
-    (hbltu_0 : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_0 : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -488,8 +488,8 @@ theorem divK_loop_n2_call_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  iteration spec
   have J1 := divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu_1
-    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu_1
+    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -499,31 +499,31 @@ theorem divK_loop_n2_call_call_spec
   have J0 := divK_loop_body_n2_call_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
     (base + 516) v1 (div128DLo v1) (div128Un0 u1)
     base halign
 
     hbltu_0
-    (hcarry2 (div128Quot (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-                          (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v1)
+    (hcarry2 (div128Quot (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+                          (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
       u0_orig
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -552,19 +552,19 @@ theorem divK_loop_n2_call_call_spec
 
 theorem divK_loop_n2_max_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 max (BLTU not taken), j=0 call (BLTU taken)
     (hbltu_1 : ¬BitVec.ult u2 v1)
-    (hbltu_0 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_0 : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -572,9 +572,9 @@ theorem divK_loop_n2_max_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 max  spec (no scratch cells)
   have J1 := divK_loop_body_n2_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig, q0_old, AND scratch cells (max doesn't touch scratch)
   have J1f := cpsTriple_frameR
@@ -586,32 +586,32 @@ theorem divK_loop_n2_max_call_spec
   have J0 := divK_loop_body_n2_call_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
     ret_mem d_mem dlo_mem scratch_un0
     base
     halign
 
     hbltu_0
-    (hcarry2 (div128Quot (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-                          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v1)
+    (hcarry2 (div128Quot (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+                          (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v1)
       u0_orig
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 max  postcondition → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -640,19 +640,19 @@ theorem divK_loop_n2_max_call_spec
 
 theorem divK_loop_n2_call_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 call (BLTU taken), j=0 max (BLTU not taken)
     (hbltu_1 : BitVec.ult u2 v1)
-    (hbltu_0 : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_0 : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN2Iter10PreWithScratch loopN2Iter10Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -660,10 +660,10 @@ theorem divK_loop_n2_call_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  spec (with scratch cells)
   have J1 := divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
     halign
     hbltu_1
-    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -673,27 +673,27 @@ theorem divK_loop_n2_call_max_spec
   have J0 := divK_loop_body_n2_max_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old base
 
     hbltu_0
     (hcarry2 (signExtend12 4095) u0_orig
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1]) AND j=1's scratch cells
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1) **
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v1) **

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -21,30 +21,30 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 -- ============================================================================
 -- Address equality lemmas for j=1 output → j=0 input transition
 --
--- j=1 postcondition uses u_base(1) = sp + signExtend12(4056) - 8
--- j=0 precondition uses u_base(0) = sp + signExtend12(4056)
--- The overlap: u_base(1) + offset_k = u_base(0) + offset_{k-1}
+-- j=1 postcondition uses uBase(1) = sp + signExtend12(4056) - 8
+-- j=0 precondition uses uBase(0) = sp + signExtend12(4056)
+-- The overlap: uBase(1) + offset_k = uBase(0) + offset_{k-1}
 -- ============================================================================
 
-/-- j=1 un0 at u_base(1)+0 = j=0 u1 at u_base(0)-8 -/
+/-- j=1 un0 at uBase(1)+0 = j=0 u1 at uBase(0)-8 -/
 theorem u_j1_0_eq_j0_4088 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
-/-- j=1 un1 at u_base(1)-8 = j=0 u2 at u_base(0)-16 -/
+/-- j=1 un1 at uBase(1)-8 = j=0 u2 at uBase(0)-16 -/
 theorem u_j1_4088_eq_j0_4080 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
-/-- j=1 un2 at u_base(1)-16 = j=0 u3 at u_base(0)-24 -/
+/-- j=1 un2 at uBase(1)-16 = j=0 u3 at uBase(0)-24 -/
 theorem u_j1_4080_eq_j0_4072 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=1 un3 at u_base(1)-24 = j=0 uTop at u_base(0)-32 -/
+/-- j=1 un3 at uBase(1)-24 = j=0 uTop at uBase(0)-32 -/
 theorem u_j1_4072_eq_j0_4064 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -58,7 +58,7 @@ theorem u_j1_4072_eq_j0_4064 (sp : Word) :
     Composes j=1 (base+448→base+448) with j=0 (base+448→base+904). -/
 theorem divK_loop_n3_max_skip_skip_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
     (base : Word)
     -- Branch conditions (j=1)
     (hbltu_1 : ¬BitVec.ult u3 v2)
@@ -66,11 +66,11 @@ theorem divK_loop_n3_max_skip_skip_spec
                   then (1 : Word) else 0) = (0 : Word))
     -- Branch conditions (j=0, depend on j=1 mulsub output)
     (hbltu_0 : isMaxBltuN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3)
-    (hborrow_0 : isSkipBorrowN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3 u0_orig) :
+    (hborrow_0 : isSkipBorrowN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3 u0Orig) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
-      (loopN3MaxSkipSkipPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old)
+      (loopN3MaxSkipSkipPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -79,28 +79,28 @@ theorem divK_loop_n3_max_skip_skip_spec
   -- Unfold bundled condition defs
   delta isMaxBltuN3After_j1_skip isSkipBorrowN3After_j1_skip at hbltu_0 hborrow_0
   simp only [] at hbltu_0 hborrow_0
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   -- 1. j=1 iteration spec
   have J1 := divK_loop_body_n3_max_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
   intro_lets at J1
   have J1s := J1 hborrow_1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1s
   have J0 := divK_loop_body_n3_max_skip_j0_spec sp (1 : Word)
-    ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1 ms.2.2.2.2 q_hat ms.2.2.2.1
-    v0 v1 v2 v3 u0_orig ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q0_old base
+    ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1 ms.2.2.2.2 qHat ms.2.2.2.1
+    v0 v1 v2 v3 u0Orig ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 q0_old base
 
     hbltu_0
   intro_lets at J0
   have J0s := J0 hborrow_0
   -- Frame j=0 with j=1's carried atoms (u4_new, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (uTop - ms.2.2.2.2)) ** (q_addr_1 ↦ₘ q_hat))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (uTop - ms.2.2.2.2)) ** (q_addr_1 ↦ₘ qHat))
     (by pcFree) J0s
   -- 3. Compose via perm: rewrite j=1 postcondition addresses → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -132,7 +132,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -140,14 +140,14 @@ theorem divK_loop_body_n3_max_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -183,7 +183,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -191,14 +191,14 @@ theorem divK_loop_body_n3_max_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
       (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -231,12 +231,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec
 theorem divK_loop_body_n3_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -244,24 +244,24 @@ theorem divK_loop_body_n3_call_unified_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n3_call_addback_beq_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J1
@@ -272,7 +272,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
   · -- skip path
     have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n3_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -289,12 +289,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec
 theorem divK_loop_body_n3_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -302,24 +302,24 @@ theorem divK_loop_body_n3_call_unified_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n3_call_addback_beq_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J0
@@ -332,7 +332,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec
   · -- skip path
     have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n3_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0
@@ -353,15 +353,15 @@ theorem divK_loop_body_n3_call_unified_j0_spec
 
 theorem divK_loop_n3_max_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
     (base : Word)
     (hbltu_1 : ¬BitVec.ult u3 v2)
     (hbltu_0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
-      (loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old)
+      (loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -373,9 +373,9 @@ theorem divK_loop_n3_max_max_spec
     hbltu_1
     (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0  iteration spec (inputs from j=1 via iterN3Max)
   have J0 := divK_loop_body_n3_max_unified_j0_spec sp (1 : Word)
@@ -384,7 +384,7 @@ theorem divK_loop_n3_max_max_spec
     ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -392,7 +392,7 @@ theorem divK_loop_n3_max_max_spec
     q0_old base
 
     hbltu_0
-    (hcarry2 (signExtend12 4095) u0_orig
+    (hcarry2 (signExtend12 4095) u0Orig
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -433,8 +433,8 @@ theorem divK_loop_n3_max_max_spec
 
 theorem divK_loop_n3_call_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : BitVec.ult u3 v2)
@@ -442,9 +442,9 @@ theorem divK_loop_n3_call_call_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -452,13 +452,13 @@ theorem divK_loop_n3_call_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  iteration spec
   have J1 := divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base halign
     hbltu_1
     (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0 call  iteration spec (inputs from j=1 via iterN3Call)
   have J0 := divK_loop_body_n3_call_unified_j0_spec sp (1 : Word)
@@ -467,7 +467,7 @@ theorem divK_loop_n3_call_call_spec
     ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -480,7 +480,7 @@ theorem divK_loop_n3_call_call_spec
     hbltu_0
     (hcarry2 (div128Quot (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
                           (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v2)
-      u0_orig
+      u0Orig
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -519,8 +519,8 @@ theorem divK_loop_n3_call_call_spec
 
 theorem divK_loop_n3_max_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 max (BLTU not taken), j=0 call (BLTU taken)
@@ -529,9 +529,9 @@ theorem divK_loop_n3_max_call_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -543,11 +543,11 @@ theorem divK_loop_n3_max_call_spec
     hbltu_1
     (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig, q0_old, AND scratch cells (max doesn't touch scratch)
+  -- Frame j=1 with u0Orig, q0_old, AND scratch cells (max doesn't touch scratch)
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) J1
   -- 3. j=0 call  spec (inputs from j=1 via iterN3Max, scratch from frame)
   have J0 := divK_loop_body_n3_call_unified_j0_spec sp (1 : Word)
@@ -556,20 +556,20 @@ theorem divK_loop_n3_max_call_spec
     ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
     (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
-    ret_mem d_mem dlo_mem scratch_un0
+    retMem dMem dloMem scratch_un0
     base
     halign
 
     hbltu_0
     (hcarry2 (div128Quot (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
                           (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v2)
-      u0_orig
+      u0Orig
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -607,8 +607,8 @@ theorem divK_loop_n3_max_call_spec
 
 theorem divK_loop_n3_call_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 call (BLTU taken), j=0 max (BLTU not taken)
@@ -617,9 +617,9 @@ theorem divK_loop_n3_call_max_spec
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -627,13 +627,13 @@ theorem divK_loop_n3_call_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  spec (with scratch cells)
   have J1 := divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base
     halign hbltu_1
     (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
-  -- Frame j=1 with u0_orig and q0_old
+  -- Frame j=1 with u0Orig and q0_old
   have J1f := cpsTriple_frameR
-    (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+    (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
     (by pcFree) J1
   -- 3. j=0 max  spec (inputs from j=1 via iterN3Call)
   have J0 := divK_loop_body_n3_max_unified_j0_spec sp (1 : Word)
@@ -642,7 +642,7 @@ theorem divK_loop_n3_call_max_spec
     ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
     ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
-    u0_orig
+    u0Orig
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
     (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -650,7 +650,7 @@ theorem divK_loop_n3_call_max_spec
     q0_old base
 
     hbltu_0
-    (hcarry2 (signExtend12 4095) u0_orig
+    (hcarry2 (signExtend12 4095) u0Orig
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -44,7 +44,7 @@ theorem u_j1_4080_eq_j0_4072 (sp : Word) :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
-/-- j=1 un3 at u_base(1)-24 = j=0 u_top at u_base(0)-32 -/
+/-- j=1 un3 at u_base(1)-24 = j=0 uTop at u_base(0)-32 -/
 theorem u_j1_4072_eq_j0_4064 (sp : Word) :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
@@ -58,19 +58,19 @@ theorem u_j1_4072_eq_j0_4064 (sp : Word) :
     Composes j=1 (base+448→base+448) with j=0 (base+448→base+904). -/
 theorem divK_loop_n3_max_skip_skip_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (base : Word)
     -- Branch conditions (j=1)
     (hbltu_1 : ¬BitVec.ult u3 v2)
-    (hborrow_1 : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
+    (hborrow_1 : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                   then (1 : Word) else 0) = (0 : Word))
     -- Branch conditions (j=0, depend on j=1 mulsub output)
     (hbltu_0 : isMaxBltuN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3)
     (hborrow_0 : isSkipBorrowN3After_j1_skip v0 v1 v2 v3 u0 u1 u2 u3 u0_orig) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
-      (loopN3MaxSkipSkipPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
+      (loopN3MaxSkipSkipPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -83,7 +83,7 @@ theorem divK_loop_n3_max_skip_skip_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   -- 1. j=1 iteration spec
   have J1 := divK_loop_body_n3_max_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
   intro_lets at J1
   have J1s := J1 hborrow_1
@@ -100,7 +100,7 @@ theorem divK_loop_n3_max_skip_skip_spec
   have J0s := J0 hborrow_0
   -- Frame j=0 with j=1's carried atoms (u4_new, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (u_top - ms.2.2.2.2)) ** (q_addr_1 ↦ₘ q_hat))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (uTop - ms.2.2.2.2)) ** (q_addr_1 ↦ₘ q_hat))
     (by pcFree) J0s
   -- 3. Compose via perm: rewrite j=1 postcondition addresses → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -128,10 +128,10 @@ theorem divK_loop_n3_max_skip_skip_spec
 
 theorem divK_loop_body_n3_max_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -144,16 +144,16 @@ theorem divK_loop_body_n3_max_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN3Max sp (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J1 := divK_loop_body_n3_max_addback_beq_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu hcarry2_nz
     intro_lets at J1
     exact cpsTriple_weaken
@@ -161,10 +161,10 @@ theorem divK_loop_body_n3_max_unified_j1_spec
       (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J1 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J1 := divK_loop_body_n3_max_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J1
     exact cpsTriple_weaken
@@ -179,10 +179,10 @@ theorem divK_loop_body_n3_max_unified_j1_spec
 
 theorem divK_loop_body_n3_max_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -195,16 +195,16 @@ theorem divK_loop_body_n3_max_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
     have J0 := divK_loop_body_n3_max_addback_beq_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu hcarry2_nz
     intro_lets at J0
     exact cpsTriple_weaken
@@ -212,10 +212,10 @@ theorem divK_loop_body_n3_max_unified_j0_spec
       (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       (J0 hborrow)
   · -- skip path
-    have hborrow : (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
+    have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
     have J0 := divK_loop_body_n3_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old base
       hbltu
     intro_lets at J0
     exact cpsTriple_weaken
@@ -230,12 +230,12 @@ theorem divK_loop_body_n3_max_unified_j0_spec
 
 theorem divK_loop_body_n3_call_unified_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -248,20 +248,20 @@ theorem divK_loop_body_n3_call_unified_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN3Call sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
     have J1 := divK_loop_body_n3_call_addback_beq_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J1
@@ -270,9 +270,9 @@ theorem divK_loop_body_n3_call_unified_j1_spec
       (fun h hp => by rw [← loopIterPostN3Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J1
   · -- skip path
-    have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J1 := divK_loop_body_n3_call_skip_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J1
@@ -288,12 +288,12 @@ theorem divK_loop_body_n3_call_unified_j1_spec
 
 theorem divK_loop_body_n3_call_unified_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -306,20 +306,20 @@ theorem divK_loop_body_n3_call_unified_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
-  by_cases hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
+  by_cases hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)
   · -- addback path: use _beq spec
-    have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+    have hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN3Call; simp only []; rw [if_pos hb]; decide
     have J0 := divK_loop_body_n3_call_addback_beq_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow hcarry2_nz
     intro_lets at J0
@@ -330,9 +330,9 @@ theorem divK_loop_body_n3_call_unified_j0_spec
         rw [← loopIterPostN3Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
       J0
   · -- skip path
-    have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := if_neg hb
+    have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
     have J0 := divK_loop_body_n3_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
       hbltu hborrow
     intro_lets at J0
@@ -353,15 +353,15 @@ theorem divK_loop_body_n3_call_unified_j0_spec
 
 theorem divK_loop_n3_max_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (base : Word)
     (hbltu_1 : ¬BitVec.ult u3 v2)
-    (hbltu_0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old)
-      (loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old)
+      (loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -369,9 +369,9 @@ theorem divK_loop_n3_max_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1  iteration spec
   have J1 := divK_loop_body_n3_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -381,27 +381,27 @@ theorem divK_loop_n3_max_max_spec
   have J0 := divK_loop_body_n3_max_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old base
 
     hbltu_0
     (hcarry2 (signExtend12 4095) u0_orig
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
   --    loopIterPostN3Max unfolds to if-then-else, so we case-split on borrow
@@ -433,18 +433,18 @@ theorem divK_loop_n3_max_max_spec
 
 theorem divK_loop_n3_call_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : BitVec.ult u3 v2)
-    (hbltu_0 : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -452,9 +452,9 @@ theorem divK_loop_n3_call_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  iteration spec
   have J1 := divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base halign
     hbltu_1
-    (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 u_top : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -464,32 +464,32 @@ theorem divK_loop_n3_call_call_spec
   have J0 := divK_loop_body_n3_call_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
     (base + 516) v2 (div128DLo v2) (div128Un0 u2)
     base
     halign
 
     hbltu_0
-    (hcarry2 (div128Quot (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-                          (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v2)
+    (hcarry2 (div128Quot (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+                          (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v2)
       u0_orig
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1  postcondition → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -519,19 +519,19 @@ theorem divK_loop_n3_call_call_spec
 
 theorem divK_loop_n3_max_call_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 max (BLTU not taken), j=0 call (BLTU taken)
     (hbltu_1 : ¬BitVec.ult u3 v2)
-    (hbltu_0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -539,9 +539,9 @@ theorem divK_loop_n3_max_call_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 max  spec (no scratch cells)
   have J1 := divK_loop_body_n3_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
     hbltu_1
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig, q0_old, AND scratch cells (max doesn't touch scratch)
   have J1f := cpsTriple_frameR
@@ -553,32 +553,32 @@ theorem divK_loop_n3_max_call_spec
   have J0 := divK_loop_body_n3_call_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old
     ret_mem d_mem dlo_mem scratch_un0
     base
     halign
 
     hbltu_0
-    (hcarry2 (div128Quot (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-                          (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v2)
+    (hcarry2 (div128Quot (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+                          (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v2)
       u0_orig
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1])
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
     (by pcFree) J0
   -- 4. Compose: rewrite j=1 max  postcondition → j=0 precondition
   have full := cpsTriple_seq_perm_same_cr
@@ -607,19 +607,19 @@ theorem divK_loop_n3_max_call_spec
 
 theorem divK_loop_n3_call_max_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Branch conditions: j=1 call (BLTU taken), j=0 max (BLTU not taken)
     (hbltu_1 : BitVec.ult u3 v2)
-    (hbltu_0 : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig) := by
+      (loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig) := by
   delta loopN3PreWithScratch loopN3Pre; simp only []
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
@@ -627,9 +627,9 @@ theorem divK_loop_n3_call_max_spec
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- 1. j=1 call  spec (with scratch cells)
   have J1 := divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu_1
-    (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 u_top : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u3 u2 v2) u0 u1 u2 u3 uTop : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J1
   -- Frame j=1 with u0_orig and q0_old
   have J1f := cpsTriple_frameR
@@ -639,27 +639,27 @@ theorem divK_loop_n3_call_max_spec
   have J0 := divK_loop_body_n3_max_unified_j0_spec sp (1 : Word)
     ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
     ((mulsubN4 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+    ((iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     v0 v1 v2 v3
     u0_orig
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+    (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
     q0_old base
 
     hbltu_0
     (hcarry2 (signExtend12 4095) u0_orig
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
   intro_lets at J0
   -- Frame j=0 with j=1's carried atoms (u4, q[1]) AND j=1's scratch cells
   have J0f := cpsTriple_frameR
-    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-     (q_addr_1 ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1) **
+    (((u_base_1 + signExtend12 4064) ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+     (q_addr_1 ↦ₘ (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
      (sp + signExtend12 3952 ↦ₘ div128DLo v2) **

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -32,7 +32,7 @@ open EvmAsm.Rv64
     Bundles registers, v-cells, u-cells at j=1 base, and extra j=0 cells. -/
 @[irreducible]
 def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -46,7 +46,7 @@ def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_1 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_1 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_1 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
   ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
   (q_addr_0 ↦ₘ q0_old)
@@ -60,10 +60,10 @@ def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Used when at least one iteration takes the call (div128) path. -/
 @[irreducible]
 def loopN3PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **
   (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -79,7 +79,7 @@ def loopN3PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     for j=1 (u0_orig_1, q1_old) and j=0 (u0_orig_0, q0_old). -/
 @[irreducible]
 def loopN2Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old : Word) : Assertion :=
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -97,7 +97,7 @@ def loopN2Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_2 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_2 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_2 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_2 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_2 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_2 ↦ₘ q2_old) **
   ((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) **
   (q_addr_1 ↦ₘ q1_old) **
@@ -108,12 +108,12 @@ def loopN2Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Used when at least one iteration may take the call (div128) path. -/
 @[irreducible]
 def loopN2PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN2Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0 q2_old q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **
@@ -129,7 +129,7 @@ def loopN2PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Same structure as loopN3Pre but with n_mem = 2. -/
 @[irreducible]
 def loopN2Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -143,7 +143,7 @@ def loopN2Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_1 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_1 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_1 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
   ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
   (q_addr_0 ↦ₘ q0_old)
@@ -151,10 +151,10 @@ def loopN2Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
 /-- Precondition for n=2 two-iteration loop with scratch cells. -/
 @[irreducible]
 def loopN2Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN2Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **
   (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -170,7 +170,7 @@ def loopN2Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2
     for j=2 (u0_orig_2, q2_old), j=1 (u0_orig_1, q1_old), and j=0 (u0_orig_0, q0_old). -/
 @[irreducible]
 def loopN1Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_2 u0_orig_1 u0_orig_0
     q3_old q2_old q1_old q0_old : Word) : Assertion :=
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
@@ -190,7 +190,7 @@ def loopN1Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_3 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_3 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_3 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_3 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_3 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_3 ↦ₘ q3_old) **
   ((u_base_2 + signExtend12 0) ↦ₘ u0_orig_2) **
   (q_addr_2 ↦ₘ q2_old) **
@@ -203,12 +203,12 @@ def loopN1Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Used when at least one iteration may take the call (div128) path. -/
 @[irreducible]
 def loopN1PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_2 u0_orig_1 u0_orig_0
     q3_old q2_old q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN1Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **
@@ -224,7 +224,7 @@ def loopN1PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Same structure as loopN2Iter10Pre but with n_mem = 1. -/
 @[irreducible]
 def loopN1Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -238,7 +238,7 @@ def loopN1Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_1 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_1 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_1 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
   ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
   (q_addr_0 ↦ₘ q0_old)
@@ -246,10 +246,10 @@ def loopN1Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
 /-- Precondition for n=1 two-iteration loop with scratch cells. -/
 @[irreducible]
 def loopN1Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN1Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **
   (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -264,7 +264,7 @@ def loopN1Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2
     Same structure as loopN2Pre but with n_mem = 1, starting at j=2. -/
 @[irreducible]
 def loopN1Iter210Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old : Word) : Assertion :=
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -282,7 +282,7 @@ def loopN1Iter210Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base_2 + signExtend12 4088) ↦ₘ u1) **
   ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base_2 + signExtend12 4080) ↦ₘ u2) **
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_2 + signExtend12 4072) ↦ₘ u3) **
-  ((u_base_2 + signExtend12 4064) ↦ₘ u_top) **
+  ((u_base_2 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_2 ↦ₘ q2_old) **
   ((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) **
   (q_addr_1 ↦ₘ q1_old) **
@@ -292,12 +292,12 @@ def loopN1Iter210Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
 /-- Precondition for n=1 three-iteration loop with scratch cells. -/
 @[irreducible]
 def loopN1Iter210PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old
     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   loopN1Iter210Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0 q2_old q1_old q0_old **
   (sp + signExtend12 3968 ↦ₘ ret_mem) **
   (sp + signExtend12 3960 ↦ₘ d_mem) **

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -32,7 +32,7 @@ open EvmAsm.Rv64
     Bundles registers, v-cells, u-cells at j=1 base, and extra j=0 cells. -/
 @[irreducible]
 def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -48,7 +48,7 @@ def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
   ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
-  ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
+  ((u_base_0 + signExtend12 0) ↦ₘ u0Orig) **
   (q_addr_0 ↦ₘ q0_old)
 
 
@@ -60,13 +60,13 @@ def loopN3Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     Used when at least one iteration takes the call (div128) path. -/
 @[irreducible]
 def loopN3PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN3Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 
@@ -111,13 +111,13 @@ def loopN2PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN2Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0 q2_old q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 
@@ -126,10 +126,10 @@ def loopN2PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
 -- ============================================================================
 
 /-- Precondition for n=2 two-iteration loop (j=1, j=0).
-    Same structure as loopN3Pre but with n_mem = 2. -/
+    Same structure as loopN3Pre but with nMem = 2. -/
 @[irreducible]
 def loopN2Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -145,19 +145,19 @@ def loopN2Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
   ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
-  ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
+  ((u_base_0 + signExtend12 0) ↦ₘ u0Orig) **
   (q_addr_0 ↦ₘ q0_old)
 
 /-- Precondition for n=2 two-iteration loop with scratch cells. -/
 @[irreducible]
 def loopN2Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN2Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 
@@ -206,13 +206,13 @@ def loopN1PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_2 u0_orig_1 u0_orig_0
     q3_old q2_old q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN1Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 
@@ -221,10 +221,10 @@ def loopN1PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
 -- ============================================================================
 
 /-- Precondition for n=1 two-iteration loop (j=1, j=0).
-    Same structure as loopN2Iter10Pre but with n_mem = 1. -/
+    Same structure as loopN2Iter10Pre but with nMem = 1. -/
 @[irreducible]
 def loopN1Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word) : Assertion :=
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -240,19 +240,19 @@ def loopN1Iter10Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
   ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base_1 + signExtend12 4072) ↦ₘ u3) **
   ((u_base_1 + signExtend12 4064) ↦ₘ uTop) **
   (q_addr_1 ↦ₘ q1_old) **
-  ((u_base_0 + signExtend12 0) ↦ₘ u0_orig) **
+  ((u_base_0 + signExtend12 0) ↦ₘ u0Orig) **
   (q_addr_0 ↦ₘ q0_old)
 
 /-- Precondition for n=1 two-iteration loop with scratch cells. -/
 @[irreducible]
 def loopN1Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN1Iter10Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 
@@ -261,7 +261,7 @@ def loopN1Iter10PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v2
 -- ============================================================================
 
 /-- Precondition for n=1 three-iteration loop (j=2, j=1, j=0).
-    Same structure as loopN2Pre but with n_mem = 1, starting at j=2. -/
+    Same structure as loopN2Pre but with nMem = 1, starting at j=2. -/
 @[irreducible]
 def loopN1Iter210Pre (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
@@ -295,13 +295,13 @@ def loopN1Iter210PreWithScratch (sp j_old v5_old v6_old v7_old v10_old v11_old v
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   loopN1Iter210Pre sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
     v0 v1 v2 v3 u0 u1 u2 u3 uTop
     u0_orig_1 u0_orig_0 q2_old q1_old q0_old **
-  (sp + signExtend12 3968 ↦ₘ ret_mem) **
-  (sp + signExtend12 3960 ↦ₘ d_mem) **
-  (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+  (sp + signExtend12 3968 ↦ₘ retMem) **
+  (sp + signExtend12 3960 ↦ₘ dMem) **
+  (sp + signExtend12 3952 ↦ₘ dloMem) **
   (sp + signExtend12 3944 ↦ₘ scratch_un0)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -119,21 +119,21 @@ theorem addbackN4_fst4_u4_indep (un0 un1 un2 un3 u4 u4' v0 v1 v2 v3 : Word) :
   refine ⟨rfl, rfl, rfl, rfl⟩
 
 /-- The mulsub carry c3 for n=4, used in borrow conditions. -/
-def mulsubN4_c3 (q_hat v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Word :=
-  (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+def mulsubN4_c3 (qHat v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Word :=
+  (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
 
 -- ============================================================================
 -- div128 quotient computation (shared across all n-cases)
 -- ============================================================================
 
-/-- Trial quotient from the div128 subroutine: divides u_hi:u_lo by v_top. -/
-def div128Quot (u_hi u_lo v_top : Word) : Word :=
-  let dHi := v_top >>> (32 : BitVec 6).toNat
-  let dLo := (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u_lo >>> (32 : BitVec 6).toNat
-  let div_un0 := (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u_hi dHi
-  let rhat := u_hi - q1 * dHi
+/-- Trial quotient from the div128 subroutine: divides uHi:uLo by vTop. -/
+def div128Quot (uHi uLo vTop : Word) : Word :=
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := uLo >>> (32 : BitVec 6).toNat
+  let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
   let rhatc := if hi1 = 0 then rhat else rhat + dHi
@@ -154,58 +154,58 @@ def div128Quot (u_hi u_lo v_top : Word) : Word :=
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
   (q1' <<< (32 : BitVec 6).toNat) ||| q0'
 
-/-- Low 32 bits of v_top, stored to scratch during div128 call path. -/
-def div128DLo (v_top : Word) : Word :=
-  (v_top <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+/-- Low 32 bits of vTop, stored to scratch during div128 call path. -/
+def div128DLo (vTop : Word) : Word :=
+  (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
 
-/-- Low 32 bits of u_lo, stored to scratch during div128 call path. -/
-def div128Un0 (u_lo : Word) : Word :=
-  (u_lo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+/-- Low 32 bits of uLo, stored to scratch during div128 call path. -/
+def div128Un0 (uLo : Word) : Word :=
+  (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
 
 -- ============================================================================
 -- Double-addback iter variants (model the FIXED algorithm with double addback)
 -- ============================================================================
 
-/-- Helper: single iteration with double addback, parameterized by q_hat.
+/-- Helper: single iteration with double addback, parameterized by qHat.
     Used by all iter* variants. -/
-def iterWithDoubleAddback (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+def iterWithDoubleAddback (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   if BitVec.ult uTop c3 then
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
     if carry = 0 then
       let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-      (q_hat + signExtend12 4095 + signExtend12 4095,
+      (qHat + signExtend12 4095 + signExtend12 4095,
        ab'.1, ab'.2.1, ab'.2.2.1, ab'.2.2.2.1, ab'.2.2.2.2)
     else
-      (q_hat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2)
+      (qHat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2)
   else
-    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - c3)
+    (qHat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - c3)
 
 -- Equation lemmas for iterWithDoubleAddback in each branch.
 -- These avoid expanding the full definition inline; producers `rw` with them.
 
-theorem iterWithDoubleAddback_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (hb : BitVec.ult uTop (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+theorem iterWithDoubleAddback_borrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     if carry = 0 then
-      (q_hat + signExtend12 4095 + signExtend12 4095,
+      (qHat + signExtend12 4095 + signExtend12 4095,
        ab'.1, ab'.2.1, ab'.2.2.1, ab'.2.2.2.1, ab'.2.2.2.2)
     else
-      (q_hat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2) := by
+      (qHat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2) := by
   simp only [iterWithDoubleAddback, if_pos hb]
 
-theorem iterWithDoubleAddback_no_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (hb : ¬BitVec.ult uTop (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
-    let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
-    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - ms.2.2.2.2) := by
+theorem iterWithDoubleAddback_no_borrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+    let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+    iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    (qHat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - ms.2.2.2.2) := by
   simp only [iterWithDoubleAddback, if_neg hb]
 
 @[irreducible] def iterN1Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
@@ -295,34 +295,34 @@ theorem iterN1_false (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 
 /-- Borrow condition for n=1 call+skip: mulsub doesn't overflow. -/
 def isSkipBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u1 u0 v0
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  let qHat := div128Quot u1 u0 v0
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=1 call+addback: mulsub overflows. -/
 def isAddbackBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u1 u0 v0
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  let qHat := div128Quot u1 u0 v0
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
-/-- Double-addback progress for given q_hat: if the first addback produces
+/-- Double-addback progress for given qHat: if the first addback produces
     carry 0, the second addback must produce nonzero carry. -/
-def isAddbackCarry2Nz (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+def isAddbackCarry2Nz (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
   addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
     addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0
 
 /-- Specialization of `isAddbackCarry2Nz` for n=1 call path, where
-    `q_hat = div128Quot u1 u0 v0`. -/
+    `qHat = div128Quot u1 u0 v0`. -/
 def isAddbackCarry2NzN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=1 max path, where
-    `q_hat = signExtend12 4095` (i.e. 2^64-1). -/
+    `qHat = signExtend12 4095` (i.e. 2^64-1). -/
 def isAddbackCarry2NzN1Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=2 call path, where
-    `q_hat = div128Quot u2 u1 v1`. -/
+    `qHat = div128Quot u2 u1 v1`. -/
 def isAddbackCarry2NzN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
@@ -331,7 +331,7 @@ def isAddbackCarry2NzN2Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=3 call path, where
-    `q_hat = div128Quot u3 u2 v2`. -/
+    `qHat = div128Quot u3 u2 v2`. -/
 def isAddbackCarry2NzN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
@@ -340,7 +340,7 @@ def isAddbackCarry2NzN3Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=4 call path, where
-    `q_hat = div128Quot uTop u3 v3`. -/
+    `qHat = div128Quot uTop u3 v3`. -/
 def isAddbackCarry2NzN4Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   isAddbackCarry2Nz (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
@@ -357,35 +357,35 @@ def isAddbackCarry2NzN4Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
     the double-addback plan — overestimate bound on `div128Quot` + the Knuth
     (normalized divisor, max-path) overestimate bound). Any spec that invokes
     a per-iteration `*_unified_j*_spec` requiring `isAddbackCarry2Nz*` discharges
-    its obligation by specializing this universal to the local q_hat and state. -/
+    its obligation by specializing this universal to the local qHat and state. -/
 def Carry2NzAll (v0 v1 v2 v3 : Word) : Prop :=
-  ∀ q_hat u0 u1 u2 u3 uTop : Word,
-    isAddbackCarry2Nz q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  ∀ qHat u0 u1 u2 u3 uTop : Word,
+    isAddbackCarry2Nz qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 
 /-- Borrow condition for n=2 call+skip: mulsub doesn't overflow. -/
 def isSkipBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u2 u1 v1
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  let qHat := div128Quot u2 u1 v1
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=2 call+addback: mulsub overflows. -/
 def isAddbackBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u2 u1 v1
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  let qHat := div128Quot u2 u1 v1
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 
 /-- j=0 BLTU condition for n=3 max path after j=1 max+skip: u3_j0 ≥ v2. -/
 def isMaxBltuN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Prop :=
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   ¬BitVec.ult ms.2.2.1 v2
 
 /-- j=0 borrow=0 condition for n=3 max path after j=1 max+skip. -/
-def isSkipBorrowN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 u0_orig : Word) : Prop :=
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+def isSkipBorrowN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 u0Orig : Word) : Prop :=
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   (if BitVec.ult ms.2.2.2.1
-      (mulsubN4_c3 q_hat v0 v1 v2 v3 u0_orig ms.1 ms.2.1 ms.2.2.1)
+      (mulsubN4_c3 qHat v0 v1 v2 v3 u0Orig ms.1 ms.2.1 ms.2.2.1)
     then (1 : Word) else 0) = (0 : Word)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -168,12 +168,12 @@ def div128Un0 (u_lo : Word) : Word :=
 
 /-- Helper: single iteration with double addback, parameterized by q_hat.
     Used by all iter* variants. -/
-def iterWithDoubleAddback (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+def iterWithDoubleAddback (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
-  if BitVec.ult u_top c3 then
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  if BitVec.ult uTop c3 then
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
     if carry = 0 then
       let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
@@ -182,18 +182,18 @@ def iterWithDoubleAddback (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
     else
       (q_hat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2)
   else
-    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, u_top - c3)
+    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - c3)
 
 -- Equation lemmas for iterWithDoubleAddback in each branch.
 -- These avoid expanding the full definition inline; producers `rw` with them.
 
-theorem iterWithDoubleAddback_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+theorem iterWithDoubleAddback_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top =
+    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     if carry = 0 then
       (q_hat + signExtend12 4095 + signExtend12 4095,
        ab'.1, ab'.2.1, ab'.2.2.1, ab'.2.2.2.1, ab'.2.2.2.2)
@@ -201,92 +201,92 @@ theorem iterWithDoubleAddback_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word
       (q_hat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2) := by
   simp only [iterWithDoubleAddback, if_pos hb]
 
-theorem iterWithDoubleAddback_no_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
+theorem iterWithDoubleAddback_no_borrow (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
     let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, u_top - ms.2.2.2.2) := by
+    iterWithDoubleAddback q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    (q_hat, ms.1, ms.2.1, ms.2.2.1, ms.2.2.2.1, uTop - ms.2.2.2.2) := by
   simp only [iterWithDoubleAddback, if_neg hb]
 
-@[irreducible] def iterN1Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN1Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
-@[irreducible] def iterN1Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
-@[irreducible] def iterN2Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN2Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
-@[irreducible] def iterN2Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Unified per-iteration computation with double addback for n=2. -/
-def iterN2 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+def iterN2 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  if bltu then iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  else iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  if bltu then iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 @[simp]
-theorem iterN2_true (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN2 true v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN2_true (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN2 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN2]
 
 @[simp]
-theorem iterN2_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN2 false v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN2_false (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN2 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN2]
 
-@[irreducible] def iterN3Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN3Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
-@[irreducible] def iterN3Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+@[irreducible] def iterN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  iterWithDoubleAddback (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  iterWithDoubleAddback (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Unified per-iteration computation with double addback for n=3. -/
-def iterN3 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+def iterN3 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  if bltu then iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  else iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  if bltu then iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 @[simp]
-theorem iterN3_true (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN3 true v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN3_true (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN3]
 
 @[simp]
-theorem iterN3_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN3 false v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN3_false (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN3 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN3]
 
 -- ============================================================================
 -- Unified per-iteration computation with double addback for n=1.
 -- ============================================================================
 
-def iterN1 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
+def iterN1 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
-  if bltu then iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  else iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  if bltu then iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 @[simp]
-theorem iterN1_true (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN1 true v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN1_true (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN1 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN1]
 
 @[simp]
-theorem iterN1_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    iterN1 false v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem iterN1_false (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    iterN1 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [iterN1]
 
 -- ============================================================================
@@ -294,62 +294,62 @@ theorem iterN1_false (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
 -- ============================================================================
 
 /-- Borrow condition for n=1 call+skip: mulsub doesn't overflow. -/
-def isSkipBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isSkipBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u1 u0 v0
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=1 call+addback: mulsub overflows. -/
-def isAddbackBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isAddbackBorrowN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u1 u0 v0
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 /-- Double-addback progress for given q_hat: if the first addback produces
     carry 0, the second addback must produce nonzero carry. -/
-def isAddbackCarry2Nz (q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isAddbackCarry2Nz (q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
   addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3 = 0 →
     addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0
 
 /-- Specialization of `isAddbackCarry2Nz` for n=1 call path, where
     `q_hat = div128Quot u1 u0 v0`. -/
-def isAddbackCarry2NzN1Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN1Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=1 max path, where
     `q_hat = signExtend12 4095` (i.e. 2^64-1). -/
-def isAddbackCarry2NzN1Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN1Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=2 call path, where
     `q_hat = div128Quot u2 u1 v1`. -/
-def isAddbackCarry2NzN2Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=2 max path. -/
-def isAddbackCarry2NzN2Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN2Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=3 call path, where
     `q_hat = div128Quot u3 u2 v2`. -/
-def isAddbackCarry2NzN3Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=3 max path. -/
-def isAddbackCarry2NzN3Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN3Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=4 call path, where
-    `q_hat = div128Quot u_top u3 v3`. -/
-def isAddbackCarry2NzN4Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (div128Quot u_top u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    `q_hat = div128Quot uTop u3 v3`. -/
+def isAddbackCarry2NzN4Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Specialization of `isAddbackCarry2Nz` for n=4 max path. -/
-def isAddbackCarry2NzN4Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
-  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def isAddbackCarry2NzN4Max (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
+  isAddbackCarry2Nz (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 /-- Universal carry2-nz hypothesis for double-addback: for *any* trial quotient
-    and *any* per-iteration (u, u_top) state, the second addback carry is
+    and *any* per-iteration (u, uTop) state, the second addback carry is
     nonzero whenever the first is zero.
 
     This is a placeholder threaded through the Loop*/Compose layers until the
@@ -359,19 +359,19 @@ def isAddbackCarry2NzN4Max (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
     a per-iteration `*_unified_j*_spec` requiring `isAddbackCarry2Nz*` discharges
     its obligation by specializing this universal to the local q_hat and state. -/
 def Carry2NzAll (v0 v1 v2 v3 : Word) : Prop :=
-  ∀ q_hat u0 u1 u2 u3 u_top : Word,
-    isAddbackCarry2Nz q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  ∀ q_hat u0 u1 u2 u3 uTop : Word,
+    isAddbackCarry2Nz q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 
 /-- Borrow condition for n=2 call+skip: mulsub doesn't overflow. -/
-def isSkipBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isSkipBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u2 u1 v1
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=2 call+addback: mulsub overflows. -/
-def isAddbackBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isAddbackBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u2 u1 v1
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 
 /-- j=0 BLTU condition for n=3 max path after j=1 max+skip: u3_j0 ≥ v2. -/

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -24,47 +24,47 @@ open EvmAsm.Rv64
 -- ============================================================================
 -- Loop exit postcondition for n
 -- Common assertion shape for both cpsBranch exits (taken/ntaken).
--- Parameterized by the final output values (un0_f..un3_f, u4_f, q_f, c3).
+-- Parameterized by the final output values (un0F..un3F, u4F, q_f, c3).
 -- ============================================================================
 
 /-- Loop exit postcondition for n. Both taken (loop-back) and ntaken (exit)
     paths produce this same assertion shape, differing only in the output values.
-    Encapsulates u_base/j'/q_addr address computation + 21-atom assertion chain. -/
+    Encapsulates uBase/j'/qAddr address computation + 21-atom assertion chain. -/
 @[irreducible]
-def loopExitPost (n : Word) (sp j q_f c3 un0_f un1_f un2_f un3_f u4_f
+def loopExitPost (n : Word) (sp j q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) : Assertion :=
-  let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+  let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
   let j' := j + signExtend12 4095
-  let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+  let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-  (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
-  (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
+  (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
+  (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-  ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_f) **
-  ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_f) **
-  ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_f) **
-  ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_f) **
-  ((u_base + signExtend12 4064) ↦ₘ u4_f) **
-  (q_addr ↦ₘ q_f)
+  ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0F) **
+  ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1F) **
+  ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2F) **
+  ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3F) **
+  ((uBase + signExtend12 4064) ↦ₘ u4F) **
+  (qAddr ↦ₘ q_f)
 
-theorem loopExitPost_unfold (n: Word) (sp j q_f c3 un0_f un1_f un2_f un3_f u4_f
+theorem loopExitPost_unfold (n: Word) (sp j q_f c3 un0F un1F un2F un3F u4F
     v0 v1 v2 v3 : Word) :
-    loopExitPost n sp j q_f c3 un0_f un1_f un2_f un3_f u4_f v0 v1 v2 v3 =
-    let u_base := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    loopExitPost n sp j q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let j' := j + signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j') **
-    (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ u_base) **
-    (.x7 ↦ᵣ q_addr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
-    (.x2 ↦ᵣ un3_f) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x5 ↦ᵣ j <<< (3 : BitVec 6).toNat) ** (.x6 ↦ᵣ uBase) **
+    (.x7 ↦ᵣ qAddr) ** (.x10 ↦ᵣ c3) ** (.x11 ↦ᵣ q_f) **
+    (.x2 ↦ᵣ un3F) ** (.x0 ↦ᵣ (0 : Word)) **
     (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-    ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_f) **
-    ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_f) **
-    ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_f) **
-    ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_f) **
-    ((u_base + signExtend12 4064) ↦ₘ u4_f) **
-    (q_addr ↦ₘ q_f) := by
+    ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0F) **
+    ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1F) **
+    ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2F) **
+    ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3F) **
+    ((uBase + signExtend12 4064) ↦ₘ u4F) **
+    (qAddr ↦ₘ q_f) := by
   delta loopExitPost; rfl
 
 /-- Loop exit postcondition abbreviations for n -/
@@ -78,19 +78,19 @@ abbrev loopExitPostN4 := loopExitPost (4 : Word)
 -- ============================================================================
 /-- Full mulsub-skip postcondition for n loop body. -/
 @[irreducible]
-def loopBodySkipPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  loopExitPost n sp j q_hat ms.2.2.2.2 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
+def loopBodySkipPost (n : Word) (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  loopExitPost n sp j qHat ms.2.2.2.2 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
 
 /-- Full mulsub-addback postcondition for n loop body. -/
 @[irreducible]
-def loopBodyAddbackPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+def loopBodyAddbackPost (n : Word) (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let un0 := ms.1; let un1 := ms.2.1; let un2 := ms.2.2.1
   let un3 := ms.2.2.2.1; let c3 := ms.2.2.2.2
   let u4_new := uTop - c3
   let ab := addbackN4 un0 un1 un2 un3 u4_new v0 v1 v2 v3
-  loopExitPost n sp j (q_hat + signExtend12 4095) c3 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
+  loopExitPost n sp j (qHat + signExtend12 4095) c3 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
 
 /-- Backward-compatible abbreviations for loopBodySkipPost and loopBodyAddbackPost. -/
 abbrev loopBodyN1SkipPost := loopBodySkipPost (1 : Word)
@@ -105,20 +105,20 @@ abbrev loopBodyN4AddbackPost := loopBodyAddbackPost (4 : Word)
 /-- Full mulsub-addback postcondition with BEQ double-addback handling.
     Handles both carry=0 (double addback) and carry≠0 (single addback) cases. -/
 @[irreducible]
-def loopBodyAddbackBeqPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+def loopBodyAddbackBeqPost (n : Word) (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  loopExitPost n sp j q_out c3 un0_out un1_out un2_out un3_out u4_out v0 v1 v2 v3
+  loopExitPost n sp j q_out c3 un0Out un1Out un2Out un3Out u4_out v0 v1 v2 v3
 
 abbrev loopBodyN1AddbackBeqPost := loopBodyAddbackBeqPost (1 : Word)
 abbrev loopBodyN2AddbackBeqPost := loopBodyAddbackBeqPost (2 : Word)
@@ -133,8 +133,8 @@ abbrev loopBodyN4AddbackBeqPost := loopBodyAddbackBeqPost (4 : Word)
     Bundles div128Quot computation + loopBodyN3SkipPost + scratch cells. -/
 @[irreducible]
 def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -144,8 +144,8 @@ def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Asser
     Bundles div128Quot computation + loopBodyN3AddbackPost + scratch cells. -/
 @[irreducible]
 def loopBodyN3CallAddbackPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3AddbackPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -153,13 +153,13 @@ def loopBodyN3CallAddbackPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
 
 /-- Borrow condition for n=3 call+skip: mulsub doesn't overflow. -/
 def isSkipBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u3 u2 v2
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  let qHat := div128Quot u3 u2 v2
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=3 call+addback: mulsub overflows. -/
 def isAddbackBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
-  let q_hat := div128Quot u3 u2 v2
-  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  let qHat := div128Quot u3 u2 v2
+  (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 -- ============================================================================
 -- Generic j versions of call path postconditions (for multi-iteration loops)
@@ -169,8 +169,8 @@ def isAddbackBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
     Bundles div128Quot computation + loopBodyN3SkipPost + scratch cells. -/
 @[irreducible]
 def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -180,8 +180,8 @@ def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
     Bundles div128Quot computation + loopBodyN3AddbackPost + scratch cells. -/
 @[irreducible]
 def loopBodyN3CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3AddbackPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -190,8 +190,8 @@ def loopBodyN3CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 /-- Call+addback BEQ postcondition for n=3 at j=0, with double-addback handling. -/
 @[irreducible]
 def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -200,8 +200,8 @@ def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 /-- Call+addback BEQ postcondition for n=3, generic j, with double-addback handling. -/
 @[irreducible]
 def loopBodyN3CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u3 u2 v2
+  loopBodyN3AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -220,11 +220,11 @@ theorem loopBodyN3CallAddbackBeqPost_eq_J (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop 
 
 /-- Call+skip postcondition for n=1 loop body, generic j.
     Bundles div128Quot computation + loopBodyN1SkipPost + scratch cells.
-    For n=1: div128 uses u_hi=u1, u_lo=u0, v_top=v0. -/
+    For n=1: div128 uses uHi=u1, uLo=u0, vTop=v0. -/
 @[irreducible]
 def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u1 u0 v0
-  loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u1 u0 v0
+  loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -234,8 +234,8 @@ def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
     Bundles div128Quot computation + loopBodyN1AddbackPost + scratch cells. -/
 @[irreducible]
 def loopBodyN1CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u1 u0 v0
-  loopBodyN1AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u1 u0 v0
+  loopBodyN1AddbackPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -244,8 +244,8 @@ def loopBodyN1CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 /-- Call+addback BEQ postcondition for n=1, generic j, with double-addback handling. -/
 @[irreducible]
 def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u1 u0 v0
-  loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u1 u0 v0
+  loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -257,11 +257,11 @@ def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
 
 /-- Call+skip postcondition for n=2 loop body, generic j.
     Bundles div128Quot computation + loopBodyN2SkipPost + scratch cells.
-    For n=2: div128 uses u_hi=u2, u_lo=u1, v_top=v1. -/
+    For n=2: div128 uses uHi=u2, uLo=u1, vTop=v1. -/
 @[irreducible]
 def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u2 u1 v1
-  loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u2 u1 v1
+  loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -271,8 +271,8 @@ def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : As
     Bundles div128Quot computation + loopBodyN2AddbackPost + scratch cells. -/
 @[irreducible]
 def loopBodyN2CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u2 u1 v1
-  loopBodyN2AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u2 u1 v1
+  loopBodyN2AddbackPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -281,8 +281,8 @@ def loopBodyN2CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 /-- Call+addback BEQ postcondition for n=2, generic j, with double-addback handling. -/
 @[irreducible]
 def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  let q_hat := div128Quot u2 u1 v1
-  loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  let qHat := div128Quot u2 u1 v1
+  loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -295,15 +295,15 @@ def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
 /-- Postcondition for the full n=3 two-iteration loop (max+skip at both j=1 and j=0).
     Includes the j=0 exit postcondition plus j=1's carried frame atoms (u4_new, q[1]). -/
 @[irreducible]
-def loopN3MaxSkipSkipPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
-  let q_hat : Word := signExtend12 4095
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+def loopN3MaxSkipSkipPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
+  let qHat : Word := signExtend12 4095
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-  loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3
-    u0_orig ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
+  loopBodyN3SkipPost sp (0 : Word) qHat v0 v1 v2 v3
+    u0Orig ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ (uTop - ms.2.2.2.2)) **
-  (q_addr_1 ↦ₘ q_hat)
+  (q_addr_1 ↦ₘ qHat)
 
 -- ============================================================================
 -- Double-addback iteration postconditions
@@ -332,8 +332,8 @@ theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
 
 @[irreducible] def loopIterPostN1Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let r := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  let q_hat := div128Quot u1 u0 v0
-  let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  let qHat := div128Quot u1 u0 v0
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN1 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
@@ -384,8 +384,8 @@ theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
 
 @[irreducible] def loopIterPostN2Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let r := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  let q_hat := div128Quot u2 u1 v1
-  let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  let qHat := div128Quot u2 u1 v1
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
@@ -438,8 +438,8 @@ theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
 
 @[irreducible] def loopIterPostN3Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let r := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  let q_hat := div128Quot u3 u2 v2
-  let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  let qHat := div128Quot u3 u2 v2
+  let c3 := (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN3 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
@@ -475,42 +475,42 @@ def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
 
 /-- Postcondition for n=3 two-iteration loop (both max path) with double addback. -/
 @[irreducible]
-def loopN3MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN3MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=3 two-iteration loop (both call path) with double addback. -/
 @[irreducible]
-def loopN3CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN3CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=3 two-iteration loop (j=1 max, j=0 call) with double addback. -/
 @[irreducible]
-def loopN3MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN3MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=3 two-iteration loop (j=1 call, j=0 max) with double addback. -/
 @[irreducible]
-def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
@@ -519,18 +519,18 @@ def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : As
 
 /-- Unified n=3 two-iteration postcondition with double addback. -/
 def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   match bltu_1, bltu_0 with
   | false, false =>
-    loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig **
-    (sp + signExtend12 3968 ↦ₘ ret_mem) **
-    (sp + signExtend12 3960 ↦ₘ d_mem) **
-    (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
-  | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-  | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-  | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
 
 -- ============================================================================
 -- Two-/three-iteration path postconditions with double addback for n=2
@@ -538,42 +538,42 @@ def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
 
 /-- Postcondition for n=2 two-iteration loop (both max path) with double addback. -/
 @[irreducible]
-def loopN2MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN2MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=2 two-iteration loop (both call path) with double addback. -/
 @[irreducible]
-def loopN2CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN2CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=2 two-iteration loop (j=1 max, j=0 call) with double addback. -/
 @[irreducible]
-def loopN2MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN2MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1)
 
 /-- Postcondition for n=2 two-iteration loop (j=1 call, j=0 max) with double addback. -/
 @[irreducible]
-def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Assertion :=
   let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1) **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
@@ -582,18 +582,18 @@ def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : As
 
 /-- Unified n=2 two-iteration postcondition with double addback. -/
 def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word)
+    (retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   match bltu_1, bltu_0 with
   | false, false =>
-    loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig **
-    (sp + signExtend12 3968 ↦ₘ ret_mem) **
-    (sp + signExtend12 3960 ↦ₘ d_mem) **
-    (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
-  | true,  true  => loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-  | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-  | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | true,  true  => loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+  | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
 
 /-- Unified n=2 three-iteration postcondition with double addback.
     Parameterized by `(bltu_2 bltu_1 bltu_0 : Bool)` covering all 8 path combinations. -/
@@ -601,16 +601,16 @@ def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
 def loopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
-     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   -- Compute j=2 result
   let r2 := iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   -- Address bases for j=2 carried atoms
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   -- Scratch values: call path overwrites them, max path passes through
-  let scratch_ret := if bltu_2 then (base + 516) else ret_mem
-  let scratch_d := if bltu_2 then v1 else d_mem
-  let scratch_dlo := if bltu_2 then div128DLo v1 else dlo_mem
+  let scratch_ret := if bltu_2 then (base + 516) else retMem
+  let scratch_d := if bltu_2 then v1 else dMem
+  let scratch_dlo := if bltu_2 then div128DLo v1 else dloMem
   let scratch_un0 := if bltu_2 then div128Un0 u1 else scratch_un0
   -- Two-iteration (j=1,j=0)  postcondition with j=2's outputs as inputs
   loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3
@@ -626,19 +626,19 @@ def loopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
 /-- Postcondition for n=1 two-iteration loop (j=1, j=0) with double addback.
     Same structure as loopN1Iter10Post but uses iterN1 and loopIterPostN1. -/
 def loopN1Iter10Post (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let r1 := iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN1 bltu_0 sp base (0 : Word) v0 v1 v2 v3
-    u0_orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
+    u0Orig r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 **
   ((u_base_1 + signExtend12 4064) ↦ₘ r1.2.2.2.2.2) ** (q_addr_1 ↦ₘ r1.1) **
   match bltu_1, bltu_0 with
   | false, false =>
-    (sp + signExtend12 3968 ↦ₘ ret_mem) **
-    (sp + signExtend12 3960 ↦ₘ d_mem) **
-    (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+    (sp + signExtend12 3968 ↦ₘ retMem) **
+    (sp + signExtend12 3960 ↦ₘ dMem) **
+    (sp + signExtend12 3952 ↦ₘ dloMem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
   | false, true  => empAssertion
   | true,  false =>
@@ -654,14 +654,14 @@ def loopN1Iter10Post (bltu_1 bltu_0 : Bool)
 def loopN1Iter210Post (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
-     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   let r2 := iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   -- Scratch values: call path overwrites them, max path passes through
-  let scratch_ret := if bltu_2 then (base + 516) else ret_mem
-  let scratch_d := if bltu_2 then v0 else d_mem
-  let scratch_dlo := if bltu_2 then div128DLo v0 else dlo_mem
+  let scratch_ret := if bltu_2 then (base + 516) else retMem
+  let scratch_d := if bltu_2 then v0 else dMem
+  let scratch_dlo := if bltu_2 then div128DLo v0 else dloMem
   let scratch_un0 := if bltu_2 then div128Un0 u0 else scratch_un0
   -- Two-iteration (j=1,j=0)  postcondition with j=2's outputs as inputs
   loopN1Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3
@@ -676,16 +676,16 @@ def loopN1Iter210Post (bltu_2 bltu_1 bltu_0 : Bool)
 def loopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
-     ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
+     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
   -- Compute j=3 result
   let r3 := iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   -- Address bases for j=3 carried atoms
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_3 := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
   -- Scratch values: call path overwrites them, max path passes through
-  let scratch_ret := if bltu_3 then (base + 516) else ret_mem
-  let scratch_d := if bltu_3 then v0 else d_mem
-  let scratch_dlo := if bltu_3 then div128DLo v0 else dlo_mem
+  let scratch_ret := if bltu_3 then (base + 516) else retMem
+  let scratch_d := if bltu_3 then v0 else dMem
+  let scratch_dlo := if bltu_3 then div128DLo v0 else dloMem
   let scratch_un0 := if bltu_3 then div128Un0 u0 else scratch_un0
   -- Three-iteration (j=2,j=1,j=0)  postcondition with j=3's outputs as inputs
   loopN1Iter210Post bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -78,17 +78,17 @@ abbrev loopExitPostN4 := loopExitPost (4 : Word)
 -- ============================================================================
 /-- Full mulsub-skip postcondition for n loop body. -/
 @[irreducible]
-def loopBodySkipPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodySkipPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  loopExitPost n sp j q_hat ms.2.2.2.2 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - ms.2.2.2.2) v0 v1 v2 v3
+  loopExitPost n sp j q_hat ms.2.2.2.2 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - ms.2.2.2.2) v0 v1 v2 v3
 
 /-- Full mulsub-addback postcondition for n loop body. -/
 @[irreducible]
-def loopBodyAddbackPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyAddbackPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let un0 := ms.1; let un1 := ms.2.1; let un2 := ms.2.2.1
   let un3 := ms.2.2.2.1; let c3 := ms.2.2.2.2
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let ab := addbackN4 un0 un1 un2 un3 u4_new v0 v1 v2 v3
   loopExitPost n sp j (q_hat + signExtend12 4095) c3 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
 
@@ -105,11 +105,11 @@ abbrev loopBodyN4AddbackPost := loopBodyAddbackPost (4 : Word)
 /-- Full mulsub-addback postcondition with BEQ double-addback handling.
     Handles both carry=0 (double addback) and carry≠0 (single addback) cases. -/
 @[irreducible]
-def loopBodyAddbackBeqPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyAddbackBeqPost (n : Word) (sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -132,9 +132,9 @@ abbrev loopBodyN4AddbackBeqPost := loopBodyAddbackBeqPost (4 : Word)
 /-- Call+skip postcondition for n=3 loop body at j=0.
     Bundles div128Quot computation + loopBodyN3SkipPost + scratch cells. -/
 @[irreducible]
-def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -143,23 +143,23 @@ def loopBodyN3CallSkipPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Asse
 /-- Call+addback postcondition for n=3 loop body at j=0.
     Bundles div128Quot computation + loopBodyN3AddbackPost + scratch cells. -/
 @[irreducible]
-def loopBodyN3CallAddbackPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallAddbackPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3AddbackPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
 /-- Borrow condition for n=3 call+skip: mulsub doesn't overflow. -/
-def isSkipBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isSkipBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u3 u2 v2
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word)
 
 /-- Borrow condition for n=3 call+addback: mulsub overflows. -/
-def isAddbackBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
+def isAddbackBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   let q_hat := div128Quot u3 u2 v2
-  (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
+  (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 -- ============================================================================
 -- Generic j versions of call path postconditions (for multi-iteration loops)
@@ -168,9 +168,9 @@ def isAddbackBorrowN3Call (v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Prop :=
 /-- Call+skip postcondition for n=3 loop body, generic j.
     Bundles div128Quot computation + loopBodyN3SkipPost + scratch cells. -/
 @[irreducible]
-def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -179,9 +179,9 @@ def loopBodyN3CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : A
 /-- Call+addback postcondition for n=3 loop body, generic j.
     Bundles div128Quot computation + loopBodyN3AddbackPost + scratch cells. -/
 @[irreducible]
-def loopBodyN3CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -189,9 +189,9 @@ def loopBodyN3CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) 
 
 /-- Call+addback BEQ postcondition for n=3 at j=0, with double-addback handling. -/
 @[irreducible]
-def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
@@ -199,18 +199,18 @@ def loopBodyN3CallAddbackBeqPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) 
 
 /-- Call+addback BEQ postcondition for n=3, generic j, with double-addback handling. -/
 @[irreducible]
-def loopBodyN3CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN3CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u3 u2 v2
-  loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN3AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v2) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v2) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
 /-- Bridge: j=0 specific call addback beq = generic-j at j=0. -/
-theorem loopBodyN3CallAddbackBeqPost_eq_J (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) :
-    loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopBodyN3CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopBodyN3CallAddbackBeqPost_eq_J (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopBodyN3CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopBodyN3CallAddbackBeqPost loopBodyN3CallAddbackBeqPostJ; rfl
 
 
@@ -222,9 +222,9 @@ theorem loopBodyN3CallAddbackBeqPost_eq_J (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
     Bundles div128Quot computation + loopBodyN1SkipPost + scratch cells.
     For n=1: div128 uses u_hi=u1, u_lo=u0, v_top=v0. -/
 @[irreducible]
-def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u1 u0 v0
-  loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN1SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -233,9 +233,9 @@ def loopBodyN1CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : A
 /-- Call+addback postcondition for n=1 loop body, generic j.
     Bundles div128Quot computation + loopBodyN1AddbackPost + scratch cells. -/
 @[irreducible]
-def loopBodyN1CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN1CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u1 u0 v0
-  loopBodyN1AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN1AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -243,9 +243,9 @@ def loopBodyN1CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) 
 
 /-- Call+addback BEQ postcondition for n=1, generic j, with double-addback handling. -/
 @[irreducible]
-def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u1 u0 v0
-  loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN1AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v0) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -259,9 +259,9 @@ def loopBodyN1CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Wor
     Bundles div128Quot computation + loopBodyN2SkipPost + scratch cells.
     For n=2: div128 uses u_hi=u2, u_lo=u1, v_top=v1. -/
 @[irreducible]
-def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u2 u1 v1
-  loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN2SkipPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -270,9 +270,9 @@ def loopBodyN2CallSkipPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : A
 /-- Call+addback postcondition for n=2 loop body, generic j.
     Bundles div128Quot computation + loopBodyN2AddbackPost + scratch cells. -/
 @[irreducible]
-def loopBodyN2CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN2CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u2 u1 v1
-  loopBodyN2AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN2AddbackPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -280,9 +280,9 @@ def loopBodyN2CallAddbackPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) 
 
 /-- Call+addback BEQ postcondition for n=2, generic j, with double-addback handling. -/
 @[irreducible]
-def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   let q_hat := div128Quot u2 u1 v1
-  loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+  loopBodyN2AddbackBeqPost sp j q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
   (sp + signExtend12 3968 ↦ₘ (base + 516)) **
   (sp + signExtend12 3960 ↦ₘ v1) **
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
@@ -295,43 +295,43 @@ def loopBodyN2CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Wor
 /-- Postcondition for the full n=3 two-iteration loop (max+skip at both j=1 and j=0).
     Includes the j=0 exit postcondition plus j=1's carried frame atoms (u4_new, q[1]). -/
 @[irreducible]
-def loopN3MaxSkipSkipPost (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
+def loopN3MaxSkipSkipPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
   let q_hat : Word := signExtend12 4095
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3
     u0_orig ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 **
-  ((u_base_1 + signExtend12 4064) ↦ₘ (u_top - ms.2.2.2.2)) **
+  ((u_base_1 + signExtend12 4064) ↦ₘ (uTop - ms.2.2.2.2)) **
   (q_addr_1 ↦ₘ q_hat)
 
 -- ============================================================================
 -- Double-addback iteration postconditions
 -- ============================================================================
 
-@[irreducible] def loopIterPostN1Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN1Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN1 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
-theorem loopIterPostN1Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN1AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN1Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN1Max iterN1Max iterWithDoubleAddback
         loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN1SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN1Max iterN1Max iterWithDoubleAddback
         loopBodyN1SkipPost loopBodySkipPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-@[irreducible] def loopIterPostN1Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN1Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let q_hat := div128Quot u1 u0 v0
   let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN1 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
@@ -340,50 +340,50 @@ theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
 
-theorem loopIterPostN1Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN1Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN1Call iterN1Call iterWithDoubleAddback
         loopBodyN1CallAddbackBeqPostJ loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN1Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN1Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN1Call iterN1Call iterWithDoubleAddback
         loopBodyN1CallSkipPostJ loopBodyN1SkipPost loopBodySkipPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-def loopIterPostN1 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopIterPostN1 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   match bltu with
-  | true => loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  | false => loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion
+  | true => loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  | false => loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop ** empAssertion
 
-@[irreducible] def loopIterPostN2Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN2Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
-theorem loopIterPostN2Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN2Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN2Max iterN2Max iterWithDoubleAddback
         loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN2Max iterN2Max iterWithDoubleAddback
         loopBodyN2SkipPost loopBodySkipPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-@[irreducible] def loopIterPostN2Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN2Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let q_hat := div128Quot u2 u1 v1
   let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
@@ -392,52 +392,52 @@ theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
 
-theorem loopIterPostN2Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN2Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN2Call iterN2Call iterWithDoubleAddback
         loopBodyN2CallAddbackBeqPostJ loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN2Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN2Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN2Call iterN2Call iterWithDoubleAddback
         loopBodyN2CallSkipPostJ loopBodyN2SkipPost loopBodySkipPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-def loopIterPostN2 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopIterPostN2 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   match bltu with
-  | true => loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  | false => loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion
+  | true => loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  | false => loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop ** empAssertion
 
-@[irreducible] def loopIterPostN3Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN3Max (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN3 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
 /-- Producer equation: addback beq postcondition equals loopIterPostN3Max when borrow holds. -/
-theorem loopIterPostN3Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN3Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN3Max iterN3Max iterWithDoubleAddback
         loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
 /-- Producer equation: skip postcondition equals loopIterPostN3Max when ¬borrow. -/
-theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN3SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN3Max iterN3Max iterWithDoubleAddback
         loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-@[irreducible] def loopIterPostN3Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
-  let r := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+@[irreducible] def loopIterPostN3Call (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let r := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let q_hat := div128Quot u3 u2 v2
   let c3 := (mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN3 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3 **
@@ -447,27 +447,27 @@ theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
 /-- Producer equation: call addback beq postcondition equals loopIterPostN3Call when borrow holds. -/
-theorem loopIterPostN3Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : BitVec.ult u_top (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN3CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN3Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
         loopBodyN3CallAddbackBeqPostJ loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
 /-- Producer equation: call skip postcondition equals loopIterPostN3Call when ¬borrow. -/
-theorem loopIterPostN3Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word)
-    (hb : ¬BitVec.ult u_top (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
-    loopBodyN3CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top =
-    loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top := by
+theorem loopIterPostN3Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
+    loopBodyN3CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopIterPostN3Call iterN3Call iterWithDoubleAddback
         loopBodyN3CallSkipPostJ loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word) : Assertion :=
+def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
   match bltu with
-  | true => loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top
-  | false => loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 u_top ** empAssertion
+  | true => loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  | false => loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop ** empAssertion
 
 -- ============================================================================
 -- Two-iteration path postconditions with double addback for n=3
@@ -475,8 +475,8 @@ def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 u_top : Word
 
 /-- Postcondition for n=3 two-iteration loop (both max path) with double addback. -/
 @[irreducible]
-def loopN3MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN3MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
@@ -485,8 +485,8 @@ def loopN3MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion 
 
 /-- Postcondition for n=3 two-iteration loop (both call path) with double addback. -/
 @[irreducible]
-def loopN3CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN3CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3
@@ -495,8 +495,8 @@ def loopN3CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : 
 
 /-- Postcondition for n=3 two-iteration loop (j=1 max, j=0 call) with double addback. -/
 @[irreducible]
-def loopN3MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN3MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Call sp base (0 : Word) v0 v1 v2 v3
@@ -505,8 +505,8 @@ def loopN3MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : A
 
 /-- Postcondition for n=3 two-iteration loop (j=1 call, j=0 max) with double addback. -/
 @[irreducible]
-def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN3Max sp (0 : Word) v0 v1 v2 v3
@@ -519,18 +519,18 @@ def loopN3CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : A
 
 /-- Unified n=3 two-iteration postcondition with double addback. -/
 def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   match bltu_1, bltu_0 with
   | false, false =>
-    loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig **
+    loopN3MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig **
     (sp + signExtend12 3968 ↦ₘ ret_mem) **
     (sp + signExtend12 3960 ↦ₘ d_mem) **
     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
-  | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
-  | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
-  | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+  | true,  true  => loopN3CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | false, true  => loopN3MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | true,  false => loopN3CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
 
 -- ============================================================================
 -- Two-/three-iteration path postconditions with double addback for n=2
@@ -538,8 +538,8 @@ def loopN3UnifiedPost (bltu_1 bltu_0 : Bool)
 
 /-- Postcondition for n=2 two-iteration loop (both max path) with double addback. -/
 @[irreducible]
-def loopN2MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN2MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
@@ -548,8 +548,8 @@ def loopN2MaxPost (sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion 
 
 /-- Postcondition for n=2 two-iteration loop (both call path) with double addback. -/
 @[irreducible]
-def loopN2CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN2CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3
@@ -558,8 +558,8 @@ def loopN2CallCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : 
 
 /-- Postcondition for n=2 two-iteration loop (j=1 max, j=0 call) with double addback. -/
 @[irreducible]
-def loopN2MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN2MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Call sp base (0 : Word) v0 v1 v2 v3
@@ -568,8 +568,8 @@ def loopN2MaxCallPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : A
 
 /-- Postcondition for n=2 two-iteration loop (j=1 call, j=0 max) with double addback. -/
 @[irreducible]
-def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : Assertion :=
-  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word) : Assertion :=
+  let r1 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN2Max sp (0 : Word) v0 v1 v2 v3
@@ -582,28 +582,28 @@ def loopN2CallMaxPost (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word) : A
 
 /-- Unified n=2 two-iteration postcondition with double addback. -/
 def loopN2Iter10Post (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig : Word)
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   match bltu_1, bltu_0 with
   | false, false =>
-    loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig **
+    loopN2MaxPost sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig **
     (sp + signExtend12 3968 ↦ₘ ret_mem) **
     (sp + signExtend12 3960 ↦ₘ d_mem) **
     (sp + signExtend12 3952 ↦ₘ dlo_mem) **
     (sp + signExtend12 3944 ↦ₘ scratch_un0)
-  | true,  true  => loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
-  | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
-  | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+  | true,  true  => loopN2CallCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | false, true  => loopN2MaxCallPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
+  | true,  false => loopN2CallMaxPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
 
 /-- Unified n=2 three-iteration postcondition with double addback.
     Parameterized by `(bltu_2 bltu_1 bltu_0 : Bool)` covering all 8 path combinations. -/
 @[irreducible]
 def loopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   -- Compute j=2 result
-  let r2 := iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   -- Address bases for j=2 carried atoms
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -626,9 +626,9 @@ def loopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
 /-- Postcondition for n=1 two-iteration loop (j=1, j=0) with double addback.
     Same structure as loopN1Iter10Post but uses iterN1 and loopIterPostN1. -/
 def loopN1Iter10Post (bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
      ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
-  let r1 := iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r1 := iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_1 := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
   loopIterPostN1 bltu_0 sp base (0 : Word) v0 v1 v2 v3
@@ -652,10 +652,10 @@ def loopN1Iter10Post (bltu_1 bltu_0 : Bool)
     Parameterized by `(bltu_2 bltu_1 bltu_0 : Bool)` covering all 8 path combinations. -/
 @[irreducible]
 def loopN1Iter210Post (bltu_2 bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
-  let r2 := iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
   -- Scratch values: call path overwrites them, max path passes through
@@ -674,11 +674,11 @@ def loopN1Iter210Post (bltu_2 bltu_1 bltu_0 : Bool)
     Parameterized by `(bltu_3 bltu_2 bltu_1 bltu_0 : Bool)` covering all 16 path combinations. -/
 @[irreducible]
 def loopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
-    (sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      ret_mem d_mem dlo_mem scratch_un0 : Word) : Assertion :=
   -- Compute j=3 result
-  let r3 := iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r3 := iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop
   -- Address bases for j=3 carried atoms
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_3 := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat

--- a/EvmAsm/Evm64/DivMod/LoopIterN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1.lean
@@ -18,7 +18,7 @@
   - LoopIterN1.MaxBeq:  BLTU not-taken path, BEQ double-addback
   - LoopIterN1.CallBeq: BLTU taken path, BEQ double-addback
 
-  For n=1: BLTU compares u1 vs v0, div128 uses u_hi=u1, u_lo=u0, v_top=v0.
+  For n=1: BLTU compares u1 vs v0, div128 uses uHi=u1, uLo=u0, vTop=v0.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopIterN1.Max

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -24,31 +24,31 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -71,56 +71,56 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (0 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (0 : Word)] at TF
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -147,31 +147,31 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -194,57 +194,57 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -271,31 +271,31 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -318,57 +318,57 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -395,31 +395,31 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_skip_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallSkipPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -442,57 +442,57 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -23,12 +23,12 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n1_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -41,13 +41,13 @@ theorem divK_loop_body_n1_call_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -81,7 +81,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   rw [u_addr_eq_n1 sp (0 : Word)] at TF
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -103,13 +103,13 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -146,12 +146,12 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -164,13 +164,13 @@ theorem divK_loop_body_n1_call_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -204,7 +204,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -226,14 +226,14 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -270,12 +270,12 @@ set_option maxRecDepth 4096 in
     Since j=2, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_call_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -288,13 +288,13 @@ theorem divK_loop_body_n1_call_skip_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -328,7 +328,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -350,14 +350,14 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -394,12 +394,12 @@ set_option maxRecDepth 4096 in
     Since j=3, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_call_skip_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -412,13 +412,13 @@ theorem divK_loop_body_n1_call_skip_j3_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallSkipPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -452,7 +452,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -474,14 +474,14 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have hj_pos := slt_jpos_3
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -24,32 +24,32 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -72,33 +72,33 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (0 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (0 : Word)] at TF
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -106,20 +106,20 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -142,32 +142,32 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -190,33 +190,33 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -225,20 +225,20 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -261,32 +261,32 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -309,33 +309,33 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -344,20 +344,20 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **
@@ -380,32 +380,32 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j3_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN1CallAddbackBeqPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_addr
+  intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u0 >>> (32 : BitVec 6).toNat
@@ -428,33 +428,33 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u1 u0 v0 ret_mem d_mem dlo_mem scratch_un0 base
+    u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -463,20 +463,20 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v0) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -23,13 +23,13 @@ open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -42,13 +42,13 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -85,7 +85,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -97,7 +97,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -108,7 +108,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -141,13 +141,13 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -160,13 +160,13 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -203,7 +203,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -215,7 +215,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -227,7 +227,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -260,13 +260,13 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -279,13 +279,13 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -322,7 +322,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -334,7 +334,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -346,7 +346,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -379,13 +379,13 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_call_addback_j3_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -398,13 +398,13 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1CallAddbackBeqPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v0 >>> (32 : BitVec 6).toNat
   let d_lo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -441,7 +441,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -453,7 +453,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let carry_out := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -465,7 +465,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -26,51 +26,51 @@ theorem divK_loop_body_n1_max_skip_j0_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
@@ -79,33 +79,33 @@ theorem divK_loop_body_n1_max_skip_j0_spec
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (0 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells (n=1: u1,u0,v0 consumed by trial; v1,u2,v2,u3,v3,uTop in frame)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
@@ -129,74 +129,74 @@ theorem divK_loop_body_n1_max_skip_j3_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1SkipPost sp (3 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (3 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (3 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -218,74 +218,74 @@ theorem divK_loop_body_n1_max_skip_j1_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1SkipPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (1 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -307,74 +307,74 @@ theorem divK_loop_body_n1_max_skip_j2_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1SkipPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (2 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -23,13 +23,13 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n1_max_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -40,9 +40,9 @@ theorem divK_loop_body_n1_max_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -69,7 +69,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
@@ -79,7 +79,7 @@ theorem divK_loop_body_n1_max_skip_j0_spec
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCS
@@ -87,12 +87,12 @@ theorem divK_loop_body_n1_max_skip_j0_spec
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
   have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
-  -- 4. Frame TF with mulsub cells (n=1: u1,u0,v0 consumed by trial; v1,u2,v2,u3,v3,u_top in frame)
+  -- 4. Frame TF with mulsub cells (n=1: u1,u0,v0 consumed by trial; v1,u2,v2,u3,v3,uTop in frame)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -126,13 +126,13 @@ set_option maxRecDepth 4096 in
     Since j=3, the BGE loop-back is taken (j' = 2 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_max_skip_j3_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -143,9 +143,9 @@ theorem divK_loop_body_n1_max_skip_j3_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1SkipPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -165,7 +165,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
@@ -173,7 +173,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (3 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCS
@@ -185,7 +185,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -215,13 +215,13 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken (j' = 0 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_max_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -232,9 +232,9 @@ theorem divK_loop_body_n1_max_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -254,7 +254,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
@@ -262,7 +262,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCS
@@ -274,7 +274,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -304,13 +304,13 @@ set_option maxRecDepth 4096 in
     Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n1_max_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -321,9 +321,9 @@ theorem divK_loop_body_n1_max_skip_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -343,7 +343,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
@@ -351,7 +351,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCS
@@ -363,7 +363,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -27,48 +27,48 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (0 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (0 : Word)] at TF
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (0 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
@@ -77,20 +77,20 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -109,48 +109,48 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 -(3 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    let uBase := sp + signExtend12 4056 -(3 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1AddbackBeqPost sp (3 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (3 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (3 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
@@ -160,20 +160,20 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -192,48 +192,48 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 -(1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    let uBase := sp + signExtend12 4056 -(1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (1 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
@@ -243,20 +243,20 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -275,48 +275,48 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 -(2 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
-    let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    let uBase := sp + signExtend12 4056 -(2 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
+    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
-       (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat q_addr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
+       (qAddr ↦ₘ q_old))
+      (loopBodyN1AddbackBeqPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u0 vtop_base u1 v0 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (2 : Word) u0 vtopBase u1 v0 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
@@ -326,20 +326,20 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
-     (q_addr ↦ₘ q_old))
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
+     (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (1 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -23,14 +23,14 @@ open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_max_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -41,14 +41,14 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -67,7 +67,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
   rw [u_addr_eq_n1 sp (0 : Word)] at TF
   rw [u_addr8_eq_n1 sp (0 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCA
@@ -79,7 +79,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -105,14 +105,14 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_max_addback_j3_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 -(3 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -123,14 +123,14 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1AddbackBeqPost sp (3 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -149,7 +149,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   rw [u_addr_eq_n1 sp (3 : Word)] at TF
   rw [u_addr8_eq_n1 sp (3 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (3 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCA
@@ -162,7 +162,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -188,14 +188,14 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_max_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 -(1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -206,14 +206,14 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -232,7 +232,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   rw [u_addr_eq_n1 sp (1 : Word)] at TF
   rw [u_addr8_eq_n1 sp (1 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCA
@@ -245,7 +245,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -271,14 +271,14 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n1_max_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 -(2 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -289,14 +289,14 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN1AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN1AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -315,7 +315,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   rw [u_addr_eq_n1 sp (2 : Word)] at TF
   rw [u_addr8_eq_n1 sp (2 : Word)] at TF
   rw [vtop_eq_v0_n1 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u0 vtop_base u1 v0 v2_old base
 
   intro_lets at MCA
@@ -328,7 +328,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -12,7 +12,7 @@
   - j=1 (middle iteration): cpsTriple base+448 → base+448
   - j=2 (first iteration): cpsTriple base+448 → base+448
 
-  For n=2: BLTU compares u2 vs v1, div128 uses u_hi=u2, u_lo=u1, v_top=v1.
+  For n=2: BLTU compares u2 vs v1, div128 uses uHi=u2, uLo=u1, vTop=v1.
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBodyN2
@@ -36,44 +36,44 @@ theorem divK_loop_body_n2_max_skip_j0_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (loopBodyN2SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -89,33 +89,33 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells (n=2: u2,u1,v1 consumed by trial; v0,u0,v2,u3,v3,uTop in frame)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
@@ -137,12 +137,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -150,19 +150,19 @@ theorem divK_loop_body_n2_call_skip_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
-  -- Reconstruct div128 intermediates for n=2: v_top=v1, u_hi=u2, u_lo=u1
+  intro uBase qAddr
+  -- Reconstruct div128 intermediates for n=2: vTop=v1, uHi=u2, uLo=u1
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -185,13 +185,13 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (0 : Word)] at TF
@@ -199,50 +199,50 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- Mulsub intermediates for store spec
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (for n=2: v1, u1, u2 consumed by trial; v0, u0, v2, u3, v3, uTop in frame)
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -272,39 +272,39 @@ theorem divK_loop_body_n2_max_skip_j1_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (loopBodyN2SkipPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
@@ -316,30 +316,30 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -359,12 +359,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -372,18 +372,18 @@ theorem divK_loop_body_n2_call_skip_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -406,57 +406,57 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -487,39 +487,39 @@ theorem divK_loop_body_n2_max_skip_j2_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (loopBodyN2SkipPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
@@ -531,30 +531,30 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -574,12 +574,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -587,18 +587,18 @@ theorem divK_loop_body_n2_call_skip_j2_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -621,57 +621,57 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -705,35 +705,35 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+      (loopBodyN2AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -745,7 +745,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   rw [u_addr_eq_n2 sp (0 : Word)] at TF
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
@@ -755,20 +755,20 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -786,13 +786,13 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -800,18 +800,18 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   -- Reconstruct div128 intermediates for n=2
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -835,20 +835,20 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isAddbackBorrowN2Call div128Quot at hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -856,7 +856,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (0 : Word)] at TF
@@ -864,7 +864,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -874,22 +874,22 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -918,35 +918,35 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+      (loopBodyN2AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -958,7 +958,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
@@ -969,20 +969,20 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -1000,13 +1000,13 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -1014,18 +1014,18 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -1048,33 +1048,33 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1083,20 +1083,20 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **
@@ -1124,35 +1124,35 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+      (loopBodyN2AddbackBeqPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -1164,7 +1164,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtopBase u2 v1 v2_old base
 
   intro_lets at MCA
@@ -1175,20 +1175,20 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -1206,13 +1206,13 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
@@ -1220,18 +1220,18 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN2CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
   let div_un1 := u1 >>> (32 : BitVec 6).toNat
@@ -1254,33 +1254,33 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u2 u1 v1 ret_mem d_mem dlo_mem scratch_un0 base
+    u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1289,20 +1289,20 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v1) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -33,13 +33,13 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n2_max_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -50,9 +50,9 @@ theorem divK_loop_body_n2_max_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -79,7 +79,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
@@ -89,7 +89,7 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCS
@@ -97,12 +97,12 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
   have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
-  -- 4. Frame TF with mulsub cells (n=2: u2,u1,v1 consumed by trial; v0,u0,v2,u3,v3,u_top in frame)
+  -- 4. Frame TF with mulsub cells (n=2: u2,u1,v1 consumed by trial; v0,u0,v2,u3,v3,uTop in frame)
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -136,12 +136,12 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n2_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -154,13 +154,13 @@ theorem divK_loop_body_n2_call_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallSkipPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates for n=2: v_top=v1, u_hi=u2, u_lo=u1
   let d_hi := v1 >>> (32 : BitVec 6).toNat
@@ -198,7 +198,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -221,15 +221,15 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
   have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
-  -- 4. Frame TF (for n=2: v1, u1, u2 consumed by trial; v0, u0, v2, u3, v3, u_top in frame)
+  -- 4. Frame TF (for n=2: v1, u1, u2 consumed by trial; v0, u0, v2, u3, v3, uTop in frame)
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -269,13 +269,13 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken (j' = 0 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n2_max_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -286,9 +286,9 @@ theorem divK_loop_body_n2_max_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -308,7 +308,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
@@ -316,7 +316,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCS
@@ -328,7 +328,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -358,12 +358,12 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n2_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -376,13 +376,13 @@ theorem divK_loop_body_n2_call_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v1 >>> (32 : BitVec 6).toNat
   let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -416,7 +416,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -438,14 +438,14 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -484,13 +484,13 @@ set_option maxRecDepth 4096 in
     Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n2_max_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -501,9 +501,9 @@ theorem divK_loop_body_n2_max_skip_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2SkipPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -523,7 +523,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) j_old v5_old v6_old v7_old v10_old v11_old
     u2 u1 v1 base hbltu
@@ -531,7 +531,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCS
@@ -543,7 +543,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -573,12 +573,12 @@ set_option maxRecDepth 4096 in
     Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n2_call_skip_j2_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -591,13 +591,13 @@ theorem divK_loop_body_n2_call_skip_j2_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v1 >>> (32 : BitVec 6).toNat
   let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -631,7 +631,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -653,14 +653,14 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   have hj_pos := slt_jpos_2
   have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCS0
@@ -701,14 +701,14 @@ theorem divK_loop_body_n2_call_skip_j2_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_max_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -719,14 +719,14 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -745,7 +745,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   rw [u_addr_eq_n2 sp (0 : Word)] at TF
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCA
@@ -757,7 +757,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -785,13 +785,13 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -804,13 +804,13 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates for n=2
   let d_hi := v1 >>> (32 : BitVec 6).toNat
@@ -841,7 +841,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -863,7 +863,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   rw [u_addr8_eq_n2 sp (0 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -876,7 +876,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
@@ -914,14 +914,14 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_max_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -932,14 +932,14 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -958,7 +958,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCA
@@ -971,7 +971,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -999,13 +999,13 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j1_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -1018,13 +1018,13 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v1 >>> (32 : BitVec 6).toNat
   let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1053,7 +1053,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -1073,7 +1073,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   rw [u_addr_eq_n2 sp (1 : Word)] at TF
   rw [u_addr8_eq_n2 sp (1 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -1085,7 +1085,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -1120,14 +1120,14 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_max_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -1138,14 +1138,14 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN2AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2AddbackBeqPost sp (2 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -1164,7 +1164,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtop_base u2 v1 v2_old base
 
   intro_lets at MCA
@@ -1177,7 +1177,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -1205,13 +1205,13 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
 set_option maxRecDepth 4096 in
 theorem divK_loop_body_n2_call_addback_j2_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
-    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -1224,13 +1224,13 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN2CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   let d_hi := v1 >>> (32 : BitVec 6).toNat
   let d_lo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1259,7 +1259,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -1279,7 +1279,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   rw [u_addr_eq_n2 sp (2 : Word)] at TF
   rw [u_addr8_eq_n2 sp (2 : Word)] at TF
   rw [vtop_eq_v1_n2 sp] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -1291,7 +1291,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -31,44 +31,44 @@ theorem divK_loop_body_n3_max_skip_j0_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (loopBodyN3SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -84,33 +84,33 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
@@ -132,12 +132,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n3_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -145,18 +145,18 @@ theorem divK_loop_body_n3_call_skip_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
   let dHi := v2 >>> (32 : BitVec 6).toNat
   let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -180,13 +180,13 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  -- Unfold borrow condition to match proof-level q_hat
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  -- Unfold borrow condition to match proof-level qHat
   unfold isSkipBorrowN3Call div128Quot at hborrow
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp (0 : Word)] at TF
@@ -194,50 +194,50 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- Mulsub intermediates for store spec
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, uTop in frame)
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
@@ -267,44 +267,44 @@ theorem divK_loop_body_n3_max_skip_j1_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN3SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+      (loopBodyN3SkipPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -320,34 +320,34 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+880 → base+448)
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_jgt0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store + SLf
@@ -369,12 +369,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n3_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -382,18 +382,18 @@ theorem divK_loop_body_n3_call_skip_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions
   let dHi := v2 >>> (32 : BitVec 6).toNat
   let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -417,13 +417,13 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN3Call div128Quot at hborrow
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp (1 : Word)] at TF
@@ -431,51 +431,51 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- Mulsub intermediates for store spec
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   -- 3. Store + loop back j=1 (cpsTriple base+880 → base+448)
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, uTop in frame)
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_jgt0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
@@ -506,37 +506,37 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN3AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   unfold isAddbackCarry2NzN3Max isAddbackCarry2Nz at hcarry2_nz
   -- Named-function lets (NOT inline expansion)
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -550,7 +550,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
@@ -560,20 +560,20 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -593,13 +593,13 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n3_call_addback_beq_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
@@ -607,18 +607,18 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
   let dHi := v2 >>> (32 : BitVec 6).toNat
   let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -642,21 +642,21 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  -- Unfold borrow condition to match proof-level q_hat
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  -- Unfold borrow condition to match proof-level qHat
   unfold isAddbackBorrowN3Call div128Quot at hborrow
   -- Named-function lets (NOT inline expansion)
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -664,7 +664,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp (0 : Word)] at TF
@@ -672,7 +672,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -682,22 +682,22 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **
@@ -728,37 +728,37 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
     (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN3AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN3AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   unfold isAddbackCarry2NzN3Max isAddbackCarry2Nz at hcarry2_nz
   -- Named-function lets (NOT inline expansion)
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -772,7 +772,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtopBase u3 v2 v2_old base
 
   intro_lets at MCA
@@ -783,20 +783,20 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)))
     (by pcFree) SL
   have full := cpsTriple_seq_perm_same_cr
@@ -816,13 +816,13 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n3_call_addback_beq_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
     (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
@@ -830,18 +830,18 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base qAddr
+  intro uBase qAddr
   -- Reconstruct div128 intermediates as raw expressions
   let dHi := v2 >>> (32 : BitVec 6).toNat
   let dLo := (v2 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -865,21 +865,21 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-  let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isAddbackBorrowN3Call div128Quot at hborrow
   -- Named-function lets (NOT inline expansion)
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -887,7 +887,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let vtopBase := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u3 u2 v2 ret_mem d_mem dlo_mem scratch_un0 base
+    u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n3 sp (1 : Word)] at TF
@@ -895,7 +895,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -906,22 +906,22 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop_jgt0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -28,13 +28,13 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n3_max_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -45,9 +45,9 @@ theorem divK_loop_body_n3_max_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -74,7 +74,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
@@ -84,7 +84,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCS
@@ -97,7 +97,7 @@ theorem divK_loop_body_n3_max_skip_j0_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -131,12 +131,12 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n3_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -149,13 +149,13 @@ theorem divK_loop_body_n3_call_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3CallSkipPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
   let d_hi := v2 >>> (32 : BitVec 6).toNat
@@ -193,7 +193,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -216,15 +216,15 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
   have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
   intro_lets at SL
-  -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, u_top in frame)
+  -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, uTop in frame)
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -264,13 +264,13 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken (j' = 0 ≥ 0), giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n3_max_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -281,9 +281,9 @@ theorem divK_loop_body_n3_max_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN3SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3SkipPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
@@ -310,7 +310,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (1 : Word) (3 : Word) j_old v5_old v6_old v7_old v10_old v11_old
@@ -320,7 +320,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCS
@@ -334,7 +334,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -368,12 +368,12 @@ set_option maxRecDepth 4096 in
     Since j=1, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
 theorem divK_loop_body_n3_call_skip_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -386,13 +386,13 @@ theorem divK_loop_body_n3_call_skip_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions
   let d_hi := v2 >>> (32 : BitVec 6).toNat
@@ -430,7 +430,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -453,16 +453,16 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
   -- 3. Store + loop back j=1 (cpsTriple base+880 → base+448)
   have hj_pos := slt_jpos_1
   have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_hat u4_new (0 : Word) q_old base hj_pos
   intro_lets at SL
-  -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, u_top in frame)
+  -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, uTop in frame)
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
@@ -502,14 +502,14 @@ set_option maxRecDepth 4096 in
     Uses divK_mulsub_correction_addback_beq_spec to eliminate sorry. -/
 theorem divK_loop_body_n3_max_addback_beq_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -520,16 +520,16 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   unfold isAddbackCarry2NzN3Max isAddbackCarry2Nz at hcarry2_nz
   -- Named-function lets (NOT inline expansion)
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -550,7 +550,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCA
@@ -562,7 +562,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -592,13 +592,13 @@ set_option maxRecDepth 4096 in
     Uses divK_mulsub_correction_addback_beq_spec to eliminate sorry. -/
 theorem divK_loop_body_n3_call_addback_beq_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
@@ -611,13 +611,13 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions (matching trial spec's internal let chain)
   let d_hi := v2 >>> (32 : BitVec 6).toNat
@@ -649,7 +649,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -671,7 +671,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   rw [u_addr8_eq_n3 sp (0 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -684,7 +684,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
@@ -724,14 +724,14 @@ set_option maxRecDepth 4096 in
     Uses divK_mulsub_correction_addback_beq_spec to eliminate sorry. -/
 theorem divK_loop_body_n3_max_addback_beq_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -742,16 +742,16 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN3AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3AddbackBeqPost sp (1 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   unfold isAddbackCarry2NzN3Max isAddbackCarry2Nz at hcarry2_nz
   -- Named-function lets (NOT inline expansion)
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -772,7 +772,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtop_base u3 v2 v2_old base
 
   intro_lets at MCA
@@ -785,7 +785,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
     ((.x2 ↦ᵣ v2_old) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   seqFrame TFf MCA0
@@ -815,13 +815,13 @@ set_option maxRecDepth 4096 in
     Uses divK_mulsub_correction_addback_beq_spec to eliminate sorry. -/
 theorem divK_loop_body_n3_call_addback_beq_j1_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u3 v2)
-    (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hborrow : isAddbackBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
     let q_addr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
@@ -834,13 +834,13 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN3CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_addr
   -- Reconstruct div128 intermediates as raw expressions
   let d_hi := v2 >>> (32 : BitVec 6).toNat
@@ -872,7 +872,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -894,7 +894,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   rw [u_addr8_eq_n3 sp (1 : Word)] at TF
   rw [vtop_eq_v2_n3 sp] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA
@@ -908,7 +908,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ u_top) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4064) ↦ₘ uTop) **
      (q_addr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -27,46 +27,46 @@ theorem divK_loop_body_n4_max_skip_j0_spec
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   -- Expand mulsub computation locally
 
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi
   let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0
   let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi
   let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1
   let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi
   let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2
   let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi
@@ -83,33 +83,33 @@ theorem divK_loop_body_n4_max_skip_j0_spec
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u3 vtopBase uTop v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
@@ -131,11 +131,11 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n4_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -161,50 +161,50 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
 
-  let p0_lo := q_hat * v0; let p0_hi := rv64_mulhu q_hat v0
+  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
   let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
   let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
   let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := q_hat * v1; let p1_hi := rv64_mulhu q_hat v1
+  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
   let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
   let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
   let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := q_hat * v2; let p2_hi := rv64_mulhu q_hat v2
+  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
   let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
   let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
   let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := q_hat * v3; let p3_hi := rv64_mulhu q_hat v3
+  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
@@ -213,7 +213,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
@@ -221,31 +221,31 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+880 → base+904)
-  have SL := divK_store_loop_j0_spec sp q_hat u4_new (0 : Word) q_old base
+  have SL := divK_store_loop_j0_spec sp qHat u4_new (0 : Word) q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCS0
   seqFrame TFf MCS0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_new) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **
@@ -275,37 +275,37 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
     (base : Word)
     (hbltu : ¬BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let q_hat : Word := signExtend12 4095  -- MAX64
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let qHat : Word := signExtend12 4095  -- MAX64
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro u_base q_hat qAddr hborrow
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  intro uBase qHat qAddr hborrow
   -- Local lets matching beq_spec structure (NOT the old inline expansion)
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -319,7 +319,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u3 vtopBase uTop v3 v2_old base
 
   intro_lets at MCA
@@ -331,22 +331,22 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop_j0 with remaining atoms
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)))
     (by pcFree) SL
   -- 7. Compose pre_store (cpsTriple) with SLf (cpsTriple)
@@ -370,12 +370,12 @@ set_option maxRecDepth 4096 in
 theorem divK_loop_body_n4_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult uTop v3)
     (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let dHi := v3 >>> (32 : BitVec 6).toNat
     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -401,47 +401,47 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
-    let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
        (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
        (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ uTop) **
+       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
+       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
+       ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro u_base
+  intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q_hat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
   -- Local lets matching beq_spec structure
-  let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
+  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
   let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
-               else q_hat + signExtend12 4095
-  let un0_out := if carry = 0 then ab'.1 else ab.1
-  let un1_out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
@@ -449,7 +449,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   let vtopBase := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
@@ -457,7 +457,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2_un0 q0' dHi q0_dlo q1' (base + 516) base
+    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -467,22 +467,22 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
+    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
      (qAddr ↦ₘ q_old))
     (by pcFree) TF
   -- 5. Compose TF + MCA0
   seqFrame TFf MCA0
   -- 6. Frame store_loop_j0
   have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
      (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ un1_out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
-     ((u_base + signExtend12 4064) ↦ₘ u4_out) **
+     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
+     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
+     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
+     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
+     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
      (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
      (sp + signExtend12 3968 ↦ₘ (base + 516)) **
      (sp + signExtend12 3960 ↦ₘ v3) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -24,14 +24,14 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n4_max_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3) :
+    (hbltu : ¬BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -42,9 +42,9 @@ theorem divK_loop_body_n4_max_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   -- Expand mulsub computation locally
 
@@ -72,19 +72,19 @@ theorem divK_loop_body_n4_max_skip_j0_spec
   let pc3 := ba3 + p3_hi
   let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
 
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
-    u_top u3 v3 base hbltu
+    uTop u3 v3 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u3 vtop_base u_top v3 v2_old base
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u3 vtop_base uTop v3 v2_old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -130,19 +130,19 @@ set_option maxRecDepth 4096 in
     Since j=0, the BGE loop-back is not taken, giving a cpsTriple to base+904. -/
 theorem divK_loop_body_n4_call_skip_j0_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3) :
+    (hbltu : BitVec.ult uTop v3) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -164,7 +164,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -175,13 +175,13 @@ theorem divK_loop_body_n4_call_skip_j0_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4SkipPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -208,19 +208,19 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := u_top - c3
+  let u4_new := uTop - c3
 
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
-  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCS := divK_mulsub_correction_skip_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCS
@@ -271,15 +271,15 @@ set_option maxRecDepth 4096 in
     eliminating the sorry for aco3 ≠ 0. -/
 theorem divK_loop_body_n4_max_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (base : Word)
-    (hbltu : ¬BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hbltu : ¬BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     let q_hat : Word := signExtend12 4095  -- MAX64
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -290,15 +290,15 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro u_base q_hat q_addr hborrow
   -- Local lets matching beq_spec structure (NOT the old inline expansion)
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -313,14 +313,14 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial max full (base+448 → base+516)
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old
-    u_top u3 v3 base hbltu
+    uTop u3 v3 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
-    (0 : Word) u3 vtop_base u_top v3 v2_old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    (0 : Word) u3 vtop_base uTop v3 v2_old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Max isAddbackCarry2Nz at hcarry2_nz
@@ -369,20 +369,20 @@ set_option maxRecDepth 4096 in
     eliminating the sorry for aco3 ≠ 0. -/
 theorem divK_loop_body_n4_call_addback_j0_beq_spec
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u_top v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
     let u_base := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- div128 intermediates
     let d_hi := v3 >>> (32 : BitVec 6).toNat
     let d_lo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := u3 >>> (32 : BitVec 6).toNat
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u_top d_hi
-    let rhat := u_top - q1 * d_hi
+    let q1 := rv64_divu uTop d_hi
+    let rhat := uTop - q1 * d_hi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
     let rhatc := if hi1 = 0 then rhat else rhat + d_hi
@@ -404,7 +404,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     let q_hat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let q_addr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0
-    (if BitVec.ult u_top (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
+    (if BitVec.ult uTop (mulsubN4_c3 q_hat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
@@ -415,13 +415,13 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
        ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
+       ((u_base + signExtend12 4064) ↦ₘ uTop) **
        (q_addr ↦ₘ q_old) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 u_top **
+      (loopBodyN4AddbackBeqPost sp (0 : Word) q_hat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v3) **
        (sp + signExtend12 3952 ↦ₘ d_lo) **
@@ -434,7 +434,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   let ms := mulsubN4 q_hat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (u_top - c3) v0 v1 v2 v3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
   let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
   let q_out := if carry = 0 then q_hat + signExtend12 4095 + signExtend12 4095
                else q_hat + signExtend12 4095
@@ -449,14 +449,14 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
   -- 1. Trial call full (base+448 → base+516)
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    u_top u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
+    uTop u3 v3 ret_mem d_mem dlo_mem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n4 sp (0 : Word)] at TF
   rw [u_addr8_eq_n4 sp (0 : Word)] at TF
   rw [vtop_eq_v3_n4 sp] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
-  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2_un0 q0' d_hi q0_dlo q1' (base + 516) base
 
   intro_lets at MCA

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -38,27 +38,27 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 jpred_2 jpred_3)
     Dispatches to existing  per-iteration specs in LoopComposeN1.lean. -/
 theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     -- Validity hypotheses
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Unified branch conditions (using iterN1 for j=0)
     (hbltu_1 : bltu_1 = BitVec.ult u1 v0)
-    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+      (loopN1Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
         ret_mem d_mem dlo_mem scratch_un0) := by
   -- Dispatch to per-iteration  specs via case analysis on (bltu_1, bltu_0)
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN1_true, iterN1_false] at hbltu_0
   · -- (false, false) = max*max
     have hbltu_1' : ¬BitVec.ult u1 v0 := by
       rw [show BitVec.ult u1 v0 = false from hbltu_1.symm]; decide
-    have hbltu_0' : ¬BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0 := by
+    have hbltu_0' : ¬BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0 := by
       rw [show BitVec.ult _ v0 = false from hbltu_0.symm]; decide
     delta loopN1Iter10PreWithScratch loopN1Iter10Pre; simp only []
     let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -67,10 +67,10 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 max  spec
     have J1 := divK_loop_body_n1_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
 
       hbltu_1'
-      (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
     -- Frame j=1 with u0_orig, q0_old, and scratch
     have J1f := cpsTriple_frameR
@@ -83,27 +83,27 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have J0 := divK_loop_body_n1_max_unified_j0_spec sp (1 : Word)
       ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
       ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
       u0_orig
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
       q0_old base
 
       hbltu_0'
       (hcarry2 (signExtend12 4095) u0_orig
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     intro_lets at J0
     -- Frame j=0 with j=1's carried atoms and scratch
     have J0f := cpsTriple_frameR
-      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-       (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1) **
+      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+       (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) J0
@@ -129,7 +129,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
   · -- (false, true) = max*call
     have hbltu_1' : ¬BitVec.ult u1 v0 := by
       rw [show BitVec.ult u1 v0 = false from hbltu_1.symm]; decide
-    have hbltu_0' : BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0 :=
+    have hbltu_0' : BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0 :=
       hbltu_0.symm ▸ rfl
     delta loopN1Iter10PreWithScratch loopN1Iter10Pre; simp only []
     let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -138,10 +138,10 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 max  spec
     have J1 := divK_loop_body_n1_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old base
 
       hbltu_1'
-      (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
     have J1f := cpsTriple_frameR
       (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old) **
@@ -152,28 +152,28 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have J0 := divK_loop_body_n1_call_unified_j0_spec sp (1 : Word)
       ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
       ((mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+      ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
       u0_orig
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
       q0_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
 
       hbltu_0'
-      (hcarry2 (div128Quot (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 u0_orig v0) u0_orig
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (hcarry2 (div128Quot (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0_orig v0) u0_orig
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     intro_lets at J0
     -- Frame j=0 with j=1's carried atoms only
     have J0f := cpsTriple_frameR
-      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-       (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+       (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
       (by pcFree) J0
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
@@ -194,7 +194,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       full
   · -- (true, false) = call*max
     have hbltu_1' : BitVec.ult u1 v0 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : ¬BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0 := by
+    have hbltu_0' : ¬BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0 := by
       rw [show BitVec.ult _ v0 = false from hbltu_0.symm]; decide
     delta loopN1Iter10PreWithScratch loopN1Iter10Pre; simp only []
     let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -203,11 +203,11 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 call  spec (includes scratch)
     have J1 := divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
 
       hbltu_1'
-      (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
     -- Frame j=1 with u0_orig, q0_old only (scratch is in call spec)
     have J1f := cpsTriple_frameR
@@ -217,27 +217,27 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have J0 := divK_loop_body_n1_max_unified_j0_spec sp (1 : Word)
       ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
       ((mulsubN4 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
       u0_orig
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
       q0_old base
 
       hbltu_0'
       (hcarry2 (signExtend12 4095) u0_orig
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     intro_lets at J0
     -- Frame j=0 with j=1's carried atoms + j=1 scratch (persists from call)
     have J0f := cpsTriple_frameR
-      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-       (q_addr_1 ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1) **
+      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+       (q_addr_1 ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ v0) **
        (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
@@ -262,7 +262,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       full
   · -- (true, true) = call*call
     have hbltu_1' : BitVec.ult u1 v0 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0 :=
+    have hbltu_0' : BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0 :=
       hbltu_0.symm ▸ rfl
     delta loopN1Iter10PreWithScratch loopN1Iter10Pre; simp only []
     let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -271,11 +271,11 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 call  spec (includes scratch)
     have J1 := divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q1_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
       halign
 
       hbltu_1'
-      (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+      (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
     -- Frame j=1 with u0_orig, q0_old only
     have J1f := cpsTriple_frameR
@@ -285,29 +285,29 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have J0 := divK_loop_body_n1_call_unified_j0_spec sp (1 : Word)
       ((1 : Word) <<< (3 : BitVec 6).toNat) u_base_1 q_addr_1
       ((mulsubN4 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
-      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1)
-      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
+      ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
       u0_orig
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
       q0_old
       (base + 516) v0 (div128DLo v0) (div128Un0 u0) base
       halign
 
       hbltu_0'
-      (hcarry2 (div128Quot (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 u0_orig v0) u0_orig
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1)
+      (hcarry2 (div128Quot (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0_orig v0) u0_orig
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
     intro_lets at J0
     -- Frame j=0 with j=1's carried atoms only
     have J0f := cpsTriple_frameR
-      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.2) **
-       (q_addr_1 ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).1))
+      (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
+       (q_addr_1 ↦ₘ (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1))
       (by pcFree) J0
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
@@ -336,28 +336,28 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     Composes j=2  max spec with the 2-iteration iter10 unified  spec. -/
 theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : ¬BitVec.ult u1 v0)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1Iter210Post false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1Iter210Post false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r2 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -366,10 +366,10 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=2 max  spec
   have J2 := divK_loop_body_n1_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q2_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old base
 
     hbltu_2
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J2
   -- Frame j=2 with iter10 extra atoms and scratch
   have J2f := cpsTriple_frameR
@@ -419,28 +419,28 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
     Composes j=2  call spec with the 2-iteration iter10 unified  spec. -/
 theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : BitVec.ult u1 v0)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1Iter210Post true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1Iter210Post true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r2 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -449,10 +449,10 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=2 call  spec (includes scratch)
   have J2 := divK_loop_body_n1_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
 
     hbltu_2
-    (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J2
   -- Frame j=2 with iter10 extra atoms only (scratch consumed by call)
   have J2f := cpsTriple_frameR
@@ -505,26 +505,26 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
     Dispatches to divK_loop_n1_max_iter10_spec / divK_loop_n1_call_iter10_spec. -/
 theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u1 v0)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1Iter210Post bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1Iter210Post bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
   cases bltu_2 <;> simp only [iterN1_true, iterN1_false] at hbltu_1 hbltu_0
   · -- bltu_2 = false -> max
@@ -532,7 +532,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       rw [show BitVec.ult u1 v0 = false from hbltu_2.symm]; decide
     exact divK_loop_n1_max_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_1 u0_orig_0 q2_old q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -543,7 +543,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     have hbltu_2' : BitVec.ult u1 v0 := hbltu_2.symm ▸ rfl
     exact divK_loop_n1_call_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_1 u0_orig_0 q2_old q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -560,49 +560,49 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     Composes j=3  max spec with the 3-iteration iter210 unified  spec. -/
 theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : ¬BitVec.ult u1 v0)
-    (hbltu_2 : bltu_2 = BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1UnifiedPost false bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1UnifiedPost false bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r3 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r3 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_3 := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
@@ -613,10 +613,10 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=3 max  spec
   have J3 := divK_loop_body_n1_max_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q3_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q3_old base
 
     hbltu_3
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J3
   -- Frame j=3 with iter210 extra atoms and scratch
   have J3f := cpsTriple_frameR
@@ -658,7 +658,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (fun h hp => by
       delta loopN1UnifiedPost loopN1Iter210Post loopN1Iter10Post loopIterPostN1 at hp ⊢
       simp only [iterN1_false, Bool.false_eq_true, ↓reduceIte, sepConj_emp_right'] at hp ⊢
-      have hr3 : r3 = iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top := rfl
+      have hr3 : r3 = iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := rfl
       have hub3 : u_base_3 = sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat := rfl
       have hqa3 : q_addr_3 = sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat := rfl
       simp only [hr3, hub3, hqa3] at hp
@@ -670,49 +670,49 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     Composes j=3  call spec with the 3-iteration iter210 unified  spec. -/
 theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : BitVec.ult u1 v0)
-    (hbltu_2 : bltu_2 = BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1UnifiedPost true bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1UnifiedPost true bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r3 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r3 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_3 := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
@@ -723,9 +723,9 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=3 call  spec (includes scratch)
   have J3 := divK_loop_body_n1_call_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q3_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q3_old ret_mem d_mem dlo_mem scratch_un0 base halign
     hbltu_3
-    (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 u_top : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J3
   -- Frame j=3 with iter210 extra atoms only (scratch consumed by call)
   have J3f := cpsTriple_frameR
@@ -765,7 +765,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (fun h hp => by
       delta loopN1UnifiedPost loopN1Iter210Post loopN1Iter10Post loopIterPostN1 at hp ⊢
       simp only [iterN1_true, ite_true, sepConj_emp_right'] at hp ⊢
-      have hr3 : r3 = iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top := rfl
+      have hr3 : r3 = iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := rfl
       have hub3 : u_base_3 = sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat := rfl
       have hqa3 : q_addr_3 = sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat := rfl
       simp only [hr3, hub3, hqa3] at hp
@@ -782,47 +782,47 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     Dispatches to divK_loop_n1_max_iter210_spec / divK_loop_n1_call_iter210_spec. -/
 theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
-    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1 v0)
+    (hbltu_2 : bltu_2 = BitVec.ult (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 v0)
     (hbltu_1 : bltu_1 = BitVec.ult (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1 v0)
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1 v0)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN1 bltu_1 v0 v1 v2 v3 u0_orig_1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.1
       (iterN1 bltu_2 v0 v1 v2 v3 u0_orig_2
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.2.2.1).2.1 v0)
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+        (iterN1 bltu_3 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.2.2.1).2.1 v0)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
   cases bltu_3 <;> simp only [iterN1_true, iterN1_false] at hbltu_2 hbltu_1 hbltu_0
   · -- bltu_3 = false -> max
@@ -830,7 +830,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
       rw [show BitVec.ult u1 v0 = false from hbltu_3.symm]; decide
     exact divK_loop_n1_max_iter210_spec bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_2 u0_orig_1 u0_orig_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_3' hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -838,7 +838,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     have hbltu_3' : BitVec.ult u1 v0 := hbltu_3.symm ▸ rfl
     exact divK_loop_n1_call_iter210_spec bltu_2 bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_2 u0_orig_1 u0_orig_0
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base
       halign

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -38,8 +38,8 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1 jpred_2 jpred_3)
     Dispatches to existing  per-iteration specs in LoopComposeN1.lean. -/
 theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     -- Validity hypotheses
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
@@ -49,10 +49,10 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN1Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN1Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN1Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) := by
   -- Dispatch to per-iteration  specs via case analysis on (bltu_1, bltu_0)
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN1_true, iterN1_false] at hbltu_0
   · -- (false, false) = max*max
@@ -72,11 +72,11 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       hbltu_1'
       (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
-    -- Frame j=1 with u0_orig, q0_old, and scratch
+    -- Frame j=1 with u0Orig, q0_old, and scratch
     have J1f := cpsTriple_frameR
-      (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) J1
     -- Derive j=0 validity via j=1->j=0 address linking
     -- j=0 max  spec (inputs from j=1 via iterN1Max)
@@ -86,7 +86,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
       ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
-      u0_orig
+      u0Orig
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -94,7 +94,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       q0_old base
 
       hbltu_0'
-      (hcarry2 (signExtend12 4095) u0_orig
+      (hcarry2 (signExtend12 4095) u0Orig
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -104,8 +104,8 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have J0f := cpsTriple_frameR
       (((u_base_1 + signExtend12 4064) ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.2) **
        (q_addr_1 ↦ₘ (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) J0
     -- Compose j=1 and j=0 via address rewriting
     have full := cpsTriple_seq_perm_same_cr
@@ -144,9 +144,9 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
     have J1f := cpsTriple_frameR
-      (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) J1
     -- j=0 call  spec (includes scratch in pre/post)
     have J0 := divK_loop_body_n1_call_unified_j0_spec sp (1 : Word)
@@ -155,16 +155,16 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
       ((iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
-      u0_orig
+      u0Orig
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
       (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1
-      q0_old ret_mem d_mem dlo_mem scratch_un0 base
+      q0_old retMem dMem dloMem scratch_un0 base
       halign
 
       hbltu_0'
-      (hcarry2 (div128Quot (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0_orig v0) u0_orig
+      (hcarry2 (div128Quot (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0Orig v0) u0Orig
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
         (iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -203,15 +203,15 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 call  spec (includes scratch)
     have J1 := divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base
       halign
 
       hbltu_1'
       (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
-    -- Frame j=1 with u0_orig, q0_old only (scratch is in call spec)
+    -- Frame j=1 with u0Orig, q0_old only (scratch is in call spec)
     have J1f := cpsTriple_frameR
-      (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+      (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
       (by pcFree) J1
     -- j=0 max  spec (no scratch)
     have J0 := divK_loop_body_n1_max_unified_j0_spec sp (1 : Word)
@@ -220,7 +220,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
       ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
-      u0_orig
+      u0Orig
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -228,7 +228,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       q0_old base
 
       hbltu_0'
-      (hcarry2 (signExtend12 4095) u0_orig
+      (hcarry2 (signExtend12 4095) u0Orig
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -271,15 +271,15 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- j=1 call  spec (includes scratch)
     have J1 := divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old ret_mem d_mem dlo_mem scratch_un0 base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop q1_old retMem dMem dloMem scratch_un0 base
       halign
 
       hbltu_1'
       (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     intro_lets at J1
-    -- Frame j=1 with u0_orig, q0_old only
+    -- Frame j=1 with u0Orig, q0_old only
     have J1f := cpsTriple_frameR
-      (((u_base_0 + signExtend12 0) ↦ₘ u0_orig) ** (q_addr_0 ↦ₘ q0_old))
+      (((u_base_0 + signExtend12 0) ↦ₘ u0Orig) ** (q_addr_0 ↦ₘ q0_old))
       (by pcFree) J1
     -- j=0 call  spec (includes scratch -- j=0 overwrites j=1's scratch)
     have J0 := divK_loop_body_n1_call_unified_j0_spec sp (1 : Word)
@@ -288,7 +288,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).1)
       ((iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1)
       v0 v1 v2 v3
-      u0_orig
+      u0Orig
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
       (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -298,7 +298,7 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       halign
 
       hbltu_0'
-      (hcarry2 (div128Quot (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0_orig v0) u0_orig
+      (hcarry2 (div128Quot (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1 u0Orig v0) u0Orig
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
         (iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
@@ -339,7 +339,7 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : ¬BitVec.ult u1 v0)
@@ -354,9 +354,9 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1Iter210Post false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r2 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -375,8 +375,8 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
   have J2f := cpsTriple_frameR
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1_old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0_old) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) J2
   -- iter10  unified spec (inputs from j=2 max  output)
   have H10 := divK_loop_n1_iter10_unified_spec bltu_1 bltu_0
@@ -386,7 +386,7 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
     v0 v1 v2 v3
     u0_orig_1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
     u0_orig_0 q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -422,7 +422,7 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : BitVec.ult u1 v0)
@@ -437,9 +437,9 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1Iter210Post true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r2 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -449,7 +449,7 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=2 call  spec (includes scratch)
   have J2 := divK_loop_body_n1_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old retMem dMem dloMem scratch_un0 base halign
 
     hbltu_2
     (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
@@ -508,7 +508,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u1 v0)
@@ -523,9 +523,9 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (loopN1Iter210PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1Iter210Post bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   cases bltu_2 <;> simp only [iterN1_true, iterN1_false] at hbltu_1 hbltu_0
   · -- bltu_2 = false -> max
     have hbltu_2' : ¬BitVec.ult u1 v0 := by
@@ -533,7 +533,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     exact divK_loop_n1_max_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -544,7 +544,7 @@ theorem divK_loop_n1_iter210_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     exact divK_loop_n1_call_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -563,7 +563,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : ¬BitVec.ult u1 v0)
@@ -599,9 +599,9 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost false bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r3 := iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -623,8 +623,8 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (((u_base_2 + signExtend12 0) ↦ₘ u0_orig_2) ** (q_addr_2 ↦ₘ q2_old) **
      ((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1_old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0_old) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) J3
   -- iter210  unified spec (inputs from j=3 max  output)
   have H210 := divK_loop_n1_iter210_unified_spec bltu_2 bltu_1 bltu_0
@@ -635,7 +635,7 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
     u0_orig_2 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
     u0_orig_1 u0_orig_0
     q2_old q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    retMem dMem dloMem scratch_un0 base halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
   -- Frame iter210 with j=3 carried atoms
   have H210f := cpsTriple_frameR
@@ -673,7 +673,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : BitVec.ult u1 v0)
@@ -709,9 +709,9 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost true bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r3 := iterN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_3 := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -723,7 +723,7 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   -- j=3 call  spec (includes scratch)
   have J3 := divK_loop_body_n1_call_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q3_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q3_old retMem dMem dloMem scratch_un0 base halign
     hbltu_3
     (hcarry2 (div128Quot u1 u0 v0) u0 u1 u2 u3 uTop : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J3
@@ -785,7 +785,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_2 u0_orig_1 u0_orig_0
      q3_old q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u1 v0)
@@ -821,9 +821,9 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
       (loopN1PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 q3_old q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_2 u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   cases bltu_3 <;> simp only [iterN1_true, iterN1_false] at hbltu_2 hbltu_1 hbltu_0
   · -- bltu_3 = false -> max
     have hbltu_3' : ¬BitVec.ult u1 v0 := by
@@ -832,7 +832,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_3' hbltu_2 hbltu_1 hbltu_0 hcarry2
   · -- bltu_3 = true -> call
     have hbltu_3' : BitVec.ult u1 v0 := hbltu_3.symm ▸ rfl
@@ -840,7 +840,7 @@ theorem divK_loop_n1_unified_spec (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0
       q3_old q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base
+      retMem dMem dloMem scratch_un0 base
       halign
       hbltu_3' hbltu_2 hbltu_1 hbltu_0 hcarry2
 

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -34,28 +34,28 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_2)
     Dispatches to existing  per-path specs in LoopComposeN2.lean. -/
 theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Unified branch conditions (using iterN2 for j=0)
     (hbltu_1 : bltu_1 = BitVec.ult u2 v1)
-    (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+      (loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
         ret_mem d_mem dlo_mem scratch_un0) := by
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN2_true, iterN2_false] at hbltu_0
   · -- (false, false) = max×max
     have hbltu_1' : ¬BitVec.ult u2 v1 := by
       rw [show BitVec.ult u2 v1 = false from hbltu_1.symm]; decide
-    have hbltu_0' : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1 := by
+    have hbltu_0' : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
       rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     have hMM := divK_loop_n2_max_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTriple_frameR
       ((sp + signExtend12 3968 ↦ₘ ret_mem) **
@@ -70,10 +70,10 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
   · -- (false, true) = max×call
     have hbltu_1' : ¬BitVec.ult u2 v1 := by
       rw [show BitVec.ult u2 v1 = false from hbltu_1.symm]; decide
-    have hbltu_0' : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1 :=
+    have hbltu_0' : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
       hbltu_0.symm ▸ rfl
     have hMC := divK_loop_n2_max_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -85,10 +85,10 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       hMC
   · -- (true, false) = call×max
     have hbltu_1' : BitVec.ult u2 v1 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1 := by
+    have hbltu_0' : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
       rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     have hCM := divK_loop_n2_call_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -100,10 +100,10 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
       hCM
   · -- (true, true) = call×call
     have hbltu_1' : BitVec.ult u2 v1 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1 :=
+    have hbltu_0' : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
       hbltu_0.symm ▸ rfl
     have hCC := divK_loop_n2_call_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -123,28 +123,28 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     Composes j=2  max spec with the 2-iteration iter10 unified  spec. -/
 theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : ¬BitVec.ult u2 v1)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1)
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2UnifiedPost false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN2UnifiedPost false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -152,10 +152,10 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   have J2 := divK_loop_body_n2_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q2_old base
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old base
 
     hbltu_2
-    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J2
   have J2f := cpsTriple_frameR
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1_old) **
@@ -201,28 +201,28 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
     Composes j=2  call spec with the 2-iteration iter10 unified  spec. -/
 theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : BitVec.ult u2 v1)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1)
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2UnifiedPost true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN2UnifiedPost true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
-  let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+  let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_2 := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
@@ -230,10 +230,10 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   have J2 := divK_loop_body_n2_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 u_top q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
 
     hbltu_2
-    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 u_top : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
   intro_lets at J2
   have J2f := cpsTriple_frameR
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1_old) **
@@ -282,26 +282,26 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
     Dispatches to divK_loop_n2_max_iter10_spec / divK_loop_n2_call_iter10_spec. -/
 theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
-    (hbltu_1 : bltu_1 = BitVec.ult (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1 v1)
+    (hbltu_1 : bltu_1 = BitVec.ult (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1)
     (hbltu_0 : bltu_0 = BitVec.ult (iterN2 bltu_1 v0 v1 v2 v3 u0_orig_1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1
-      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.2.1).2.2.1 v1)
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1
+      (iterN2 bltu_2 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.2.1).2.2.1 v1)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
   cases bltu_2 <;> simp only [iterN2_true, iterN2_false] at hbltu_1 hbltu_0
   · -- bltu_2 = false → max
@@ -309,7 +309,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       rw [show BitVec.ult u2 v1 = false from hbltu_2.symm]; decide
     exact divK_loop_n2_max_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_1 u0_orig_0 q2_old q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 
@@ -320,7 +320,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     have hbltu_2' : BitVec.ult u2 v1 := hbltu_2.symm ▸ rfl
     exact divK_loop_n2_call_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig_1 u0_orig_0 q2_old q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
 
 

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -34,8 +34,8 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_2)
     Dispatches to existing  per-path specs in LoopComposeN2.lean. -/
 theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Unified branch conditions (using iterN2 for j=0)
@@ -44,10 +44,10 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN2Iter10PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN2Iter10Post bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) := by
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN2_true, iterN2_false] at hbltu_0
   · -- (false, false) = max×max
     have hbltu_1' : ¬BitVec.ult u2 v1 := by
@@ -55,12 +55,12 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : ¬BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
       rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     have hMM := divK_loop_n2_max_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTriple_frameR
-      ((sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) hMM
     exact cpsTriple_weaken
@@ -73,8 +73,8 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : BitVec.ult (iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
       hbltu_0.symm ▸ rfl
     have hMC := divK_loop_n2_max_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -88,8 +88,8 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : ¬BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 := by
       rw [show BitVec.ult _ v1 = false from hbltu_0.symm]; decide
     have hCM := divK_loop_n2_call_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -103,8 +103,8 @@ theorem divK_loop_n2_iter10_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : BitVec.ult (iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.1 v1 :=
       hbltu_0.symm ▸ rfl
     have hCC := divK_loop_n2_call_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -126,7 +126,7 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : ¬BitVec.ult u2 v1)
@@ -141,9 +141,9 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost false bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r2 := iterN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -160,8 +160,8 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
   have J2f := cpsTriple_frameR
     (((u_base_1 + signExtend12 0) ↦ₘ u0_orig_1) ** (q_addr_1 ↦ₘ q1_old) **
      ((u_base_0 + signExtend12 0) ↦ₘ u0_orig_0) ** (q_addr_0 ↦ₘ q0_old) **
-     (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
-     (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) J2
   have H10 := divK_loop_n2_iter10_unified_spec bltu_1 bltu_0
     sp (2 : Word) ((2 : Word) <<< (3 : BitVec 6).toNat) u_base_2 q_addr_2
@@ -170,7 +170,7 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
     v0 v1 v2 v3
     u0_orig_1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
     u0_orig_0 q1_old q0_old
-    ret_mem d_mem dlo_mem scratch_un0 base halign
+    retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -204,7 +204,7 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : BitVec.ult u2 v1)
@@ -219,9 +219,9 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost true bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   let r2 := iterN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop
   let u_base_2 := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
   let u_base_1 := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
@@ -230,7 +230,7 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
   let u_base_0 := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
   let q_addr_0 := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
   have J2 := divK_loop_body_n2_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old ret_mem d_mem dlo_mem scratch_un0 base halign
+    v0 v1 v2 v3 u0 u1 u2 u3 uTop q2_old retMem dMem dloMem scratch_un0 base halign
 
     hbltu_2
     (hcarry2 (div128Quot u2 u1 v1) u0 u1 u2 u3 uTop : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
@@ -285,7 +285,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
      v0 v1 v2 v3 u0 u1 u2 u3 uTop
      u0_orig_1 u0_orig_0
      q2_old q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u2 v1)
@@ -300,9 +300,9 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
       (loopN2PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
+        retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
-        u0_orig_1 u0_orig_0 ret_mem d_mem dlo_mem scratch_un0) := by
+        u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) := by
   cases bltu_2 <;> simp only [iterN2_true, iterN2_false] at hbltu_1 hbltu_0
   · -- bltu_2 = false → max
     have hbltu_2' : ¬BitVec.ult u2 v1 := by
@@ -310,7 +310,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     exact divK_loop_n2_max_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
 
 
 
@@ -321,7 +321,7 @@ theorem divK_loop_n2_unified_spec (bltu_2 bltu_1 bltu_0 : Bool)
     exact divK_loop_n2_call_iter10_spec bltu_1 bltu_0
       sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2_old q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      retMem dMem dloMem scratch_un0 base halign
 
 
 

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -32,8 +32,8 @@ open EvmAsm.Rv64
     Postcondition is loopN3UnifiedPost which uses iterN* values. -/
 theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Unified branch conditions (using iterN3 for j=0)
@@ -42,10 +42,10 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-        ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
-        ret_mem d_mem dlo_mem scratch_un0) := by
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+        retMem dMem dloMem scratch_un0)
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
+        retMem dMem dloMem scratch_un0) := by
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN3_true, iterN3_false] at hbltu_0
   · -- (false, false) = max×max
     have hbltu_1' : ¬BitVec.ult u3 v2 := by
@@ -53,12 +53,12 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
       rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
     have hMM := divK_loop_n3_max_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTriple_frameR
-      ((sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
+      ((sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (by pcFree) hMM
     exact cpsTriple_weaken
@@ -71,8 +71,8 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 :=
       hbltu_0.symm ▸ rfl
     have hMC := divK_loop_n3_max_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -83,8 +83,8 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
       rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
     have hCM := divK_loop_n3_call_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -95,8 +95,8 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     have hbltu_0' : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 :=
       hbltu_0.symm ▸ rfl
     have hCC := divK_loop_n3_call_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
-      ret_mem d_mem dlo_mem scratch_un0 base halign
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1_old q0_old
+      retMem dMem dloMem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken
       (fun h hp => hp)

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN3.lean
@@ -32,28 +32,28 @@ open EvmAsm.Rv64
     Postcondition is loopN3UnifiedPost which uses iterN* values. -/
 theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old : Word)
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     -- Unified branch conditions (using iterN3 for j=0)
     (hbltu_1 : bltu_1 = BitVec.ult u3 v2)
-    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2)
+    (hbltu_0 : bltu_0 = BitVec.ult (iterN3 bltu_1 v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2)
     (hcarry2 : Carry2NzAll v0 v1 v2 v3) :
     cpsTriple (base + loopBodyOff) (base + denormOff) (sharedDivModCode base)
       (loopN3PreWithScratch sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
         ret_mem d_mem dlo_mem scratch_un0)
-      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig
+      (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig
         ret_mem d_mem dlo_mem scratch_un0) := by
   cases bltu_1 <;> cases bltu_0 <;> simp only [iterN3_true, iterN3_false] at hbltu_0
   · -- (false, false) = max×max
     have hbltu_1' : ¬BitVec.ult u3 v2 := by
       rw [show BitVec.ult u3 v2 = false from hbltu_1.symm]; decide
-    have hbltu_0' : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 := by
+    have hbltu_0' : ¬BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
       rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
     have hMM := divK_loop_n3_max_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old base
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old base
       hbltu_1' hbltu_0' hcarry2
     have hMMF := cpsTriple_frameR
       ((sp + signExtend12 3968 ↦ₘ ret_mem) **
@@ -68,10 +68,10 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
   · -- (false, true) = max×call
     have hbltu_1' : ¬BitVec.ult u3 v2 := by
       rw [show BitVec.ult u3 v2 = false from hbltu_1.symm]; decide
-    have hbltu_0' : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 :=
+    have hbltu_0' : BitVec.ult (iterN3Max v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 :=
       hbltu_0.symm ▸ rfl
     have hMC := divK_loop_n3_max_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken
@@ -80,10 +80,10 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
       hMC
   · -- (true, false) = call×max
     have hbltu_1' : BitVec.ult u3 v2 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 := by
+    have hbltu_0' : ¬BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 := by
       rw [show BitVec.ult _ v2 = false from hbltu_0.symm]; decide
     have hCM := divK_loop_n3_call_max_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken
@@ -92,10 +92,10 @@ theorem divK_loop_n3_unified_spec (bltu_1 bltu_0 : Bool)
       hCM
   · -- (true, true) = call×call
     have hbltu_1' : BitVec.ult u3 v2 := hbltu_1.symm ▸ rfl
-    have hbltu_0' : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top).2.2.2.1 v2 :=
+    have hbltu_0' : BitVec.ult (iterN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop).2.2.2.1 v2 :=
       hbltu_0.symm ▸ rfl
     have hCC := divK_loop_n3_call_call_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top u0_orig q1_old q0_old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig q1_old q0_old
       ret_mem d_mem dlo_mem scratch_un0 base halign
       hbltu_1' hbltu_0' hcarry2
     exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/NormDefs.lean
+++ b/EvmAsm/Evm64/DivMod/NormDefs.lean
@@ -21,36 +21,36 @@ open EvmAsm.Rv64
 
 /-- Normalize a non-leading limb by shifting left and OR-ing in bits from the
     lower-adjacent limb. Used for b[1], b[2], b[3] and u[1], u[2], u[3]. -/
-def normLimb (prev cur shift anti_shift : Word) : Word :=
-  (cur <<< (shift.toNat % 64)) ||| (prev >>> (anti_shift.toNat % 64))
+def normLimb (prev cur shift antiShift : Word) : Word :=
+  (cur <<< (shift.toNat % 64)) ||| (prev >>> (antiShift.toNat % 64))
 
 /-- Normalize the lowest limb (no lower neighbor to OR in). -/
 def normLimb_lo (lo shift : Word) : Word :=
   lo <<< (shift.toNat % 64)
 
 /-- Compute the carry limb above the top a[] limb after normalization. -/
-def normLimb_top (hi anti_shift : Word) : Word :=
-  hi >>> (anti_shift.toNat % 64)
+def normLimb_top (hi antiShift : Word) : Word :=
+  hi >>> (antiShift.toNat % 64)
 
 /-- Bundle: normalize all 4 b-limbs.
     Returns (b0', b1', b2', b3') where b[] is left-shifted by `shift`. -/
-def normBLimbs (b0 b1 b2 b3 shift anti_shift : Word) :
+def normBLimbs (b0 b1 b2 b3 shift antiShift : Word) :
     Word × Word × Word × Word :=
   ( normLimb_lo b0 shift,
-    normLimb b0 b1 shift anti_shift,
-    normLimb b1 b2 shift anti_shift,
-    normLimb b2 b3 shift anti_shift )
+    normLimb b0 b1 shift antiShift,
+    normLimb b1 b2 shift antiShift,
+    normLimb b2 b3 shift antiShift )
 
 /-- Bundle: normalize all 4 a-limbs plus carry.
     Returns (u0, u1, u2, u3, u4) where a[] is left-shifted by `shift`
     and u4 is the overflow carry. -/
-def normULimbs (a0 a1 a2 a3 shift anti_shift : Word) :
+def normULimbs (a0 a1 a2 a3 shift antiShift : Word) :
     Word × Word × Word × Word × Word :=
   ( normLimb_lo a0 shift,
-    normLimb a0 a1 shift anti_shift,
-    normLimb a1 a2 shift anti_shift,
-    normLimb a2 a3 shift anti_shift,
-    normLimb_top a3 anti_shift )
+    normLimb a0 a1 shift antiShift,
+    normLimb a1 a2 shift antiShift,
+    normLimb a2 a3 shift antiShift,
+    normLimb_top a3 antiShift )
 
 -- ============================================================================
 -- Denormalization: shift remainder u[] right by `shift` bits
@@ -58,8 +58,8 @@ def normULimbs (a0 a1 a2 a3 shift anti_shift : Word) :
 
 /-- Denormalize a non-top remainder limb by shifting right and OR-ing in
     bits from the higher-adjacent limb. -/
-def denormLimb (cur next shift anti_shift : Word) : Word :=
-  (cur >>> (shift.toNat % 64)) ||| (next <<< (anti_shift.toNat % 64))
+def denormLimb (cur next shift antiShift : Word) : Word :=
+  (cur >>> (shift.toNat % 64)) ||| (next <<< (antiShift.toNat % 64))
 
 /-- Denormalize the top remainder limb (no higher neighbor). -/
 def denormLimb_top (hi shift : Word) : Word :=
@@ -67,11 +67,11 @@ def denormLimb_top (hi shift : Word) : Word :=
 
 /-- Bundle: denormalize 4 remainder limbs.
     Returns (r0', r1', r2', r3') where u[] is right-shifted by `shift`. -/
-def denormRLimbs (u0 u1 u2 u3 shift anti_shift : Word) :
+def denormRLimbs (u0 u1 u2 u3 shift antiShift : Word) :
     Word × Word × Word × Word :=
-  ( denormLimb u0 u1 shift anti_shift,
-    denormLimb u1 u2 shift anti_shift,
-    denormLimb u2 u3 shift anti_shift,
+  ( denormLimb u0 u1 shift antiShift,
+    denormLimb u1 u2 shift antiShift,
+    denormLimb u2 u3 shift antiShift,
     denormLimb_top u3 shift )
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -30,12 +30,12 @@
   Register allocation:
     x12 = EVM stack pointer (preserved)
     x1  = loop counter j / temp
-    x2  = anti_shift / subroutine return addr
+    x2  = antiShift / subroutine return addr
     x5  = general temp
-    x6  = general temp / u_base in mul-sub
+    x6  = general temp / uBase in mul-sub
     x7  = general temp
     x10 = general temp / carry in mul-sub
-    x11 = general temp / q_hat
+    x11 = general temp / qHat
 -/
 
 import EvmAsm.Evm64.Stack
@@ -51,8 +51,8 @@ open EvmAsm.Rv64
 
 /-- 128/64-bit unsigned division subroutine (Hacker's Delight divlu).
     Called via JAL x2, offset. Returns via JALR x0, x2, 0.
-    Input: x7 = u_hi (< d), x5 = u_lo, x10 = d (normalized, >= 2^63)
-    Output: x11 = floor((u_hi * 2^64 + u_lo) / d)
+    Input: x7 = uHi (< d), x5 = uLo, x10 = d (normalized, >= 2^63)
+    Output: x11 = floor((uHi * 2^64 + uLo) / d)
     Clobbers: x1, x5, x6, x7, x10, x11. Preserves: x2, x12.
     Uses scratch memory at 3992, 3984, 3976, 3968 (offsets from x12). -/
 def divK_div128 : Program :=
@@ -63,12 +63,12 @@ def divK_div128 : Program :=
   SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
   SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
   SD .x12 .x1 3952 ;;                         -- [5]  save dLo
-  -- Split u_lo: un1 = u_lo >> 32, un0 = (u_lo << 32) >> 32
+  -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
   SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
   SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
   SD .x12 .x5 3944 ;;                         -- [9]  save un0
-  -- Step 1: q1 = DIVU(u_hi, dHi), rhat = u_hi - q1*dHi
-  -- x7 = u_hi, x6 = dHi
+  -- Step 1: q1 = DIVU(uHi, dHi), rhat = uHi - q1*dHi
+  -- x7 = uHi, x6 = dHi
   single (.DIVU .x10 .x7 .x6) ;;             -- [10] x10 = q1 (use x10 since we saved d)
   single (.MUL .x5 .x10 .x6) ;;              -- [11] x5 = q1 * dHi
   single (.SUB .x7 .x7 .x5) ;;               -- [12] x7 = rhat
@@ -168,15 +168,15 @@ def divK_clz : Program :=
   SRLI .x7 .x5 63 ;; single (.BNE .x7 .x0 8) ;;
   ADDI .x6 .x6 1
 
-/-- Phase C2: Store shift, compute anti_shift, BEQ if shift=0.
-    4 instructions. x6 = shift, x2 = anti_shift. -/
+/-- Phase C2: Store shift, compute antiShift, BEQ if shift=0.
+    4 instructions. x6 = shift, x2 = antiShift. -/
 def divK_phaseC2 (shift0_off : BitVec 13) : Program :=
   SD .x12 .x6 3992 ;;
   ADDI .x2 .x0 0 ;; single (.SUB .x2 .x2 .x6) ;;
   single (.BEQ .x6 .x0 shift0_off)
 
 /-- Phase C3a: Normalize b in-place (shift > 0).
-    21 instructions. x6 = shift, x2 = anti_shift. -/
+    21 instructions. x6 = shift, x2 = antiShift. -/
 def divK_normB : Program :=
   LD .x5 .x12 56 ;; LD .x7 .x12 48 ;;
   single (.SLL .x5 .x5 .x6) ;; single (.SRL .x7 .x7 .x2) ;; single (.OR .x5 .x5 .x7) ;;
@@ -217,19 +217,19 @@ def divK_copyAU : Program :=
 
 /-- Loop setup: compute m = 4-n, j = m (start of loop counter).
     4 instructions. BLT if j < 0 (signed). -/
-def divK_loopSetup (blt_off : BitVec 13) : Program :=
+def divK_loopSetup (bltOff : BitVec 13) : Program :=
   LD .x5 .x12 3984 ;;
   ADDI .x1 .x0 4 ;; single (.SUB .x1 .x1 .x5) ;;
-  single (.BLT .x1 .x0 blt_off)
+  single (.BLT .x1 .x0 bltOff)
 
 /-- Loop body: trial quotient + multiply-subtract + correction + store q[j].
     Starts at loop_start. Includes save/restore of j.
 
     Layout within loop body (instruction indices relative to loop_start):
       [0]     SD save j
-      [1..13] load u[j+n], u[j+n-1], v_top; check u_hi>=v_top; call 128/64
+      [1..13] load u[j+n], u[j+n-1], vTop; check uHi>=vTop; call 128/64
       [14]    LD restore j
-      [15..17] mul-sub setup (u_base, carry=0)
+      [15..17] mul-sub setup (uBase, carry=0)
       [18..61] mul-sub 4 limbs (4 × 11 instrs)
       [62..65] subtract carry from u[j+4]
       [66]    BEQ skip correction
@@ -251,42 +251,42 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   LD .x7 .x5 0 ;;                             -- [6] x7 = u[j+n] (hi)
   LD .x5 .x5 8 ;;                             -- [7] x5 = u[j+n-1] (lo)
 
-  -- Load v_top = b[n-1]
+  -- Load vTop = b[n-1]
   LD .x6 .x12 3984 ;;                         -- [8] n
   ADDI .x6 .x6 4095 ;;                        -- [9] n-1
   SLLI .x6 .x6 3 ;;                           -- [10] (n-1)*8
   single (.ADD .x6 .x12 .x6) ;;              -- [11] &b[n-1]
-  LD .x10 .x6 32 ;;                            -- [12] x10 = v_top = b[n-1]
+  LD .x10 .x6 32 ;;                            -- [12] x10 = vTop = b[n-1]
 
   -- Trial quotient
-  single (.BLTU .x7 .x10 12) ;;              -- [13] u_hi < v_top? → [16] call 128/64
-  ADDI .x11 .x0 4095 ;;                       -- [14] q_hat = MAX64
+  single (.BLTU .x7 .x10 12) ;;              -- [13] uHi < vTop? → [16] call 128/64
+  ADDI .x11 .x0 4095 ;;                       -- [14] qHat = MAX64
   JAL .x0 8 ;;                                 -- [15] skip call → [17]
   JAL .x2 subr_off ;;                          -- [16] call 128/64 subroutine
 
-  -- Restore j, compute u_base
+  -- Restore j, compute uBase
   LD .x1 .x12 3976 ;;                         -- [17] restore j
   SLLI .x5 .x1 3 ;;                           -- [18] j*8
   ADDI .x6 .x12 4056 ;;                       -- [19] sp-40
-  single (.SUB .x6 .x6 .x5) ;;               -- [20] x6 = u_base = &u[j]
+  single (.SUB .x6 .x6 .x5) ;;               -- [20] x6 = uBase = &u[j]
 
   -- Init carry = 0
   ADDI .x10 .x0 0 ;;                          -- [21] carry = 0
 
-  -- MUL-SUB LIMB 0: v[0] at sp+32, u[j+0] at u_base+0
+  -- MUL-SUB LIMB 0: v[0] at sp+32, u[j+0] at uBase+0
   LD .x5 .x12 32 ;;                           -- [22]
   single (.MUL .x7 .x11 .x5) ;;              -- [23] prod_lo
   single (.MULHU .x5 .x11 .x5) ;;            -- [24] prod_hi
   single (.ADD .x7 .x7 .x10) ;;              -- [25] full_sub = prod_lo + carry
-  single (.SLTU .x10 .x7 .x10) ;;            -- [26] borrow_add
+  single (.SLTU .x10 .x7 .x10) ;;            -- [26] borrowAdd
   single (.ADD .x10 .x10 .x5) ;;             -- [27] partial_carry = borrow + prod_hi
   LD .x2 .x6 0 ;;                             -- [28] u[j+0]
-  single (.SLTU .x5 .x2 .x7) ;;              -- [29] borrow_sub
+  single (.SLTU .x5 .x2 .x7) ;;              -- [29] borrowSub
   single (.SUB .x2 .x2 .x7) ;;               -- [30] uNew
   single (.ADD .x10 .x10 .x5) ;;             -- [31] carryOut
   SD .x6 .x2 0 ;;                             -- [32] store u[j+0]
 
-  -- MUL-SUB LIMB 1: v[1] at sp+40, u[j+1] at u_base-8 (4088)
+  -- MUL-SUB LIMB 1: v[1] at sp+40, u[j+1] at uBase-8 (4088)
   LD .x5 .x12 40 ;;                           -- [33]
   single (.MUL .x7 .x11 .x5) ;;              -- [34]
   single (.MULHU .x5 .x11 .x5) ;;            -- [35]
@@ -299,7 +299,7 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   single (.ADD .x10 .x10 .x5) ;;             -- [42]
   SD .x6 .x2 4088 ;;                          -- [43]
 
-  -- MUL-SUB LIMB 2: v[2] at sp+48, u[j+2] at u_base-16 (4080)
+  -- MUL-SUB LIMB 2: v[2] at sp+48, u[j+2] at uBase-16 (4080)
   LD .x5 .x12 48 ;;                           -- [44]
   single (.MUL .x7 .x11 .x5) ;;              -- [45]
   single (.MULHU .x5 .x11 .x5) ;;            -- [46]
@@ -312,7 +312,7 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   single (.ADD .x10 .x10 .x5) ;;             -- [53]
   SD .x6 .x2 4080 ;;                          -- [54]
 
-  -- MUL-SUB LIMB 3: v[3] at sp+56, u[j+3] at u_base-24 (4072)
+  -- MUL-SUB LIMB 3: v[3] at sp+56, u[j+3] at uBase-24 (4072)
   LD .x5 .x12 56 ;;                           -- [55]
   single (.MUL .x7 .x11 .x5) ;;              -- [56]
   single (.MULHU .x5 .x11 .x5) ;;            -- [57]
@@ -325,17 +325,17 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   single (.ADD .x10 .x10 .x5) ;;             -- [64]
   SD .x6 .x2 4072 ;;                          -- [65]
 
-  -- SUBTRACT CARRY FROM u[j+4]: u_base-32 (4064)
+  -- SUBTRACT CARRY FROM u[j+4]: uBase-32 (4064)
   LD .x5 .x6 4064 ;;                          -- [66] u[j+4]
   single (.SLTU .x7 .x5 .x10) ;;             -- [67] borrow
   single (.SUB .x5 .x5 .x10) ;;              -- [68]
   SD .x6 .x5 4064 ;;                          -- [69]
 
-  -- CORRECTION: if borrow (x7 != 0), add v back and q_hat--
+  -- CORRECTION: if borrow (x7 != 0), add v back and qHat--
   -- BEQ x7 x0 skips 38 instructions → offset = 38*4+4 = 156
   single (.BEQ .x7 .x0 156) ;;               -- [70] skip correction → [109]
 
-  -- Add-back: v[0..3] to u[j..j+3] with carry, then u[j+4]++, q_hat--
+  -- Add-back: v[0..3] to u[j..j+3] with carry, then u[j+4]++, qHat--
   ADDI .x7 .x0 0 ;;                           -- [71] carry = 0
   -- Limb 0
   LD .x5 .x12 32 ;; LD .x2 .x6 0 ;;          -- [72,73]
@@ -373,7 +373,7 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   LD .x5 .x6 4064 ;;                          -- [104]
   single (.ADD .x5 .x5 .x7) ;;               -- [105]
   SD .x6 .x5 4064 ;;                          -- [106]
-  -- q_hat--
+  -- qHat--
   ADDI .x11 .x11 4095 ;;                      -- [107]
 
   -- DOUBLE ADDBACK CHECK: if carry (x7) = 0, repeat addback
@@ -384,7 +384,7 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   SLLI .x5 .x1 3 ;;                           -- [109] j*8
   ADDI .x7 .x12 4088 ;;                       -- [110] sp-8
   single (.SUB .x7 .x7 .x5) ;;               -- [111] &q[j]
-  SD .x7 .x11 0 ;;                            -- [112] q[j] = q_hat
+  SD .x7 .x11 0 ;;                            -- [112] q[j] = qHat
 
   -- LOOP CONTROL
   ADDI .x1 .x1 4095 ;;                        -- [113] j--
@@ -395,7 +395,7 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
 def divK_denorm : Program :=
   LD .x6 .x12 3992 ;;                         -- [0] shift
   single (.BEQ .x6 .x0 96) ;;                -- [1] if shift=0, skip → [25]
-  ADDI .x2 .x0 0 ;; single (.SUB .x2 .x2 .x6) ;; -- [2,3] anti_shift
+  ADDI .x2 .x0 0 ;; single (.SUB .x2 .x2 .x6) ;; -- [2,3] antiShift
   -- u[0]
   LD .x5 .x12 4056 ;; LD .x7 .x12 4048 ;;    -- [4,5]
   single (.SRL .x5 .x5 .x6) ;;               -- [6]

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1083,7 +1083,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   have hshift_lt_64 : (clzResult (b.getLimbN 3)).1.toNat < 64 := by omega
   have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =
       (clzResult (b.getLimbN 3)).1.toNat := by omega
-  -- c3_n ≤ u_top from runtime skip borrow, specialized to our shift form.
+  -- c3_n ≤ uTop from runtime skip borrow, specialized to our shift form.
   have hc3_le := EvmWord.c3_le_u_top_of_skip_borrow
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) hborrow

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -102,7 +102,7 @@ def isMaxTrialN4Evm (a b : EvmWord) : Prop :=
 
 /-- Skip-addback condition at n=4 max in EvmWord form: the runtime borrow
     check `u4 < mulsubN4_c3` does not fire, so the algorithm skips the
-    addback step and uses `q_hat` as the quotient digit. -/
+    addback step and uses `qHat` as the quotient digit. -/
 def isSkipBorrowN4MaxEvm (a b : EvmWord) : Prop :=
   isSkipBorrowN4Max (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
@@ -235,7 +235,7 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
 def divN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) : Assertion :=
+     shiftMem nMem jMem : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -243,30 +243,30 @@ def divN4StackPre (sp : Word) (a b : EvmWord)
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem
+    shiftMem nMem jMem
 
 theorem pcFree_divN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem).pcFree := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem).pcFree := by
   delta divN4StackPre; pcFree
 
 instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem) :=
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem) :=
   ⟨pcFree_divN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem⟩
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
 
 /-- Named unfold for `divN4StackPre`. Restores access to the atomic
     components once `@[irreducible]` has made `delta` the only path in. -/
 theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) :
+     shiftMem nMem jMem : Word) :
     divN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -274,7 +274,7 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shiftMem n_mem jMem) := by
+       shiftMem nMem jMem) := by
   delta divN4StackPre; rfl
 
 /-- Full-depth unfold of `divN4StackPre`: expands the bundle, both `evmWordIs`
@@ -285,9 +285,9 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
 theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) :
+     shiftMem nMem jMem : Word) :
     divN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -304,7 +304,7 @@ theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-      ((sp + signExtend12 3984) ↦ₘ n_mem) **
+      ((sp + signExtend12 3984) ↦ₘ nMem) **
       ((sp + signExtend12 3976) ↦ₘ jMem))) := by
   rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchValues_unfold]
@@ -317,7 +317,7 @@ theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
 def modN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) : Assertion :=
+     shiftMem nMem jMem : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -325,29 +325,29 @@ def modN4StackPre (sp : Word) (a b : EvmWord)
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem n_mem jMem
+    shiftMem nMem jMem
 
 theorem pcFree_modN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem).pcFree := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem).pcFree := by
   delta modN4StackPre; pcFree
 
 instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem) :=
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem) :=
   ⟨pcFree_modN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem⟩
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
 
 /-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
 theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) :
+     shiftMem nMem jMem : Word) :
     modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -355,7 +355,7 @@ theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shiftMem n_mem jMem) := by
+       shiftMem nMem jMem) := by
   delta modN4StackPre; rfl
 
 /-- Full-depth unfold of `modN4StackPre`: expands the bundle, both
@@ -364,9 +364,9 @@ theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
 theorem modN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem n_mem jMem : Word) :
+     shiftMem nMem jMem : Word) :
     modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -383,7 +383,7 @@ theorem modN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-      ((sp + signExtend12 3984) ↦ₘ n_mem) **
+      ((sp + signExtend12 3984) ↦ₘ nMem) **
       ((sp + signExtend12 3976) ↦ₘ jMem))) := by
   rw [modN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchValues_unfold]
@@ -445,7 +445,7 @@ instance (sp : Word) (a b : EvmWord) :
 theorem div_n4_max_skip_stack_weaken
     (sp : Word) (a b : EvmWord)
     (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
-    (q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
      shift_p n_p j_p : Word) :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
@@ -454,7 +454,7 @@ theorem div_n4_max_skip_stack_weaken
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
-       divScratchValues sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p
+       divScratchValues sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
          u5_p u6_p u7_p shift_p n_p j_p) h →
       divN4MaxSkipStackPost sp a b h := by
   intro h hp
@@ -465,7 +465,7 @@ theorem div_n4_max_skip_stack_weaken
   apply sepConj_mono_right
   apply sepConj_mono_right
   exact divScratchValues_implies_divScratchOwn
-    sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
     shift_p n_p j_p
 
 /-- MOD counterpart of `divN4MaxSkipStackPost`: same structure, same register
@@ -545,7 +545,7 @@ theorem modN4MaxSkipStackPost_unfold_atoms_right (sp : Word) (a b : EvmWord)
     `divN4StackPre_unfold_atoms_right`. -/
 theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word)
     (Q : Assertion) :
     (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -563,10 +563,10 @@ theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
        ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
     (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem ** Q) := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem ** Q) := by
   rw [modN4StackPre_unfold_atoms]
 
 /-- Mid-tree variant of `divN4StackPre_unfold_atoms`: threads a remainder
@@ -575,7 +575,7 @@ theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     fold variants. -/
 theorem divN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word)
     (Q : Assertion) :
     (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -593,10 +593,10 @@ theorem divN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
        ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-       ((sp + signExtend12 3984) ↦ₘ n_mem) **
+       ((sp + signExtend12 3984) ↦ₘ nMem) **
        ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
     (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem ** Q) := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem ** Q) := by
   rw [divN4StackPre_unfold_atoms]
 
 /-- Mid-tree variant of the `divN4MaxSkipStackPost_unfold_atoms` family:
@@ -643,7 +643,7 @@ instance (sp : Word) (a b : EvmWord) :
 theorem mod_n4_max_skip_stack_weaken
     (sp : Word) (a b : EvmWord)
     (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
-    (q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
      shift_p n_p j_p : Word) :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
@@ -652,7 +652,7 @@ theorem mod_n4_max_skip_stack_weaken
        (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
        (.x0 ↦ᵣ (0 : Word)) **
        evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
-       divScratchValues sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p
+       divScratchValues sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
          u5_p u6_p u7_p shift_p n_p j_p) h →
       modN4MaxSkipStackPost sp a b h := by
   intro h hp
@@ -663,7 +663,7 @@ theorem mod_n4_max_skip_stack_weaken
   apply sepConj_mono_right
   apply sepConj_mono_right
   exact divScratchValues_implies_divScratchOwn
-    sp q0_p q1_p q2_p q3_p u0_p u1_p u2_p u3_p u4_p u5_p u6_p u7_p
+    sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
     shift_p n_p j_p
 
 /-- EvmWord-level wrapper around `evm_div_n4_full_max_skip_spec`. Same
@@ -676,7 +676,7 @@ theorem mod_n4_max_skip_stack_weaken
 theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11_old : Word)
     (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -690,7 +690,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
        (.x11 ↦ᵣ v11_old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValues sp q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old
-         u5 u6 u7 shiftMem n_mem jMem)
+         u5 u6 u7 shiftMem nMem jMem)
       (fullDivN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
@@ -701,7 +701,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v5 v6 v7 v10 v11_old
     q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-    n_mem shiftMem jMem
+    nMem shiftMem jMem
     hbnz' hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun h hp => by
@@ -738,7 +738,7 @@ theorem divScratchCellCount_pos : 0 < divScratchCellCount := by decide
 theorem evm_div_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -746,13 +746,13 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (hborrow : isSkipBorrowN4MaxEvm a b) :
     cpsTriple base (base + nopOff) (divCode base)
       (divN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
       (fullDivN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have h := evm_div_n4_full_max_skip_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    n_mem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
+    nMem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun _ hp => by rw [divN4StackPre_unfold] at hp; exact hp)
     (fun _ hq => hq)
@@ -871,7 +871,7 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
 theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11_old : Word)
     (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -885,7 +885,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
        (.x11 ↦ᵣ v11_old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValues sp q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old
-         u5 u6 u7 shiftMem n_mem jMem)
+         u5 u6 u7 shiftMem nMem jMem)
       (fullModN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
@@ -896,7 +896,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v5 v6 v7 v10 v11_old
     q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-    n_mem shiftMem jMem
+    nMem shiftMem jMem
     hbnz' hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun h hp => by
@@ -913,7 +913,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
 theorem evm_mod_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -921,13 +921,13 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (hborrow : isSkipBorrowN4MaxEvm a b) :
     cpsTriple base (base + nopOff) (modCode base)
       (modN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
       (fullModN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have h := evm_mod_n4_full_max_skip_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    n_mem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
+    nMem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun _ hp => by rw [modN4StackPre_unfold] at hp; exact hp)
     (fun _ hq => hq)
@@ -991,7 +991,7 @@ theorem output_slot_to_evmWordIs_mod_n4_max_skip (sp : Word) (a b : EvmWord)
 theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -1000,10 +1000,10 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
     (hsem : n4MaxSkipSemanticHolds a b) :
     cpsTriple base (base + nopOff) (divCode base)
       (divN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
       (divN4MaxSkipStackPost sp a b) := by
   have h_pre := evm_div_n4_full_max_skip_stack_pre_spec_bundled sp base a b
-    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shiftMem jMem
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 nMem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3, _, _, _, _⟩ :=
     n4_max_skip_div_mod_getLimbN a b hb3nz hsem
@@ -1055,7 +1055,7 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
 theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shiftMem jMem : Word)
+     nMem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -1066,10 +1066,10 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
         2 ^ (64 - (clzResult (b.getLimbN 3)).1.toNat)) :
     cpsTriple base (base + nopOff) (modCode base)
       (modN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
       (modN4MaxSkipStackPost sp a b) := by
   have h_pre := evm_mod_n4_full_max_skip_stack_pre_spec_bundled sp base a b
-    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shiftMem jMem
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 nMem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   -- Shift bound: clzResult.1.toNat ≤ 63, and hshift_nz gives it > 0.
   have hshift_le_63 := clzResult_fst_toNat_le (b.getLimbN 3)

--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -17,7 +17,7 @@ open EvmAsm.Rv64
 
 /-- EQ limb 0 spec (3 instructions): LD x7, LD x6, XOR x7 x7 x6. -/
 theorem eq_limb0_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let cr :=
@@ -26,17 +26,17 @@ theorem eq_limb0_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 8) (.XOR .x7 .x7 .x6)))
     cpsTriple base (base + 12) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a_limb ^^^ b_limb)) ** (.x6 ↦ᵣ b_limb) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ^^^ bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 /-- EQ OR-limb spec (4 instructions): LD x6, LD x5, XOR x6 x6 x5, OR x7 x7 x6. -/
 theorem eq_or_limb_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v6 v5 acc : Word) (base : Word) :
+    (sp aLimb bLimb v6 v5 acc : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let xorK := a_limb ^^^ b_limb
+    let xorK := aLimb ^^^ bLimb
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x6 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x5 .x12 offB))
@@ -44,9 +44,9 @@ theorem eq_or_limb_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 12) (.OR .x7 .x7 .x6))))
     cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ acc) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ b_limb) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| xorK)) ** (.x6 ↦ᵣ xorK) ** (.x5 ↦ᵣ bLimb) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -225,13 +225,13 @@ theorem add_carry_chain_correct (a b : EvmWord) :
 -- ============================================================================
 
 /-- Helper: subtraction of a single limb with borrow produces the right toNat value. -/
-private theorem sub_limb_toNat {a_limb b_limb borrow : Word}
+private theorem sub_limb_toNat {aLimb bLimb borrow : Word}
     (hborrow : borrow.toNat = 0 ∨ borrow.toNat = 1) :
-    (a_limb - b_limb - borrow).toNat =
-    (a_limb.toNat + 2^64 - b_limb.toNat + 2^64 - borrow.toNat) % 2^64 := by
+    (aLimb - bLimb - borrow).toNat =
+    (aLimb.toNat + 2^64 - bLimb.toNat + 2^64 - borrow.toNat) % 2^64 := by
   simp only [BitVec.toNat_sub]
-  have ha := a_limb.isLt
-  have hb := b_limb.isLt
+  have ha := aLimb.isLt
+  have hb := bLimb.isLt
   rcases hborrow with h | h <;> simp only [h] <;> omega
 
 /-- Each limb of a - b equals the borrow-chain result at that limb position. -/

--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -54,90 +54,90 @@ theorem halfword_combine_hi_lo (x : Word) :
 -- 128-bit Euclidean uniqueness (Nat level)
 -- ============================================================================
 
-/-- If `val128 u_hi u_lo = d * q + r` with `r < d`, then `q = val128 u_hi u_lo / d`.
+/-- If `val128 uHi uLo = d * q + r` with `r < d`, then `q = val128 uHi uLo / d`.
     Used to verify div128 output by checking the division equation and remainder bound. -/
-theorem val128_div_unique (u_hi u_lo : Word) (d q r : Nat)
+theorem val128_div_unique (uHi uLo : Word) (d q r : Nat)
     (hr : r < d)
-    (heq : val128 u_hi u_lo = d * q + r) :
-    q = val128 u_hi u_lo / d := by
-  have h1 : q * d ≤ val128 u_hi u_lo := by rw [heq]; nlinarith [Nat.mul_comm d q]
-  have h2 : val128 u_hi u_lo < (q + 1) * d := by rw [heq]; nlinarith [Nat.mul_comm d q]
+    (heq : val128 uHi uLo = d * q + r) :
+    q = val128 uHi uLo / d := by
+  have h1 : q * d ≤ val128 uHi uLo := by rw [heq]; nlinarith [Nat.mul_comm d q]
+  have h2 : val128 uHi uLo < (q + 1) * d := by rw [heq]; nlinarith [Nat.mul_comm d q]
   exact (Nat.div_eq_of_lt_le h1 h2).symm
 
 /-- Remainder uniqueness: if the Euclidean equation holds, the remainder equals mod. -/
-theorem val128_mod_unique (u_hi u_lo : Word) (d q r : Nat)
+theorem val128_mod_unique (uHi uLo : Word) (d q r : Nat)
     (hr : r < d)
-    (heq : val128 u_hi u_lo = d * q + r) :
-    r = val128 u_hi u_lo % d := by
-  have hq := val128_div_unique u_hi u_lo d q r hr heq
-  have hdm := Nat.div_add_mod (val128 u_hi u_lo) d
-  subst hq; nlinarith [Nat.mul_comm d (val128 u_hi u_lo / d)]
+    (heq : val128 uHi uLo = d * q + r) :
+    r = val128 uHi uLo % d := by
+  have hq := val128_div_unique uHi uLo d q r hr heq
+  have hdm := Nat.div_add_mod (val128 uHi uLo) d
+  subst hq; nlinarith [Nat.mul_comm d (val128 uHi uLo / d)]
 
 -- ============================================================================
 -- Trial quotient bounds (Knuth TAOCP Vol 2, Section 4.3.1)
 -- ============================================================================
 
--- The trial quotient q̂ = ⌊u_hi / d_hi⌋ overestimates the true quotient digit
--- qTrue = ⌊(u_hi * B + un1) / d⌋ where d = d_hi * B + d_lo, B = 2^32.
+-- The trial quotient q̂ = ⌊uHi / dHi⌋ overestimates the true quotient digit
+-- qTrue = ⌊(uHi * B + un1) / d⌋ where d = dHi * B + dLo, B = 2^32.
 --
 -- Bound 1 (no normalization needed): q̂ ≥ qTrue
--- Bound 2 (normalization: d_hi ≥ B/2): q̂ ≤ qTrue + 2
+-- Bound 2 (normalization: dHi ≥ B/2): q̂ ≤ qTrue + 2
 
-/-- Trial quotient upper bound: `⌊u_hi / d_hi⌋ ≥ ⌊(u_hi * B + un1) / d⌋`.
+/-- Trial quotient upper bound: `⌊uHi / dHi⌋ ≥ ⌊(uHi * B + un1) / d⌋`.
     The trial quotient never underestimates. No normalization needed.
 
-    Proof idea: `(q̂ + 1) * d_hi > u_hi`, so `(q̂ + 1) * d > u_hi * B + un1`. -/
-theorem trial_quotient_ge (u_hi un1 d_hi d_lo : Nat)
-    (hd_hi : 0 < d_hi) (hun1 : un1 < 2^32) :
-    (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) ≤ u_hi / d_hi := by
-  have hd_pos : 0 < d_hi * 2^32 + d_lo := by positivity
-  have : (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) < u_hi / d_hi + 1 :=
+    Proof idea: `(q̂ + 1) * dHi > uHi`, so `(q̂ + 1) * d > uHi * B + un1`. -/
+theorem trial_quotient_ge (uHi un1 dHi dLo : Nat)
+    (hd_hi : 0 < dHi) (hun1 : un1 < 2^32) :
+    (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) ≤ uHi / dHi := by
+  have hd_pos : 0 < dHi * 2^32 + dLo := by positivity
+  have : (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) < uHi / dHi + 1 :=
     (Nat.div_lt_iff_lt_mul hd_pos).mpr (by
-      have hq : u_hi < d_hi * (u_hi / d_hi + 1) := Nat.lt_mul_div_succ u_hi hd_hi
-      calc u_hi * 2^32 + un1
-          < (u_hi + 1) * 2^32 := by nlinarith
-        _ ≤ d_hi * (u_hi / d_hi + 1) * 2^32 := by nlinarith
-        _ = (u_hi / d_hi + 1) * (d_hi * 2^32) := by ring
-        _ ≤ (u_hi / d_hi + 1) * (d_hi * 2^32 + d_lo) := by nlinarith)
+      have hq : uHi < dHi * (uHi / dHi + 1) := Nat.lt_mul_div_succ uHi hd_hi
+      calc uHi * 2^32 + un1
+          < (uHi + 1) * 2^32 := by nlinarith
+        _ ≤ dHi * (uHi / dHi + 1) * 2^32 := by nlinarith
+        _ = (uHi / dHi + 1) * (dHi * 2^32) := by ring
+        _ ≤ (uHi / dHi + 1) * (dHi * 2^32 + dLo) := by nlinarith)
   omega
 
-/-- Trial quotient lower bound: `⌊u_hi / d_hi⌋ ≤ ⌊(u_hi * B + un1) / d⌋ + 2`.
-    The trial quotient overestimates by at most 2 when d_hi ≥ B/2 (normalized).
+/-- Trial quotient lower bound: `⌊uHi / dHi⌋ ≤ ⌊(uHi * B + un1) / d⌋ + 2`.
+    The trial quotient overestimates by at most 2 when dHi ≥ B/2 (normalized).
 
     This is the key bound from Knuth's analysis. The normalization condition ensures
-    `q̂ ≤ B + 1`, so `q̂ * d_lo < B² ≤ 2d`, giving `q̂ * d ≤ u_hi * B + 2d`. -/
-theorem trial_quotient_le (u_hi un1 d_hi d_lo : Nat)
-    (hd_hi_bound : d_hi < 2^32) (hd_lo : d_lo < 2^32)
-    (hun1 : un1 < 2^32) (hu : u_hi < d_hi * 2^32 + d_lo) (hnorm : d_hi ≥ 2^31) :
-    u_hi / d_hi ≤ (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) + 2 := by
-  have hd_hi : 0 < d_hi := by omega
-  set d := d_hi * 2^32 + d_lo
-  set qHat := u_hi / d_hi
+    `q̂ ≤ B + 1`, so `q̂ * dLo < B² ≤ 2d`, giving `q̂ * d ≤ uHi * B + 2d`. -/
+theorem trial_quotient_le (uHi un1 dHi dLo : Nat)
+    (hd_hi_bound : dHi < 2^32) (hd_lo : dLo < 2^32)
+    (hun1 : un1 < 2^32) (hu : uHi < dHi * 2^32 + dLo) (hnorm : dHi ≥ 2^31) :
+    uHi / dHi ≤ (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) + 2 := by
+  have hd_hi : 0 < dHi := by omega
+  set d := dHi * 2^32 + dLo
+  set qHat := uHi / dHi
   have hd_pos : 0 < d := by positivity
-  have hq_mul : qHat * d_hi ≤ u_hi := Nat.div_mul_le_self u_hi d_hi
-  -- q̂ ≤ B + 1: if q̂ ≥ B+2 then q̂*d_hi ≥ (B+2)*d_hi, giving 2*d_hi ≤ d_lo,
-  -- contradicting d_hi ≥ B/2 and d_lo < B.
+  have hq_mul : qHat * dHi ≤ uHi := Nat.div_mul_le_self uHi dHi
+  -- q̂ ≤ B + 1: if q̂ ≥ B+2 then q̂*dHi ≥ (B+2)*dHi, giving 2*dHi ≤ dLo,
+  -- contradicting dHi ≥ B/2 and dLo < B.
   have hq_bound : qHat ≤ 2^32 + 1 := by
     by_contra h_contra; push Not at h_contra
-    have h1 : (2^32 + 2) * d_hi ≤ qHat * d_hi := Nat.mul_le_mul_right d_hi (by omega)
-    have h2 : 2 * d_hi ≤ d_lo := by omega
+    have h1 : (2^32 + 2) * dHi ≤ qHat * dHi := Nat.mul_le_mul_right dHi (by omega)
+    have h2 : 2 * dHi ≤ dLo := by omega
     omega
-  -- q̂ * d_lo < B² ≤ 2d
-  have hq_dlo_bound : qHat * d_lo < 2^64 := by
-    have : d_lo ≤ 2^32 - 1 := by omega
-    have : qHat * d_lo ≤ (2^32 + 1) * (2^32 - 1) := Nat.mul_le_mul hq_bound this
+  -- q̂ * dLo < B² ≤ 2d
+  have hq_dlo_bound : qHat * dLo < 2^64 := by
+    have : dLo ≤ 2^32 - 1 := by omega
+    have : qHat * dLo ≤ (2^32 + 1) * (2^32 - 1) := Nat.mul_le_mul hq_bound this
     norm_num at this ⊢; omega
   have h2d_ge : 2 * d ≥ 2^64 := by
-    show 2 * (d_hi * 2^32 + d_lo) ≥ _; omega
-  have hq_d_eq : qHat * d = qHat * d_hi * 2^32 + qHat * d_lo := by
-    show qHat * (d_hi * 2^32 + d_lo) = _; ring
-  -- Key: q̂ * d ≤ u_hi * B + 2d ≤ X + 2d where X = u_hi * B + un1
-  set X := u_hi * 2^32 + un1
+    show 2 * (dHi * 2^32 + dLo) ≥ _; omega
+  have hq_d_eq : qHat * d = qHat * dHi * 2^32 + qHat * dLo := by
+    show qHat * (dHi * 2^32 + dLo) = _; ring
+  -- Key: q̂ * d ≤ uHi * B + 2d ≤ X + 2d where X = uHi * B + un1
+  set X := uHi * 2^32 + un1
   have key : qHat * d ≤ X + 2 * d := by
-    calc qHat * d = qHat * d_hi * 2^32 + qHat * d_lo := hq_d_eq
-      _ ≤ u_hi * 2^32 + qHat * d_lo := by nlinarith
-      _ ≤ u_hi * 2^32 + 2^64 := by omega
-      _ ≤ u_hi * 2^32 + 2 * d := by omega
+    calc qHat * d = qHat * dHi * 2^32 + qHat * dLo := hq_d_eq
+      _ ≤ uHi * 2^32 + qHat * dLo := by nlinarith
+      _ ≤ uHi * 2^32 + 2^64 := by omega
+      _ ≤ uHi * 2^32 + 2 * d := by omega
       _ ≤ X + 2 * d := by omega
   -- Convert: q̂ * d ≤ X + 2d < (X/d + 3) * d → q̂ < X/d + 3 → q̂ ≤ X/d + 2
   have hXmod : X < (X / d + 1) * d := by
@@ -149,67 +149,67 @@ theorem trial_quotient_le (u_hi un1 d_hi d_lo : Nat)
   omega
 
 /-- Combined: the trial quotient is within 2 of the true value.
-    `qTrue ≤ q̂ ≤ qTrue + 2` when `d_hi ≥ B/2` (normalization condition). -/
-theorem trial_quotient_range (u_hi un1 d_hi d_lo : Nat)
-    (hd_hi_bound : d_hi < 2^32) (hd_lo : d_lo < 2^32)
-    (hun1 : un1 < 2^32) (hu : u_hi < d_hi * 2^32 + d_lo) (hnorm : d_hi ≥ 2^31) :
-    let qHat := u_hi / d_hi
-    let qTrue := (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo)
+    `qTrue ≤ q̂ ≤ qTrue + 2` when `dHi ≥ B/2` (normalization condition). -/
+theorem trial_quotient_range (uHi un1 dHi dLo : Nat)
+    (hd_hi_bound : dHi < 2^32) (hd_lo : dLo < 2^32)
+    (hun1 : un1 < 2^32) (hu : uHi < dHi * 2^32 + dLo) (hnorm : dHi ≥ 2^31) :
+    let qHat := uHi / dHi
+    let qTrue := (uHi * 2^32 + un1) / (dHi * 2^32 + dLo)
     qTrue ≤ qHat ∧ qHat ≤ qTrue + 2 :=
-  ⟨trial_quotient_ge u_hi un1 d_hi d_lo (by omega) hun1,
-   trial_quotient_le u_hi un1 d_hi d_lo hd_hi_bound hd_lo hun1 hu hnorm⟩
+  ⟨trial_quotient_ge uHi un1 dHi dLo (by omega) hun1,
+   trial_quotient_le uHi un1 dHi dLo hd_hi_bound hd_lo hun1 hu hnorm⟩
 
 -- ============================================================================
 -- Product check correction: reduces overestimate from ≤ 2 to ≤ 1
 -- ============================================================================
 
--- After computing q̂ = ⌊u_hi / d_hi⌋ and r̂ = u_hi mod d_hi, the div128
--- algorithm checks: is q̂ * d_lo > r̂ * B + un1?
+-- After computing q̂ = ⌊uHi / dHi⌋ and r̂ = uHi mod dHi, the div128
+-- algorithm checks: is q̂ * dLo > r̂ * B + un1?
 -- If yes, q̂ overestimates by ≥ 1, so decrement.
 -- After at most one correction, the overestimate is ≤ 1.
 
-/-- Product check soundness: if `q̂ * d_lo > r̂ * B + un1`,
+/-- Product check soundness: if `q̂ * dLo > r̂ * B + un1`,
     then `q̂ > qTrue` (the trial quotient strictly overestimates).
 
-    Proof: q̂ * d = q̂ * d_hi * B + q̂ * d_lo > r̂ * d_hi * B + r̂ * B + un1
-    and from r̂ = u_hi - q̂ * d_hi: q̂ * d_hi = u_hi - r̂,
-    so q̂ * d > (u_hi - r̂) * B + r̂ * B + un1 = u_hi * B + un1. -/
-theorem product_check_gt_imp_overestimate (u_hi un1 d_hi d_lo qHat r_hat : Nat)
+    Proof: q̂ * d = q̂ * dHi * B + q̂ * dLo > r̂ * dHi * B + r̂ * B + un1
+    and from r̂ = uHi - q̂ * dHi: q̂ * dHi = uHi - r̂,
+    so q̂ * d > (uHi - r̂) * B + r̂ * B + un1 = uHi * B + un1. -/
+theorem product_check_gt_imp_overestimate (uHi un1 dHi dLo qHat r_hat : Nat)
     (B : Nat := 2^32)
-    (hd_pos : 0 < d_hi * B + d_lo)
-    (hr_hat : r_hat = u_hi - qHat * d_hi)
-    (hq_mul : qHat * d_hi ≤ u_hi)
-    (hcheck : qHat * d_lo > r_hat * B + un1) :
-    qHat > (u_hi * B + un1) / (d_hi * B + d_lo) := by
-  set d := d_hi * B + d_lo
-  set X := u_hi * B + un1
-  -- q̂ * d = q̂ * d_hi * B + q̂ * d_lo > (u_hi - r̂) * B + r̂ * B + un1 = X
+    (hd_pos : 0 < dHi * B + dLo)
+    (hr_hat : r_hat = uHi - qHat * dHi)
+    (hq_mul : qHat * dHi ≤ uHi)
+    (hcheck : qHat * dLo > r_hat * B + un1) :
+    qHat > (uHi * B + un1) / (dHi * B + dLo) := by
+  set d := dHi * B + dLo
+  set X := uHi * B + un1
+  -- q̂ * d = q̂ * dHi * B + q̂ * dLo > (uHi - r̂) * B + r̂ * B + un1 = X
   have hqd_gt : qHat * d > X := by
-    calc qHat * d = qHat * (d_hi * B + d_lo) := rfl
-      _ = qHat * d_hi * B + qHat * d_lo := by ring
-      _ > qHat * d_hi * B + r_hat * B + un1 := by omega
-      _ = (qHat * d_hi + r_hat) * B + un1 := by ring
-      _ = u_hi * B + un1 := by
+    calc qHat * d = qHat * (dHi * B + dLo) := rfl
+      _ = qHat * dHi * B + qHat * dLo := by ring
+      _ > qHat * dHi * B + r_hat * B + un1 := by omega
+      _ = (qHat * dHi + r_hat) * B + un1 := by ring
+      _ = uHi * B + un1 := by
             rw [hr_hat, Nat.add_sub_cancel' hq_mul]
   exact (Nat.div_lt_iff_lt_mul hd_pos).mpr hqd_gt
 
-/-- If the product check passes (`q̂ * d_lo ≤ r̂ * B + un1`), then `q̂ ≤ qTrue`.
+/-- If the product check passes (`q̂ * dLo ≤ r̂ * B + un1`), then `q̂ ≤ qTrue`.
     The trial quotient does NOT overestimate the true quotient in this branch. -/
-theorem product_check_pass_imp_le (u_hi un1 d_hi d_lo qHat r_hat : Nat)
+theorem product_check_pass_imp_le (uHi un1 dHi dLo qHat r_hat : Nat)
     (B : Nat := 2^32)
-    (hd_pos : 0 < d_hi * B + d_lo)
-    (hr_hat : r_hat = u_hi - qHat * d_hi)
-    (hq_mul : qHat * d_hi ≤ u_hi)
-    (hcheck_pass : qHat * d_lo ≤ r_hat * B + un1) :
-    qHat ≤ (u_hi * B + un1) / (d_hi * B + d_lo) := by
-  set d := d_hi * B + d_lo
-  set X := u_hi * B + un1
+    (hd_pos : 0 < dHi * B + dLo)
+    (hr_hat : r_hat = uHi - qHat * dHi)
+    (hq_mul : qHat * dHi ≤ uHi)
+    (hcheck_pass : qHat * dLo ≤ r_hat * B + un1) :
+    qHat ≤ (uHi * B + un1) / (dHi * B + dLo) := by
+  set d := dHi * B + dLo
+  set X := uHi * B + un1
   have hqd_le : qHat * d ≤ X := by
-    calc qHat * d = qHat * (d_hi * B + d_lo) := rfl
-      _ = qHat * d_hi * B + qHat * d_lo := by ring
-      _ ≤ qHat * d_hi * B + r_hat * B + un1 := by omega
-      _ = (qHat * d_hi + r_hat) * B + un1 := by ring
-      _ = u_hi * B + un1 := by
+    calc qHat * d = qHat * (dHi * B + dLo) := rfl
+      _ = qHat * dHi * B + qHat * dLo := by ring
+      _ ≤ qHat * dHi * B + r_hat * B + un1 := by omega
+      _ = (qHat * dHi + r_hat) * B + un1 := by ring
+      _ = uHi * B + un1 := by
             rw [hr_hat, Nat.add_sub_cancel' hq_mul]
   exact Nat.le_div_iff_mul_le hd_pos |>.mpr hqd_le
 
@@ -217,25 +217,25 @@ theorem product_check_pass_imp_le (u_hi un1 d_hi d_lo qHat r_hat : Nat)
     fails), the trial quotient overestimates by at most 1.
     - If check passes: `q̂ ≤ qTrue` (from `product_check_pass_imp_le`)
     - If check fails: `q̂ - 1 ≤ qTrue + 1` since `q̂ > qTrue` and `q̂ ≤ qTrue + 2` -/
-theorem correction_step_overestimate_le_one (u_hi un1 d_hi d_lo qHat r_hat : Nat)
+theorem correction_step_overestimate_le_one (uHi un1 dHi dLo qHat r_hat : Nat)
     (B : Nat := 2^32)
-    (hd_pos : 0 < d_hi * B + d_lo)
-    (hr_hat : r_hat = u_hi - qHat * d_hi)
-    (hq_mul : qHat * d_hi ≤ u_hi)
-    (hq_upper : qHat ≤ (u_hi * B + un1) / (d_hi * B + d_lo) + 2) :
-    (if qHat * d_lo > r_hat * B + un1 then qHat - 1 else qHat) ≤
-      (u_hi * B + un1) / (d_hi * B + d_lo) + 1 := by
-  set qTrue := (u_hi * B + un1) / (d_hi * B + d_lo)
+    (hd_pos : 0 < dHi * B + dLo)
+    (hr_hat : r_hat = uHi - qHat * dHi)
+    (hq_mul : qHat * dHi ≤ uHi)
+    (hq_upper : qHat ≤ (uHi * B + un1) / (dHi * B + dLo) + 2) :
+    (if qHat * dLo > r_hat * B + un1 then qHat - 1 else qHat) ≤
+      (uHi * B + un1) / (dHi * B + dLo) + 1 := by
+  set qTrue := (uHi * B + un1) / (dHi * B + dLo)
   split
   · -- Product check fails: decrement. q̂ > qTrue and q̂ ≤ qTrue + 2.
     rename_i hfail
-    have hgt : qHat > qTrue := product_check_gt_imp_overestimate u_hi un1 d_hi d_lo qHat r_hat B
+    have hgt : qHat > qTrue := product_check_gt_imp_overestimate uHi un1 dHi dLo qHat r_hat B
       hd_pos hr_hat hq_mul hfail
     exact Nat.sub_le_of_le_add (by omega : qHat ≤ qTrue + 1 + 1)
   · -- Product check passes: q̂ ≤ qTrue, so q̂ ≤ qTrue + 1 trivially.
     rename_i hpass
     simp only [not_lt] at hpass
-    have := product_check_pass_imp_le u_hi un1 d_hi d_lo qHat r_hat B
+    have := product_check_pass_imp_le uHi un1 dHi dLo qHat r_hat B
       hd_pos hr_hat hq_mul hpass
     omega
 
@@ -245,53 +245,53 @@ theorem correction_step_overestimate_le_one (u_hi un1 d_hi d_lo qHat r_hat : Nat
 
 /-- Full half-round: any quotient q satisfying qTrue ≤ q ≤ qTrue + 2
     (the trial quotient range) can be corrected to qTrue ≤ q' ≤ qTrue + 1
-    via the product check, provided q * d_hi ≤ u_hi (the trial division invariant).
+    via the product check, provided q * dHi ≤ uHi (the trial division invariant).
 
     This captures both the overflow correction case (which reduces the bound
     from ≤ qTrue + 2 to ≤ qTrue + 1) and the no-overflow case (where
     correction_step_overestimate_le_one applies directly). -/
-theorem half_round_overestimate_le_one (u_hi un1 d_hi d_lo q r : Nat)
-    (hd_pos : 0 < d_hi * 2^32 + d_lo)
-    (hr : r = u_hi - q * d_hi)
-    (hq_mul : q * d_hi ≤ u_hi)
-    (hq_ge : (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) ≤ q)
-    (hq_le : q ≤ (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) + 2) :
-    let qTrue := (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo)
-    let q' := if q * d_lo > r * 2^32 + un1 then q - 1 else q
+theorem half_round_overestimate_le_one (uHi un1 dHi dLo q r : Nat)
+    (hd_pos : 0 < dHi * 2^32 + dLo)
+    (hr : r = uHi - q * dHi)
+    (hq_mul : q * dHi ≤ uHi)
+    (hq_ge : (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) ≤ q)
+    (hq_le : q ≤ (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) + 2) :
+    let qTrue := (uHi * 2^32 + un1) / (dHi * 2^32 + dLo)
+    let q' := if q * dLo > r * 2^32 + un1 then q - 1 else q
     qTrue ≤ q' ∧ q' ≤ qTrue + 1 := by
   constructor
   · -- Lower bound: q' ≥ qTrue
     split
     · rename_i hfail
-      have hgt : q > (u_hi * 2^32 + un1) / (d_hi * 2^32 + d_lo) :=
-        product_check_gt_imp_overestimate u_hi un1 d_hi d_lo q r (2^32)
+      have hgt : q > (uHi * 2^32 + un1) / (dHi * 2^32 + dLo) :=
+        product_check_gt_imp_overestimate uHi un1 dHi dLo q r (2^32)
           hd_pos hr hq_mul hfail
       omega
     · exact hq_ge
   · -- Upper bound: q' ≤ qTrue + 1
-    exact correction_step_overestimate_le_one u_hi un1 d_hi d_lo q r (2^32)
+    exact correction_step_overestimate_le_one uHi un1 dHi dLo q r (2^32)
       hd_pos hr hq_mul hq_le
 
 -- ============================================================================
 -- Generalized trial quotient bound (any base)
 -- ============================================================================
 
-/-- Generalized trial quotient bound: ⌊(u_hi * Bk + u_rest) / (d_hi * Bk + d_rest)⌋ ≤ ⌊u_hi / d_hi⌋.
+/-- Generalized trial quotient bound: ⌊(uHi * Bk + u_rest) / (dHi * Bk + d_rest)⌋ ≤ ⌊uHi / dHi⌋.
     Works for any "base" Bk (e.g., 2^32, 2^64, 2^128). The trial quotient using only the
     top portions never underestimates the true quotient. -/
-theorem trial_quotient_ge_general (u_hi u_rest d_hi d_rest Bk : Nat)
-    (hd_hi : 0 < d_hi) (hu_rest : u_rest < Bk) :
-    (u_hi * Bk + u_rest) / (d_hi * Bk + d_rest) ≤ u_hi / d_hi := by
+theorem trial_quotient_ge_general (uHi u_rest dHi d_rest Bk : Nat)
+    (hd_hi : 0 < dHi) (hu_rest : u_rest < Bk) :
+    (uHi * Bk + u_rest) / (dHi * Bk + d_rest) ≤ uHi / dHi := by
   have hBk : 0 < Bk := by omega
-  have hd_pos : 0 < d_hi * Bk + d_rest := by positivity
-  have : (u_hi * Bk + u_rest) / (d_hi * Bk + d_rest) < u_hi / d_hi + 1 :=
+  have hd_pos : 0 < dHi * Bk + d_rest := by positivity
+  have : (uHi * Bk + u_rest) / (dHi * Bk + d_rest) < uHi / dHi + 1 :=
     (Nat.div_lt_iff_lt_mul hd_pos).mpr (by
-      have hq : u_hi < d_hi * (u_hi / d_hi + 1) := Nat.lt_mul_div_succ u_hi hd_hi
-      calc u_hi * Bk + u_rest
-          < (u_hi + 1) * Bk := by nlinarith
-        _ ≤ d_hi * (u_hi / d_hi + 1) * Bk := by nlinarith
-        _ = (u_hi / d_hi + 1) * (d_hi * Bk) := by ring
-        _ ≤ (u_hi / d_hi + 1) * (d_hi * Bk + d_rest) := by nlinarith)
+      have hq : uHi < dHi * (uHi / dHi + 1) := Nat.lt_mul_div_succ uHi hd_hi
+      calc uHi * Bk + u_rest
+          < (uHi + 1) * Bk := by nlinarith
+        _ ≤ dHi * (uHi / dHi + 1) * Bk := by nlinarith
+        _ = (uHi / dHi + 1) * (dHi * Bk) := by ring
+        _ ≤ (uHi / dHi + 1) * (dHi * Bk + d_rest) := by nlinarith)
   omega
 
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -62,20 +62,20 @@ theorem val256_zero_upper_1 (q0 q1 q2 : Word) :
 
 /-- 1 iteration (n=4 case): the single mulsub directly gives the Euclidean equation.
     No accumulation needed — this is the base case. -/
-theorem iter_accumulate_1 {u_val v_val q0_nat r_val : Nat}
-    (h0 : u_val = q0_nat * v_val + r_val) :
-    u_val = q0_nat * v_val + r_val := h0
+theorem iter_accumulate_1 {uVal vVal q0Nat r_val : Nat}
+    (h0 : uVal = q0Nat * vVal + r_val) :
+    uVal = q0Nat * vVal + r_val := h0
 
 /-- 2 iterations (n=3 case): digits q1 (high) and q0 (low).
 
     Iteration 1 (j=1): operates on u[1..4], produces q1.
-      u_hi * 2^64 + u_lo_part = q1 * v + u'
+      uHi * 2^64 + u_lo_part = q1 * v + u'
     This means the "upper portion" of the dividend satisfies the equation.
 
     Iteration 0 (j=0): operates on u'[0..3], produces q0.
       u' = q0 * v + r
 
-    Combined: u_hi * 2^64 + u_lo_part = (q1 * 2^64 + q0) * v + r
+    Combined: uHi * 2^64 + u_lo_part = (q1 * 2^64 + q0) * v + r
     But we work at the full val level where the iteration equations are:
 
     iter 1: u_total = q1 * (v * 2^64) + u'_total  (q1 accounts for position)
@@ -84,28 +84,28 @@ theorem iter_accumulate_1 {u_val v_val q0_nat r_val : Nat}
     Actually, in Algorithm D, the iterations work on shifted windows. Let me
     use a more direct formulation: the accumulated quotient digits form the
     full quotient. -/
-theorem iter_accumulate_2 {u_val v_val q1_nat q0_nat mid_val r_val : Nat}
-    (h1 : u_val = q1_nat * v_val * 2^64 + mid_val)
-    (h0 : mid_val = q0_nat * v_val + r_val) :
-    u_val = (q1_nat * 2^64 + q0_nat) * v_val + r_val := by
+theorem iter_accumulate_2 {uVal vVal q1Nat q0Nat mid_val r_val : Nat}
+    (h1 : uVal = q1Nat * vVal * 2^64 + mid_val)
+    (h0 : mid_val = q0Nat * vVal + r_val) :
+    uVal = (q1Nat * 2^64 + q0Nat) * vVal + r_val := by
   nlinarith
 
 /-- 3 iterations (n=2 case): digits q2, q1, q0. -/
-theorem iter_accumulate_3 {u_val v_val q2_nat q1_nat q0_nat mid2_val mid1_val r_val : Nat}
-    (h2 : u_val = q2_nat * v_val * 2^128 + mid2_val)
-    (h1 : mid2_val = q1_nat * v_val * 2^64 + mid1_val)
-    (h0 : mid1_val = q0_nat * v_val + r_val) :
-    u_val = (q2_nat * 2^128 + q1_nat * 2^64 + q0_nat) * v_val + r_val := by
+theorem iter_accumulate_3 {uVal vVal q2Nat q1Nat q0Nat mid2_val mid1_val r_val : Nat}
+    (h2 : uVal = q2Nat * vVal * 2^128 + mid2_val)
+    (h1 : mid2_val = q1Nat * vVal * 2^64 + mid1_val)
+    (h0 : mid1_val = q0Nat * vVal + r_val) :
+    uVal = (q2Nat * 2^128 + q1Nat * 2^64 + q0Nat) * vVal + r_val := by
   nlinarith
 
 /-- 4 iterations (n=1 case): digits q3, q2, q1, q0. -/
 theorem iter_accumulate_4
-    {u_val v_val q3_nat q2_nat q1_nat q0_nat mid3_val mid2_val mid1_val r_val : Nat}
-    (h3 : u_val = q3_nat * v_val * 2^192 + mid3_val)
-    (h2 : mid3_val = q2_nat * v_val * 2^128 + mid2_val)
-    (h1 : mid2_val = q1_nat * v_val * 2^64 + mid1_val)
-    (h0 : mid1_val = q0_nat * v_val + r_val) :
-    u_val = (q3_nat * 2^192 + q2_nat * 2^128 + q1_nat * 2^64 + q0_nat) * v_val + r_val := by
+    {uVal vVal q3Nat q2Nat q1Nat q0Nat mid3_val mid2_val mid1_val r_val : Nat}
+    (h3 : uVal = q3Nat * vVal * 2^192 + mid3_val)
+    (h2 : mid3_val = q2Nat * vVal * 2^128 + mid2_val)
+    (h1 : mid2_val = q1Nat * vVal * 2^64 + mid1_val)
+    (h0 : mid1_val = q0Nat * vVal + r_val) :
+    uVal = (q3Nat * 2^192 + q2Nat * 2^128 + q1Nat * 2^64 + q0Nat) * vVal + r_val := by
   nlinarith
 
 -- ============================================================================
@@ -264,17 +264,17 @@ theorem div_correct_n1_no_shift
 
     This handles all n-cases and both shift=0 and shift≠0. For shift=0,
     use s=0 (2^0 = 1, so the equation simplifies to val256(a) = q_val * val256(b) + r). -/
-theorem div_quotient_of_normalized {a_val b_val q_val r_norm : Nat} (s : Nat)
-    (hmulsub : a_val * 2^s = q_val * (b_val * 2^s) + r_norm)
-    (hlt : r_norm < b_val * 2^s) :
-    q_val = a_val / b_val :=
+theorem div_quotient_of_normalized {aVal bVal q_val r_norm : Nat} (s : Nat)
+    (hmulsub : aVal * 2^s = q_val * (bVal * 2^s) + r_norm)
+    (hlt : r_norm < bVal * 2^s) :
+    q_val = aVal / bVal :=
   (norm_euclidean_correct s hmulsub hlt).1
 
 /-- Normalization also recovers the remainder: r_norm / 2^s = a % b. -/
-theorem mod_remainder_of_normalized {a_val b_val q_val r_norm : Nat} (s : Nat)
-    (hmulsub : a_val * 2^s = q_val * (b_val * 2^s) + r_norm)
-    (hlt : r_norm < b_val * 2^s) :
-    r_norm / 2^s = a_val % b_val :=
+theorem mod_remainder_of_normalized {aVal bVal q_val r_norm : Nat} (s : Nat)
+    (hmulsub : aVal * 2^s = q_val * (bVal * 2^s) + r_norm)
+    (hlt : r_norm < bVal * 2^s) :
+    r_norm / 2^s = aVal % bVal :=
   (norm_euclidean_correct s hmulsub hlt).2
 
 /-- Bridge from val256-level quotient correctness to EvmWord.div.

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
@@ -122,12 +122,12 @@ theorem addback_4limb_val256_with_carry
     2. addback: val256(r_ms) + val256(v) = val256(r_ab) + carry * 2^256
     3. Carry = 1 (since r_ms is close to 2^256), cancelling: val256(u) = val256(r_ab) + (q-1)*val256(v) -/
 theorem addback_correction_euclidean
-    (u_val v_val r_ms_val r_ab_val : Nat) (q_nat : Nat)
-    (h_mulsub : u_val + 2^256 = r_ms_val + q_nat * v_val)
-    (h_addback : r_ms_val + v_val = r_ab_val + 2^256)
-    (hq : 0 < q_nat) :
-    u_val = r_ab_val + (q_nat - 1) * v_val := by
-  nlinarith [mulsub_correction_eq u_val v_val r_ms_val q_nat h_mulsub hq]
+    (uVal vVal rMsVal rAbVal : Nat) (qNat : Nat)
+    (h_mulsub : uVal + 2^256 = rMsVal + qNat * vVal)
+    (h_addback : rMsVal + vVal = rAbVal + 2^256)
+    (hq : 0 < qNat) :
+    uVal = rAbVal + (qNat - 1) * vVal := by
+  nlinarith [mulsub_correction_eq uVal vVal rMsVal qNat h_mulsub hq]
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -190,16 +190,16 @@ theorem mulsub_carry_word_eq (borrowAdd prodHi borrowSub : Word)
 /-- Composing 4 per-limb Nat-level equations gives the full val256 equation
     via `mulsub_chain_nat`. The carries cb0..cb3 telescope, leaving only cb3:
       val256 u + cb3 * 2^256 = val256 r + q * val256 v -/
-theorem mulsub_4limb_val256 (q_nat : Nat)
+theorem mulsub_4limb_val256 (qNat : Nat)
     (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
     (cb0 cb1 cb2 cb3 : Nat)
-    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + q_nat * v0.toNat)
-    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + q_nat * v1.toNat + cb0)
-    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + q_nat * v2.toNat + cb1)
-    (h3 : u3.toNat + cb3 * 2^64 = r3.toNat + q_nat * v3.toNat + cb2) :
+    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + qNat * v0.toNat)
+    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + qNat * v1.toNat + cb0)
+    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + qNat * v2.toNat + cb1)
+    (h3 : u3.toNat + cb3 * 2^64 = r3.toNat + qNat * v3.toNat + cb2) :
     val256 u0 u1 u2 u3 + cb3 * 2^256 =
-    val256 r0 r1 r2 r3 + q_nat * val256 v0 v1 v2 v3 :=
-  mulsub_chain_nat q_nat u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 cb0 cb1 cb2 cb3
+    val256 r0 r1 r2 r3 + qNat * val256 v0 v1 v2 v3 :=
+  mulsub_chain_nat qNat u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 cb0 cb1 cb2 cb3
     h0 h1 h2 h3
 
 /-- When the final carry cb3 = 0 (no underflow) and remainder < divisor,
@@ -207,14 +207,14 @@ theorem mulsub_4limb_val256 (q_nat : Nat)
     q = EvmWord.div and r = EvmWord.mod.
 
     This handles the single-digit quotient case (n=4 in Knuth's Algorithm D). -/
-theorem mulsub_4limb_euclidean_div (q_nat : Nat)
+theorem mulsub_4limb_euclidean_div (qNat : Nat)
     (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
     (cb0 cb1 cb2 : Nat)
-    (hq_bound : q_nat < 2^64)
-    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + q_nat * v0.toNat)
-    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + q_nat * v1.toNat + cb0)
-    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + q_nat * v2.toNat + cb1)
-    (h3 : u3.toNat = r3.toNat + q_nat * v3.toNat + cb2)
+    (hq_bound : qNat < 2^64)
+    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + qNat * v0.toNat)
+    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + qNat * v1.toNat + cb0)
+    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + qNat * v2.toNat + cb1)
+    (h3 : u3.toNat = r3.toNat + qNat * v3.toNat + cb2)
     (h_rem : val256 r0 r1 r2 r3 < val256 v0 v1 v2 v3)
     (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0) :
     let a := fromLimbs fun i : Fin 4 =>
@@ -222,20 +222,20 @@ theorem mulsub_4limb_euclidean_div (q_nat : Nat)
     let b := fromLimbs fun i : Fin 4 =>
       match i with | 0 => v0 | 1 => v1 | 2 => v2 | 3 => v3
     let q := fromLimbs fun i : Fin 4 =>
-      match i with | 0 => BitVec.ofNat 64 q_nat | _ => 0
+      match i with | 0 => BitVec.ofNat 64 qNat | _ => 0
     let r := fromLimbs fun i : Fin 4 =>
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have h_chain := mulsub_chain_no_underflow q_nat u0 u1 u2 u3 v0 v1 v2 v3
+  have h_chain := mulsub_chain_no_underflow qNat u0 u1 u2 u3 v0 v1 v2 v3
     r0 r1 r2 r3 cb0 cb1 cb2 h0 h1 h2 h3
   -- Connect fromLimbs.toNat to val256
   have ha : a.toNat = val256 u0 u1 u2 u3 := by
     show (fromLimbs _).toNat = _; rw [fromLimbs_toNat]; dsimp only []; unfold val256; norm_num
   have hb : b.toNat = val256 v0 v1 v2 v3 := by
     show (fromLimbs _).toNat = _; rw [fromLimbs_toNat]; dsimp only []; unfold val256; norm_num
-  have hq : q.toNat = q_nat := by
-    show (fromLimbs _).toNat = q_nat; rw [fromLimbs_toNat, show (0 : Word).toNat = 0 from rfl]
+  have hq : q.toNat = qNat := by
+    show (fromLimbs _).toNat = qNat; rw [fromLimbs_toNat, show (0 : Word).toNat = 0 from rfl]
     simp only [BitVec.toNat_ofNat]; omega
   have hr : r.toNat = val256 r0 r1 r2 r3 := by
     show (fromLimbs _).toNat = _; rw [fromLimbs_toNat]; dsimp only []; unfold val256; norm_num

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -112,7 +112,7 @@ theorem hq_over_from_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
 -- ============================================================================
 
 /-- Double-addback path (c3 = 1, carry1 = 0, carry2 = 1, max trial) at n=4:
-    the corrected quotient `q_hat - 2 = signExtend12 4095 * 3 = 2^64 - 3`
+    the corrected quotient `qHat - 2 = signExtend12 4095 * 3 = 2^64 - 3`
     equals ⌊val256(a)/val256(b)⌋, and the second-addback remainder equals
     `val256(a) mod val256(b)`.
 
@@ -135,21 +135,21 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0 b1 b2 b3
-    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+    let qHat'' : Word := signExtend12 (4095 : BitVec 12) +
       signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
     let a := fromLimbs fun i : Fin 4 =>
       match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
     let b := fromLimbs fun i : Fin 4 =>
       match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
     let q := fromLimbs fun i : Fin 4 =>
-      match i with | 0 => q_hat'' | 1 => (0 : Word) | 2 => (0 : Word) | 3 => (0 : Word)
+      match i with | 0 => qHat'' | 1 => (0 : Word) | 2 => (0 : Word) | 3 => (0 : Word)
     let r := fromLimbs fun i : Fin 4 =>
       match i with | 0 => ab'.1 | 1 => ab'.2.1 | 2 => ab'.2.2.1 | 3 => ab'.2.2.2.1
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
-  intro ms ab ab' q_hat'' a b q r
+  intro ms ab ab' qHat'' a b q r
   have hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0 := by
     intro h; exact hb3nz (BitVec.or_eq_zero_iff.mp h).2
-  -- Bridge: for any u_top, addbackN4's low-4 outputs are the same. So both
+  -- Bridge: for any uTop, addbackN4's low-4 outputs are the same. So both
   -- the algorithm's `ab` (u4_new = 0 - c3) and lemma's ab (u4_new = 0) share
   -- low-4 limbs, and the second-addback low-4 outputs also match.
   have h_ab_indep := addbackN4_fst4_u4_indep ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
@@ -171,7 +171,7 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   -- Derive hq_over from carry2 = 1.
   have hq_over := hq_over_from_second_carry_one (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     hbnz hc3_one hcarry1_zero hcarry2_lem
-  -- q_hat ≥ 2: trivial.
+  -- qHat ≥ 2: trivial.
   have hq_hat_toNat : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2 ^ 64 - 1 := by decide
   have hq_ge_2 : (signExtend12 (4095 : BitVec 12) : Word).toNat ≥ 2 := by
     rw [hq_hat_toNat]; decide
@@ -180,8 +180,8 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3 hbnz hq_over hc3_one hcarry1_zero hq_ge_2
   simp only [] at hcombined
   -- Bridge from lemma's ab' to algorithm's ab': both second addbacks compute
-  -- from the same low-4 ab limbs (low 4 are u_top-independent), and second
-  -- addback's low-4 outputs are themselves u_top-independent. So their
+  -- from the same low-4 ab limbs (low 4 are uTop-independent), and second
+  -- addback's low-4 outputs are themselves uTop-independent. So their
   -- low-4 val256s match.
   have h_ab'_alg_indep := addbackN4_fst4_u4_indep ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
     ab.2.2.2.2 0 b0 b1 b2 b3
@@ -258,11 +258,11 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   have hab'_bound : val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 < val256 b0 b1 b2 b3 := by
     rw [hab'_eq1, hab'_eq21, hab'_eq221, hab'_eq2221]; exact hab'_bound_lem
   -- Rewrite the Euclidean equation in val256_euclidean_to_div_mod's expected form.
-  have hq_hat''_toNat : q_hat''.toNat = (signExtend12 (4095 : BitVec 12) : Word).toNat - 2 := by
-    simp only [q_hat'']; decide
-  have hq_val : val256 q_hat'' 0 0 0 = q_hat''.toNat := val256_zero_upper_3 q_hat''
+  have hq_hat''_toNat : qHat''.toNat = (signExtend12 (4095 : BitVec 12) : Word).toNat - 2 := by
+    simp only [qHat'']; decide
+  have hq_val : val256 qHat'' 0 0 0 = qHat''.toNat := val256_zero_upper_3 qHat''
   have heuclid : val256 a0 a1 a2 a3 =
-      val256 q_hat'' 0 0 0 * val256 b0 b1 b2 b3 +
+      val256 qHat'' 0 0 0 * val256 b0 b1 b2 b3 +
       val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 := by
     rw [hq_val, hq_hat''_toNat]; exact hcombined
   exact val256_euclidean_to_div_mod hbnz heuclid hab'_bound
@@ -274,7 +274,7 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
 /-- n=4 max+double-addback path: per-limb quotient/remainder equalities.
     Direct consumer-facing form of `n4_max_double_addback_correct` —
     parallels `n4_max_addback_div_mod_limbs`. The corrected quotient is
-    `q_hat'' = 3 * signExtend12 4095 = 2^64 - 3` in the low limb. -/
+    `qHat'' = 3 * signExtend12 4095 = 2^64 - 3` in the low limb. -/
 theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
     (hc3_one : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 1)
@@ -291,13 +291,13 @@ theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0 b1 b2 b3
-    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+    let qHat'' : Word := signExtend12 (4095 : BitVec 12) +
       signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
     let a := fromLimbs fun i : Fin 4 =>
       match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
     let b := fromLimbs fun i : Fin 4 =>
       match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
-    (EvmWord.div a b).getLimbN 0 = q_hat'' ∧
+    (EvmWord.div a b).getLimbN 0 = qHat'' ∧
     (EvmWord.div a b).getLimbN 1 = 0 ∧
     (EvmWord.div a b).getLimbN 2 = 0 ∧
     (EvmWord.div a b).getLimbN 3 = 0 ∧
@@ -305,7 +305,7 @@ theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (EvmWord.mod a b).getLimbN 1 = ab'.2.1 ∧
     (EvmWord.mod a b).getLimbN 2 = ab'.2.2.1 ∧
     (EvmWord.mod a b).getLimbN 3 = ab'.2.2.2.1 := by
-  intro ms ab ab' q_hat'' a b
+  intro ms ab ab' qHat'' a b
   have ⟨hq, hr⟩ := n4_max_double_addback_correct a0 a1 a2 a3 b0 b1 b2 b3
     hb3nz hc3_one hcarry1_zero hcarry2_one
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
@@ -355,9 +355,9 @@ theorem n4_max_double_addback_div_mod_getLimbN (a b : EvmWord)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+    let qHat'' : Word := signExtend12 (4095 : BitVec 12) +
       signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
-    (EvmWord.div a b).getLimbN 0 = q_hat'' ∧
+    (EvmWord.div a b).getLimbN 0 = qHat'' ∧
     (EvmWord.div a b).getLimbN 1 = 0 ∧
     (EvmWord.div a b).getLimbN 2 = 0 ∧
     (EvmWord.div a b).getLimbN 3 = 0 ∧

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
@@ -6,7 +6,7 @@
   runs a single loop iteration. These lemmas establish:
   - quotient bound (≤ 1) from MSB condition
   - division correctness for the q=0 and q=1 subcases
-  - val128 simplification when u_hi = 0
+  - val128 simplification when uHi = 0
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivBridge
@@ -21,22 +21,22 @@ namespace EvmWord
 -- val128 simplification
 -- ============================================================================
 
-/-- When u_hi = 0, val128 reduces to the low word's toNat. -/
-theorem val128_zero_hi (u_lo : Word) : val128 0 u_lo = u_lo.toNat := by
+/-- When uHi = 0, val128 reduces to the low word's toNat. -/
+theorem val128_zero_hi (uLo : Word) : val128 0 uLo = uLo.toNat := by
   unfold val128; simp
 
 -- ============================================================================
 -- Quotient bound for n=4 shift=0
 -- ============================================================================
 
-/-- When the divisor's MSB is set (d ≥ 2^63) and u_hi = 0,
+/-- When the divisor's MSB is set (d ≥ 2^63) and uHi = 0,
     the 128-bit quotient is at most 1.
     This is the key bound for n=4 shift=0: the single loop iteration
     produces a trial quotient q̂ ∈ {0, 1}. -/
-theorem div_nat_le_one_of_msb (u_lo d : Word) (hd : d.toNat ≥ 2^63) :
-    u_lo.toNat / d.toNat ≤ 1 := by
-  have hulo := u_lo.isLt
-  have : u_lo.toNat / d.toNat < 2 := by
+theorem div_nat_le_one_of_msb (uLo d : Word) (hd : d.toNat ≥ 2^63) :
+    uLo.toNat / d.toNat ≤ 1 := by
+  have hulo := uLo.isLt
+  have : uLo.toNat / d.toNat < 2 := by
     rw [Nat.div_lt_iff_lt_mul (by omega : 0 < d.toNat)]
     nlinarith
   omega
@@ -88,7 +88,7 @@ theorem mod_sub_of_ge_lt (a b : EvmWord)
 -- ============================================================================
 
 /-- If the top limb b3 has MSB set (b3 ≥ 2^63), then its upper half-word
-    satisfies the normalization condition d_hi ≥ 2^31 for trial quotient bounds. -/
+    satisfies the normalization condition dHi ≥ 2^31 for trial quotient bounds. -/
 theorem msb_imp_hi32_ge (b3 : Word) (hmsb : b3.toNat ≥ 2^63) :
     (hi32 b3).toNat ≥ 2^31 := by
   unfold hi32

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -19,7 +19,7 @@ namespace EvmAsm.Evm64
 open EvmWord EvmAsm.Rv64
 
 -- ============================================================================
--- Max trial overestimate: q_hat = 2^64 - 1 ≥ ⌊val256(a)/val256(b)⌋
+-- Max trial overestimate: qHat = 2^64 - 1 ≥ ⌊val256(a)/val256(b)⌋
 -- ============================================================================
 
 /-- When b3 ≠ 0, val256(a)/val256(b) ≤ 2^64 - 1.
@@ -54,7 +54,7 @@ theorem max_trial_overestimate_n4 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (hb3nz : b3 �
 
 /-- Skip path (c3 = 0, max trial) at n=4: when mulsubN4 produces no borrow,
     the max trial quotient (2^64-1) equals ⌊val256(a)/val256(b)⌋
-    and fromLimbs [q_hat, 0, 0, 0] = EvmWord.div a b. -/
+    and fromLimbs [qHat, 0, 0, 0] = EvmWord.div a b. -/
 theorem n4_max_skip_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
     (hc3_zero : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 0) :
@@ -83,7 +83,7 @@ theorem n4_max_skip_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   have hmulsub : val256 a0 a1 a2 a3 =
       (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 +
       val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 := by linarith
-  -- Overestimate: val256(a)/val256(b) ≤ q_hat.toNat
+  -- Overestimate: val256(a)/val256(b) ≤ qHat.toNat
   have hge := max_trial_overestimate_n4 a0 a1 a2 a3 b0 b1 b2 b3 hb3nz
   exact div_correct_n4_no_shift hbnz hmulsub hge
 
@@ -141,7 +141,7 @@ theorem mulsub_addback_val256_combined (q v0 v1 v2 v3 u0 u1 u2 u3 u4_new : Word)
 -- ============================================================================
 
 /-- Addback path (c3 = 1, max trial) at n=4: when mulsubN4 underflows with
-    borrow 1 and addback produces carry 1, the corrected quotient (q_hat - 1)
+    borrow 1 and addback produces carry 1, the corrected quotient (qHat - 1)
     equals ⌊val256(a)/val256(b)⌋. -/
 theorem n4_max_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
@@ -154,21 +154,21 @@ theorem n4_max_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
       b0 b1 b2 b3 = 1) :
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
-    let q_hat' := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    let qHat' := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
     let a := fromLimbs fun i : Fin 4 =>
       match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
     let b := fromLimbs fun i : Fin 4 =>
       match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
     let q := fromLimbs fun i : Fin 4 =>
-      match i with | 0 => q_hat' | 1 => (0 : Word) | 2 => (0 : Word) | 3 => (0 : Word)
+      match i with | 0 => qHat' | 1 => (0 : Word) | 2 => (0 : Word) | 3 => (0 : Word)
     let r := fromLimbs fun i : Fin 4 =>
       match i with | 0 => ab.1 | 1 => ab.2.1 | 2 => ab.2.2.1 | 3 => ab.2.2.2.1
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
-  intro ms ab q_hat' a b q r
+  intro ms ab qHat' a b q r
   have hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0 := by
     intro h; exact hb3nz (BitVec.or_eq_zero_iff.mp h).2
   have hq_hat_toNat : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-  have hq_hat'_toNat : q_hat'.toNat = 2^64 - 2 := by decide
+  have hq_hat'_toNat : qHat'.toNat = 2^64 - 2 := by decide
   -- Combined Euclidean equation from mulsub(c3=1) + addback(carry=1)
   -- Pass u4_new = 0 - ms.2.2.2.2 so addbackN4 matches ab's definition
   have hcombined := mulsub_addback_val256_combined
@@ -176,23 +176,23 @@ theorem n4_max_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     hc3_one hcarry_one (by rw [hq_hat_toNat]; omega)
   simp only [] at hcombined
   -- hcombined now mentions addbackN4 ... (0 - ms.2.2.2.2) ... which matches ab
-  -- Rewrite (signExtend12 4095).toNat - 1 to q_hat'.toNat
-  rw [show (signExtend12 (4095 : BitVec 12) : Word).toNat - 1 = q_hat'.toNat from by
+  -- Rewrite (signExtend12 4095).toNat - 1 to qHat'.toNat
+  rw [show (signExtend12 (4095 : BitVec 12) : Word).toNat - 1 = qHat'.toNat from by
     rw [hq_hat_toNat, hq_hat'_toNat]; omega] at hcombined
   -- Normalize hcombined to use let-bound ab
-  change val256 a0 a1 a2 a3 = q_hat'.toNat * val256 b0 b1 b2 b3 +
+  change val256 a0 a1 a2 a3 = qHat'.toNat * val256 b0 b1 b2 b3 +
     val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 at hcombined
-  -- Strict overestimate: c3 ≥ 1 implies q_hat * v > u, so u/v < q_hat, hence u/v ≤ q_hat'
-  have hge : val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤ q_hat'.toNat := by
+  -- Strict overestimate: c3 ≥ 1 implies qHat * v > u, so u/v < qHat, hence u/v ≤ qHat'
+  have hge : val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤ qHat'.toNat := by
     rw [hq_hat'_toNat]
-    -- From mulsubN4_val256_eq with c3 = 1: q_hat * val(v) ≥ val(u) + 1
+    -- From mulsubN4_val256_eq with c3 = 1: qHat * val(v) ≥ val(u) + 1
     have hmulsub_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     simp only [] at hmulsub_raw
     rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub_raw
     have h1 : (1 : Word).toNat = 1 := by decide
     rw [h1] at hmulsub_raw
-    -- hmulsub_raw: val256 u + 1 * 2^256 = val256 un + q_hat * val256 v
-    -- So q_hat * val256 v ≥ val256 u + 1 (since 2^256 > val256 un)
+    -- hmulsub_raw: val256 u + 1 * 2^256 = val256 un + qHat * val256 v
+    -- So qHat * val256 v ≥ val256 u + 1 (since 2^256 > val256 un)
     have hv_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
     have hv_pos := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
     have hq_mul_gt : (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 >
@@ -601,7 +601,7 @@ theorem n4_max_skip_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
 
 /-- n=4 max+addback path: per-limb quotient/remainder equalities. Direct
     consumer-facing form of `n4_max_addback_correct` — the corrected quotient
-    is `q_hat' = 2 * signExtend12 4095 = 2^64 - 2` in the low limb, zeros above. -/
+    is `qHat' = 2 * signExtend12 4095 = 2^64 - 2` in the low limb, zeros above. -/
 theorem n4_max_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
     (hc3_one : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 1)
@@ -613,12 +613,12 @@ theorem n4_max_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
       b0 b1 b2 b3 = 1) :
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
-    let q_hat' : Word := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    let qHat' : Word := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
     let a := fromLimbs fun i : Fin 4 =>
       match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
     let b := fromLimbs fun i : Fin 4 =>
       match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
-    (EvmWord.div a b).getLimbN 0 = q_hat' ∧
+    (EvmWord.div a b).getLimbN 0 = qHat' ∧
     (EvmWord.div a b).getLimbN 1 = 0 ∧
     (EvmWord.div a b).getLimbN 2 = 0 ∧
     (EvmWord.div a b).getLimbN 3 = 0 ∧
@@ -626,7 +626,7 @@ theorem n4_max_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (EvmWord.mod a b).getLimbN 1 = ab.2.1 ∧
     (EvmWord.mod a b).getLimbN 2 = ab.2.2.1 ∧
     (EvmWord.mod a b).getLimbN 3 = ab.2.2.2.1 := by
-  intro ms ab q_hat' a b
+  intro ms ab qHat' a b
   have ⟨hq, hr⟩ := n4_max_addback_correct a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hc3_one hcarry_one
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
   · rw [← hq]; exact getLimbN_fromLimbs_0 _ _ _ _
@@ -719,8 +719,8 @@ theorem n4_max_addback_div_mod_getLimbN (a b : EvmWord)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    let q_hat' : Word := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
-    (EvmWord.div a b).getLimbN 0 = q_hat' ∧
+    let qHat' : Word := signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    (EvmWord.div a b).getLimbN 0 = qHat' ∧
     (EvmWord.div a b).getLimbN 1 = 0 ∧
     (EvmWord.div a b).getLimbN 2 = 0 ∧
     (EvmWord.div a b).getLimbN 3 = 0 ∧
@@ -728,7 +728,7 @@ theorem n4_max_addback_div_mod_getLimbN (a b : EvmWord)
     (EvmWord.mod a b).getLimbN 1 = ab.2.1 ∧
     (EvmWord.mod a b).getLimbN 2 = ab.2.2.1 ∧
     (EvmWord.mod a b).getLimbN 3 = ab.2.2.2.1 := by
-  intro ms ab q_hat'
+  intro ms ab qHat'
   have hraw := n4_max_addback_div_mod_limbs
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -64,12 +64,12 @@ theorem remainder_lt_of_ge_floor {a b q r : Nat} (hb : 0 < b)
 
     This is the happy path of Algorithm D: mulsub doesn't underflow,
     so no addback is needed, and the result is directly correct. -/
-theorem mulsub_no_underflow_correct {u_val v_val q_nat r_val : Nat}
-    (hv : 0 < v_val)
-    (hmulsub : u_val = r_val + q_nat * v_val)
-    (hge : u_val / v_val ≤ q_nat) :
-    q_nat = u_val / v_val ∧ r_val < v_val := by
-  have heq : u_val = q_nat * v_val + r_val := by omega
+theorem mulsub_no_underflow_correct {uVal vVal qNat r_val : Nat}
+    (hv : 0 < vVal)
+    (hmulsub : uVal = r_val + qNat * vVal)
+    (hge : uVal / vVal ≤ qNat) :
+    qNat = uVal / vVal ∧ r_val < vVal := by
+  have heq : uVal = qNat * vVal + r_val := by omega
   exact remainder_lt_of_ge_floor hv heq hge
 
 -- ============================================================================
@@ -79,14 +79,14 @@ theorem mulsub_no_underflow_correct {u_val v_val q_nat r_val : Nat}
 /-- Underflow implies strict overestimate: if `u < q * v` (mulsub underflowed),
     then `u / v + 1 ≤ q`. Equivalently, the quotient digit strictly exceeds the
     floor division value. -/
-theorem underflow_imp_strict_overestimate {u_val v_val q_nat : Nat}
-    (hoverflow : u_val < q_nat * v_val) :
-    u_val / v_val + 1 ≤ q_nat := by
+theorem underflow_imp_strict_overestimate {uVal vVal qNat : Nat}
+    (hoverflow : uVal < qNat * vVal) :
+    uVal / vVal + 1 ≤ qNat := by
   -- q * v > u means q > u / v
-  have : u_val / v_val < q_nat := by
+  have : uVal / vVal < qNat := by
     by_contra h; push Not at h
-    have := Nat.div_mul_le_self u_val v_val
-    nlinarith [Nat.mul_le_mul_right v_val h]
+    have := Nat.div_mul_le_self uVal vVal
+    nlinarith [Nat.mul_le_mul_right vVal h]
   omega
 
 /-- Addback correctness: after mulsub underflow and addback, the corrected
@@ -99,15 +99,15 @@ theorem underflow_imp_strict_overestimate {u_val v_val q_nat : Nat}
     - underflow occurred: `q * v > u` (otherwise cb3 would be 0)
 
     Then: `q - 1 = u / v` and `r_ab < v`. -/
-theorem mulsub_addback_correct {u_val v_val q_nat r_ab_val : Nat}
-    (hv : 0 < v_val)
-    (h_combined : u_val = r_ab_val + (q_nat - 1) * v_val)
-    (hge : u_val / v_val + 1 ≤ q_nat) :
-    q_nat - 1 = u_val / v_val ∧ r_ab_val < v_val := by
-  have hge0 := Nat.zero_le (u_val / v_val)
-  have hq1 : q_nat ≥ 1 := by omega
-  have heq : u_val = (q_nat - 1) * v_val + r_ab_val := by omega
-  have hge' : u_val / v_val ≤ q_nat - 1 := by omega
+theorem mulsub_addback_correct {uVal vVal qNat rAbVal : Nat}
+    (hv : 0 < vVal)
+    (h_combined : uVal = rAbVal + (qNat - 1) * vVal)
+    (hge : uVal / vVal + 1 ≤ qNat) :
+    qNat - 1 = uVal / vVal ∧ rAbVal < vVal := by
+  have hge0 := Nat.zero_le (uVal / vVal)
+  have hq1 : qNat ≥ 1 := by omega
+  have heq : uVal = (qNat - 1) * vVal + rAbVal := by omega
+  have hge' : uVal / vVal ≤ qNat - 1 := by omega
   exact remainder_lt_of_ge_floor hv heq hge'
 
 -- ============================================================================
@@ -120,16 +120,16 @@ theorem mulsub_addback_correct {u_val v_val q_nat r_ab_val : Nat}
     - Underflow (cb3 = 1) + addback: q-1 is correct, corrected remainder in range
 
     This produces the final quotient digit and remainder for one iteration. -/
-theorem single_iteration_correct {u_val v_val q_digit r_val : Nat}
-    (hv : 0 < v_val)
-    (heuclidean : u_val = q_digit * v_val + r_val)
-    (hge : u_val / v_val ≤ q_digit) :
-    q_digit = u_val / v_val ∧ r_val = u_val % v_val ∧ r_val < v_val := by
+theorem single_iteration_correct {uVal vVal q_digit r_val : Nat}
+    (hv : 0 < vVal)
+    (heuclidean : uVal = q_digit * vVal + r_val)
+    (hge : uVal / vVal ≤ q_digit) :
+    q_digit = uVal / vVal ∧ r_val = uVal % vVal ∧ r_val < vVal := by
   have ⟨hq, hr_lt⟩ := remainder_lt_of_ge_floor hv heuclidean hge
   subst hq
-  have h_mod := Nat.div_add_mod u_val v_val
+  have h_mod := Nat.div_add_mod uVal vVal
   refine ⟨rfl, ?_, hr_lt⟩
-  nlinarith [Nat.mul_comm v_val (u_val / v_val)]
+  nlinarith [Nat.mul_comm vVal (uVal / vVal)]
 
 -- ============================================================================
 -- val256-level Euclidean → EvmWord.div/mod via fromLimbs
@@ -179,13 +179,13 @@ theorem val256_euclidean_to_div_mod
 
     This is used when shift ≠ 0: the algorithm normalizes, computes, then
     denormalizes the remainder by right-shifting by s. -/
-theorem norm_euclidean_correct {a_val b_val q_nat r_norm : Nat} (s : Nat)
-    (heq : a_val * 2^s = q_nat * (b_val * 2^s) + r_norm)
-    (hlt : r_norm < b_val * 2^s) :
-    q_nat = a_val / b_val ∧ r_norm / 2^s = a_val % b_val := by
+theorem norm_euclidean_correct {aVal bVal qNat r_norm : Nat} (s : Nat)
+    (heq : aVal * 2^s = qNat * (bVal * 2^s) + r_norm)
+    (hlt : r_norm < bVal * 2^s) :
+    qNat = aVal / bVal ∧ r_norm / 2^s = aVal % bVal := by
   -- Convert to the form expected by norm_euclidean_bridge
-  have heq' : a_val * 2^s = b_val * 2^s * q_nat + r_norm := by linarith
-  exact norm_euclidean_bridge a_val b_val q_nat r_norm s heq' hlt
+  have heq' : aVal * 2^s = bVal * 2^s * qNat + r_norm := by linarith
+  exact norm_euclidean_bridge aVal bVal qNat r_norm s heq' hlt
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -87,9 +87,9 @@ theorem val256_denorm_eq_val256_mod_max_skip
   -- Massage h_n_raw to use Vb * 2^s for the divisor.
   rw [h_norm_b] at h_n_raw
   -- Now combine:
-  --   h_un_raw : val256 a = val256 ms_un + q_hat * val256 b
+  --   h_un_raw : val256 a = val256 ms_un + qHat * val256 b
   --   h_norm_u : val256 u + uTop * 2^256 = val256 a * 2^s
-  --   h_n_raw : val256 u + c3_n * 2^256 = val256 msN + q_hat * (val256 b * 2^s)
+  --   h_n_raw : val256 u + c3_n * 2^256 = val256 msN + qHat * (val256 b * 2^s)
   --   h_utop_eq : uTop.toNat = c3_n.toNat
   -- Derive: val256(msN) = val256(ms_un) * 2^s.
   have h_ms_n_scaled :

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -71,7 +71,7 @@ theorem val256_denorm_eq_val256_mod_max_skip
   -- Step 1: Apply Lemma A (val256_denormalize).
   have h_denorm := val256_denormalize hs0 hs msN.1 msN.2.1 msN.2.2.1 msN.2.2.2.1
   -- h_denorm : val256(u') = val256(msN) / 2^s
-  -- Step 2: Use Lemma C (u_top = c3_n) to derive val256(msN) = val256(ms_un) * 2^s.
+  -- Step 2: Use Lemma C (uTop = c3_n) to derive val256(msN) = val256(ms_un) * 2^s.
   have h_utop_eq := u_top_eq_c3_n_max_skip a0 a1 a2 a3 b0 b1 b2 b3
     hbnz hb3nz s hs0 hs hb3_bound hc3_un_zero hc3_n_le_u_top
   -- Step 3: Derive val256(msN) = val256(ms_un) * 2^s from Lemma C + Euclidean equations.
@@ -88,9 +88,9 @@ theorem val256_denorm_eq_val256_mod_max_skip
   rw [h_norm_b] at h_n_raw
   -- Now combine:
   --   h_un_raw : val256 a = val256 ms_un + q_hat * val256 b
-  --   h_norm_u : val256 u + u_top * 2^256 = val256 a * 2^s
+  --   h_norm_u : val256 u + uTop * 2^256 = val256 a * 2^s
   --   h_n_raw : val256 u + c3_n * 2^256 = val256 msN + q_hat * (val256 b * 2^s)
-  --   h_utop_eq : u_top.toNat = c3_n.toNat
+  --   h_utop_eq : uTop.toNat = c3_n.toNat
   -- Derive: val256(msN) = val256(ms_un) * 2^s.
   have h_ms_n_scaled :
       val256 msN.1 msN.2.1 msN.2.2.1 msN.2.2.2.1 =
@@ -110,7 +110,7 @@ theorem val256_denorm_eq_val256_mod_max_skip
     set Vb : Nat := val256 b0 b1 b2 b3
     set Q : Nat := (signExtend12 (4095 : BitVec 12)).toNat
     have hqa : Q * (Vb * 2 ^ s) = Q * Vb * 2 ^ s := by ring
-    -- Substitute u_top = c3_n via h_utop_eq into h_norm_u.
+    -- Substitute uTop = c3_n via h_utop_eq into h_norm_u.
     rw [h_utop_eq] at h_norm_u
     -- Now:
     --   h_norm_u : Vu + c3_n * 2^256 = Va * 2^s

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -1,19 +1,19 @@
 /-
   EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
 
-  The `u_top = c3_n` invariant for Knuth algorithm D at n=4 max+skip.
+  The `uTop = c3_n` invariant for Knuth algorithm D at n=4 max+skip.
 
   During algorithm D's normalization step, the top bits of the dividend
-  `a3 >>> (64 - s)` become an implicit 5th limb `u_top`. The mulsub on
+  `a3 >>> (64 - s)` become an implicit 5th limb `uTop`. The mulsub on
   the normalized 4-limb dividend + divisor produces `ms_n` with carry
   `c3_n`. This lemma proves that under the max+skip conditions,
-  `u_top = c3_n` (not merely `u_top ≥ c3_n` as the runtime skip check
+  `uTop = c3_n` (not merely `uTop ≥ c3_n` as the runtime skip check
   gives). The identity is the key missing invariant for the MOD
   denormalization bridge.
 
   Preconditions used:
   - b3 ≠ 0 and CLZ top-limb bound `b3 < 2^(64 - s)` (for s = clz(b3)).
-  - `hborrow` : the runtime skip borrow gives `c3_n ≤ u_top`.
+  - `hborrow` : the runtime skip borrow gives `c3_n ≤ uTop`.
   - `hsem`    : un-normalized mulsub carry is 0 (semantic skip).
 -/
 
@@ -49,7 +49,7 @@ theorem nat_top_eq_of_lt_pow256 {vPow vN u c : Nat}
     normalized dividend) and `val256_normalize` (for the normalized divisor,
     which needs the CLZ top-limb bound), substituting into
     `mulsubN4_val256_eq`, yields a combined Euclidean equation with an
-    `(u_top - c3_n) * 2^256` residual term.
+    `(uTop - c3_n) * 2^256` residual term.
 
     The caller uses this + `nat_top_eq_of_lt_pow256` to collapse the
     residual to zero (yielding Lemma C). -/
@@ -65,16 +65,16 @@ theorem val256_normalized_mulsub_eq
     let u2 := (a2 <<< s) ||| (a1 >>> (64 - s))
     let u1 := (a1 <<< s) ||| (a0 >>> (64 - s))
     let u0 := a0 <<< s
-    let u_top := a3 >>> (64 - s)
+    let uTop := a3 >>> (64 - s)
     let q_hat : Word := signExtend12 4095
     let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
     val256 a0 a1 a2 a3 * 2^s + ms.2.2.2.2.toNat * 2 ^ 256
       = q_hat.toNat * (val256 b0 b1 b2 b3 * 2^s) +
         val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 +
-        u_top.toNat * 2 ^ 256 := by
-  intro b3' b2' b1' b0' u3 u2 u1 u0 u_top q_hat ms
+        uTop.toNat * 2 ^ 256 := by
+  intro b3' b2' b1' b0' u3 u2 u1 u0 uTop q_hat ms
   -- Normalize the dividend limbs.
-  have h_norm_a : val256 u0 u1 u2 u3 + u_top.toNat * 2 ^ 256 =
+  have h_norm_a : val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
       val256 a0 a1 a2 a3 * 2^s :=
     val256_normalize_general hs0 hs a0 a1 a2 a3
   -- Normalize the divisor limbs (needs the CLZ bound on b3).
@@ -104,40 +104,40 @@ theorem val256_lt_of_b3_bound (b0 b1 b2 b3 : Word) (s : Nat) (hs : s ≤ 64)
   nlinarith [h0, h1, h2, hb3_bound,
              (show 0 < 2 ^ (64 - s) from by positivity)]
 
-/-- Fully abstract Nat-level `u_top = c3_n` lemma. Takes all relevant
+/-- Fully abstract Nat-level `uTop = c3_n` lemma. Takes all relevant
     Euclidean equations and bounds as plain Nat facts — lets the caller
     plug in `val256(ms_un)`, `val256(a) * 2^s`, etc. without forcing
     the elaborator to unfold `mulsubN4` or `val256_normalized_mulsub_eq`
     internals. Composes the un-normalized Euclidean equation with the
     normalization identity and the 2^256 pigeonhole to collapse
-    `u_top - c3_n = 0`. -/
+    `uTop - c3_n = 0`. -/
 theorem u_top_eq_c3_nat_form
     {Va Vb Vms_un Vms_n Vu Vbn : Nat}
-    {u_top c3_n Q : Nat}
+    {uTop c3_n Q : Nat}
     (s : Nat)
     (h_Va : Va = Vms_un + Q * Vb)
-    (h_norm_u : Vu + u_top * 2 ^ 256 = Va * 2 ^ s)
+    (h_norm_u : Vu + uTop * 2 ^ 256 = Va * 2 ^ s)
     (h_norm_b : Vbn = Vb * 2 ^ s)
     (h_Vn : Vu + c3_n * 2 ^ 256 = Vms_n + Q * Vbn)
     (h_Vms_un_lt_Vb : Vms_un < Vb)
     (h_Vb_bound : Vb < 2 ^ (256 - s))
     (hs_le : s ≤ 256)
     (hs_pos : 0 < 2 ^ s)
-    (h_c3_le : c3_n ≤ u_top) :
-    u_top = c3_n := by
+    (h_c3_le : c3_n ≤ uTop) :
+    uTop = c3_n := by
   -- Scale un-normalized Euclidean by 2^s.
   have h_Va_scaled : Va * 2 ^ s = Vms_un * 2 ^ s + Q * Vb * 2 ^ s := by
     rw [h_Va]; ring
   -- Merge the two Euclidean equations (via Va*2^s pivot).
   have h_n_combined : Vu + c3_n * 2 ^ 256 = Vms_n + Q * (Vb * 2 ^ s) := by
     rw [h_norm_b] at h_Vn; exact h_Vn
-  -- Va * 2^s + c3_n * 2^256 = Vms_n + Q * Vb * 2^s + u_top * 2^256
+  -- Va * 2^s + c3_n * 2^256 = Vms_n + Q * Vb * 2^s + uTop * 2^256
   have h_shifted : Va * 2 ^ s + c3_n * 2 ^ 256 =
-      Vms_n + Q * Vb * 2 ^ s + u_top * 2 ^ 256 := by
+      Vms_n + Q * Vb * 2 ^ s + uTop * 2 ^ 256 := by
     have hqa : Q * (Vb * 2 ^ s) = Q * Vb * 2 ^ s := by ring
     linarith [h_norm_u, h_n_combined, hqa]
   -- Substitute h_Va_scaled and cancel Q * Vb * 2^s:
-  have h_cancel : Vms_un * 2 ^ s + c3_n * 2 ^ 256 = Vms_n + u_top * 2 ^ 256 := by
+  have h_cancel : Vms_un * 2 ^ s + c3_n * 2 ^ 256 = Vms_n + uTop * 2 ^ 256 := by
     linarith
   -- Bound Vms_un * 2^s < 2^256.
   have hpow : (2 : Nat) ^ (256 - s) * 2 ^ s = 2 ^ 256 := by
@@ -147,12 +147,12 @@ theorem u_top_eq_c3_nat_form
         < Vb * 2 ^ s := Nat.mul_lt_mul_right hs_pos |>.mpr h_Vms_un_lt_Vb
       _ < 2 ^ (256 - s) * 2 ^ s := Nat.mul_lt_mul_right hs_pos |>.mpr h_Vb_bound
       _ = 2 ^ 256 := hpow
-  -- Pigeonhole: from h_cancel + h_bound + h_c3_le → u_top = c3_n.
+  -- Pigeonhole: from h_cancel + h_bound + h_c3_le → uTop = c3_n.
   have h_eq_form : Vms_un * 2 ^ s =
-      Vms_n + (u_top - c3_n) * 2 ^ 256 := by omega
+      Vms_n + (uTop - c3_n) * 2 ^ 256 := by omega
   exact nat_top_eq_of_lt_pow256 h_c3_le h_eq_form h_bound
 
-/-- Word-level wrapper: `u_top = c3_n` for the n=4 max+skip path.
+/-- Word-level wrapper: `uTop = c3_n` for the n=4 max+skip path.
     Specializes `u_top_eq_c3_nat_form` to the concrete normalized limbs
     `a_i <<< s | a_{i-1} >>> (64-s)` etc. Takes the CLZ top-limb bound on
     `b3` and the un-normalized / normalized skip conditions, and concludes

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -5,7 +5,7 @@
 
   During algorithm D's normalization step, the top bits of the dividend
   `a3 >>> (64 - s)` become an implicit 5th limb `uTop`. The mulsub on
-  the normalized 4-limb dividend + divisor produces `ms_n` with carry
+  the normalized 4-limb dividend + divisor produces `msN` with carry
   `c3_n`. This lemma proves that under the max+skip conditions,
   `uTop = c3_n` (not merely `uTop ≥ c3_n` as the runtime skip check
   gives). The identity is the key missing invariant for the MOD
@@ -66,13 +66,13 @@ theorem val256_normalized_mulsub_eq
     let u1 := (a1 <<< s) ||| (a0 >>> (64 - s))
     let u0 := a0 <<< s
     let uTop := a3 >>> (64 - s)
-    let q_hat : Word := signExtend12 4095
-    let ms := mulsubN4 q_hat b0' b1' b2' b3' u0 u1 u2 u3
+    let qHat : Word := signExtend12 4095
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
     val256 a0 a1 a2 a3 * 2^s + ms.2.2.2.2.toNat * 2 ^ 256
-      = q_hat.toNat * (val256 b0 b1 b2 b3 * 2^s) +
+      = qHat.toNat * (val256 b0 b1 b2 b3 * 2^s) +
         val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 +
         uTop.toNat * 2 ^ 256 := by
-  intro b3' b2' b1' b0' u3 u2 u1 u0 uTop q_hat ms
+  intro b3' b2' b1' b0' u3 u2 u1 u0 uTop qHat ms
   -- Normalize the dividend limbs.
   have h_norm_a : val256 u0 u1 u2 u3 + uTop.toNat * 2 ^ 256 =
       val256 a0 a1 a2 a3 * 2^s :=
@@ -81,7 +81,7 @@ theorem val256_normalized_mulsub_eq
   have h_norm_b : val256 b0' b1' b2' b3' = val256 b0 b1 b2 b3 * 2^s :=
     val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
   -- Apply mulsubN4_val256_eq on the normalized limbs.
-  have h_mulsub := mulsubN4_val256_eq q_hat b0' b1' b2' b3' u0 u1 u2 u3
+  have h_mulsub := mulsubN4_val256_eq qHat b0' b1' b2' b3' u0 u1 u2 u3
   simp only [] at h_mulsub
   -- Substitute the normalization facts and solve linearly.
   rw [h_norm_b] at h_mulsub
@@ -191,7 +191,7 @@ theorem u_top_eq_c3_n_max_skip
   simp only [] at h_un_raw
   rw [hc3_un_zero, show (0 : Word).toNat = 0 from by decide,
       Nat.zero_mul, Nat.add_zero] at h_un_raw
-  -- h_un_raw : val256(a) = val256(ms_un) + q_hat * val256(b)
+  -- h_un_raw : val256(a) = val256(ms_un) + qHat * val256(b)
   have h_n_raw := mulsubN4_val256_eq (signExtend12 4095)
     (b0 <<< s)
     ((b1 <<< s) ||| (b0 >>> (64 - s)))
@@ -202,7 +202,7 @@ theorem u_top_eq_c3_n_max_skip
     ((a2 <<< s) ||| (a1 >>> (64 - s)))
     ((a3 <<< s) ||| (a2 >>> (64 - s)))
   simp only [] at h_n_raw
-  -- h_n_raw : val256(u) + c3_n * 2^256 = val256(ms_n) + q_hat * val256(b_norm)
+  -- h_n_raw : val256(u) + c3_n * 2^256 = val256(msN) + qHat * val256(b_norm)
   have h_norm_u := val256_normalize_general hs0 hs a0 a1 a2 a3
   have h_norm_b := val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
   have h_ms_un_lt_b :=

--- a/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
@@ -63,26 +63,26 @@ theorem sub_borrow_nat (a b : Word) :
 
     - `cb_3 = 0`: no underflow, `val256 r = val256 u - q * val256 v`
     - `cb_3 > 0`: underflow occurred, correction needed (add v back, decrement q) -/
-theorem mulsub_chain_nat (q_nat : Nat) (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
+theorem mulsub_chain_nat (qNat : Nat) (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
     (cb0 cb1 cb2 cb3 : Nat)
-    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + q_nat * v0.toNat)
-    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + q_nat * v1.toNat + cb0)
-    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + q_nat * v2.toNat + cb1)
-    (h3 : u3.toNat + cb3 * 2^64 = r3.toNat + q_nat * v3.toNat + cb2) :
+    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + qNat * v0.toNat)
+    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + qNat * v1.toNat + cb0)
+    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + qNat * v2.toNat + cb1)
+    (h3 : u3.toNat + cb3 * 2^64 = r3.toNat + qNat * v3.toNat + cb2) :
     val256 u0 u1 u2 u3 + cb3 * 2^256 =
-    val256 r0 r1 r2 r3 + q_nat * val256 v0 v1 v2 v3 := by
+    val256 r0 r1 r2 r3 + qNat * val256 v0 v1 v2 v3 := by
   unfold val256; nlinarith
 
 /-- When the multiply-subtract has no underflow (`cb3 = 0`), the result is exact. -/
-theorem mulsub_chain_no_underflow (q_nat : Nat)
+theorem mulsub_chain_no_underflow (qNat : Nat)
     (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
     (cb0 cb1 cb2 : Nat)
-    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + q_nat * v0.toNat)
-    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + q_nat * v1.toNat + cb0)
-    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + q_nat * v2.toNat + cb1)
-    (h3 : u3.toNat = r3.toNat + q_nat * v3.toNat + cb2) :
-    val256 u0 u1 u2 u3 = val256 r0 r1 r2 r3 + q_nat * val256 v0 v1 v2 v3 := by
-  have := mulsub_chain_nat q_nat u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3
+    (h0 : u0.toNat + cb0 * 2^64 = r0.toNat + qNat * v0.toNat)
+    (h1 : u1.toNat + cb1 * 2^64 = r1.toNat + qNat * v1.toNat + cb0)
+    (h2 : u2.toNat + cb2 * 2^64 = r2.toNat + qNat * v2.toNat + cb1)
+    (h3 : u3.toNat = r3.toNat + qNat * v3.toNat + cb2) :
+    val256 u0 u1 u2 u3 = val256 r0 r1 r2 r3 + qNat * val256 v0 v1 v2 v3 := by
+  have := mulsub_chain_nat qNat u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3
     cb0 cb1 cb2 0 h0 h1 h2 (by linarith)
   simp at this; exact this
 
@@ -93,12 +93,12 @@ theorem mulsub_chain_no_underflow (q_nat : Nat)
 /-- After correction (add v back, decrement q), the equation holds.
     If `val256 u + 2^256 = val256 r + q * val256 v` with cb = 1 (underflow),
     then: `val256 u + 2^256 = (val256 r + val256 v) + (q - 1) * val256 v`. -/
-theorem mulsub_correction_eq (u_nat v_nat r_nat q_nat : Nat)
-    (hchain : u_nat + 2^256 = r_nat + q_nat * v_nat)
-    (hq : 0 < q_nat) :
-    u_nat + 2^256 = (r_nat + v_nat) + (q_nat - 1) * v_nat := by
-  have hq1 : q_nat = 1 + (q_nat - 1) := by omega
-  nlinarith [show q_nat * v_nat = v_nat + (q_nat - 1) * v_nat by nlinarith]
+theorem mulsub_correction_eq (u_nat v_nat r_nat qNat : Nat)
+    (hchain : u_nat + 2^256 = r_nat + qNat * v_nat)
+    (hq : 0 < qNat) :
+    u_nat + 2^256 = (r_nat + v_nat) + (qNat - 1) * v_nat := by
+  have hq1 : qNat = 1 + (qNat - 1) := by omega
+  nlinarith [show qNat * v_nat = v_nat + (qNat - 1) * v_nat by nlinarith]
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
@@ -21,19 +21,19 @@ namespace EvmWord
 theorem c3_le_u_top_of_skip_borrow (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (h : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
     let shift := (clzResult b3).1
-    let anti_shift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (anti_shift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (anti_shift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (anti_shift.toNat % 64))
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
     let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (anti_shift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (anti_shift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (anti_shift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (anti_shift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
     (mulsubN4 (signExtend12 4095) b0' b1' b2' b3' u0 u1 u2 u3).2.2.2.2.toNat ≤
     u4.toNat := by
-  intro shift anti_shift b3' b2' b1' b0' u4 u3 u2 u1 u0
+  intro shift antiShift b3' b2' b1' b0' u4 u3 u2 u1 u0
   unfold isSkipBorrowN4Max at h
   simp only [] at h
   by_cases hlt : BitVec.ult u4 (mulsubN4_c3 (signExtend12 4095) b0' b1' b2' b3' u0 u1 u2 u3)

--- a/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
@@ -1,7 +1,7 @@
 /-
   EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 
-  Extracts the Nat-level inequality `c3_n.toNat ≤ u_top.toNat` from the
+  Extracts the Nat-level inequality `c3_n.toNat ≤ uTop.toNat` from the
   runtime skip-borrow predicate `isSkipBorrowN4Max`. This fact feeds
   directly into the MOD stack spec's post reshape via
   `output_slot_to_evmWordIs_mod_n4_max_skip_denorm`.
@@ -16,8 +16,8 @@ open EvmAsm.Rv64
 
 namespace EvmWord
 
-/-- From the Word-level skip-borrow predicate (`1` if `u_top < c3_n` else `0`,
-    equal to `0`), extract the Nat-level inequality `c3_n.toNat ≤ u_top.toNat`. -/
+/-- From the Word-level skip-borrow predicate (`1` if `uTop < c3_n` else `0`,
+    equal to `0`), extract the Nat-level inequality `c3_n.toNat ≤ uTop.toNat`. -/
 theorem c3_le_u_top_of_skip_borrow (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (h : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
     let shift := (clzResult b3).1

--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -36,7 +36,7 @@ theorem val256_ms_un_eq_val256_mod_max_skip
     val256 a0 a1 a2 a3 % val256 b0 b1 b2 b3 := by
   intro ms
   -- From `mulsubN4_val256_eq` with c3 = 0:
-  --   val256(a) = q_hat * val256(b) + val256(ms)
+  --   val256(a) = qHat * val256(b) + val256(ms)
   have hmulsub_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
   simp only [] at hmulsub_raw
   rw [show ms.2.2.2.2 = (0 : Word) from hc3_zero] at hmulsub_raw
@@ -46,11 +46,11 @@ theorem val256_ms_un_eq_val256_mod_max_skip
   have hmulsub : val256 a0 a1 a2 a3 =
       (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 +
       val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 := by linarith
-  -- Overestimate: val256(a)/val256(b) ≤ q_hat.
+  -- Overestimate: val256(a)/val256(b) ≤ qHat.
   have hge := max_trial_overestimate_n4 a0 a1 a2 a3 b0 b1 b2 b3 hb3nz
   have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
   have ⟨hq, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
-  -- Substitute `q_hat = val256(a)/val256(b)` into the mulsub equation, then
+  -- Substitute `qHat = val256(a)/val256(b)` into the mulsub equation, then
   -- compare with `Nat.div_add_mod` to conclude.
   rw [hq] at hmulsub
   have hdam := Nat.div_add_mod (val256 a0 a1 a2 a3) (val256 b0 b1 b2 b3)

--- a/EvmAsm/Evm64/IsZero/LimbSpec.lean
+++ b/EvmAsm/Evm64/IsZero/LimbSpec.lean
@@ -18,16 +18,16 @@ open EvmAsm.Rv64
 /-- ISZERO OR-limb spec (2 instructions): LD x6, OR x7 x7 x6.
     Loads a limb and OR-accumulates into x7. -/
 theorem iszero_or_limb_spec (off : BitVec 12)
-    (sp a_limb v6 acc : Word) (base : Word) :
+    (sp aLimb v6 acc : Word) (base : Word) :
     let mem := sp + signExtend12 off
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x6 .x12 off))
        (CodeReq.singleton (base + 4) (.OR .x7 .x7 .x6))
     cpsTriple base (base + 8) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ acc) ** (.x6 ↦ᵣ v6) **
-       (mem ↦ₘ a_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| a_limb)) ** (.x6 ↦ᵣ a_limb) **
-       (mem ↦ₘ a_limb)) := by
+       (mem ↦ₘ aLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (acc ||| aLimb)) ** (.x6 ↦ᵣ aLimb) **
+       (mem ↦ₘ aLimb)) := by
   runBlock
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Or/LimbSpec.lean
+++ b/EvmAsm/Evm64/Or/LimbSpec.lean
@@ -17,7 +17,7 @@ open EvmAsm.Rv64
 
 /-- Per-limb OR spec (4 instructions: LD x7, LD x6, OR x7 x7 x6, SD x12 x7). -/
 theorem or_limb_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let cr :=
@@ -27,9 +27,9 @@ theorem or_limb_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a_limb ||| b_limb)) ** (.x6 ↦ᵣ b_limb) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ (a_limb ||| b_limb))) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ||| bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ (aLimb ||| bLimb))) := by
   runBlock
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -39,28 +39,28 @@ abbrev shr_merge_limb_code (src_off next_off dst_off : BitVec 12) (base : Word) 
   CodeReq.ofProg base (shr_merge_limb_prog src_off next_off dst_off)
 
 theorem shr_merge_limb_spec (src_off next_off dst_off : BitVec 12)
-    (sp src next dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
+    (sp src next dst_old v5 v10 bit_shift antiShift mask : Word) (base : Word) :
     let memSrc := sp + signExtend12 src_off
     let memNext := sp + signExtend12 next_off
     let memDst := sp + signExtend12 dst_off
     let shiftedSrc := src >>> (bit_shift.toNat % 64)
-    let shiftedNext := (next <<< (anti_shift.toNat % 64)) &&& mask
+    let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
     let result := shiftedSrc ||| shiftedNext
     let code := shr_merge_limb_code src_off next_off dst_off base
     cpsTriple base (base + 28) code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (memSrc ↦ₘ src) ** (memNext ↦ₘ next) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
        (memSrc ↦ₘ src) ** (memNext ↦ₘ next) ** (memDst ↦ₘ result)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src src_off base (by nofun)
   have SR := srl_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 next next_off (base + 8) (by nofun)
-  have SL := sll_spec_gen_rd_eq_rs1 .x10 .x7 next anti_shift (base + 12) (by nofun)
-  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (next <<< (anti_shift.toNat % 64)) mask (base + 16) (by nofun)
-  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src >>> (bit_shift.toNat % 64)) ((next <<< (anti_shift.toNat % 64)) &&& mask) (base + 20) (by nofun)
-  have SD_ := sd_spec_gen .x12 .x5 sp ((src >>> (bit_shift.toNat % 64)) ||| ((next <<< (anti_shift.toNat % 64)) &&& mask)) dst_old dst_off (base + 24)
+  have SL := sll_spec_gen_rd_eq_rs1 .x10 .x7 next antiShift (base + 12) (by nofun)
+  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (next <<< (antiShift.toNat % 64)) mask (base + 16) (by nofun)
+  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src >>> (bit_shift.toNat % 64)) ((next <<< (antiShift.toNat % 64)) &&& mask) (base + 20) (by nofun)
+  have SD_ := sd_spec_gen .x12 .x5 sp ((src >>> (bit_shift.toNat % 64)) ||| ((next <<< (antiShift.toNat % 64)) &&& mask)) dst_old dst_off (base + 24)
   runBlock L1 SR L2 SL AN OR_ SD_
 
 -- SHR Last Limb (3 instructions)
@@ -90,27 +90,27 @@ abbrev shr_merge_limb_inplace_code (off next_off : BitVec 12) (base : Word) : Co
   CodeReq.ofProg base (shr_merge_limb_inplace_prog off next_off)
 
 theorem shr_merge_limb_inplace_spec (off next_off : BitVec 12)
-    (sp src next v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
+    (sp src next v5 v10 bit_shift antiShift mask : Word) (base : Word) :
     let memLoc := sp + signExtend12 off
     let memNext := sp + signExtend12 next_off
     let shiftedSrc := src >>> (bit_shift.toNat % 64)
-    let shiftedNext := (next <<< (anti_shift.toNat % 64)) &&& mask
+    let shiftedNext := (next <<< (antiShift.toNat % 64)) &&& mask
     let result := shiftedSrc ||| shiftedNext
     let code := shr_merge_limb_inplace_code off next_off base
     cpsTriple base (base + 28) code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (memLoc ↦ₘ src) ** (memNext ↦ₘ next))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedNext) ** (.x11 ↦ᵣ mask) **
        (memLoc ↦ₘ result) ** (memNext ↦ₘ next)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src off base (by nofun)
   have SR := srl_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 next next_off (base + 8) (by nofun)
-  have SL := sll_spec_gen_rd_eq_rs1 .x10 .x7 next anti_shift (base + 12) (by nofun)
-  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (next <<< (anti_shift.toNat % 64)) mask (base + 16) (by nofun)
-  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src >>> (bit_shift.toNat % 64)) ((next <<< (anti_shift.toNat % 64)) &&& mask) (base + 20) (by nofun)
-  have SD_ := sd_spec_gen .x12 .x5 sp ((src >>> (bit_shift.toNat % 64)) ||| ((next <<< (anti_shift.toNat % 64)) &&& mask)) src off (base + 24)
+  have SL := sll_spec_gen_rd_eq_rs1 .x10 .x7 next antiShift (base + 12) (by nofun)
+  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (next <<< (antiShift.toNat % 64)) mask (base + 16) (by nofun)
+  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src >>> (bit_shift.toNat % 64)) ((next <<< (antiShift.toNat % 64)) &&& mask) (base + 20) (by nofun)
+  have SD_ := sd_spec_gen .x12 .x5 sp ((src >>> (bit_shift.toNat % 64)) ||| ((next <<< (antiShift.toNat % 64)) &&& mask)) src off (base + 24)
   runBlock L1 SR L2 SL AN OR_ SD_
 
 -- SHR Last Limb In-place (3 instructions, dst_off = 24)
@@ -169,13 +169,13 @@ theorem shr_phase_b_spec (shift0 sp r6 r7 r11 : Word) (base : Word) :
     let limb_shift := shift0 >>> (6 : BitVec 6).toNat
     let cond := if BitVec.ult (0 : Word) bit_shift then (1 : Word) else 0
     let mask := (0 : Word) - cond
-    let anti_shift := (64 : Word) - bit_shift
+    let antiShift := (64 : Word) - bit_shift
     let code := shr_phase_b_code base
     cpsTriple base (base + 28) code
       ((.x5 ↦ᵣ shift0) ** (.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ r11) ** (.x7 ↦ᵣ r7) ** (.x12 ↦ᵣ sp))
       ((.x5 ↦ᵣ limb_shift) ** (.x6 ↦ᵣ bit_shift) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ anti_shift) ** (.x12 ↦ᵣ (sp + signExtend12 32))) := by
+       (.x11 ↦ᵣ mask) ** (.x7 ↦ᵣ antiShift) ** (.x12 ↦ᵣ (sp + signExtend12 32))) := by
   have A1 := andi_spec_gen .x6 .x5 r6 shift0 63 base (by nofun)
   have SR := srli_spec_gen_same .x5 shift0 6 (base + 4) (by nofun)
   have SL := sltu_spec_gen .x11 .x0 .x6 r11 (0 : Word) (shift0 &&& signExtend12 63) (base + 8) (by nofun)
@@ -212,7 +212,7 @@ abbrev shr_body_3_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_3_prog jal_off)
 
 theorem shr_body_3_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit) :
@@ -220,10 +220,10 @@ theorem shr_body_3_spec (sp : Word)
     let code := shr_body_3_code jal_off base
     cpsTriple base exit code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)) := by
   have LL := shr_last_limb_spec 0 sp v3 v0 v5 bit_shift base
   have S0 := sd_x0_spec_gen .x12 sp v1 8 (base + 12)
@@ -239,23 +239,23 @@ abbrev shr_body_2_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_2_prog jal_off)
 
 theorem shr_body_2_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 48) + signExtend21 jal_off = exit) :
-    let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result1 := v3 >>> (bit_shift.toNat % 64)
     let code := shr_body_2_code jal_off base
     cpsTriple base exit code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v3 <<< (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ 0)) := by
-  have MM := shr_merge_limb_spec 16 24 0 sp v2 v3 v0 v5 v10 bit_shift anti_shift mask base
+  have MM := shr_merge_limb_spec 16 24 0 sp v2 v3 v0 v5 v10 bit_shift antiShift mask base
   have LL := shr_last_limb_spec 8 sp v3 v1
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 28)
   have S0 := sd_x0_spec_gen .x12 sp v2 16 (base + 40)
   have S1 := sd_x0_spec_gen .x12 sp v3 24 (base + 44)
@@ -269,28 +269,28 @@ abbrev shr_body_1_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_1_prog jal_off)
 
 theorem shr_body_1_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 72) + signExtend21 jal_off = exit) :
-    let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result2 := v3 >>> (bit_shift.toNat % 64)
     let code := shr_body_1_code jal_off base
     cpsTriple base exit code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v3 <<< (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ 0)) := by
-  have MM1 := shr_merge_limb_spec 8 16 0 sp v1 v2 v0 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shr_merge_limb_spec 8 16 0 sp v1 v2 v0 v5 v10 bit_shift antiShift mask base
   have MM2 := shr_merge_limb_spec 16 24 8 sp v2 v3 v1
-    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have LL := shr_last_limb_spec 16 sp v3 v2
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 56)
   have S0 := sd_x0_spec_gen .x12 sp v3 24 (base + 68)
   subst exit
@@ -303,33 +303,33 @@ abbrev shr_body_0_code (jal_off : BitVec 21) (base : Word) : CodeReq :=
   CodeReq.ofProg base (shr_body_0_prog jal_off)
 
 theorem shr_body_0_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit) :
-    let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+    let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result3 := v3 >>> (bit_shift.toNat % 64)
     let code := shr_body_0_code jal_off base
     cpsTriple base exit code
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v3 <<< (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  have MM1 := shr_merge_limb_inplace_spec 0 8 sp v0 v1 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shr_merge_limb_inplace_spec 0 8 sp v0 v1 v5 v10 bit_shift antiShift mask base
   have MM2 := shr_merge_limb_inplace_spec 8 16 sp v1 v2
-    ((v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have MM3 := shr_merge_limb_inplace_spec 16 24 sp v2 v3
-    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 56)
+    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 56)
   have LL := shr_last_limb_inplace_spec sp v3
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 84)
   subst exit
   have JL := jal_x0_spec_gen jal_off (base + 96)

--- a/EvmAsm/Evm64/Shift/Program.lean
+++ b/EvmAsm/Evm64/Shift/Program.lean
@@ -18,14 +18,14 @@
   Register allocation:
     x12 = EVM stack pointer
     x6  = bit_shift (0-63), preserved during limb processing
-    x7  = anti_shift = 64 - bit_shift, preserved
+    x7  = antiShift = 64 - bit_shift, preserved
     x11 = mask (0 or 0xFFFFFFFFFFFFFFFF), preserved
     x5  = temp: current limb during processing, limb_shift during dispatch
     x10 = temp: next limb during processing
 
   Program layout (90 instructions = 360 bytes):
     Phase A (9 instrs):  Check shift >= 256
-    Phase B (7 instrs):  Extract bit_shift, limb_shift, mask, anti_shift
+    Phase B (7 instrs):  Extract bit_shift, limb_shift, mask, antiShift
     Phase C (5 instrs):  Cascade dispatch on limb_shift (0-3)
     Phase D (64 instrs): 4 shift bodies (ls3 through ls0)
     Phase E (5 instrs):  Zero path (shift >= 256)
@@ -62,7 +62,7 @@ def shr_phase_b : Program :=
   single (.SLTU .x11 .x0 .x6) ;;            -- x11 = (bit_shift > 0)
   single (.SUB .x11 .x0 .x11) ;;            -- x11 = mask
   LI .x7 64 ;;                               -- x7 = 64
-  single (.SUB .x7 .x7 .x6) ;;              -- x7 = anti_shift
+  single (.SUB .x7 .x7 .x6) ;;              -- x7 = antiShift
   ADDI .x12 .x12 32                          -- pop shift word
 
 /-- Phase C: Cascade dispatch (5 instructions). -/
@@ -151,7 +151,7 @@ def evm_shr : Program :=
 
   For output limb i (with limb_shift L):
     result[i] = (value[i - L] <<< bit_shift) |
-                ((value[i - L - 1] >>> anti_shift) &&& mask)
+                ((value[i - L - 1] >>> antiShift) &&& mask)
   where undefined indices → 0.
 
   Register allocation: same as SHR.
@@ -485,7 +485,7 @@ example : runShlCheck 1024 0 0 0 0  0xFF 0 0 0  42 =
   Register allocation: same as SHR/SHL.
   Program layout: 95 instructions = 380 bytes.
     Phase A (9 instrs):  Check shift >= 256 → sign_fill path
-    Phase B (7 instrs):  Extract bit_shift, limb_shift, mask, anti_shift (reuses shr_phase_b)
+    Phase B (7 instrs):  Extract bit_shift, limb_shift, mask, antiShift (reuses shr_phase_b)
     Phase C (5 instrs):  Cascade dispatch on limb_shift (0-3)
     Phase D (67 instrs): 4 shift bodies (ls3=8, ls2=14, ls1=20, ls0=25)
     Phase E (7 instrs):  Sign-fill path (shift >= 256)
@@ -646,9 +646,9 @@ example : runSarResult 1024 1 0 0 0  0xFF 0 0 0  42 =
 -- value = [0, 0, 0, 0x8000000000000000] (= -2^255 in signed)
 -- SAR(1): result[3] = SRA(0x8000000000000000, 1) = 0xC000000000000000
 -- result[2] = (0>>>1) | ((0x8000000000000000 <<< 63) & mask) = 0
--- Actually anti_shift = 63, value[3] <<< 63 = 0x8000000000000000 <<< 63 = 0
+-- Actually antiShift = 63, value[3] <<< 63 = 0x8000000000000000 <<< 63 = 0
 -- Hmm, let me think more carefully...
--- bit_shift=1, anti_shift=63
+-- bit_shift=1, antiShift=63
 -- merge(16,24,16): SRL value[2] by 1 | (SLL value[3] by 63) & mask
 -- value[2]=0, value[3]=0x8000000000000000
 -- SRL 0 by 1 = 0, SLL 0x8000000000000000 by 63 = 0 (bit 63 shifted out)

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -86,7 +86,7 @@ abbrev sar_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     result[0] = value[3] SRA bs; result[1..3] = signExt.
     Comprises: sar_last_limb(0), SRAI, 3x SD, JAL. -/
 theorem sar_body_3_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 28) + signExtend21 jal_off = exit) :
@@ -95,10 +95,10 @@ theorem sar_body_3_spec (sp : Word)
     let cr := sar_body_3_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
   have h63 := bv6_toNat_63
   have LL := sar_last_limb_spec 0 sp v3 v0 v5 bit_shift base
@@ -119,28 +119,28 @@ abbrev sar_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     result[2..3] = signExt.
     Comprises: shr_merge_limb(16,24,0), sar_last_limb(8), SRAI, 2x SD, JAL. -/
 theorem sar_body_2_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 52) + signExtend21 jal_off = exit) :
-    let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result1 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
     let signExt := BitVec.sshiftRight result1 63
     let cr := sar_body_2_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
   have h63 := bv6_toNat_63
-  have MM := shr_merge_limb_spec 16 24 0 sp v2 v3 v0 v5 v10 bit_shift anti_shift mask base
+  have MM := shr_merge_limb_spec 16 24 0 sp v2 v3 v0 v5 v10 bit_shift antiShift mask base
   have LL := sar_last_limb_spec 8 sp v3 v1
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 28)
   have SR := srai_spec_gen .x10 .x5
-    ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63 (base + 40) (by nofun)
   simp only [h63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
@@ -159,33 +159,33 @@ abbrev sar_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     result[2] = value[3] SRA bs; result[3] = signExt.
     Comprises: 2x shr_merge_limb, sar_last_limb(16), SRAI, SD, JAL. -/
 theorem sar_body_1_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 76) + signExtend21 jal_off = exit) :
-    let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    let result1 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result2 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
     let signExt := BitVec.sshiftRight result2 63
     let cr := sar_body_1_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ signExt)) := by
   have h63 := bv6_toNat_63
-  have MM1 := shr_merge_limb_spec 8 16 0 sp v1 v2 v0 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shr_merge_limb_spec 8 16 0 sp v1 v2 v0 v5 v10 bit_shift antiShift mask base
   have MM2 := shr_merge_limb_spec 16 24 8 sp v2 v3 v1
-    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have LL := sar_last_limb_spec 16 sp v3 v2
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 56)
   have SR := srai_spec_gen .x10 .x5
-    ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63 (base + 68) (by nofun)
   simp only [h63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
@@ -203,33 +203,33 @@ abbrev sar_body_0_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     No vacated limbs — identical structure to SHR body_0 but with SRA for last limb.
     Comprises: 3x shr_merge_limb_inplace + sar_last_limb_inplace + JAL. -/
 theorem sar_body_0_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit) :
-    let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask)
+    let result0 := (v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+    let result1 := (v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    let result2 := (v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     let result3 := BitVec.sshiftRight v3 (bit_shift.toNat % 64)
     let cr := sar_body_0_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v3 <<< (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v3 <<< (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  have MM1 := shr_merge_limb_inplace_spec 0 8 sp v0 v1 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shr_merge_limb_inplace_spec 0 8 sp v0 v1 v5 v10 bit_shift antiShift mask base
   have MM2 := shr_merge_limb_inplace_spec 8 16 sp v1 v2
-    ((v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v1 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v0 >>> (bit_shift.toNat % 64)) ||| ((v1 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v1 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have MM3 := shr_merge_limb_inplace_spec 16 24 sp v2 v3
-    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (anti_shift.toNat % 64)) &&& mask))
-    ((v2 <<< (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 56)
+    ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask))
+    ((v2 <<< (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 56)
   have LL := sar_last_limb_inplace_spec sp v3
-    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (anti_shift.toNat % 64)) &&& mask))
+    ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 84)
   have JL := jal_x0_spec_gen jal_off (base + 96)
   rw [hexit] at JL

--- a/EvmAsm/Evm64/Shift/ShlSpec.lean
+++ b/EvmAsm/Evm64/Shift/ShlSpec.lean
@@ -34,31 +34,31 @@ abbrev shl_merge_limb_code (base : Word) (src_off prev_off dst_off : BitVec 12) 
     LD x5, src_off(x12); SLL x5,x5,x6; LD x10, prev_off(x12);
     SRL x10,x10,x7; AND x10,x10,x11; OR x5,x5,x10; SD x12,x5,dst_off
 
-    Computes: result = (src <<< bit_shift) ||| ((prev >>> anti_shift) &&& mask)
+    Computes: result = (src <<< bit_shift) ||| ((prev >>> antiShift) &&& mask)
     Mirror of shr_merge_limb_spec with SLL/SRL swapped. -/
 theorem shl_merge_limb_spec (src_off prev_off dst_off : BitVec 12)
-    (sp src prev dst_old v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
+    (sp src prev dst_old v5 v10 bit_shift antiShift mask : Word) (base : Word) :
     let memSrc := sp + signExtend12 src_off
     let memPrev := sp + signExtend12 prev_off
     let memDst := sp + signExtend12 dst_off
     let shiftedSrc := src <<< (bit_shift.toNat % 64)
-    let shiftedPrev := (prev >>> (anti_shift.toNat % 64)) &&& mask
+    let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
     let result := shiftedSrc ||| shiftedPrev
     let cr := shl_merge_limb_code base src_off prev_off dst_off
     cpsTriple base (base + 28) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (memSrc ↦ₘ src) ** (memPrev ↦ₘ prev) ** (memDst ↦ₘ dst_old))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
        (memSrc ↦ₘ src) ** (memPrev ↦ₘ prev) ** (memDst ↦ₘ result)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src src_off base (by nofun)
   have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 prev prev_off (base + 8) (by nofun)
-  have SR := srl_spec_gen_rd_eq_rs1 .x10 .x7 prev anti_shift (base + 12) (by nofun)
-  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (prev >>> (anti_shift.toNat % 64)) mask (base + 16) (by nofun)
-  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src <<< (bit_shift.toNat % 64)) ((prev >>> (anti_shift.toNat % 64)) &&& mask) (base + 20) (by nofun)
-  have SD_ := sd_spec_gen .x12 .x5 sp ((src <<< (bit_shift.toNat % 64)) ||| ((prev >>> (anti_shift.toNat % 64)) &&& mask)) dst_old dst_off (base + 24)
+  have SR := srl_spec_gen_rd_eq_rs1 .x10 .x7 prev antiShift (base + 12) (by nofun)
+  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (prev >>> (antiShift.toNat % 64)) mask (base + 16) (by nofun)
+  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src <<< (bit_shift.toNat % 64)) ((prev >>> (antiShift.toNat % 64)) &&& mask) (base + 20) (by nofun)
+  have SD_ := sd_spec_gen .x12 .x5 sp ((src <<< (bit_shift.toNat % 64)) ||| ((prev >>> (antiShift.toNat % 64)) &&& mask)) dst_old dst_off (base + 24)
   runBlock L1 SL L2 SR AN OR_ SD_
 
 -- ============================================================================
@@ -107,27 +107,27 @@ abbrev shl_merge_limb_inplace_code (base : Word) (off prev_off : BitVec 12) : Co
 /-- SHL merge limb in-place spec (7 instructions):
     Same as shl_merge_limb_spec but src_off = dst_off. -/
 theorem shl_merge_limb_inplace_spec (off prev_off : BitVec 12)
-    (sp src prev v5 v10 bit_shift anti_shift mask : Word) (base : Word) :
+    (sp src prev v5 v10 bit_shift antiShift mask : Word) (base : Word) :
     let memLoc := sp + signExtend12 off
     let memPrev := sp + signExtend12 prev_off
     let shiftedSrc := src <<< (bit_shift.toNat % 64)
-    let shiftedPrev := (prev >>> (anti_shift.toNat % 64)) &&& mask
+    let shiftedPrev := (prev >>> (antiShift.toNat % 64)) &&& mask
     let result := shiftedSrc ||| shiftedPrev
     let cr := shl_merge_limb_inplace_code base off prev_off
     cpsTriple base (base + 28) cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (memLoc ↦ₘ src) ** (memPrev ↦ₘ prev))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ shiftedPrev) ** (.x11 ↦ᵣ mask) **
        (memLoc ↦ₘ result) ** (memPrev ↦ₘ prev)) := by
   have L1 := ld_spec_gen .x5 .x12 sp v5 src off base (by nofun)
   have SL := sll_spec_gen_rd_eq_rs1 .x5 .x6 src bit_shift (base + 4) (by nofun)
   have L2 := ld_spec_gen .x10 .x12 sp v10 prev prev_off (base + 8) (by nofun)
-  have SR := srl_spec_gen_rd_eq_rs1 .x10 .x7 prev anti_shift (base + 12) (by nofun)
-  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (prev >>> (anti_shift.toNat % 64)) mask (base + 16) (by nofun)
-  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src <<< (bit_shift.toNat % 64)) ((prev >>> (anti_shift.toNat % 64)) &&& mask) (base + 20) (by nofun)
-  have SD_ := sd_spec_gen .x12 .x5 sp ((src <<< (bit_shift.toNat % 64)) ||| ((prev >>> (anti_shift.toNat % 64)) &&& mask)) src off (base + 24)
+  have SR := srl_spec_gen_rd_eq_rs1 .x10 .x7 prev antiShift (base + 12) (by nofun)
+  have AN := and_spec_gen_rd_eq_rs1 .x10 .x11 (prev >>> (antiShift.toNat % 64)) mask (base + 16) (by nofun)
+  have OR_ := or_spec_gen_rd_eq_rs1 .x5 .x10 (src <<< (bit_shift.toNat % 64)) ((prev >>> (antiShift.toNat % 64)) &&& mask) (base + 20) (by nofun)
+  have SD_ := sd_spec_gen .x12 .x5 sp ((src <<< (bit_shift.toNat % 64)) ||| ((prev >>> (antiShift.toNat % 64)) &&& mask)) src off (base + 24)
   runBlock L1 SL L2 SR AN OR_ SD_
 
 -- ============================================================================
@@ -167,7 +167,7 @@ abbrev shl_body_3_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     Comprises: shl_first_limb(24), 3x SD, JAL.
     7 instructions from base to exit (via JAL). -/
 theorem shl_body_3_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 24) + signExtend21 jal_off = exit) :
@@ -175,10 +175,10 @@ theorem shl_body_3_spec (sp : Word)
     let cr := shl_body_3_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result3) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ 0) ** ((sp + 24) ↦ₘ result3)) := by
   have FL := shl_first_limb_spec 24 sp v0 v3 v5 bit_shift base
   have S0 := sd_x0_spec_gen .x12 sp v2 16 (base + 12)
@@ -197,23 +197,23 @@ abbrev shl_body_2_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     Comprises: shl_merge_limb(8,0,24), shl_first_limb(16), 2x SD, JAL.
     13 instructions from base to exit (via JAL). -/
 theorem shl_body_2_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 48) + signExtend21 jal_off = exit) :
-    let result3 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
+    let result3 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
     let result2 := v0 <<< (bit_shift.toNat % 64)
     let cr := shl_body_2_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v0 >>> (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ 0) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  have MM := shl_merge_limb_spec 8 0 24 sp v1 v0 v3 v5 v10 bit_shift anti_shift mask base
+  have MM := shl_merge_limb_spec 8 0 24 sp v1 v0 v3 v5 v10 bit_shift antiShift mask base
   have FL := shl_first_limb_spec 16 sp v0 v2
-    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask))
+    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 28)
   have S0 := sd_x0_spec_gen .x12 sp v1 8 (base + 40)
   have S1 := sd_x0_spec_gen .x12 sp v0 0 (base + 44)
@@ -232,28 +232,28 @@ abbrev shl_body_1_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     shl_first_limb(8), SD, JAL.
     19 instructions from base to exit (via JAL). -/
 theorem shl_body_1_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 72) + signExtend21 jal_off = exit) :
-    let result3 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
-    let result2 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
+    let result3 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+    let result2 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
     let result1 := v0 <<< (bit_shift.toNat % 64)
     let cr := shl_body_1_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v0 >>> (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ 0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  have MM1 := shl_merge_limb_spec 16 8 24 sp v2 v1 v3 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shl_merge_limb_spec 16 8 24 sp v2 v1 v3 v5 v10 bit_shift antiShift mask base
   have MM2 := shl_merge_limb_spec 8 0 16 sp v1 v0 v2
-    ((v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask))
-    ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask))
+    ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have FL := shl_first_limb_spec 8 sp v0 v1
-    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask))
+    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 56)
   have S0 := sd_x0_spec_gen .x12 sp v0 0 (base + 68)
   have JL := jal_x0_spec_gen jal_off (base + 72)
@@ -269,33 +269,33 @@ abbrev shl_body_0_code (base : Word) (jal_off : BitVec 21) : CodeReq :=
     Comprises: 3x shl_merge_limb_inplace + shl_first_limb_inplace + JAL.
     25 instructions from base to exit (via JAL). -/
 theorem shl_body_0_spec (sp : Word)
-    (v5 v10 bit_shift anti_shift mask : Word)
+    (v5 v10 bit_shift antiShift mask : Word)
     (v0 v1 v2 v3 : Word)
     (base exit : Word) (jal_off : BitVec 21)
     (hexit : (base + 96) + signExtend21 jal_off = exit) :
-    let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (anti_shift.toNat % 64)) &&& mask)
-    let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
-    let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask)
+    let result3 := (v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (antiShift.toNat % 64)) &&& mask)
+    let result2 := (v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+    let result1 := (v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask)
     let result0 := v0 <<< (bit_shift.toNat % 64)
     let cr := shl_body_0_code base jal_off
     cpsTriple base exit cr
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ v10) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ v0) ** ((sp + 8) ↦ₘ v1) ** ((sp + 16) ↦ₘ v2) ** ((sp + 24) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
-       (.x7 ↦ᵣ anti_shift) ** (.x10 ↦ᵣ ((v0 >>> (anti_shift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
+       (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ ((v0 >>> (antiShift.toNat % 64)) &&& mask)) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ result3)) := by
-  have MM1 := shl_merge_limb_inplace_spec 24 16 sp v3 v2 v5 v10 bit_shift anti_shift mask base
+  have MM1 := shl_merge_limb_inplace_spec 24 16 sp v3 v2 v5 v10 bit_shift antiShift mask base
   have MM2 := shl_merge_limb_inplace_spec 16 8 sp v2 v1
-    ((v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (anti_shift.toNat % 64)) &&& mask))
-    ((v2 >>> (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 28)
+    ((v3 <<< (bit_shift.toNat % 64)) ||| ((v2 >>> (antiShift.toNat % 64)) &&& mask))
+    ((v2 >>> (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 28)
   have MM3 := shl_merge_limb_inplace_spec 8 0 sp v1 v0
-    ((v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (anti_shift.toNat % 64)) &&& mask))
-    ((v1 >>> (anti_shift.toNat % 64)) &&& mask)
-    bit_shift anti_shift mask (base + 56)
+    ((v2 <<< (bit_shift.toNat % 64)) ||| ((v1 >>> (antiShift.toNat % 64)) &&& mask))
+    ((v1 >>> (antiShift.toNat % 64)) &&& mask)
+    bit_shift antiShift mask (base + 56)
   have FL := shl_first_limb_inplace_spec sp v0
-    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (anti_shift.toNat % 64)) &&& mask))
+    ((v1 <<< (bit_shift.toNat % 64)) ||| ((v0 >>> (antiShift.toNat % 64)) &&& mask))
     bit_shift (base + 84)
   have JL := jal_x0_spec_gen jal_off (base + 96)
   rw [hexit] at JL

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -18,11 +18,11 @@ open EvmAsm.Rv64
 /-- SUB limb 0 spec (5 instructions): LD, LD, SLTU, SUB, SD.
     Computes diff = a - b (mod 2^64) and borrow = (a < b ? 1 : 0). -/
 theorem sub_limb0_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 v5 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 v5 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let borrow := if BitVec.ult a_limb b_limb then (1 : Word) else 0
-    let diff := a_limb - b_limb
+    let borrow := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+    let diff := aLimb - bLimb
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
@@ -31,39 +31,39 @@ theorem sub_limb0_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 16) (.SD .x12 .x7 offB)))))
     cpsTriple base (base + 20) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ v5) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ borrow) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ diff)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ diff) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrow) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ diff)) := by
   runBlock
 
 /-- SUB carry limb phase 1 (4 instructions): LD, LD, SLTU, SUB.
-    Loads a_limb and b_limb, computes borrow1 = (a < b ? 1 : 0), temp = a - b. -/
+    Loads aLimb and bLimb, computes borrow1 = (a < b ? 1 : 0), temp = a - b. -/
 theorem sub_limb_carry_spec_phase1 (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 borrowIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let borrow1 := if BitVec.ult a_limb b_limb then (1 : Word) else 0
-    let temp := a_limb - b_limb
+    let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+    let temp := aLimb - bLimb
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
       (CodeReq.union (CodeReq.singleton (base + 4) (.LD .x6 .x12 offB))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SLTU .x11 .x7 .x6))
        (CodeReq.singleton (base + 12) (.SUB .x7 .x7 .x6))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrow_in) ** (.x11 ↦ᵣ v11) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ borrow_in) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ v11) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ borrow1) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb)) := by
   runBlock
 
 /-- SUB carry limb phase 2 (4 instructions): SLTU, SUB, OR, SD.
-    Takes temp, borrow1, borrow_in, computes borrow2 = (temp < borrow_in ? 1 : 0),
-    result = temp - borrow_in, borrowOut = borrow1 ||| borrow2. -/
+    Takes temp, borrow1, borrowIn, computes borrow2 = (temp < borrowIn ? 1 : 0),
+    result = temp - borrowIn, borrowOut = borrow1 ||| borrow2. -/
 theorem sub_limb_carry_spec_phase2 (offB : BitVec 12)
-    (sp temp b_limb borrow_in borrow1 a_limb : Word) (memA : Word) (base : Word) :
+    (sp temp bLimb borrowIn borrow1 aLimb : Word) (memA : Word) (base : Word) :
     let memB := sp + signExtend12 offB
-    let borrow2 := if BitVec.ult temp borrow_in then (1 : Word) else 0
-    let result := temp - borrow_in
+    let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+    let result := temp - borrowIn
     let borrowOut := borrow1 ||| borrow2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SLTU .x6 .x7 .x5))
@@ -71,22 +71,22 @@ theorem sub_limb_carry_spec_phase2 (offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x5 .x11 .x6))
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ borrow_in) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ temp) ** (.x6 ↦ᵣ bLimb) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ borrow1) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ result)) := by
   runBlock
 
 /-- SUB carry limb spec (8 instructions): LD, LD, SLTU, SUB, SLTU, SUB, OR, SD.
     Composed from phase1 and phase2. -/
 theorem sub_limb_carry_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 borrow_in v11 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 borrowIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
-    let borrow1 := if BitVec.ult a_limb b_limb then (1 : Word) else 0
-    let temp := a_limb - b_limb
-    let borrow2 := if BitVec.ult temp borrow_in then (1 : Word) else 0
-    let result := temp - borrow_in
+    let borrow1 := if BitVec.ult aLimb bLimb then (1 : Word) else 0
+    let temp := aLimb - bLimb
+    let borrow2 := if BitVec.ult temp borrowIn then (1 : Word) else 0
+    let result := temp - borrowIn
     let borrowOut := borrow1 ||| borrow2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -98,14 +98,14 @@ theorem sub_limb_carry_spec (offA offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x5 .x11 .x6))
        (CodeReq.singleton (base + 28) (.SD .x12 .x7 offB))))))))
     cpsTriple base (base + 32) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrow_in) ** (.x11 ↦ᵣ v11) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ borrowIn) ** (.x11 ↦ᵣ v11) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ borrow2) ** (.x5 ↦ᵣ borrowOut) ** (.x11 ↦ᵣ borrow1) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
-  have p1 := sub_limb_carry_spec_phase1 offA offB sp a_limb b_limb v7 v6 borrow_in v11 base
-  have p2 := sub_limb_carry_spec_phase2 offB sp (a_limb - b_limb) b_limb borrow_in
-    (if BitVec.ult a_limb b_limb then (1 : Word) else 0)
-    a_limb (sp + signExtend12 offA) (base + 16)
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ result)) := by
+  have p1 := sub_limb_carry_spec_phase1 offA offB sp aLimb bLimb v7 v6 borrowIn v11 base
+  have p2 := sub_limb_carry_spec_phase2 offB sp (aLimb - bLimb) bLimb borrowIn
+    (if BitVec.ult aLimb bLimb then (1 : Word) else 0)
+    aLimb (sp + signExtend12 offA) (base + 16)
   runBlock p1 p2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/Program.lean
+++ b/EvmAsm/Evm64/Sub/Program.lean
@@ -13,7 +13,7 @@ open EvmAsm.Rv64
 
 /-- 256-bit EVM SUB: binary, pops 2, pushes 1.
     Limb 0: LD, LD, SLTU (borrow), SUB, SD (5 instructions).
-    Limbs 1-3: LD, LD, SLTU (borrow1), SUB, SLTU (borrow2), SUB (borrow_in), OR (borrow_out), SD (8 each).
+    Limbs 1-3: LD, LD, SLTU (borrow1), SUB, SLTU (borrow2), SUB (borrowIn), OR (borrowOut), SD (8 each).
     Then ADDI sp, sp, 32. -/
 def evm_sub : Program :=
   -- Limb 0 (5 instructions)

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -22,16 +22,16 @@ open EvmAsm.Rv64
 /-- Four-instruction spec for SWAP per-limb: LD x7 from A, LD x6 from B,
     SD x6 to A, SD x7 to B. Swaps values at offsets off_a and off_b. -/
 theorem swap_limb_spec (sp : Word)
-    (off_a off_b : BitVec 12) (a_val b_val v7 v6 : Word) (base : Word) :
+    (off_a off_b : BitVec 12) (aVal bVal v7 v6 : Word) (base : Word) :
     cpsTriple base (base + 16)
       (CodeReq.singleton base (.LD .x7 .x12 off_a) |>.union
         (CodeReq.singleton (base + 4) (.LD .x6 .x12 off_b) |>.union
         (CodeReq.singleton (base + 8) (.SD .x12 .x6 off_a) |>.union
          (CodeReq.singleton (base + 12) (.SD .x12 .x7 off_b)))))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
-       ((sp + signExtend12 off_a) ↦ₘ a_val) ** ((sp + signExtend12 off_b) ↦ₘ b_val))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ a_val) ** (.x6 ↦ᵣ b_val) **
-       ((sp + signExtend12 off_a) ↦ₘ b_val) ** ((sp + signExtend12 off_b) ↦ₘ a_val)) := by
+       ((sp + signExtend12 off_a) ↦ₘ aVal) ** ((sp + signExtend12 off_b) ↦ₘ bVal))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ aVal) ** (.x6 ↦ᵣ bVal) **
+       ((sp + signExtend12 off_a) ↦ₘ bVal) ** ((sp + signExtend12 off_b) ↦ₘ aVal)) := by
   runBlock
 
 -- ============================================================================

--- a/EvmAsm/Evm64/Xor/LimbSpec.lean
+++ b/EvmAsm/Evm64/Xor/LimbSpec.lean
@@ -17,7 +17,7 @@ open EvmAsm.Rv64
 
 /-- Per-limb XOR spec (4 instructions: LD x7, LD x6, XOR x7 x7 x6, SD x12 x7). -/
 theorem xor_limb_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 : Word) (base : Word) :
+    (sp aLimb bLimb v7 v6 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let cr :=
@@ -27,9 +27,9 @@ theorem xor_limb_spec (offA offB : BitVec 12)
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (a_limb ^^^ b_limb)) ** (.x6 ↦ᵣ b_limb) **
-       (memA ↦ₘ a_limb) ** (memB ↦ₘ (a_limb ^^^ b_limb))) := by
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ bLimb))
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ (aLimb ^^^ bLimb)) ** (.x6 ↦ᵣ bLimb) **
+       (memA ↦ₘ aLimb) ** (memB ↦ₘ (aLimb ^^^ bLimb))) := by
   runBlock
 
 end EvmAsm.Evm64

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -74,39 +74,39 @@ owns the containing doubleword; the postcondition preserves it unchanged. -/
 
 theorem generic_lbu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LBU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LBU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LBU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LBU rd rs1 offset)) :=
     step_lbu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LBU rd rs1 offset) =
-      (s.setReg rd ((extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getByte_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)
+      (v' := (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
@@ -119,39 +119,39 @@ The precondition owns the containing doubleword; the postcondition preserves it 
 
 theorem generic_lb_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LB rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LB rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LB rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LB rd rs1 offset)) :=
     step_lb s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LB rd rs1 offset) =
-      (s.setReg rd ((extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getByte_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64)
+      (v' := (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -61,39 +61,39 @@ LHU reads a halfword from memory at a 2-byte aligned address and zero-extends it
 
 theorem generic_lhu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LHU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LHU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LHU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LHU rd rs1 offset)) :=
     step_lhu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LHU rd rs1 offset) =
-      (s.setReg rd ((extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getHalfword_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)
+      (v' := (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
@@ -105,39 +105,39 @@ LH reads a halfword from memory at a 2-byte aligned address and sign-extends it.
 
 theorem generic_lh_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LH rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LH rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LH rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LH rd rs1 offset)) :=
     step_lh s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LH rd rs1 offset) =
-      (s.setReg rd ((extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getHalfword_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)
+      (v' := (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -93,12 +93,12 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
     CodeReq.Disjoint.singleton (by bv_omega) _ _
   -- Step 1: SLLI x11, x11, 8 — use `slli_spec_gen_same` (rd = rs1),
   -- then frame with x12 to bring it into scope.
-  have s1_base := slli_spec_gen_same .x11 len 8 base (by nofun)
+  have s1Base := slli_spec_gen_same .x11 len 8 base (by nofun)
   have s1 : cpsTriple base (base + 4)
       (CodeReq.singleton base (.SLLI .x11 .x11 8))
       ((.x11 ↦ᵣ len) ** (.x12 ↦ᵣ byte))
       ((.x11 ↦ᵣ (len <<< (8 : BitVec 6).toNat)) ** (.x12 ↦ᵣ byte)) :=
-    cpsTriple_frameR (.x12 ↦ᵣ byte) (by pcFree) s1_base
+    cpsTriple_frameR (.x12 ↦ᵣ byte) (by pcFree) s1Base
   -- Step 2: ADD x11, x11, x12 — `add_spec_gen_rd_eq_rs1` (rd = rs1 = x11,
   -- rs2 = x12). No framing needed.
   have s2 := add_spec_gen_rd_eq_rs1 .x11 .x12

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -56,20 +56,20 @@ example : rlp_phase2_long_iter_prog.length = 5 := rfl
     unchanged. -/
 @[irreducible]
 def rlp_phase2_long_iter_post
-    (len ptr cnt byteZext word_val dwordAddr : Word) : Assertion :=
+    (len ptr cnt byteZext wordVal dwordAddr : Word) : Assertion :=
   let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   let cnt'    := cnt + signExtend12 (-1 : BitVec 12)
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ cnt') **
-    (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)
+    (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_iter_post_unfold
-    (len ptr cnt byteZext word_val dwordAddr : Word) :
-    rlp_phase2_long_iter_post len ptr cnt byteZext word_val dwordAddr =
+    (len ptr cnt byteZext wordVal dwordAddr : Word) :
+    rlp_phase2_long_iter_post len ptr cnt byteZext wordVal dwordAddr =
     ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
-     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) := by
+     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_iter_post; rfl
 
 -- ============================================================================
@@ -113,15 +113,15 @@ private theorem iter_addrs_distinct (base : Word) :
     ADDI (counter) — each framed with the registers and memory not
     touched by that instruction. -/
 theorem rlp_phase2_long_iter_spec
-    (len ptr cnt v12_old word_val dwordAddr : Word) (base : Word)
+    (len ptr cnt v12_old wordVal dwordAddr : Word) (base : Word)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 20)
       (CodeReq.ofProg base rlp_phase2_long_iter_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_iter_post len ptr cnt byteZext word_val dwordAddr) := by
+       (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_iter_post len ptr cnt byteZext wordVal dwordAddr) := by
   simp only [rlp_phase2_long_iter_post_unfold]
   rw [iter_code_split]
   -- Helpers: `signExtend12 1 = 1` and `signExtend12 0 = 0`.
@@ -131,13 +131,13 @@ theorem rlp_phase2_long_iter_spec
   -- Distinct-addresses plumbing.
   obtain ⟨h01, h02, h03, h04, h12, h13, h14, h23, h24, h34⟩ :=
     iter_addrs_distinct base
-  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   -- Step 1: LBU x12, x13, 0.
   have halign0 : alignToDword (ptr + signExtend12 (0 : BitVec 12)) = dwordAddr := by
     rw [h_se0]; simpa using halign
   have hvalid0 : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
     rw [h_se0]; simpa using hvalid
-  have lbu_raw := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr word_val
+  have lbu_raw := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr wordVal
     (by nofun) halign0 hvalid0
   rw [show ptr + signExtend12 (0 : BitVec 12) = ptr from by
         rw [h_se0]; bv_omega] at lbu_raw
@@ -168,9 +168,9 @@ theorem rlp_phase2_long_iter_spec
   have s1 : cpsTriple base (base + 4)
       (CodeReq.singleton base (.LBU .x12 .x13 0))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ word_val))
+       (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
@@ -179,56 +179,56 @@ theorem rlp_phase2_long_iter_spec
   have s2 : cpsTriple (base + 4) (base + 8)
       (CodeReq.singleton (base + 4) (.SLLI .x11 .x11 8))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ (len <<< 8)) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
         ((.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
-         (dwordAddr ↦ₘ word_val)) (by pcFree) slli_raw)
+         (dwordAddr ↦ₘ wordVal)) (by pcFree) slli_raw)
   -- Step 3 (ADD x11 x11 x12) — uses (x11, x12); frames (x13, x14, mem).
   have s3 : cpsTriple (base + 8) (base + 12)
       (CodeReq.singleton (base + 8) (.ADD .x11 .x11 .x12))
       ((.x11 ↦ᵣ (len <<< 8)) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
        (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val)) :=
+       (dwordAddr ↦ₘ wordVal)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
-        ((.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) ** (dwordAddr ↦ₘ word_val))
+        ((.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) ** (dwordAddr ↦ₘ wordVal))
         (by pcFree) add_raw)
   -- Step 4 (ADDI x13 x13 1) — mutates x13; frames the rest.
   have s4 : cpsTriple (base + 12) (base + 16)
       (CodeReq.singleton (base + 12) (.ADDI .x13 .x13 1))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
        (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val)) :=
+       (dwordAddr ↦ₘ wordVal)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
         ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x14 ↦ᵣ cnt) **
-         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
+         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal))
         (by pcFree) addi_ptr_raw)
   -- Step 5 (ADDI x14 x14 -1) — mutates x14; frames the rest.
   have s5 : cpsTriple (base + 16) (base + 20)
       (CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1)))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
         ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
-         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
+         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal))
         (by pcFree) addi_cnt_raw)
   -- Disjointness builders for the union chain produced by `cpsTriple_seq`.
   have hd5 : CodeReq.Disjoint

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -51,16 +51,16 @@ example : rlp_phase2_long_load_acc_prog.length = 3 := rfl
     `@[irreducible]` to keep the let-bindings out of the theorem statement. -/
 @[irreducible]
 def rlp_phase2_long_load_acc_post
-    (len ptr byteZext word_val dwordAddr : Word) : Assertion :=
+    (len ptr byteZext wordVal dwordAddr : Word) : Assertion :=
   let length' := (len <<< 8) + byteZext
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_load_acc_post_unfold
-    (len ptr byteZext word_val dwordAddr : Word) :
-    rlp_phase2_long_load_acc_post len ptr byteZext word_val dwordAddr =
+    (len ptr byteZext wordVal dwordAddr : Word) :
+    rlp_phase2_long_load_acc_post len ptr byteZext wordVal dwordAddr =
     ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
-     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) := by
+     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_load_acc_post; rfl
 
 /-- `cpsTriple` spec for the load-and-accumulate step.
@@ -69,16 +69,16 @@ theorem rlp_phase2_long_load_acc_post_unfold
     `ptr` (established via `halign`, `hvalid`). After execution, `x11`
     holds `len * 256 + byte` (as BitVec arithmetic) and `x12` holds the
     zero-extended byte. `x13` and memory are preserved. -/
-theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word)
+theorem rlp_phase2_long_load_acc_spec (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 12)
       (CodeReq.ofProg base rlp_phase2_long_load_acc_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
-       (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_load_acc_post len ptr byteZext word_val dwordAddr) := by
+       (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_load_acc_post len ptr byteZext wordVal dwordAddr) := by
   simp only [rlp_phase2_long_load_acc_post_unfold]
   -- Reshape the top-level CodeReq: `ofProg base (LBU :: acc_prog)` unfolds
   -- to `singleton base LBU ∪ ofProg (base + 4) acc_prog`.
@@ -104,17 +104,17 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word
     rw [hptr_eq]; exact halign
   have hvalid' : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
     rw [hptr_eq]; exact hvalid
-  have lbu := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr word_val
+  have lbu := generic_lbu_spec .x12 .x13 ptr v12_old 0 base dwordAddr wordVal
     (by nofun) halign' hvalid'
   rw [hptr_eq] at lbu
   -- Frame LBU with `x11 ↦ᵣ len` and permute to match the sequence shape.
-  let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  let byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have lbu_framed : cpsTriple base (base + 4)
       (CodeReq.singleton base (.LBU .x12 .x13 0))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val)) :=
+       (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -126,14 +126,14 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word
   have acc_framed : cpsTriple (base + 4) (base + 12)
       (CodeReq.ofProg (base + 4) rlp_phase2_long_acc_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
-       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
-        ((.x13 ↦ᵣ ptr) ** (dwordAddr ↦ₘ word_val)) (by pcFree) acc)
+        ((.x13 ↦ᵣ ptr) ** (dwordAddr ↦ₘ wordVal)) (by pcFree) acc)
   exact cpsTriple_seq _ _ _ _ _ hd _ _ _ lbu_framed acc_framed
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -55,22 +55,22 @@ example (back : BitVec 13) :
     fall-through exit). -/
 @[irreducible]
 def rlp_phase2_long_loop_body_post
-    (len ptr cnt byteZext word_val dwordAddr : Word) (P : Prop) : Assertion :=
+    (len ptr cnt byteZext wordVal dwordAddr : Word) (P : Prop) : Assertion :=
   let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   let cnt'    := cnt + signExtend12 (-1 : BitVec 12)
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ cnt') **
     (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val) ** ⌜P⌝
+    (dwordAddr ↦ₘ wordVal) ** ⌜P⌝
 
 theorem rlp_phase2_long_loop_body_post_unfold
-    (len ptr cnt byteZext word_val dwordAddr : Word) (P : Prop) :
-    rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val dwordAddr P =
+    (len ptr cnt byteZext wordVal dwordAddr : Word) (P : Prop) :
+    rlp_phase2_long_loop_body_post len ptr cnt byteZext wordVal dwordAddr P =
     ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
      (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val) ** ⌜P⌝) := by
+     (dwordAddr ↦ₘ wordVal) ** ⌜P⌝) := by
   delta rlp_phase2_long_loop_body_post; rfl
 
 /-- `cpsBranch` spec for one pass through the long-form length-loop body.
@@ -80,21 +80,21 @@ theorem rlp_phase2_long_loop_body_post_unfold
     (`cnt' ≠ 0` on taken, `cnt' = 0` on fall-through) flows directly from
     BNE's postcondition. -/
 theorem rlp_phase2_long_loop_body_spec
-    (len ptr cnt v12_old word_val dwordAddr : Word)
+    (len ptr cnt v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
     let cnt'      := cnt + signExtend12 (-1 : BitVec 12)
     cpsBranch base (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((base + 20) + signExtend13 back)
-        (rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val
+        (rlp_phase2_long_loop_body_post len ptr cnt byteZext wordVal
            dwordAddr (cnt' ≠ 0))
       (base + 24)
-        (rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val
+        (rlp_phase2_long_loop_body_post len ptr cnt byteZext wordVal
            dwordAddr (cnt' = 0)) := by
   -- The loop-body `ofProg` splits as `ofProg base iter_prog ∪ ofProg (base+20) [BNE]`
   -- via `ofProg_append`; the tail is one singleton plus an `empty`.
@@ -131,21 +131,21 @@ theorem rlp_phase2_long_loop_body_spec
   rw [hcr_eq]
   simp only [rlp_phase2_long_loop_body_post_unfold]
   -- Get iter_spec (5 instructions base → base+20).
-  have iter := rlp_phase2_long_iter_spec len ptr cnt v12_old word_val dwordAddr
+  have iter := rlp_phase2_long_iter_spec len ptr cnt v12_old wordVal dwordAddr
     base halign hvalid
   simp only [rlp_phase2_long_iter_post_unfold] at iter
-  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   set cnt' := cnt + signExtend12 (-1 : BitVec 12)
   -- Frame iter with (.x0 ↦ᵣ 0) so the composition state matches bne's.
   have iter' : cpsTriple base (base + 20)
       (CodeReq.ofProg base rlp_phase2_long_iter_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
        (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
        (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val)) :=
+       (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
@@ -159,17 +159,17 @@ theorem rlp_phase2_long_loop_body_spec
       ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
        (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
        (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((base + 20) + signExtend13 back)
         ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
          (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-         (dwordAddr ↦ₘ word_val) ** ⌜cnt' ≠ 0⌝)
+         (dwordAddr ↦ₘ wordVal) ** ⌜cnt' ≠ 0⌝)
       (base + 24)
         ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
          (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-         (dwordAddr ↦ₘ word_val) ** ⌜cnt' = 0⌝) := by
+         (dwordAddr ↦ₘ wordVal) ** ⌜cnt' = 0⌝) := by
     have h_eq_20_4 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
     rw [h_eq_20_4] at bne_raw
     exact cpsBranch_weaken
@@ -179,7 +179,7 @@ theorem rlp_phase2_long_loop_body_spec
       (cpsBranch_frameR
         ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x12 ↦ᵣ byteZext) **
-         (dwordAddr ↦ₘ word_val)) (by pcFree) bne_raw)
+         (dwordAddr ↦ₘ wordVal)) (by pcFree) bne_raw)
   -- Disjointness between iter CR and BNE-singleton-union-empty CR.
   have hd_iter_bne : (CodeReq.ofProg base rlp_phase2_long_iter_prog).Disjoint
       ((CodeReq.singleton (base + 20) (.BNE .x14 .x0 back)).union

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64
 /-- Bundled post for the five-iteration loop closure. -/
 @[irreducible]
 def rlp_phase2_long_loop_five_byte_post
-    (len ptr byte1 byte2 byte3 byte4 byte5 word_val dwordAddr : Word) :
+    (len ptr byte1 byte2 byte3 byte4 byte5 wordVal dwordAddr : Word) :
     Assertion :=
   let length' :=
     (((((((len <<< 8) + byte1) <<< 8) + byte2) <<< 8) + byte3) <<< 8
@@ -34,25 +34,25 @@ def rlp_phase2_long_loop_five_byte_post
   let ptr'    := ptr + 5
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
     (.x12 ↦ᵣ byte5) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_loop_five_byte_post_unfold
-    (len ptr byte1 byte2 byte3 byte4 byte5 word_val dwordAddr : Word) :
+    (len ptr byte1 byte2 byte3 byte4 byte5 wordVal dwordAddr : Word) :
     rlp_phase2_long_loop_five_byte_post len ptr byte1 byte2 byte3 byte4 byte5
-        word_val dwordAddr =
+        wordVal dwordAddr =
     ((.x11 ↦ᵣ ((((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8 + byte3) <<< 8
                 + byte4) <<< 8 + byte5)) **
      (.x13 ↦ᵣ (ptr + 5)) **
      (.x14 ↦ᵣ (0 : Word)) **
      (.x12 ↦ᵣ byte5) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val)) := by
+     (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_loop_five_byte_post; rfl
 
 /-- `cpsTriple` spec for the five-iteration (lenLen = 5) closure.
 
     Iter 1 (cnt 5→4, BNE taken) + four-byte closure (iters 2–5). -/
 theorem rlp_phase2_long_loop_five_byte_spec
-    (len ptr v12_old word_val dwordAddr : Word)
+    (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign1 : alignToDword ptr = dwordAddr)
     (halign2 : alignToDword (ptr + 1) = dwordAddr)
@@ -69,23 +69,23 @@ theorem rlp_phase2_long_loop_five_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (5 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       (rlp_phase2_long_loop_five_byte_post len ptr
-        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 3))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 4))).zeroExtend 64)
-        word_val dwordAddr) := by
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 3))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 4))).zeroExtend 64)
+        wordVal dwordAddr) := by
   simp only [rlp_phase2_long_loop_five_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (5 : Word) v12_old
-    word_val dwordAddr base back halign1 hvalid1
+    wordVal dwordAddr base back halign1 hvalid1
   have hcnt' : (5 : Word) + signExtend12 (-1 : BitVec 12) = (4 : Word) := by
     decide
   rw [hcnt'] at body
-  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (5 : Word) byte1 word_val
+      rlp_phase2_long_loop_body_post len ptr (5 : Word) byte1 wordVal
          dwordAddr ((4 : Word) = 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
@@ -102,10 +102,10 @@ theorem rlp_phase2_long_loop_five_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (5 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (4 : Word)) ** (.x12 ↦ᵣ byte1) **
-       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by
@@ -117,7 +117,7 @@ theorem rlp_phase2_long_loop_five_byte_spec
       tri1
   -- Iters 2-5: four-byte closure at base with (ptr+1, cnt=4).
   have four_byte := rlp_phase2_long_loop_four_byte_spec ((len <<< 8) + byte1)
-    (ptr + 1) byte1 word_val dwordAddr base back
+    (ptr + 1) byte1 wordVal dwordAddr base back
     halign2
     (by rw [show (ptr + 1 : Word) + 1 = ptr + 2 from by bv_omega]; exact halign3)
     (by rw [show (ptr + 1 : Word) + 2 = ptr + 3 from by bv_omega]; exact halign4)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -27,31 +27,31 @@ open EvmAsm.Rv64
 /-- Bundled post for the four-iteration loop closure. -/
 @[irreducible]
 def rlp_phase2_long_loop_four_byte_post
-    (len ptr byte1 byte2 byte3 byte4 word_val dwordAddr : Word) : Assertion :=
+    (len ptr byte1 byte2 byte3 byte4 wordVal dwordAddr : Word) : Assertion :=
   let length' :=
     ((((((len <<< 8) + byte1) <<< 8) + byte2) <<< 8) + byte3) <<< 8 + byte4
   let ptr'    := ptr + 4
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
     (.x12 ↦ᵣ byte4) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_loop_four_byte_post_unfold
-    (len ptr byte1 byte2 byte3 byte4 word_val dwordAddr : Word) :
+    (len ptr byte1 byte2 byte3 byte4 wordVal dwordAddr : Word) :
     rlp_phase2_long_loop_four_byte_post len ptr byte1 byte2 byte3 byte4
-        word_val dwordAddr =
+        wordVal dwordAddr =
     ((.x11 ↦ᵣ (((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8 + byte3) <<< 8
                + byte4)) **
      (.x13 ↦ᵣ (ptr + 4)) **
      (.x14 ↦ᵣ (0 : Word)) **
      (.x12 ↦ᵣ byte4) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val)) := by
+     (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_loop_four_byte_post; rfl
 
 /-- `cpsTriple` spec for the four-iteration (lenLen = 4) closure.
 
     Iter 1 (cnt 4→3, BNE taken) + three-byte closure (iters 2–4). -/
 theorem rlp_phase2_long_loop_four_byte_spec
-    (len ptr v12_old word_val dwordAddr : Word)
+    (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign1 : alignToDword ptr = dwordAddr)
     (halign2 : alignToDword (ptr + 1) = dwordAddr)
@@ -66,23 +66,23 @@ theorem rlp_phase2_long_loop_four_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (4 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       (rlp_phase2_long_loop_four_byte_post len ptr
-        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 3))).zeroExtend 64)
-        word_val dwordAddr) := by
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 3))).zeroExtend 64)
+        wordVal dwordAddr) := by
   simp only [rlp_phase2_long_loop_four_byte_post_unfold]
   -- Iter 1: body at cnt = 4. cnt' = 3.
   have body := rlp_phase2_long_loop_body_spec len ptr (4 : Word) v12_old
-    word_val dwordAddr base back halign1 hvalid1
+    wordVal dwordAddr base back halign1 hvalid1
   have hcnt' : (4 : Word) + signExtend12 (-1 : BitVec 12) = (3 : Word) := by
     decide
   rw [hcnt'] at body
-  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (4 : Word) byte1 word_val
+      rlp_phase2_long_loop_body_post len ptr (4 : Word) byte1 wordVal
          dwordAddr ((3 : Word) = 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
@@ -99,10 +99,10 @@ theorem rlp_phase2_long_loop_four_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (4 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (3 : Word)) ** (.x12 ↦ᵣ byte1) **
-       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by
@@ -114,7 +114,7 @@ theorem rlp_phase2_long_loop_four_byte_spec
       tri1
   -- Iters 2-4: three-byte closure at base with (ptr+1, cnt=3).
   have three_byte := rlp_phase2_long_loop_three_byte_spec ((len <<< 8) + byte1)
-    (ptr + 1) byte1 word_val dwordAddr base back
+    (ptr + 1) byte1 wordVal dwordAddr base back
     halign2
     (by rw [show (ptr + 1 : Word) + 1 = ptr + 2 from by bv_omega]; exact halign3)
     (by rw [show (ptr + 1 : Word) + 2 = ptr + 3 from by bv_omega]; exact halign4)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -34,21 +34,21 @@ open EvmAsm.Rv64
     fact is needed (the caller knows we exited via fall-through). -/
 @[irreducible]
 def rlp_phase2_long_loop_one_byte_post
-    (len ptr byteZext word_val dwordAddr : Word) : Assertion :=
+    (len ptr byteZext wordVal dwordAddr : Word) : Assertion :=
   let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
     (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_loop_one_byte_post_unfold
-    (len ptr byteZext word_val dwordAddr : Word) :
-    rlp_phase2_long_loop_one_byte_post len ptr byteZext word_val dwordAddr =
+    (len ptr byteZext wordVal dwordAddr : Word) :
+    rlp_phase2_long_loop_one_byte_post len ptr byteZext wordVal dwordAddr =
     ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (0 : Word)) **
      (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val)) := by
+     (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_loop_one_byte_post; rfl
 
 /-- `cpsTriple` spec for the single-iteration (lenLen = 1) closure of
@@ -60,31 +60,31 @@ theorem rlp_phase2_long_loop_one_byte_post_unfold
     `cpsBranch_elim_ntaken` rule then turns the two-exit branch into a
     single-exit triple at the fall-through. -/
 theorem rlp_phase2_long_loop_one_byte_spec
-    (len ptr v12_old word_val dwordAddr : Word)
+    (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 24)
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (1 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_loop_one_byte_post len ptr byteZext word_val
+       (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_loop_one_byte_post len ptr byteZext wordVal
          dwordAddr) := by
   simp only [rlp_phase2_long_loop_one_byte_post_unfold]
   -- Body spec instantiated at cnt = 1.
   have body := rlp_phase2_long_loop_body_spec len ptr (1 : Word) v12_old
-    word_val dwordAddr base back halign hvalid
+    wordVal dwordAddr base back halign hvalid
   -- For cnt = 1, `cnt' = (1 : Word) + signExtend12 (-1 : BitVec 12) = 0`.
   have hcnt' : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by
     decide
   rw [hcnt'] at body
   -- The taken post carries `⌜(0 : Word) ≠ 0⌝`, which is False. Extract it
   -- via six layers of destructuring and derive the contradiction.
-  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (1 : Word) byteZext word_val
+      rlp_phase2_long_loop_body_post len ptr (1 : Word) byteZext wordVal
          dwordAddr ((0 : Word) ≠ 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -34,22 +34,22 @@ open EvmAsm.Rv64
     `x11` in big-endian order. -/
 @[irreducible]
 def rlp_phase2_long_loop_three_byte_post
-    (len ptr byte1 byte2 byte3 word_val dwordAddr : Word) : Assertion :=
+    (len ptr byte1 byte2 byte3 wordVal dwordAddr : Word) : Assertion :=
   let length' := ((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8) + byte3
   let ptr'    := ptr + 3
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
     (.x12 ↦ᵣ byte3) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_loop_three_byte_post_unfold
-    (len ptr byte1 byte2 byte3 word_val dwordAddr : Word) :
-    rlp_phase2_long_loop_three_byte_post len ptr byte1 byte2 byte3 word_val
+    (len ptr byte1 byte2 byte3 wordVal dwordAddr : Word) :
+    rlp_phase2_long_loop_three_byte_post len ptr byte1 byte2 byte3 wordVal
         dwordAddr =
     ((.x11 ↦ᵣ ((((len <<< 8) + byte1) <<< 8 + byte2) <<< 8 + byte3)) **
      (.x13 ↦ᵣ (ptr + 3)) **
      (.x14 ↦ᵣ (0 : Word)) **
      (.x12 ↦ᵣ byte3) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val)) := by
+     (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_loop_three_byte_post; rfl
 
 /-- `cpsTriple` spec for the three-iteration (lenLen = 3) closure of
@@ -59,7 +59,7 @@ theorem rlp_phase2_long_loop_three_byte_post_unfold
     `cnt' = 2 ≠ 0`); the remaining two iterations are folded into
     `rlp_phase2_long_loop_two_byte_spec` (#336). -/
 theorem rlp_phase2_long_loop_three_byte_spec
-    (len ptr v12_old word_val dwordAddr : Word)
+    (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign1 : alignToDword ptr = dwordAddr)
     (halign2 : alignToDword (ptr + 1) = dwordAddr)
@@ -72,23 +72,23 @@ theorem rlp_phase2_long_loop_three_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (3 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       (rlp_phase2_long_loop_three_byte_post len ptr
-        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 2))).zeroExtend 64)
-        word_val dwordAddr) := by
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        wordVal dwordAddr) := by
   simp only [rlp_phase2_long_loop_three_byte_post_unfold]
   -- Iter 1: body spec at cnt = 3. cnt' = 2.
   have body := rlp_phase2_long_loop_body_spec len ptr (3 : Word) v12_old
-    word_val dwordAddr base back halign1 hvalid1
+    wordVal dwordAddr base back halign1 hvalid1
   have hcnt' : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by
     decide
   rw [hcnt'] at body
   -- The fall-through carries `⌜(2 : Word) = 0⌝`, which is False.
-  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (3 : Word) byte1 word_val
+      rlp_phase2_long_loop_body_post len ptr (3 : Word) byte1 wordVal
          dwordAddr ((2 : Word) = 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
@@ -106,10 +106,10 @@ theorem rlp_phase2_long_loop_three_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (3 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (2 : Word)) ** (.x12 ↦ᵣ byte1) **
-       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by
@@ -121,7 +121,7 @@ theorem rlp_phase2_long_loop_three_byte_spec
       tri1
   -- Iter 2+3: two-byte closure starting at base with ptr+1, cnt = 2.
   have two_byte := rlp_phase2_long_loop_two_byte_spec ((len <<< 8) + byte1)
-    (ptr + 1) byte1 word_val dwordAddr base back
+    (ptr + 1) byte1 wordVal dwordAddr base back
     halign2
     (by rw [show (ptr + 1 : Word) + 1 = ptr + 2 from by bv_omega]; exact halign3)
     hvalid2

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -37,21 +37,21 @@ open EvmAsm.Rv64
     `x11` in big-endian order. -/
 @[irreducible]
 def rlp_phase2_long_loop_two_byte_post
-    (len ptr byte1 byte2 word_val dwordAddr : Word) : Assertion :=
+    (len ptr byte1 byte2 wordVal dwordAddr : Word) : Assertion :=
   let length' := ((len <<< 8) + byte1) <<< 8 + byte2
   let ptr'    := ptr + 2
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
     (.x12 ↦ᵣ byte2) ** (.x0 ↦ᵣ (0 : Word)) **
-    (dwordAddr ↦ₘ word_val)
+    (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_loop_two_byte_post_unfold
-    (len ptr byte1 byte2 word_val dwordAddr : Word) :
-    rlp_phase2_long_loop_two_byte_post len ptr byte1 byte2 word_val dwordAddr =
+    (len ptr byte1 byte2 wordVal dwordAddr : Word) :
+    rlp_phase2_long_loop_two_byte_post len ptr byte1 byte2 wordVal dwordAddr =
     ((.x11 ↦ᵣ (((len <<< 8) + byte1) <<< 8 + byte2)) **
      (.x13 ↦ᵣ (ptr + 2)) **
      (.x14 ↦ᵣ (0 : Word)) **
      (.x12 ↦ᵣ byte2) ** (.x0 ↦ᵣ (0 : Word)) **
-     (dwordAddr ↦ₘ word_val)) := by
+     (dwordAddr ↦ₘ wordVal)) := by
   delta rlp_phase2_long_loop_two_byte_post; rfl
 
 /-- `cpsTriple` spec for the two-iteration (lenLen = 2) closure of
@@ -62,7 +62,7 @@ theorem rlp_phase2_long_loop_two_byte_post_unfold
     iteration then runs with `cnt = 1`, falls through, and lands at
     `base + 24`. -/
 theorem rlp_phase2_long_loop_two_byte_spec
-    (len ptr v12_old word_val dwordAddr : Word)
+    (len ptr v12_old wordVal dwordAddr : Word)
     (base : Word) (back : BitVec 13)
     (halign1 : alignToDword ptr = dwordAddr)
     (halign2 : alignToDword (ptr + 1) = dwordAddr)
@@ -73,23 +73,23 @@ theorem rlp_phase2_long_loop_two_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (2 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       (rlp_phase2_long_loop_two_byte_post len ptr
-        ((extractByte word_val (byteOffset ptr)).zeroExtend 64)
-        ((extractByte word_val (byteOffset (ptr + 1))).zeroExtend 64)
-        word_val dwordAddr) := by
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        wordVal dwordAddr) := by
   simp only [rlp_phase2_long_loop_two_byte_post_unfold]
   -- Iter 1: loop-body spec at cnt = 2.
   have body := rlp_phase2_long_loop_body_spec len ptr (2 : Word) v12_old
-    word_val dwordAddr base back halign1 hvalid1
+    wordVal dwordAddr base back halign1 hvalid1
   -- cnt' = 2 + signExtend12 (-1) = 1. Rewrite.
   have hcnt' : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by
     decide
   rw [hcnt'] at body
   -- The fall-through carries `⌜(1 : Word) = 0⌝`, which is False.
-  set byte1 := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (2 : Word) byte1 word_val
+      rlp_phase2_long_loop_body_post len ptr (2 : Word) byte1 wordVal
          dwordAddr ((1 : Word) = 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
@@ -110,10 +110,10 @@ theorem rlp_phase2_long_loop_two_byte_spec
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (2 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (dwordAddr ↦ₘ word_val))
+       (dwordAddr ↦ₘ wordVal))
       ((.x11 ↦ᵣ ((len <<< 8) + byte1)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (1 : Word)) ** (.x12 ↦ᵣ byte1) **
-       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTriple_weaken
       (fun _ hp => hp)
       (fun h hp => by
@@ -126,7 +126,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
   -- Iter 2: one-byte spec at base, using state from tri1's post.
   -- Permute post to match one-byte spec's pre shape (put x13, x14 first).
   have one_byte := rlp_phase2_long_loop_one_byte_spec ((len <<< 8) + byte1)
-    (ptr + 1) byte1 word_val dwordAddr base back halign2 hvalid2
+    (ptr + 1) byte1 wordVal dwordAddr base back halign2 hvalid2
   simp only [rlp_phase2_long_loop_one_byte_post_unfold] at one_byte
   -- Both CRs are the same (loop body prog at base), so use `_seq_same_cr`.
   -- Need to convert tri1''s post into one_byte's pre shape via consequence.

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2479,16 +2479,16 @@ theorem CodeReq.ofProg_mono_subrange (base : Word) (pre mid suf : List Instr)
     (by rwa [← List.append_assoc]) a i
     (CodeReq.ofProg_mono_append_left _ mid suf a i h)
 
-/-- Sub-range monotonicity with explicit offset: `ofProg sub_base sub ⊆ ofProg base full`
+/-- Sub-range monotonicity with explicit offset: `ofProg subBase sub ⊆ ofProg base full`
     when `sub` is a contiguous slice of `full` starting at instruction index `idx`
-    (byte offset `sub_base = base + 4*idx`). -/
-theorem CodeReq.ofProg_mono_sub (base sub_base : Word) (full sub : List Instr)
+    (byte offset `subBase = base + 4*idx`). -/
+theorem CodeReq.ofProg_mono_sub (base subBase : Word) (full sub : List Instr)
     (idx : Nat)
-    (h_addr : sub_base = base + BitVec.ofNat 64 (4 * idx))
+    (h_addr : subBase = base + BitVec.ofNat 64 (4 * idx))
     (h_slice : (full.drop idx).take sub.length = sub)
     (h_range : idx + sub.length ≤ full.length)
     (hbound : 4 * full.length < 2^64) :
-    ∀ a i, (CodeReq.ofProg sub_base sub) a = some i →
+    ∀ a i, (CodeReq.ofProg subBase sub) a = some i →
            (CodeReq.ofProg base full) a = some i := by
   intro a i h; rw [h_addr] at h
   -- Decompose: full.drop idx = sub ++ full.drop (idx + sub.length)

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -689,32 +689,32 @@ namespace EvmAsm.Rv64
 
 @[spec_gen_rv64] theorem lbu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LBU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lbu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lbu_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lb_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidByteAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LB rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractByte word_val (byteOffset (v_addr + signExtend12 offset))).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lb_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lb_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sb_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
@@ -812,32 +812,32 @@ namespace EvmAsm.Rv64
 
 @[spec_gen_rv64] theorem lhu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LHU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lhu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lhu_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lh_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidHalfwordAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LH rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractHalfword word_val ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lh_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lh_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sh_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)
@@ -859,32 +859,32 @@ namespace EvmAsm.Rv64
 
 @[spec_gen_rv64] theorem lwu_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LWU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lwu_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lwu_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem lw_spec_gen (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (addr : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple addr (addr + 4)
       (CodeReq.singleton addr (.LW rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) :=
-  generic_lw_spec rd rs1 v_addr v_old offset addr dwordAddr word_val
+       (rd ↦ᵣ (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) :=
+  generic_lw_spec rd rs1 v_addr v_old offset addr dwordAddr wordVal
     hrd_ne_x0 halign hvalid
 
 @[spec_gen_rv64] theorem sw_spec_gen (rs1 rs2 : Reg) (v_addr v_data : Word)

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -97,7 +97,7 @@ elab "intro_lets" "at" h:ident : tactic => withMainContext do
       return none
     match existingFvar? with
     | some existingFvarId =>
-      -- Reuse existing let-def (avoids name collision like u_base vs u_base✝)
+      -- Reuse existing let-def (avoids name collision like uBase vs uBase✝)
       ty := _body.instantiate1 (.fvar existingFvarId)
     | none =>
       -- Add new local let-definition: `name : binderType := value`
@@ -720,7 +720,7 @@ private partial def verifyProgSlice (full sub : Expr) (idx : Nat)
     else break
   return some (subLen, fullLen)
 
-/-- Build a mono proof for `ofProg sub_base sub_prog ⊆ ofProg base full_prog`
+/-- Build a mono proof for `ofProg subBase sub_prog ⊆ ofProg base full_prog`
     using `ofProg_mono_sub`. Finds the sub-program as a contiguous slice. -/
 private def buildMonoProofOfProgToOfProg (oldCrW : Expr)
     (newCrBase newCrProg : Expr) : MetaM (Option Expr) := do
@@ -739,11 +739,11 @@ private def buildMonoProofOfProgToOfProg (oldCrW : Expr)
   let idx := (subOff - newOff) / 4
   -- Verify the sub-program is a contiguous slice
   let some (subLen, fullLen) ← verifyProgSlice newCrProg subProg idx | return none
-  -- Build proof: ofProg_mono_sub base sub_base full sub idx h_addr h_slice h_range hbound
+  -- Build proof: ofProg_mono_sub base subBase full sub idx h_addr h_slice h_range hbound
   let idxLit := mkNatLit idx
   let subLenLit := mkNatLit subLen
   let fullLenLit := mkNatLit fullLen
-  -- h_addr : sub_base = base + BitVec.ofNat 64 (4 * idx)
+  -- h_addr : subBase = base + BitVec.ofNat 64 (4 * idx)
   let fourIdx := mkNatLit (4 * idx)
   let bvOfNat := mkApp2 (mkConst ``BitVec.ofNat) (mkNatLit 64) fourIdx
   let addrSum := mkApp6
@@ -781,7 +781,7 @@ private def buildMonoProofOfProgToOfProg (oldCrW : Expr)
     let ltType := mkApp4 (mkConst ``LT.lt [.zero]) (mkConst ``Nat) (mkConst ``instLTNat)
       fourFullLen pow64
     mkDecideProof ltType
-  -- Assemble: ofProg_mono_sub base sub_base full sub idx h_addr h_slice h_range hbound
+  -- Assemble: ofProg_mono_sub base subBase full sub idx h_addr h_slice h_range hbound
   return some (mkAppN (mkConst ``EvmAsm.Rv64.CodeReq.ofProg_mono_sub)
     #[newCrBase, subBase, newCrProg, subProg, idxLit, h_addr, h_slice, h_range, hbound])
 

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -46,39 +46,39 @@ LWU reads a 32-bit word from memory at a 4-byte aligned address and zero-extends
 
 theorem generic_lwu_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LWU rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LWU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LWU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LWU rd rs1 offset)) :=
     step_lwu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LWU rd rs1 offset) =
-      (s.setReg rd ((extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getWord32_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)
+      (v' := (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
@@ -90,39 +90,39 @@ LW reads a 32-bit word from memory at a 4-byte aligned address and sign-extends 
 
 theorem generic_lw_spec (rd rs1 : Reg) (v_addr v_old : Word)
     (offset : BitVec 12) (base : Word)
-    (dwordAddr : Word) (word_val : Word)
+    (dwordAddr : Word) (wordVal : Word)
     (hrd_ne_x0 : rd ≠ .x0)
     (halign : alignToDword (v_addr + signExtend12 offset) = dwordAddr)
     (hvalid : isValidMemAccess (v_addr + signExtend12 offset) = true) :
     cpsTriple base (base + 4)
       (CodeReq.singleton base (.LW rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ word_val))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (dwordAddr ↦ₘ wordVal))
       ((rs1 ↦ᵣ v_addr) **
-       (rd ↦ᵣ (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64) **
-       (dwordAddr ↦ₘ word_val)) := by
+       (rd ↦ᵣ (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64) **
+       (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LW rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LW rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem dwordAddr = word_val :=
+  have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LW rd rs1 offset)) :=
     step_lw s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LW rd rs1 offset) =
-      (s.setReg rd ((extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)).setPC (s.pc + 4) := by
+      (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getWord32_eq]; rw [halign, hmem]
   refine ⟨1,
-    (s.setReg rd ((extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)).setPC (s.pc + 4),
+    (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)).setPC (s.pc + 4),
     ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h1a := holdsFor_sepConj_assoc.mp h1
     have h2 := holdsFor_sepConj_regIs_setReg
-      (v' := (extractWord32 word_val ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)
+      (v' := (extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3


### PR DESCRIPTION
## Summary
Module-wide rename of \`u_top\` → \`uTop\` across 34 files (1461 occurrences):

- DivMod: \`LoopBody\`, \`LoopBodyN{1..4}\`, \`LoopUnifiedN{1,2,3}\`, \`LoopIterN{1..4}\` (and LoopIterN1/*), \`LoopDefs/{Post,Iter,Bundle}\`, \`LoopComposeN{1,2,3}\`, \`Spec.lean\`, \`LimbSpec/{AddBackFinalLoopControl,SubCarryStoreQj}\`, \`Compose/FullPathN*{,Beq,Loop,Shift0}\`.
- EvmWordArith: \`ModBridgeUtop\`, \`ModBridgeAssemble\`, \`SkipBorrowExtract\`.

Positional callers unaffected. Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)