### PR TITLE
refactor(evm-asm): rename carry_in/carry_out/u_new to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -39,7 +39,7 @@ theorem add_limb0_spec (offA offB : BitVec 12)
 /-- ADD carry limb phase 1 (4 instructions): LD, LD, ADD, SLTU.
     Loads a_limb and b_limb, computes psum = a + b, carry1 = (psum < b ? 1 : 0). -/
 theorem add_limb_carry_spec_phase1 (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Word) :
+    (sp a_limb b_limb v7 v6 carryIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let psum := a_limb + b_limb
@@ -50,20 +50,20 @@ theorem add_limb_carry_spec_phase1 (offA offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 8) (.ADD .x7 .x7 .x6))
        (CodeReq.singleton (base + 12) (.SLTU .x11 .x7 .x6))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carry_in) ** (.x11 ↦ᵣ v11) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ v11) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carry_in) ** (.x11 ↦ᵣ carry1) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb)) := by
   runBlock
 
 /-- ADD carry limb phase 2 (4 instructions): ADD, SLTU, OR, SD.
-    Takes psum, carry1, carry_in, computes result = psum + carry_in,
-    carry2 = (result < carry_in ? 1 : 0), carryOut = carry1 ||| carry2. -/
+    Takes psum, carry1, carryIn, computes result = psum + carryIn,
+    carry2 = (result < carryIn ? 1 : 0), carryOut = carry1 ||| carry2. -/
 theorem add_limb_carry_spec_phase2 (offB : BitVec 12)
-    (sp psum b_limb carry_in carry1 a_limb : Word) (memA : Word) (base : Word) :
+    (sp psum b_limb carryIn carry1 a_limb : Word) (memA : Word) (base : Word) :
     let memB := sp + signExtend12 offB
-    let result := psum + carry_in
-    let carry2 := if BitVec.ult result carry_in then (1 : Word) else 0
+    let result := psum + carryIn
+    let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
     let carryOut := carry1 ||| carry2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.ADD .x7 .x7 .x5))
@@ -71,7 +71,7 @@ theorem add_limb_carry_spec_phase2 (offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 8) (.OR .x5 .x11 .x6))
        (CodeReq.singleton (base + 12) (.SD .x12 .x7 offB))))
     cpsTriple base (base + 16) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carry_in) ** (.x11 ↦ᵣ carry1) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ psum) ** (.x6 ↦ᵣ b_limb) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ carry1) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
@@ -80,13 +80,13 @@ theorem add_limb_carry_spec_phase2 (offB : BitVec 12)
 /-- ADD carry limb spec (8 instructions): LD, LD, ADD, SLTU, ADD, SLTU, OR, SD.
     Composed from phase1 and phase2. -/
 theorem add_limb_carry_spec (offA offB : BitVec 12)
-    (sp a_limb b_limb v7 v6 carry_in v11 : Word) (base : Word) :
+    (sp a_limb b_limb v7 v6 carryIn v11 : Word) (base : Word) :
     let memA := sp + signExtend12 offA
     let memB := sp + signExtend12 offB
     let psum := a_limb + b_limb
     let carry1 := if BitVec.ult psum b_limb then (1 : Word) else 0
-    let result := psum + carry_in
-    let carry2 := if BitVec.ult result carry_in then (1 : Word) else 0
+    let result := psum + carryIn
+    let carry2 := if BitVec.ult result carryIn then (1 : Word) else 0
     let carryOut := carry1 ||| carry2
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x7 .x12 offA))
@@ -98,12 +98,12 @@ theorem add_limb_carry_spec (offA offB : BitVec 12)
       (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x5 .x11 .x6))
        (CodeReq.singleton (base + 28) (.SD .x12 .x7 offB))))))))
     cpsTriple base (base + 32) cr
-      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carry_in) ** (.x11 ↦ᵣ v11) **
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7) ** (.x6 ↦ᵣ v6) ** (.x5 ↦ᵣ carryIn) ** (.x11 ↦ᵣ v11) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ b_limb))
       ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ result) ** (.x6 ↦ᵣ carry2) ** (.x5 ↦ᵣ carryOut) ** (.x11 ↦ᵣ carry1) **
        (memA ↦ₘ a_limb) ** (memB ↦ₘ result)) := by
-  have p1 := add_limb_carry_spec_phase1 offA offB sp a_limb b_limb v7 v6 carry_in v11 base
-  have p2 := add_limb_carry_spec_phase2 offB sp (a_limb + b_limb) b_limb carry_in
+  have p1 := add_limb_carry_spec_phase1 offA offB sp a_limb b_limb v7 v6 carryIn v11 base
+  have p2 := add_limb_carry_spec_phase2 offB sp (a_limb + b_limb) b_limb carryIn
     (if BitVec.ult (a_limb + b_limb) b_limb then (1 : Word) else 0)
     a_limb (sp + signExtend12 offA) (base + 16)
   runBlock p1 p2

--- a/EvmAsm/Evm64/Add/Program.lean
+++ b/EvmAsm/Evm64/Add/Program.lean
@@ -13,7 +13,7 @@ open EvmAsm.Rv64
 
 /-- 256-bit EVM ADD: binary, pops 2, pushes 1.
     Limb 0: LD, LD, ADD, SLTU (carry), SD (5 instructions).
-    Limbs 1-3: LD, LD, ADD, SLTU (carry1), ADD (carry_in), SLTU (carry2), OR (carry_out), SD (8 each).
+    Limbs 1-3: LD, LD, ADD, SLTU (carry1), ADD (carryIn), SLTU (carry2), OR (carryOut), SD (8 each).
     Then ADDI sp, sp, 32.
     Registers: x12=sp, x7=acc, x6=operand, x5=carry, x11=carry1. -/
 def evm_add : Program :=

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBack.lean
@@ -4,7 +4,7 @@
   CPS specs for one limb of the Knuth Algorithm D "add-back" correction,
   which un-does the mul-sub when `q_hat` over-shot by 1:
     * `divK_addback_partA_spec` — 5 instructions (LD, LD, ADD, SLTU, ADD):
-      load v[i] and u[j+i], form `uPlusCarry = u_i + carry_in`, its
+      load v[i] and u[j+i], form `uPlusCarry = u_i + carryIn`, its
       SLTU `carry1`, and `uNew = uPlusCarry + v_i`.
     * `divK_addback_partB_spec` — 3 instructions (SLTU, OR, SD): form
       `carry2 = uNew < v_i`, OR with `carry1` for `carryOut`, store
@@ -30,10 +30,10 @@ open EvmAsm.Rv64
 
 /-- Add-back Part A: LD v[i], LD u[j+i], ADD carry, SLTU carry1, ADD v[i].
     5 instructions. Produces sum (x2) and carry1 (x7). -/
-theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word)
+theorem divK_addback_partA_spec (sp u_base carryIn v5_old v2_old v_i u_i : Word)
     (v_off : BitVec 12) (u_off : BitVec 12) (base : Word) :
-    let uPlusCarry := u_i + carry_in
-    let carry1 := if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0
+    let uPlusCarry := u_i + carryIn
+    let carry1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
     let uNew := uPlusCarry + v_i
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
@@ -42,7 +42,7 @@ theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word
       (CodeReq.union (CodeReq.singleton (base + 12) (.SLTU .x7 .x2 .x7))
        (CodeReq.singleton (base + 16) (.ADD .x2 .x2 .x5)))))
     cpsTriple base (base + 20) cr
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
@@ -53,8 +53,8 @@ theorem divK_addback_partA_spec (sp u_base carry_in v5_old v2_old v_i u_i : Word
   intro uPlusCarry carry1 uNew cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
-  have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carry_in (base + 8) (by nofun)
-  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carry_in (base + 12) (by nofun)
+  have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carryIn (base + 8) (by nofun)
+  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carryIn (base + 12) (by nofun)
   have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 uPlusCarry v_i (base + 16) (by nofun)
   runBlock I0 I1 I2 I3 I4
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSub.lean
@@ -6,7 +6,7 @@
     * `divK_mulsub_partA_spec` — 6 instructions (LD, MUL, MULHU, ADD,
       SLTU, ADD): load v[i], compute `prodLo = qHat * v_i`,
       `prodHi = MULHU qHat v_i`, and form `fullSub = prodLo +
-      carry_in` and `partialCarry = (fullSub < carry_in) + prodHi`.
+      carryIn` and `partialCarry = (fullSub < carryIn) + prodHi`.
     * `divK_mulsub_partB_spec` — 5 instructions (LD, SLTU, SUB, ADD, SD):
       load u[j+i], compute `uNew = u_i - fullSub`,
       `carryOut = partialCarry + (u_i < fullSub)`, store `uNew`.
@@ -31,12 +31,12 @@ open EvmAsm.Rv64
 
 /-- Mul-sub limb Part A: LD v[i], MUL, MULHU, ADD, SLTU, ADD.
     6 instructions. Produces fullSub (x7) and partialCarry (x10). -/
-theorem divK_mulsub_partA_spec (sp qHat carry_in v5_old v7_old v_i : Word)
+theorem divK_mulsub_partA_spec (sp qHat carryIn v5_old v7_old v_i : Word)
     (v_off : BitVec 12) (base : Word) :
     let prodLo := qHat * v_i
     let prodHi := rv64_mulhu qHat v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
     let partialCarry := borrowAdd + prodHi
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x12 v_off))
@@ -46,7 +46,7 @@ theorem divK_mulsub_partA_spec (sp qHat carry_in v5_old v7_old v_i : Word)
       (CodeReq.union (CodeReq.singleton (base + 16) (.SLTU .x10 .x7 .x10))
        (CodeReq.singleton (base + 20) (.ADD .x10 .x10 .x5))))))
     cpsTriple base (base + 24) cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ partialCarry) **
@@ -56,8 +56,8 @@ theorem divK_mulsub_partA_spec (sp qHat carry_in v5_old v7_old v_i : Word)
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := mul_spec_gen .x7 .x11 .x5 v7_old qHat v_i (base + 4) (by nofun)
   have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 qHat v_i (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carry_in (base + 12) (by nofun)
-  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carry_in (base + 16) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carryIn (base + 12) (by nofun)
+  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carryIn (base + 16) (by nofun)
   have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrowAdd prodHi (base + 20) (by nofun)
   runBlock I0 I1 I2 I3 I4 I5
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/MulSubLimb.lean
@@ -29,15 +29,15 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 /-- Mul-sub full limb: partA (6 instrs) + partB (5 instrs) = 11 instructions.
-    Input: qHat (x11), carry_in (x10), v[i] and u[j+i] in memory.
+    Input: qHat (x11), carryIn (x10), v[i] and u[j+i] in memory.
     Output: carryOut (x10), uNew stored. -/
 theorem divK_mulsub_limb_spec
-    (sp u_base qHat carry_in v5_old v7_old v2_old v_i u_i : Word)
+    (sp u_base qHat carryIn v5_old v7_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
     let prodLo := qHat * v_i
     let prodHi := rv64_mulhu qHat v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
     let partialCarry := borrowAdd + prodHi
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     let uNew := u_i - fullSub
@@ -55,7 +55,7 @@ theorem divK_mulsub_limb_spec
       (CodeReq.union (CodeReq.singleton (base + 36) (.ADD .x10 .x10 .x5))
        (CodeReq.singleton (base + 40) (.SD .x6 .x2 u_off)))))))))))
     cpsTriple base (base + 44) cr
-      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ carryIn) **
        (.x6 ↦ᵣ u_base) ** (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
@@ -69,8 +69,8 @@ theorem divK_mulsub_limb_spec
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := mul_spec_gen .x7 .x11 .x5 v7_old qHat v_i (base + 4) (by nofun)
   have I2 := mulhu_spec_gen_rd_eq_rs2 .x5 .x11 qHat v_i (base + 8) (by nofun)
-  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carry_in (base + 12) (by nofun)
-  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carry_in (base + 16) (by nofun)
+  have I3 := add_spec_gen_rd_eq_rs1 .x7 .x10 prodLo carryIn (base + 12) (by nofun)
+  have I4 := sltu_spec_gen_rd_eq_rs2 .x10 .x7 fullSub carryIn (base + 16) (by nofun)
   have I5 := add_spec_gen_rd_eq_rs1 .x10 .x5 borrowAdd prodHi (base + 20) (by nofun)
   have I6 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 24) (by nofun)
   have I7 := sltu_spec_gen .x5 .x2 .x7 prodHi u_i fullSub (base + 28) (by nofun)
@@ -80,13 +80,13 @@ theorem divK_mulsub_limb_spec
   runBlock I0 I1 I2 I3 I4 I5 I6 I7 I8 I9 I10
 
 /-- Add-back full limb: partA (5 instrs) + partB (3 instrs) = 8 instructions.
-    Input: carry_in (x7), v[i] and u[j+i] in memory.
+    Input: carryIn (x7), v[i] and u[j+i] in memory.
     Output: carryOut (x7), uNew stored. -/
 theorem divK_addback_limb_spec
-    (sp u_base carry_in v5_old v2_old v_i u_i : Word)
+    (sp u_base carryIn v5_old v2_old v_i u_i : Word)
     (v_off u_off : BitVec 12) (base : Word) :
-    let uPlusCarry := u_i + carry_in
-    let carry1 := if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0
+    let uPlusCarry := u_i + carryIn
+    let carry1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
     let uNew := uPlusCarry + v_i
     let carry2 := if BitVec.ult uNew v_i then (1 : Word) else 0
     let carryOut := carry1 ||| carry2
@@ -100,7 +100,7 @@ theorem divK_addback_limb_spec
       (CodeReq.union (CodeReq.singleton (base + 24) (.OR .x7 .x7 .x5))
        (CodeReq.singleton (base + 28) (.SD .x6 .x2 u_off))))))))
     cpsTriple base (base + 32) cr
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carry_in) **
+      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ u_base) ** (.x7 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x2 ↦ᵣ v2_old) **
        ((sp + signExtend12 v_off) ↦ₘ v_i) **
        ((u_base + signExtend12 u_off) ↦ₘ u_i))
@@ -111,8 +111,8 @@ theorem divK_addback_limb_spec
   intro uPlusCarry carry1 uNew carry2 carryOut cr
   have I0 := ld_spec_gen .x5 .x12 sp v5_old v_i v_off base (by nofun)
   have I1 := ld_spec_gen .x2 .x6 u_base v2_old u_i u_off (base + 4) (by nofun)
-  have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carry_in (base + 8) (by nofun)
-  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carry_in (base + 12) (by nofun)
+  have I2 := add_spec_gen_rd_eq_rs1 .x2 .x7 u_i carryIn (base + 8) (by nofun)
+  have I3 := sltu_spec_gen_rd_eq_rs2 .x7 .x2 uPlusCarry carryIn (base + 12) (by nofun)
   have I4 := add_spec_gen_rd_eq_rs1 .x2 .x5 uPlusCarry v_i (base + 16) (by nofun)
   have I5 := sltu_spec_gen_rd_eq_rs2 .x5 .x2 uNew v_i (base + 20) (by nofun)
   have I6 := or_spec_gen_rd_eq_rs1 .x7 .x5 carry1 carry2 (base + 24) (by nofun)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -33,26 +33,26 @@ open EvmAsm.Rv64
 
 /-- Subtract carry from u[j+4].
     4 instructions: LD, SLTU, SUB, SD. Produces borrow (x7). -/
-theorem divK_sub_carry_spec (u_base carry_in v5_old v7_old u_top : Word)
+theorem divK_sub_carry_spec (u_base carryIn v5_old v7_old u_top : Word)
     (u_off : BitVec 12) (base : Word) :
-    let borrow := if BitVec.ult u_top carry_in then (1 : Word) else 0
-    let uNew := u_top - carry_in
+    let borrow := if BitVec.ult u_top carryIn then (1 : Word) else 0
+    let uNew := u_top - carryIn
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x5 .x6 u_off))
       (CodeReq.union (CodeReq.singleton (base + 4) (.SLTU .x7 .x5 .x10))
       (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x5 .x5 .x10))
        (CodeReq.singleton (base + 12) (.SD .x6 .x5 u_off))))
     cpsTriple base (base + 16) cr
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_in) **
+      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ v5_old) ** (.x7 ↦ᵣ v7_old) **
        ((u_base + signExtend12 u_off) ↦ₘ u_top))
-      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carry_in) **
+      ((.x6 ↦ᵣ u_base) ** (.x10 ↦ᵣ carryIn) **
        (.x5 ↦ᵣ uNew) ** (.x7 ↦ᵣ borrow) **
        ((u_base + signExtend12 u_off) ↦ₘ uNew)) := by
   intro borrow uNew cr
   have I0 := ld_spec_gen .x5 .x6 u_base v5_old u_top u_off base (by nofun)
-  have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old u_top carry_in (base + 4) (by nofun)
-  have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 u_top carry_in (base + 8) (by nofun)
+  have I1 := sltu_spec_gen .x7 .x5 .x10 v7_old u_top carryIn (base + 4) (by nofun)
+  have I2 := sub_spec_gen_rd_eq_rs1 .x5 .x10 u_top carryIn (base + 8) (by nofun)
   have I3 := sd_spec_gen .x6 .x5 u_base uNew u_top u_off (base + 12)
   runBlock I0 I1 I2 I3
 

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1867,7 +1867,7 @@ theorem divK_mulsub_correction_addback_beq_spec
     let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
     let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
     let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-    let carry_out := if carry = 0 then
+    let carryOut := if carry = 0 then
         addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
       else carry
     -- Hypothesis: second addback carry nonzero (only needed if first carry = 0)
@@ -1887,7 +1887,7 @@ theorem divK_mulsub_correction_addback_beq_spec
        ((u_base + signExtend12 4064) ↦ₘ u_top))
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ q_out) **
        (.x1 ↦ᵣ j) ** (.x5 ↦ᵣ u4_out) ** (.x6 ↦ᵣ u_base) **
-       (.x7 ↦ᵣ carry_out) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
+       (.x7 ↦ᵣ carryOut) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3_out) **
        (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3976 ↦ₘ j) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ un0_out) **
@@ -1895,7 +1895,7 @@ theorem divK_mulsub_correction_addback_beq_spec
        ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ un2_out) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ un3_out) **
        ((u_base + signExtend12 4064) ↦ₘ u4_out)) := by
-  intro u_base ms c3 carry ab ab' q_out un0_out un1_out un2_out un3_out u4_out carry_out
+  intro u_base ms c3 carry ab ab' q_out un0_out un1_out un2_out un3_out u4_out carryOut
         hcarry2_nz hborrow
   -- 1. Mulsub + first addback (base+516 → base+880)
   have MCA := divK_mulsub_correction_addback_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -1912,7 +1912,7 @@ theorem divK_mulsub_correction_addback_beq_spec
     have h2 : un2_out = ab'.2.2.1 := if_pos hcarry
     have h3 : un3_out = ab'.2.2.2.1 := if_pos hcarry
     have h4 : u4_out = ab'.2.2.2.2 := if_pos hcarry
-    have hc : carry_out = addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 := if_pos hcarry
+    have hc : carryOut = addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 := if_pos hcarry
     rw [hq, h0, h1, h2, h3, h4, hc]
     -- Use named 880 spec (→880 with addbackN4_carry in postcondition)
     have MCA_N := (divK_mulsub_correction_addback_named_880_spec sp q_hat j v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -1945,7 +1945,7 @@ theorem divK_mulsub_correction_addback_beq_spec
     have h2 : un2_out = ab.2.2.1 := if_neg hcarry
     have h3 : un3_out = ab.2.2.2.1 := if_neg hcarry
     have h4 : u4_out = ab.2.2.2.2 := if_neg hcarry
-    have hc : carry_out = carry := if_neg hcarry
+    have hc : carryOut = carry := if_neg hcarry
     rw [hq, h0, h1, h2, h3, h4, hc]
     -- Use the existing MCA0 (which includes BEQ passthrough) with carry ≠ 0
     exact MCA0 hcarry

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -306,7 +306,7 @@ theorem divK_loop_body_n1_max_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -321,7 +321,7 @@ theorem divK_loop_body_n1_max_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
@@ -598,7 +598,7 @@ theorem divK_loop_body_n1_call_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -614,7 +614,7 @@ theorem divK_loop_body_n1_call_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -209,7 +209,7 @@ theorem divK_loop_body_n2_max_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -227,7 +227,7 @@ theorem divK_loop_body_n2_max_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
@@ -506,7 +506,7 @@ theorem divK_loop_body_n2_call_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -525,7 +525,7 @@ theorem divK_loop_body_n2_call_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+880 → base+448/904)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -208,7 +208,7 @@ theorem divK_loop_body_n3_max_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   -- Abbreviation for vtop_base (register value, not a memory address)
@@ -227,7 +227,7 @@ theorem divK_loop_body_n3_max_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
@@ -506,7 +506,7 @@ theorem divK_loop_body_n3_call_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -525,7 +525,7 @@ theorem divK_loop_body_n3_call_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -210,7 +210,7 @@ theorem divK_loop_body_n4_max_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   -- Abbreviation for vtop_base (register value, not a memory address)
@@ -229,7 +229,7 @@ theorem divK_loop_body_n4_max_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF with non-overlapping cells
   have TFf := cpsTriple_frameR
@@ -508,7 +508,7 @@ theorem divK_loop_body_n4_call_addback_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -527,7 +527,7 @@ theorem divK_loop_body_n4_call_addback_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store loop cpsBranch (base+884 → base+448/908)
-  have SL := divK_store_loop_spec sp j q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_spec sp j q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -94,7 +94,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -103,7 +103,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
@@ -212,7 +212,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -222,7 +222,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
@@ -331,7 +331,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -341,7 +341,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
@@ -450,7 +450,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp q_hat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top
@@ -460,7 +460,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4080) ↦ₘ u2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -57,7 +57,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -73,7 +73,7 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -139,7 +139,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -156,7 +156,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -222,7 +222,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -239,7 +239,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -305,7 +305,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -322,7 +322,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -735,7 +735,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -751,7 +751,7 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -850,7 +850,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -870,7 +870,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+884 → base+908)
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
@@ -948,7 +948,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -965,7 +965,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -1062,7 +1062,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -1080,7 +1080,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
@@ -1154,7 +1154,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -1171,7 +1171,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -1268,7 +1268,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -1286,7 +1286,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -538,7 +538,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -556,7 +556,7 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+884 → base+908)
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -658,7 +658,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -678,7 +678,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop exit j=0 (cpsTriple base+884 → base+908)
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR
@@ -760,7 +760,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -779,7 +779,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+884 → base+448)
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2_old) **
@@ -881,7 +881,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -902,7 +902,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop back j=1 (cpsTriple base+884 → base+448)
   have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carry_out q_old base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut q_old base hj_pos
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -307,7 +307,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -325,8 +325,8 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  -- 3. Store loop (use q_out, u4_out, carry_out)
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  -- 3. Store loop (use q_out, u4_out, carryOut)
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
@@ -443,7 +443,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   let un2_out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
   let un3_out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
   let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carry_out := if carry = 0 then
+  let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtop_base := sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -462,8 +462,8 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  -- 3. Store loop (use q_out, u4_out, carry_out)
-  have SL := divK_store_loop_j0_spec sp q_out u4_out carry_out q_old base
+  -- 3. Store loop (use q_out, u4_out, carryOut)
+  have SL := divK_store_loop_j0_spec sp q_out u4_out carryOut q_old base
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -282,8 +282,8 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   single (.ADD .x10 .x10 .x5) ;;             -- [27] partial_carry = borrow + prod_hi
   LD .x2 .x6 0 ;;                             -- [28] u[j+0]
   single (.SLTU .x5 .x2 .x7) ;;              -- [29] borrow_sub
-  single (.SUB .x2 .x2 .x7) ;;               -- [30] u_new
-  single (.ADD .x10 .x10 .x5) ;;             -- [31] carry_out
+  single (.SUB .x2 .x2 .x7) ;;               -- [30] uNew
+  single (.ADD .x10 .x10 .x5) ;;             -- [31] carryOut
   SD .x6 .x2 0 ;;                             -- [32] store u[j+0]
 
   -- MUL-SUB LIMB 1: v[1] at sp+40, u[j+1] at u_base-8 (4088)
@@ -339,11 +339,11 @@ def divK_loopBody (subr_off : BitVec 21) (loop_back_off : BitVec 13) : Program :
   ADDI .x7 .x0 0 ;;                           -- [71] carry = 0
   -- Limb 0
   LD .x5 .x12 32 ;; LD .x2 .x6 0 ;;          -- [72,73]
-  single (.ADD .x2 .x2 .x7) ;;               -- [74] u += carry_in
+  single (.ADD .x2 .x2 .x7) ;;               -- [74] u += carryIn
   single (.SLTU .x7 .x2 .x7) ;;              -- [75] carry1
   single (.ADD .x2 .x2 .x5) ;;               -- [76] u += v[i]
   single (.SLTU .x5 .x2 .x5) ;;              -- [77] carry2
-  single (.OR .x7 .x7 .x5) ;;                -- [78] carry_out
+  single (.OR .x7 .x7 .x5) ;;                -- [78] carryOut
   SD .x6 .x2 0 ;;                             -- [79]
   -- Limb 1
   LD .x5 .x12 40 ;; LD .x2 .x6 4088 ;;       -- [80,81]

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
@@ -45,33 +45,33 @@ theorem or_toNat_eq_add_of_le_one {a b : Word}
 -- ============================================================================
 
 /-- Helper: the two overflow flags from the two-step addition can't both be 1.
-    If the first addition overflows (u + carry_in ≥ 2^64), the intermediate
+    If the first addition overflows (u + carryIn ≥ 2^64), the intermediate
     result is small, so the second addition (intermediate + v) can't also overflow
     when the total carry is ≤ 1. -/
-private theorem addback_carries_exclusive (u_i v_i carry_in : Word)
-    (hci : carry_in.toNat ≤ 1) :
-    let uPlusCarry := u_i + carry_in
+private theorem addback_carries_exclusive (u_i v_i carryIn : Word)
+    (hci : carryIn.toNat ≤ 1) :
+    let uPlusCarry := u_i + carryIn
     let uNew := uPlusCarry + v_i
-    let ac1 := if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0
+    let ac1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
     let ac2 := if BitVec.ult uNew v_i then (1 : Word) else 0
     ac1.toNat + ac2.toNat ≤ 1 := by
   intro uPlusCarry uNew ac1 ac2
   -- Convert to Nat
-  have h_ac1 : ac1.toNat = (u_i.toNat + carry_in.toNat) / 2^64 := by
-    show (if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0).toNat = _
-    have hci_lt := carry_in.isLt; have hui := u_i.isLt
-    by_cases h : u_i.toNat + carry_in.toNat < 2^64
-    · have : uPlusCarry.toNat ≥ carry_in.toNat := by
-        show (u_i + carry_in).toNat ≥ _
+  have h_ac1 : ac1.toNat = (u_i.toNat + carryIn.toNat) / 2^64 := by
+    show (if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0).toNat = _
+    have hci_lt := carryIn.isLt; have hui := u_i.isLt
+    by_cases h : u_i.toNat + carryIn.toNat < 2^64
+    · have : uPlusCarry.toNat ≥ carryIn.toNat := by
+        show (u_i + carryIn).toNat ≥ _
         rw [BitVec.toNat_add, Nat.mod_eq_of_lt h]; omega
-      simp [BitVec.ult, show ¬(uPlusCarry.toNat < carry_in.toNat) from by omega]
+      simp [BitVec.ult, show ¬(uPlusCarry.toNat < carryIn.toNat) from by omega]
       exact (Nat.div_eq_of_lt h).symm
     · push Not at h
-      have : uPlusCarry.toNat < carry_in.toNat := by
-        show (u_i + carry_in).toNat < _
+      have : uPlusCarry.toNat < carryIn.toNat := by
+        show (u_i + carryIn).toNat < _
         rw [BitVec.toNat_add]; omega
       simp [BitVec.ult, this]
-      have : u_i.toNat + carry_in.toNat < 2 * 2^64 := by omega
+      have : u_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
       omega
   have h_ac2 : ac2.toNat = (uPlusCarry.toNat + v_i.toNat) / 2^64 := by
     show (if BitVec.ult uNew v_i then (1 : Word) else 0).toNat = _
@@ -90,14 +90,14 @@ private theorem addback_carries_exclusive (u_i v_i carry_in : Word)
       have : uPlusCarry.toNat + v_i.toNat < 2 * 2^64 := by omega
       omega
   rw [h_ac1, h_ac2]
-  -- Total: u_i + v_i + carry_in < 2 * 2^64 (since each < 2^64 and carry_in ≤ 1)
+  -- Total: u_i + v_i + carryIn < 2 * 2^64 (since each < 2^64 and carryIn ≤ 1)
   have hui := u_i.isLt; have hv := v_i.isLt
-  have htot : u_i.toNat + v_i.toNat + carry_in.toNat < 2 * 2^64 := by omega
+  have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
   -- c1 + c2 = (u_i + ci) / B + (upc + v) / B where upc = (u_i + ci) % B
-  have hupc : uPlusCarry.toNat = (u_i.toNat + carry_in.toNat) % 2^64 :=
-    BitVec.toNat_add u_i carry_in
+  have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
+    BitVec.toNat_add u_i carryIn
   -- Case split on c1
-  have hc1_01 := add_carry_01 u_i carry_in
+  have hc1_01 := add_carry_01 u_i carryIn
   rcases hc1_01 with hc1_0 | hc1_1
   · -- c1 = 0: no overflow in first add. Then c2 ≤ 1.
     rw [hc1_0]; simp
@@ -105,26 +105,26 @@ private theorem addback_carries_exclusive (u_i v_i carry_in : Word)
     rcases this with h | h <;> omega
   · -- c1 = 1: first add overflowed. upc is small. Second add can't overflow.
     rw [hc1_1]
-    have : uPlusCarry.toNat = u_i.toNat + carry_in.toNat - 2^64 := by rw [hupc]; omega
+    have : uPlusCarry.toNat = u_i.toNat + carryIn.toNat - 2^64 := by rw [hupc]; omega
     have : uPlusCarry.toNat + v_i.toNat < 2^64 := by omega
     have : (uPlusCarry.toNat + v_i.toNat) / 2^64 = 0 := Nat.div_eq_of_lt (by omega)
     omega
 
 /-- Per-limb addback Nat equation using the Word OR carry directly.
-    The two-step addition `(u_i + carry_in) + v_i` with OR carry propagation
+    The two-step addition `(u_i + carryIn) + v_i` with OR carry propagation
     satisfies the same Nat equation as standard add-with-carry. -/
-theorem addback_limb_nat_word_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat ≤ 1) :
-    let uPlusCarry := u_i + carry_in
+theorem addback_limb_nat_word_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat ≤ 1) :
+    let uPlusCarry := u_i + carryIn
     let uNew := uPlusCarry + v_i
-    let ac1 := if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0
+    let ac1 := if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0
     let ac2 := if BitVec.ult uNew v_i then (1 : Word) else 0
     let carryOut := ac1 ||| ac2
     carryOut.toNat ≤ 1 ∧
-    u_i.toNat + v_i.toNat + carry_in.toNat = carryOut.toNat * 2^64 + uNew.toNat := by
+    u_i.toNat + v_i.toNat + carryIn.toNat = carryOut.toNat * 2^64 + uNew.toNat := by
   intro uPlusCarry uNew ac1 ac2 carryOut
-  have h_excl := addback_carries_exclusive u_i v_i carry_in hci
+  have h_excl := addback_carries_exclusive u_i v_i carryIn hci
   have h_ac1_01 : ac1.toNat ≤ 1 := by
-    show (if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0).toNat ≤ 1
+    show (if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0).toNat ≤ 1
     split <;> simp_all
   have h_ac2_01 : ac2.toNat ≤ 1 := by
     show (if BitVec.ult uNew v_i then (1 : Word) else 0).toNat ≤ 1
@@ -137,22 +137,22 @@ theorem addback_limb_nat_word_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat
   · -- The addback equation: derive directly from two-step addition
     rw [show carryOut = ac1 ||| ac2 from rfl, h_or]
     -- Connect ac1, ac2 to division values
-    have h_ac1_div : ac1.toNat = (u_i.toNat + carry_in.toNat) / 2^64 := by
-      show (if BitVec.ult uPlusCarry carry_in then (1 : Word) else 0).toNat = _
-      have hci_lt := carry_in.isLt; have hui := u_i.isLt
-      by_cases h : u_i.toNat + carry_in.toNat < 2^64
-      · have : ¬(uPlusCarry.toNat < carry_in.toNat) := by
-          have : uPlusCarry.toNat = (u_i.toNat + carry_in.toNat) % 2^64 :=
-            BitVec.toNat_add u_i carry_in
+    have h_ac1_div : ac1.toNat = (u_i.toNat + carryIn.toNat) / 2^64 := by
+      show (if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0).toNat = _
+      have hci_lt := carryIn.isLt; have hui := u_i.isLt
+      by_cases h : u_i.toNat + carryIn.toNat < 2^64
+      · have : ¬(uPlusCarry.toNat < carryIn.toNat) := by
+          have : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
+            BitVec.toNat_add u_i carryIn
           rw [this, Nat.mod_eq_of_lt h]; omega
         simp [BitVec.ult, this]; exact (Nat.div_eq_of_lt h).symm
       · push Not at h
-        have : uPlusCarry.toNat < carry_in.toNat := by
-          have : uPlusCarry.toNat = (u_i.toNat + carry_in.toNat) % 2^64 :=
-            BitVec.toNat_add u_i carry_in
+        have : uPlusCarry.toNat < carryIn.toNat := by
+          have : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
+            BitVec.toNat_add u_i carryIn
           rw [this]; omega
         simp [BitVec.ult, this]
-        have : u_i.toNat + carry_in.toNat < 2 * 2^64 := by omega
+        have : u_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
         omega
     have h_ac2_div : ac2.toNat = (uPlusCarry.toNat + v_i.toNat) / 2^64 := by
       show (if BitVec.ult uNew v_i then (1 : Word) else 0).toNat = _
@@ -171,8 +171,8 @@ theorem addback_limb_nat_word_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat
         simp [BitVec.ult, this]
         have : uPlusCarry.toNat + v_i.toNat < 2 * 2^64 := by omega
         omega
-    -- Step 1: u_i + carry_in = div1 * 2^64 + uPlusCarry
-    have h1 := add_carry_nat u_i carry_in
+    -- Step 1: u_i + carryIn = div1 * 2^64 + uPlusCarry
+    have h1 := add_carry_nat u_i carryIn
     -- Step 2: uPlusCarry + v_i = div2 * 2^64 + uNew
     have h2 := add_carry_nat uPlusCarry v_i
     -- Combined with ac1 = div1, ac2 = div2:
@@ -190,25 +190,25 @@ theorem addback_limb_nat_word_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat
     The let-bindings match the addback path in the loop body. -/
 theorem addback_register_4limb_val256
     (v0 v1 v2 v3 un0 un1 un2 un3 : Word) :
-    -- Limb 0 (carry_in = 0)
+    -- Limb 0 (carryIn = 0)
     let upc0 := un0 + (0 : Word)
     let aun0 := upc0 + v0
     let ac1_0 := if BitVec.ult upc0 (0 : Word) then (1 : Word) else 0
     let ac2_0 := if BitVec.ult aun0 v0 then (1 : Word) else 0
     let co0 := ac1_0 ||| ac2_0
-    -- Limb 1 (carry_in = co0)
+    -- Limb 1 (carryIn = co0)
     let upc1 := un1 + co0
     let aun1 := upc1 + v1
     let ac1_1 := if BitVec.ult upc1 co0 then (1 : Word) else 0
     let ac2_1 := if BitVec.ult aun1 v1 then (1 : Word) else 0
     let co1 := ac1_1 ||| ac2_1
-    -- Limb 2 (carry_in = co1)
+    -- Limb 2 (carryIn = co1)
     let upc2 := un2 + co1
     let aun2 := upc2 + v2
     let ac1_2 := if BitVec.ult upc2 co1 then (1 : Word) else 0
     let ac2_2 := if BitVec.ult aun2 v2 then (1 : Word) else 0
     let co2 := ac1_2 ||| ac2_2
-    -- Limb 3 (carry_in = co2)
+    -- Limb 3 (carryIn = co2)
     let upc3 := un3 + co2
     let aun3 := upc3 + v3
     let ac1_3 := if BitVec.ult upc3 co2 then (1 : Word) else 0
@@ -226,7 +226,7 @@ theorem addback_register_4limb_val256
   have h1 := addback_limb_nat_word_eq un1 v1 co0 h0.1
   have h2 := addback_limb_nat_word_eq un2 v2 co1 h1.1
   have h3 := addback_limb_nat_word_eq un3 v3 co2 h2.1
-  -- Simplify h0: carry_in = 0
+  -- Simplify h0: carryIn = 0
   have h0' : un0.toNat + v0.toNat = co0.toNat * 2^64 + aun0.toNat := by
     have := h0.2; simp only [show (0 : Word).toNat = 0 from rfl] at this; linarith
   -- Chain via addback_4limb_val256

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
@@ -28,50 +28,50 @@ namespace EvmWord
 /-- Per-limb addback Nat-level equation.
 
     The addback_limb operation does a two-step addition:
-    - uPlusCarry = u_i + carry_in (with overflow detection)
+    - uPlusCarry = u_i + carryIn (with overflow detection)
     - uNew = uPlusCarry + v_i (with overflow detection)
-    - carry_out = carry1 ||| carry2
+    - carryOut = carry1 ||| carry2
 
     At the Nat level, this is simply:
-      u_i + v_i + carry_in = carry_nat * 2^64 + uNew
-    where carry_nat = (u_i + v_i + carry_in) / 2^64 ∈ {0, 1}.
+      u_i + v_i + carryIn = carry_nat * 2^64 + uNew
+    where carry_nat = (u_i + v_i + carryIn) / 2^64 ∈ {0, 1}.
 
     We state the equation at the Nat level without referencing the
-    register-level carry_out Word, since the carries are used only
+    register-level carryOut Word, since the carries are used only
     to propagate between limbs (and the 4-limb composition telescopes). -/
-theorem addback_limb_nat_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat ≤ 1) :
-    let uPlusCarry := u_i + carry_in
+theorem addback_limb_nat_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat ≤ 1) :
+    let uPlusCarry := u_i + carryIn
     let uNew := uPlusCarry + v_i
     ∃ (carry_nat : Nat), carry_nat ≤ 1 ∧
-      u_i.toNat + v_i.toNat + carry_in.toNat = carry_nat * 2^64 + uNew.toNat := by
+      u_i.toNat + v_i.toNat + carryIn.toNat = carry_nat * 2^64 + uNew.toNat := by
   intro uPlusCarry uNew
-  -- Step 1: u_i + carry_in = c1 * 2^64 + uPlusCarry
-  have h1 := add_carry_nat u_i carry_in
+  -- Step 1: u_i + carryIn = c1 * 2^64 + uPlusCarry
+  have h1 := add_carry_nat u_i carryIn
   -- Step 2: uPlusCarry + v_i = c2 * 2^64 + uNew
   have h2 := add_carry_nat uPlusCarry v_i
   -- Combined carry
-  set c1 := (u_i.toNat + carry_in.toNat) / 2^64
+  set c1 := (u_i.toNat + carryIn.toNat) / 2^64
   set c2 := (uPlusCarry.toNat + v_i.toNat) / 2^64
-  have hc1_01 := add_carry_01 u_i carry_in
+  have hc1_01 := add_carry_01 u_i carryIn
   have hc2_01 := add_carry_01 uPlusCarry v_i
-  -- Total: u_i + v_i + carry_in = (c1 + c2) * 2^64 + uNew
+  -- Total: u_i + v_i + carryIn = (c1 + c2) * 2^64 + uNew
   -- But c1 + c2 ≤ 1 (the two carries are exclusive)
   have hu := u_i.isLt; have hv := v_i.isLt
-  have htot : u_i.toNat + v_i.toNat + carry_in.toNat < 2 * 2^64 := by omega
-  have hupc : uPlusCarry.toNat = (u_i.toNat + carry_in.toNat) % 2^64 :=
-    BitVec.toNat_add u_i carry_in
+  have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
+  have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
+    BitVec.toNat_add u_i carryIn
   -- If c1 = 1 then uPlusCarry is small, so c2 = 0
   have hexcl : c1 + c2 ≤ 1 := by
     rcases hc1_01 with h | h <;> rcases hc2_01 with h' | h'
     · omega
     · omega
     · -- c1 = 1: uPlusCarry = u_i + ci - 2^64, which is small
-      have : uPlusCarry.toNat = u_i.toNat + carry_in.toNat - 2^64 := by rw [hupc]; omega
+      have : uPlusCarry.toNat = u_i.toNat + carryIn.toNat - 2^64 := by rw [hupc]; omega
       have : uPlusCarry.toNat + v_i.toNat < 2^64 := by omega
       have : c2 = 0 := Nat.div_eq_of_lt (by omega)
       omega
     · -- c1 = 1, c2 = 1: impossible since total < 2 * 2^64
-      have : uPlusCarry.toNat = u_i.toNat + carry_in.toNat - 2^64 := by rw [hupc]; omega
+      have : uPlusCarry.toNat = u_i.toNat + carryIn.toNat - 2^64 := by rw [hupc]; omega
       have : uPlusCarry.toNat + v_i.toNat < 2^64 := by omega
       omega
   refine ⟨c1 + c2, hexcl, ?_⟩
@@ -83,8 +83,8 @@ theorem addback_limb_nat_eq (u_i v_i carry_in : Word) (hci : carry_in.toNat ≤ 
 
 /-- 4-limb addback: adding the divisor back to the underflowed remainder.
     Given per-limb carry equations, the val256 result satisfies:
-      val256 u + val256 v = val256 uNew + carry_out * 2^256
-    where carry_out ∈ {0, 1}. -/
+      val256 u + val256 v = val256 uNew + carryOut * 2^256
+    where carryOut ∈ {0, 1}. -/
 theorem addback_4limb_val256
     (u0 u1 u2 u3 v0 v1 v2 v3 r0 r1 r2 r3 : Word)
     (c0 c1 c2 c3 : Nat)
@@ -96,7 +96,7 @@ theorem addback_4limb_val256
     val256 r0 r1 r2 r3 + c3 * 2^256 := by
   unfold val256; nlinarith
 
-/-- Addback with carry_in for limb 0 (the initial carry is from the mulsub borrow).
+/-- Addback with carryIn for limb 0 (the initial carry is from the mulsub borrow).
     When the mulsub borrow is 0, the addback carry chain starts with 0.
     This variant takes a general initial carry for the first limb. -/
 theorem addback_4limb_val256_with_carry
@@ -114,7 +114,7 @@ theorem addback_4limb_val256_with_carry
 -- End-to-end: mulsub underflow + addback → corrected Euclidean
 -- ============================================================================
 
-/-- When mulsub underflows (cb3 = 1) and addback produces carry_out = 1,
+/-- When mulsub underflows (cb3 = 1) and addback produces carryOut = 1,
     the corrected result satisfies the Euclidean property with quotient q-1.
 
     This combines:

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -46,29 +46,29 @@ private theorem prodLo_le_one_of_mulhu_max {q v_i : Word}
 /-- The per-limb mulsub carry is strictly less than 2^64.
 
     The carry is `borrowAdd + prodHi + borrowSub` where:
-    - borrowAdd ∈ {0, 1} (from prodLo + carry_in overflow)
+    - borrowAdd ∈ {0, 1} (from prodLo + carryIn overflow)
     - prodHi ≤ 2^64 - 2 (from MULHU bound)
     - borrowSub ∈ {0, 1} (from u_i < fullSub underflow)
 
     When prodHi ≤ 2^64 - 3: carry ≤ 1 + (2^64 - 3) + 1 = 2^64 - 1 < 2^64.
     When prodHi = 2^64 - 2: prodLo ≤ 1, and borrowAdd = 1 forces
     fullSub.toNat = 0 (modular wrap leaves 0), making borrowSub = 0. -/
-theorem mulsub_limb_carry_strict_lt (q v_i u_i carry_in : Word) :
+theorem mulsub_limb_carry_strict_lt (q v_i u_i carryIn : Word) :
     let prodLo := q * v_i
     let prodHi := rv64_mulhu q v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64 := by
   intro prodLo prodHi fullSub borrowAdd borrowSub
   have h_ph := mulhu_toNat_le q v_i
   -- Work with Nat-level values: ba_n, bs_n ∈ {0, 1}
-  set ba_n := if fullSub.toNat < carry_in.toNat then 1 else 0 with h_ba_def
+  set ba_n := if fullSub.toNat < carryIn.toNat then 1 else 0 with h_ba_def
   set bs_n := if u_i.toNat < fullSub.toNat then 1 else 0 with h_bs_def
   -- Convert borrowAdd/borrowSub toNat to ba_n/bs_n
   have h_ba : borrowAdd.toNat = ba_n := by
-    show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = ba_n
-    simp only [h_ba_def]; by_cases h : fullSub.toNat < carry_in.toNat <;> simp [BitVec.ult, h]
+    show (if BitVec.ult fullSub carryIn then (1 : Word) else 0).toNat = ba_n
+    simp only [h_ba_def]; by_cases h : fullSub.toNat < carryIn.toNat <;> simp [BitVec.ult, h]
   have h_bs : borrowSub.toNat = bs_n := by
     show (if BitVec.ult u_i fullSub then (1 : Word) else 0).toNat = bs_n
     simp only [h_bs_def]; by_cases h : u_i.toNat < fullSub.toNat <;> simp [BitVec.ult, h]
@@ -88,22 +88,22 @@ theorem mulsub_limb_carry_strict_lt (q v_i u_i carry_in : Word) :
   have h_plo : (q * v_i).toNat ≤ 1 := prodLo_le_one_of_mulhu_max h_ph_eq
   -- Suffices: ba_n + bs_n ≤ 1
   suffices ba_n + bs_n ≤ 1 by omega
-  have h_fs_val : fullSub.toNat = ((q * v_i).toNat + carry_in.toNat) % 2^64 :=
-    BitVec.toNat_add (q * v_i) carry_in
-  have h_ci := carry_in.isLt
+  have h_fs_val : fullSub.toNat = ((q * v_i).toNat + carryIn.toNat) % 2^64 :=
+    BitVec.toNat_add (q * v_i) carryIn
+  have h_ci := carryIn.isLt
   -- Case: ba_n = 0 → immediate
   by_cases h_ba_0 : ba_n = 0
   · omega
   -- Case: ba_n = 1 → overflow → fullSub = 0 → bs_n = 0
   have h_ba_1 : ba_n = 1 := by omega
-  -- ba_n = 1 means fullSub.toNat < carry_in.toNat
-  have h_ov : fullSub.toNat < carry_in.toNat := by
+  -- ba_n = 1 means fullSub.toNat < carryIn.toNat
+  have h_ov : fullSub.toNat < carryIn.toNat := by
     simp only [h_ba_def] at h_ba_1; split at h_ba_1 <;> [assumption; omega]
-  -- overflow: (q * v_i).toNat + carry_in.toNat ≥ 2^64
-  have h_overflow : (q * v_i).toNat + carry_in.toNat ≥ 2^64 := by
+  -- overflow: (q * v_i).toNat + carryIn.toNat ≥ 2^64
+  have h_overflow : (q * v_i).toNat + carryIn.toNat ≥ 2^64 := by
     by_contra h_no; push Not at h_no
     rw [h_fs_val, Nat.mod_eq_of_lt h_no] at h_ov; omega
-  -- (q * v_i).toNat = 1 and carry_in = 2^64 - 1
+  -- (q * v_i).toNat = 1 and carryIn = 2^64 - 1
   have h_plo_1 : (q * v_i).toNat = 1 := by omega
   -- fullSub = 0
   have h_fs_0 : fullSub.toNat = 0 := by rw [h_fs_val]; omega
@@ -121,39 +121,39 @@ theorem mulsub_limb_carry_strict_lt (q v_i u_i carry_in : Word) :
 
     This follows from `mulsub_limb_carry_strict_lt` (carry < 2^64 means
     the Word additions don't overflow) and `mulsub_carry_word_eq`. -/
-theorem mulsub_limb_word_carry_eq (q v_i u_i carry_in : Word) :
+theorem mulsub_limb_word_carry_eq (q v_i u_i carryIn : Word) :
     let prodLo := q * v_i
     let prodHi := rv64_mulhu q v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     ((borrowAdd + prodHi) + borrowSub).toNat =
       borrowAdd.toNat + prodHi.toNat + borrowSub.toNat := by
   intro prodLo prodHi fullSub borrowAdd borrowSub
   exact mulsub_carry_word_eq borrowAdd prodHi borrowSub
-    (mulsub_limb_carry_strict_lt q v_i u_i carry_in)
+    (mulsub_limb_carry_strict_lt q v_i u_i carryIn)
 
 -- ============================================================================
 -- Per-limb equation using Word carry directly
 -- ============================================================================
 
-/-- Per-limb mulsub Nat equation using the Word carry_out directly.
+/-- Per-limb mulsub Nat equation using the Word carryOut directly.
     Combines `mulsub_limb_nat_eq` and `mulsub_limb_word_carry_eq` so the
-    carry_out can be passed directly as carry_in to the next limb. -/
-theorem mulsub_limb_nat_word_eq (q v_i u_i carry_in : Word) :
+    carryOut can be passed directly as carryIn to the next limb. -/
+theorem mulsub_limb_nat_word_eq (q v_i u_i carryIn : Word) :
     let prodLo := q * v_i
     let prodHi := rv64_mulhu q v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
-    let u_new := u_i - fullSub
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
+    let uNew := u_i - fullSub
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
-    let carry_out := (borrowAdd + prodHi) + borrowSub
-    u_i.toNat + carry_out.toNat * 2^64 =
-      u_new.toNat + q.toNat * v_i.toNat + carry_in.toNat := by
-  intro prodLo prodHi fullSub borrowAdd u_new borrowSub carry_out
-  rw [show carry_out = (borrowAdd + prodHi) + borrowSub from rfl,
-      mulsub_limb_word_carry_eq q v_i u_i carry_in]
-  exact mulsub_limb_nat_eq q v_i u_i carry_in
+    let carryOut := (borrowAdd + prodHi) + borrowSub
+    u_i.toNat + carryOut.toNat * 2^64 =
+      uNew.toNat + q.toNat * v_i.toNat + carryIn.toNat := by
+  intro prodLo prodHi fullSub borrowAdd uNew borrowSub carryOut
+  rw [show carryOut = (borrowAdd + prodHi) + borrowSub from rfl,
+      mulsub_limb_word_carry_eq q v_i u_i carryIn]
+  exact mulsub_limb_nat_eq q v_i u_i carryIn
 
 -- ============================================================================
 -- 4-limb composition: register ops → val256 equation
@@ -164,30 +164,30 @@ theorem mulsub_limb_nat_word_eq (q v_i u_i carry_in : Word) :
     This connects the exact register-level computation from `divK_mulsub_full_spec`
     to the mathematical Euclidean equation. The let-bindings match those in the
     mulsub loop body: for each limb i, compute prodLo/hi, fullSub, borrows,
-    updated u_new, and carry_out.
+    updated uNew, and carryOut.
 
     The initial carry is 0 (first limb). Each subsequent limb uses the
     Word carry from the previous limb. -/
 theorem mulsub_register_4limb_val256 (q v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
-    -- Limb 0 (carry_in = 0)
+    -- Limb 0 (carryIn = 0)
     let fs0 := q * v0 + (0 : Word)
     let ba0 := if BitVec.ult fs0 (0 : Word) then (1 : Word) else 0
     let un0 := u0 - fs0
     let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
     let c0 := (ba0 + rv64_mulhu q v0) + bs0
-    -- Limb 1 (carry_in = c0)
+    -- Limb 1 (carryIn = c0)
     let fs1 := q * v1 + c0
     let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
     let un1 := u1 - fs1
     let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
     let c1 := (ba1 + rv64_mulhu q v1) + bs1
-    -- Limb 2 (carry_in = c1)
+    -- Limb 2 (carryIn = c1)
     let fs2 := q * v2 + c1
     let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
     let un2 := u2 - fs2
     let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
     let c2 := (ba2 + rv64_mulhu q v2) + bs2
-    -- Limb 3 (carry_in = c2)
+    -- Limb 3 (carryIn = c2)
     let fs3 := q * v3 + c2
     let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
     let un3 := u3 - fs3
@@ -205,7 +205,7 @@ theorem mulsub_register_4limb_val256 (q v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
   have h1 := mulsub_limb_nat_word_eq q v1 u1 c0
   have h2 := mulsub_limb_nat_word_eq q v2 u2 c1
   have h3 := mulsub_limb_nat_word_eq q v3 u3 c2
-  -- Simplify h0: carry_in = 0, so (0 : Word).toNat = 0
+  -- Simplify h0: carryIn = 0, so (0 : Word).toNat = 0
   have h0' : u0.toNat + c0.toNat * 2^64 = un0.toNat + q.toNat * v0.toNat := by
     have := h0; simp only [show (0 : Word).toNat = 0 from rfl] at this; linarith
   -- Chain via mulsub_chain_nat

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -47,46 +47,46 @@ theorem mulhu_toNat_le (a b : Word) : (rv64_mulhu a b).toNat ≤ 2^64 - 2 := by
 
     The mulsub_limb operation computes:
     - prodLo = MUL(q, v_i), prodHi = MULHU(q, v_i)
-    - fullSub = ADD(prodLo, carry_in), borrowAdd = SLTU(fullSub, carry_in)
+    - fullSub = ADD(prodLo, carryIn), borrowAdd = SLTU(fullSub, carryIn)
     - uNew = SUB(u_i, fullSub), borrowSub = SLTU(u_i, fullSub)
 
     At the Nat level, this produces:
-      u_i + C * 2^64 = uNew + q * v_i + carry_in
+      u_i + C * 2^64 = uNew + q * v_i + carryIn
     where C = borrowAdd + prodHi + borrowSub (Nat sum).
 
     This is exactly the per-limb equation needed by `mulsub_chain_nat`. -/
-theorem mulsub_limb_nat_eq (q v_i u_i carry_in : Word) :
+theorem mulsub_limb_nat_eq (q v_i u_i carryIn : Word) :
     let prodLo := q * v_i
     let prodHi := rv64_mulhu q v_i
-    let fullSub := prodLo + carry_in
-    let borrowAdd := if BitVec.ult fullSub carry_in then (1 : Word) else 0
+    let fullSub := prodLo + carryIn
+    let borrowAdd := if BitVec.ult fullSub carryIn then (1 : Word) else 0
     let uNew := u_i - fullSub
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     u_i.toNat + (borrowAdd.toNat + prodHi.toNat + borrowSub.toNat) * 2^64 =
-      uNew.toNat + q.toNat * v_i.toNat + carry_in.toNat := by
+      uNew.toNat + q.toNat * v_i.toNat + carryIn.toNat := by
   intro prodLo prodHi fullSub borrowAdd uNew borrowSub
   -- Full product: q * v_i = prodHi * 2^64 + prodLo
   have h_prod := partial_product_decompose q v_i
-  -- fullSub = (prodLo + carry_in) mod 2^64
-  have h_fs : fullSub.toNat = (prodLo.toNat + carry_in.toNat) % 2^64 :=
-    BitVec.toNat_add prodLo carry_in
-  -- borrowAdd = (prodLo + carry_in) / 2^64 (is 0 or 1)
-  have h_ba : borrowAdd.toNat = (prodLo.toNat + carry_in.toNat) / 2^64 := by
-    have hpl := prodLo.isLt; have hci := carry_in.isLt
-    by_cases hov : prodLo.toNat + carry_in.toNat < 2^64
+  -- fullSub = (prodLo + carryIn) mod 2^64
+  have h_fs : fullSub.toNat = (prodLo.toNat + carryIn.toNat) % 2^64 :=
+    BitVec.toNat_add prodLo carryIn
+  -- borrowAdd = (prodLo + carryIn) / 2^64 (is 0 or 1)
+  have h_ba : borrowAdd.toNat = (prodLo.toNat + carryIn.toNat) / 2^64 := by
+    have hpl := prodLo.isLt; have hci := carryIn.isLt
+    by_cases hov : prodLo.toNat + carryIn.toNat < 2^64
     · -- no overflow
-      have hge : fullSub.toNat ≥ carry_in.toNat := by rw [h_fs, Nat.mod_eq_of_lt hov]; omega
-      show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = _
-      have : ¬(fullSub.toNat < carry_in.toNat) := by omega
+      have hge : fullSub.toNat ≥ carryIn.toNat := by rw [h_fs, Nat.mod_eq_of_lt hov]; omega
+      show (if BitVec.ult fullSub carryIn then (1 : Word) else 0).toNat = _
+      have : ¬(fullSub.toNat < carryIn.toNat) := by omega
       simp [BitVec.ult, this]
       show 0 = _; omega
     · -- overflow
       push Not at hov
-      have hlt : fullSub.toNat < carry_in.toNat := by rw [h_fs]; omega
-      show (if BitVec.ult fullSub carry_in then (1 : Word) else 0).toNat = _
+      have hlt : fullSub.toNat < carryIn.toNat := by rw [h_fs]; omega
+      show (if BitVec.ult fullSub carryIn then (1 : Word) else 0).toNat = _
       simp [BitVec.ult, hlt]
       show 1 = _
-      have : prodLo.toNat + carry_in.toNat < 2 * 2^64 := by omega
+      have : prodLo.toNat + carryIn.toNat < 2 * 2^64 := by omega
       omega
   -- borrowSub = if u_i < fullSub then 1 else 0
   have h_bs : borrowSub.toNat = if u_i.toNat < fullSub.toNat then 1 else 0 := by
@@ -104,37 +104,37 @@ theorem mulsub_limb_nat_eq (q v_i u_i carry_in : Word) :
     · simp [h]; omega
     · push Not at h; simp [show ¬(fullSub.toNat ≤ u_i.toNat) from by omega]; omega
   -- div_add_mod for the add carry
-  have hdm := Nat.div_add_mod (prodLo.toNat + carry_in.toNat) (2^64)
+  have hdm := Nat.div_add_mod (prodLo.toNat + carryIn.toNat) (2^64)
   -- Combine: normalize 2^64 to the literal everywhere
   have hB : (2:Nat)^64 = 18446744073709551616 := by norm_num
   -- Use B as shorthand for 2^64 literal
   set B := (18446744073709551616 : Nat) with hBdef
   rw [show (2:Nat)^64 = B from by omega] at h_ba h_fs h_prod hdm hu hfs h_un ⊢
-  -- Key: from hdm, (prodLo + carry_in) / B * B + fullSub = prodLo + carry_in
-  have hkey : (prodLo.toNat + carry_in.toNat) / B * B =
-      prodLo.toNat + carry_in.toNat - fullSub.toNat := by
+  -- Key: from hdm, (prodLo + carryIn) / B * B + fullSub = prodLo + carryIn
+  have hkey : (prodLo.toNat + carryIn.toNat) / B * B =
+      prodLo.toNat + carryIn.toNat - fullSub.toNat := by
     rw [h_fs]; omega
   -- Key: prodHi * B + prodLo = q * v_i
   -- (prodHi and prodLo are let-defs for rv64_mulhu and MUL, so this is h_prod rewritten)
   have h_prod' : prodHi.toNat * B + prodLo.toNat = q.toNat * v_i.toNat := by
     show (rv64_mulhu q v_i).toNat * B + (q * v_i).toNat = _; linarith
   -- Expand the compound carry multiplication
-  have hfs_le : fullSub.toNat ≤ prodLo.toNat + carry_in.toNat := by
+  have hfs_le : fullSub.toNat ≤ prodLo.toNat + carryIn.toNat := by
     rw [h_fs]; exact Nat.mod_le _ _
   have hpl_le : prodLo.toNat ≤ prodHi.toNat * B + prodLo.toNat := Nat.le_add_left _ _
   rw [h_ba, h_bs, h_un]
   -- Eliminate the nonlinear q*v_i term by replacing with prodHi*B + prodLo (linear!)
   rw [show q.toNat * v_i.toNat = prodHi.toNat * B + prodLo.toNat from h_prod'.symm]
-  -- Now everything is linear in div, prodHi, B, prodLo, carry_in, fullSub, u_i
+  -- Now everything is linear in div, prodHi, B, prodLo, carryIn, fullSub, u_i
   by_cases hcmp : fullSub.toNat ≤ u_i.toNat
   · simp only [hcmp, show ¬(u_i.toNat < fullSub.toNat) from by omega, ite_true, ite_false]
-    have h1 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B) prodHi.toNat B
+    have h1 := Nat.add_mul ((prodLo.toNat + carryIn.toNat) / B) prodHi.toNat B
     omega
   · push Not at hcmp
     simp only [show ¬(fullSub.toNat ≤ u_i.toNat) from by omega,
       show u_i.toNat < fullSub.toNat from by omega, ite_false, ite_true]
-    have h1 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B) prodHi.toNat B
-    have h2 := Nat.add_mul ((prodLo.toNat + carry_in.toNat) / B + prodHi.toNat) 1 B
+    have h1 := Nat.add_mul ((prodLo.toNat + carryIn.toNat) / B) prodHi.toNat B
+    have h2 := Nat.add_mul ((prodLo.toNat + carryIn.toNat) / B + prodHi.toNat) 1 B
     omega
 
 -- ============================================================================
@@ -149,13 +149,13 @@ theorem mulsub_limb_carry_le (q v_i : Word)
     borrowAdd_nat + (rv64_mulhu q v_i).toNat + borrowSub_nat ≤ 2^64 := by
   have := mulhu_toNat_le q v_i; omega
 
-/-- When carry_in + prodLo doesn't overflow, the add-borrow is 0. -/
-theorem borrowAdd_eq_zero_of_no_overflow (q v_i carry_in : Word)
-    (h : (q * v_i).toNat + carry_in.toNat < 2^64) :
-    (if BitVec.ult (q * v_i + carry_in) carry_in then (1 : Word) else 0) = 0 := by
-  have hge : (q * v_i + carry_in).toNat ≥ carry_in.toNat := by
+/-- When carryIn + prodLo doesn't overflow, the add-borrow is 0. -/
+theorem borrowAdd_eq_zero_of_no_overflow (q v_i carryIn : Word)
+    (h : (q * v_i).toNat + carryIn.toNat < 2^64) :
+    (if BitVec.ult (q * v_i + carryIn) carryIn then (1 : Word) else 0) = 0 := by
+  have hge : (q * v_i + carryIn).toNat ≥ carryIn.toNat := by
     rw [BitVec.toNat_add, Nat.mod_eq_of_lt (by omega)]; omega
-  simp only [BitVec.ult, show ¬((q * v_i + carry_in).toNat < carry_in.toNat) from by omega,
+  simp only [BitVec.ult, show ¬((q * v_i + carryIn).toNat < carryIn.toNat) from by omega,
     decide_false]
   decide
 
@@ -173,8 +173,8 @@ theorem mulsub_limb_carry_lt_of_sum_le_one (q v_i : Word)
   have := mulhu_toNat_le q v_i; omega
 
 /-- When the carry is < 2^64, the Word-level carry equals the Nat-level carry.
-    This ensures the register-level carry_out correctly tracks the Nat-level
-    carry for use as the next limb's carry_in. -/
+    This ensures the register-level carryOut correctly tracks the Nat-level
+    carry for use as the next limb's carryIn. -/
 theorem mulsub_carry_word_eq (borrowAdd prodHi borrowSub : Word)
     (h : borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64) :
     ((borrowAdd + prodHi) + borrowSub).toNat =


### PR DESCRIPTION
## Summary
Renames 3 commonly-used snake_case identifiers to lowerCamelCase:
- \`carry_in\` → \`carryIn\`
- \`carry_out\` → \`carryOut\`
- \`u_new\` → \`uNew\`

21 files, 260 occurrences. Callers all positional.

\`u_i\` / \`v_i\` intentionally left alone — the \`_i\` index suffix is standard math notation and \`uI\`/\`vI\` read awkwardly.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)