### PR TITLE
refactor(rlp): rename byte_zext/k_val let-bindings to camelCase (#189)

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -28,7 +28,7 @@
     * `rlp_phase1_classifier_prog` — the full 8-instruction classifier
     * `rlp_phase1_step_code` — the matching `CodeReq`
     * `rlp_phase1_step_spec` — `cpsBranch` spec preserving the dispatch fact
-      (`BitVec.ult v5 k_val` on the taken side, `¬…` on the fall-through).
+      (`BitVec.ult v5 kVal` on the taken side, `¬…` on the fall-through).
 -/
 
 import EvmAsm.Rv64.SyscallSpecs
@@ -79,27 +79,27 @@ abbrev rlp_phase1_step_code
 
 /-- `cpsBranch` spec for one cascade step.
 
-    Taken (`x5 <u k_val`):     PC := target           (BLTU took the branch)
-    Not taken (`¬ x5 <u k_val`): PC := base + 8       (fell through)
+    Taken (`x5 <u kVal`):     PC := target           (BLTU took the branch)
+    Not taken (`¬ x5 <u kVal`): PC := base + 8       (fell through)
 
     Both postconditions preserve `⌜…⌝` so downstream compositions can case
-    on the dispatch result. `k_val = (0 : Word) + signExtend12 k` matches
+    on the dispatch result. `kVal = (0 : Word) + signExtend12 k` matches
     the result of `ADDI x10, x0, k` starting from `x0 = 0`. For the RLP
-    thresholds (0x80, 0xB8, 0xC0, 0xF8), `k_val.toNat = k.toNat` since all
+    thresholds (0x80, 0xB8, 0xC0, 0xF8), `kVal.toNat = k.toNat` since all
     four fit in 11 bits (no sign extension). -/
 theorem rlp_phase1_step_spec (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := rlp_phase1_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       target
-        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
-         ⌜BitVec.ult v5 k_val⌝)
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) **
+         ⌜BitVec.ult v5 kVal⌝)
       (base + 8)
-        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
-         ⌜¬ BitVec.ult v5 k_val⌝) := by
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) **
+         ⌜¬ BitVec.ult v5 kVal⌝) := by
   have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
@@ -146,12 +146,12 @@ theorem rlp_phase1_step_spec (v5 v10 : Word)
 theorem rlp_phase1_step_spec_plain (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := rlp_phase1_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
-      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val))
-      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)) :=
+      target ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal))
+      (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal)) :=
   cpsBranch_weaken
     (fun _ hp => hp)
     (sepConj_strip_pure_end3 _ _ _ _)
@@ -224,8 +224,8 @@ private theorem step_code_Disjoint_24 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13
     Postconditions with `let` Bindings"). -/
 @[irreducible]
 def rlp_phase1_exit_post (v5 : Word) (k : BitVec 12) : Assertion :=
-  let k_val := (0 : Word) + signExtend12 k
-  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val)
+  let kVal := (0 : Word) + signExtend12 k
+  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal)
 
 /-- Unfold lemma for `rlp_phase1_exit_post`. Use when a consumer needs the
     explicit register-ownership form. -/
@@ -351,14 +351,14 @@ theorem rlp_phase1_classifier_spec (v5 v10 : Word) (base : Word)
 -- ============================================================================
 
 /-- Bundled exit postcondition with a dispatch fact: the register-ownership
-    triple (`x10 ↦ᵣ k_val`) conjoined with `⌜fact⌝`. Wrapped `@[irreducible]`
+    triple (`x10 ↦ᵣ kVal`) conjoined with `⌜fact⌝`. Wrapped `@[irreducible]`
     to keep `let` bindings out of the classifier theorem statement — see
     AGENTS.md ("Bundling Postconditions with `let` Bindings"). -/
 @[irreducible]
 def rlp_phase1_exit_post_pure
     (v5 : Word) (k : BitVec 12) (fact : Prop) : Assertion :=
-  let k_val := (0 : Word) + signExtend12 k
-  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜fact⌝
+  let kVal := (0 : Word) + signExtend12 k
+  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜fact⌝
 
 /-- Unfold lemma for `rlp_phase1_exit_post_pure`. -/
 theorem rlp_phase1_exit_post_pure_unfold
@@ -491,16 +491,16 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
 theorem rlp_phase1_step_spec_acc (Acc : Prop) (v5 v10 : Word)
     (k : BitVec 12) (offset : BitVec 13) (base target : Word)
     (htarget : (base + 4) + signExtend13 offset = target) :
-    let k_val := (0 : Word) + signExtend12 k
+    let kVal := (0 : Word) + signExtend12 k
     let code := rlp_phase1_step_code k offset base
     cpsBranch base code
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) ** ⌜Acc⌝)
       target
-        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
-         ⌜Acc ∧ BitVec.ult v5 k_val⌝)
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) **
+         ⌜Acc ∧ BitVec.ult v5 kVal⌝)
       (base + 8)
-        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) **
-         ⌜Acc ∧ ¬ BitVec.ult v5 k_val⌝) := by
+        ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) **
+         ⌜Acc ∧ ¬ BitVec.ult v5 kVal⌝) := by
   have h := rlp_phase1_step_spec v5 v10 k offset base target htarget
   -- Frame `rlp_phase1_step_spec` with `⌜Acc⌝` on the right.
   have hf := cpsBranch_frame_left base _ _ target _ (base + 8) _
@@ -517,8 +517,8 @@ theorem rlp_phase1_step_spec_acc (Acc : Prop) (v5 v10 : Word)
 @[irreducible]
 def rlp_phase1_exit_post_acc
     (v5 : Word) (k : BitVec 12) (Acc : Prop) : Assertion :=
-  let k_val := (0 : Word) + signExtend12 k
-  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ k_val) ** ⌜Acc⌝
+  let kVal := (0 : Word) + signExtend12 k
+  (.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal) ** ⌜Acc⌝
 
 /-- Unfold lemma for `rlp_phase1_exit_post_acc`. -/
 theorem rlp_phase1_exit_post_acc_unfold

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -56,20 +56,20 @@ example : rlp_phase2_long_iter_prog.length = 5 := rfl
     unchanged. -/
 @[irreducible]
 def rlp_phase2_long_iter_post
-    (len ptr cnt byte_zext word_val dwordAddr : Word) : Assertion :=
-  let length' := (len <<< 8) + byte_zext
+    (len ptr cnt byteZext word_val dwordAddr : Word) : Assertion :=
+  let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   let cnt'    := cnt + signExtend12 (-1 : BitVec 12)
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ cnt') **
-    (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)
+    (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)
 
 theorem rlp_phase2_long_iter_post_unfold
-    (len ptr cnt byte_zext word_val dwordAddr : Word) :
-    rlp_phase2_long_iter_post len ptr cnt byte_zext word_val dwordAddr =
-    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+    (len ptr cnt byteZext word_val dwordAddr : Word) :
+    rlp_phase2_long_iter_post len ptr cnt byteZext word_val dwordAddr =
+    ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
-     (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) := by
+     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) := by
   delta rlp_phase2_long_iter_post; rfl
 
 -- ============================================================================
@@ -116,12 +116,12 @@ theorem rlp_phase2_long_iter_spec
     (len ptr cnt v12_old word_val dwordAddr : Word) (base : Word)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 20)
       (CodeReq.ofProg base rlp_phase2_long_iter_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_iter_post len ptr cnt byte_zext word_val dwordAddr) := by
+      (rlp_phase2_long_iter_post len ptr cnt byteZext word_val dwordAddr) := by
   simp only [rlp_phase2_long_iter_post_unfold]
   rw [iter_code_split]
   -- Helpers: `signExtend12 1 = 1` and `signExtend12 0 = 0`.
@@ -131,7 +131,7 @@ theorem rlp_phase2_long_iter_spec
   -- Distinct-addresses plumbing.
   obtain ⟨h01, h02, h03, h04, h12, h13, h14, h23, h24, h34⟩ :=
     iter_addrs_distinct base
-  set byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
   -- Step 1: LBU x12, x13, 0.
   have halign0 : alignToDword (ptr + signExtend12 (0 : BitVec 12)) = dwordAddr := by
     rw [h_se0]; simpa using halign
@@ -146,7 +146,7 @@ theorem rlp_phase2_long_iter_spec
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at slli_raw
   rw [h_shamt] at slli_raw
   -- Step 3: ADD x11, x11, x12.
-  have add_raw := add_spec_gen_rd_eq_rs1 .x11 .x12 (len <<< 8) byte_zext
+  have add_raw := add_spec_gen_rd_eq_rs1 .x11 .x12 (len <<< 8) byteZext
     (base + 8) (by nofun)
   rw [show (base + 8 : Word) + 4 = base + 12 from by bv_omega] at add_raw
   -- Step 4: ADDI x13, x13, 1.
@@ -170,7 +170,7 @@ theorem rlp_phase2_long_iter_spec
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (dwordAddr ↦ₘ word_val))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
@@ -179,21 +179,21 @@ theorem rlp_phase2_long_iter_spec
   have s2 : cpsTriple (base + 4) (base + 8)
       (CodeReq.singleton (base + 4) (.SLLI .x11 .x11 8))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val))
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
       ((.x11 ↦ᵣ (len <<< 8)) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
-        ((.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byte_zext) **
+        ((.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
          (dwordAddr ↦ₘ word_val)) (by pcFree) slli_raw)
   -- Step 3 (ADD x11 x11 x12) — uses (x11, x12); frames (x13, x14, mem).
   have s3 : cpsTriple (base + 8) (base + 12)
       (CodeReq.singleton (base + 8) (.ADD .x11 .x11 .x12))
       ((.x11 ↦ᵣ (len <<< 8)) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
-       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byte_zext) **
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
+       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
@@ -203,32 +203,32 @@ theorem rlp_phase2_long_iter_spec
   -- Step 4 (ADDI x13 x13 1) — mutates x13; frames the rest.
   have s4 : cpsTriple (base + 12) (base + 16)
       (CodeReq.singleton (base + 12) (.ADDI .x13 .x13 1))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
-       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byte_zext) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
+       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ (ptr + 1)) **
-       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byte_zext) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
+       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
-        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x14 ↦ᵣ cnt) **
-         (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val))
+        ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x14 ↦ᵣ cnt) **
+         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
         (by pcFree) addi_ptr_raw)
   -- Step 5 (ADDI x14 x14 -1) — mutates x14; frames the rest.
   have s5 : cpsTriple (base + 16) (base + 20)
       (CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1)))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ (ptr + 1)) **
-       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byte_zext) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
+       (.x14 ↦ᵣ cnt) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ (ptr + 1)) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
        (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) :=
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
     frame_and_perm
       (fun h hp => by xperm_hyp hp) (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
-        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ (ptr + 1)) **
-         (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val))
+        ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ (ptr + 1)) **
+         (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val))
         (by pcFree) addi_cnt_raw)
   -- Disjointness builders for the union chain produced by `cpsTriple_seq`.
   have hd5 : CodeReq.Disjoint

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -43,24 +43,24 @@ example : rlp_phase2_long_load_acc_prog.length = 3 := rfl
 -- Spec
 -- ============================================================================
 
-/-- Bundled post: `x11` holds `(len <<< 8) + byte_zext`, `x12` holds the
+/-- Bundled post: `x11` holds `(len <<< 8) + byteZext`, `x12` holds the
     loaded byte (zero-extended to 64 bits), `x13` and memory are unchanged.
 
-    `byte_zext` is parametric — the caller supplies the concrete byte
+    `byteZext` is parametric — the caller supplies the concrete byte
     value extracted from the containing doubleword. Wrapped
     `@[irreducible]` to keep the let-bindings out of the theorem statement. -/
 @[irreducible]
 def rlp_phase2_long_load_acc_post
-    (len ptr byte_zext word_val dwordAddr : Word) : Assertion :=
-  let length' := (len <<< 8) + byte_zext
-  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+    (len ptr byteZext word_val dwordAddr : Word) : Assertion :=
+  let length' := (len <<< 8) + byteZext
+  (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
     (dwordAddr ↦ₘ word_val)
 
 theorem rlp_phase2_long_load_acc_post_unfold
-    (len ptr byte_zext word_val dwordAddr : Word) :
-    rlp_phase2_long_load_acc_post len ptr byte_zext word_val dwordAddr =
-    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
-     (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) := by
+    (len ptr byteZext word_val dwordAddr : Word) :
+    rlp_phase2_long_load_acc_post len ptr byteZext word_val dwordAddr =
+    ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
+     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) := by
   delta rlp_phase2_long_load_acc_post; rfl
 
 /-- `cpsTriple` spec for the load-and-accumulate step.
@@ -73,12 +73,12 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word
     (base : Word)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 12)
       (CodeReq.ofProg base rlp_phase2_long_load_acc_prog)
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
        (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_load_acc_post len ptr byte_zext word_val dwordAddr) := by
+      (rlp_phase2_long_load_acc_post len ptr byteZext word_val dwordAddr) := by
   simp only [rlp_phase2_long_load_acc_post_unfold]
   -- Reshape the top-level CodeReq: `ofProg base (LBU :: acc_prog)` unfolds
   -- to `singleton base LBU ∪ ofProg (base + 4) acc_prog`.
@@ -108,27 +108,27 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12_old word_val dwordAddr : Word
     (by nofun) halign' hvalid'
   rw [hptr_eq] at lbu
   -- Frame LBU with `x11 ↦ᵣ len` and permute to match the sequence shape.
-  let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
   have lbu_framed : cpsTriple base (base + 4)
       (CodeReq.singleton base (.LBU .x12 .x13 0))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ v12_old) **
        (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR (.x11 ↦ᵣ len) (by pcFree) lbu)
   -- Step 2: accumulation step at `base + 4`. Frame with `x13` and memory.
-  have acc := rlp_phase2_long_acc_spec len byte_zext (base + 4)
+  have acc := rlp_phase2_long_acc_spec len byteZext (base + 4)
   simp only [rlp_phase2_long_acc_post_unfold] at acc
   rw [show (base + 4 : Word) + 8 = base + 12 from by bv_omega] at acc
   have acc_framed : cpsTriple (base + 4) (base + 12)
       (CodeReq.ofProg (base + 4) rlp_phase2_long_acc_prog)
-      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byte_zext) **
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x12 ↦ᵣ byteZext) **
        (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) ** (.x13 ↦ᵣ ptr) **
-       (.x12 ↦ᵣ byte_zext) ** (dwordAddr ↦ₘ word_val)) :=
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) ** (.x13 ↦ᵣ ptr) **
+       (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ word_val)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -55,21 +55,21 @@ example (back : BitVec 13) :
     fall-through exit). -/
 @[irreducible]
 def rlp_phase2_long_loop_body_post
-    (len ptr cnt byte_zext word_val dwordAddr : Word) (P : Prop) : Assertion :=
-  let length' := (len <<< 8) + byte_zext
+    (len ptr cnt byteZext word_val dwordAddr : Word) (P : Prop) : Assertion :=
+  let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   let cnt'    := cnt + signExtend12 (-1 : BitVec 12)
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ cnt') **
-    (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
     (dwordAddr ↦ₘ word_val) ** ⌜P⌝
 
 theorem rlp_phase2_long_loop_body_post_unfold
-    (len ptr cnt byte_zext word_val dwordAddr : Word) (P : Prop) :
-    rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val dwordAddr P =
-    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+    (len ptr cnt byteZext word_val dwordAddr : Word) (P : Prop) :
+    rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val dwordAddr P =
+    ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (cnt + signExtend12 (-1 : BitVec 12))) **
-     (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
      (dwordAddr ↦ₘ word_val) ** ⌜P⌝) := by
   delta rlp_phase2_long_loop_body_post; rfl
 
@@ -84,17 +84,17 @@ theorem rlp_phase2_long_loop_body_spec
     (base : Word) (back : BitVec 13)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
     let cnt'      := cnt + signExtend12 (-1 : BitVec 12)
     cpsBranch base (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (dwordAddr ↦ₘ word_val))
       ((base + 20) + signExtend13 back)
-        (rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val
+        (rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val
            dwordAddr (cnt' ≠ 0))
       (base + 24)
-        (rlp_phase2_long_loop_body_post len ptr cnt byte_zext word_val
+        (rlp_phase2_long_loop_body_post len ptr cnt byteZext word_val
            dwordAddr (cnt' = 0)) := by
   -- The loop-body `ofProg` splits as `ofProg base iter_prog ∪ ofProg (base+20) [BNE]`
   -- via `ofProg_append`; the tail is one singleton plus an `empty`.
@@ -134,7 +134,7 @@ theorem rlp_phase2_long_loop_body_spec
   have iter := rlp_phase2_long_iter_spec len ptr cnt v12_old word_val dwordAddr
     base halign hvalid
   simp only [rlp_phase2_long_iter_post_unfold] at iter
-  set byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
   set cnt' := cnt + signExtend12 (-1 : BitVec 12)
   -- Frame iter with (.x0 ↦ᵣ 0) so the composition state matches bne's.
   have iter' : cpsTriple base (base + 20)
@@ -142,9 +142,9 @@ theorem rlp_phase2_long_loop_body_spec
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ cnt) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (dwordAddr ↦ₘ word_val))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
        (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
-       (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
        (dwordAddr ↦ₘ word_val)) :=
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
@@ -156,19 +156,19 @@ theorem rlp_phase2_long_loop_body_spec
   -- permute to the shape produced by `iter'`'s post.
   have bne_framed : cpsBranch (base + 20)
       (CodeReq.singleton (base + 20) (.BNE .x14 .x0 back))
-      ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+      ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
        (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
-       (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
        (dwordAddr ↦ₘ word_val))
       ((base + 20) + signExtend13 back)
-        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+        ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
-         (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+         (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
          (dwordAddr ↦ₘ word_val) ** ⌜cnt' ≠ 0⌝)
       (base + 24)
-        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+        ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
          (.x13 ↦ᵣ (ptr + 1)) ** (.x14 ↦ᵣ cnt') **
-         (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+         (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
          (dwordAddr ↦ₘ word_val) ** ⌜cnt' = 0⌝) := by
     have h_eq_20_4 : (base + 20 : Word) + 4 = base + 24 := by bv_omega
     rw [h_eq_20_4] at bne_raw
@@ -177,8 +177,8 @@ theorem rlp_phase2_long_loop_body_spec
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsBranch_frameR
-        ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
-         (.x13 ↦ᵣ (ptr + 1)) ** (.x12 ↦ᵣ byte_zext) **
+        ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
+         (.x13 ↦ᵣ (ptr + 1)) ** (.x12 ↦ᵣ byteZext) **
          (dwordAddr ↦ₘ word_val)) (by pcFree) bne_raw)
   -- Disjointness between iter CR and BNE-singleton-union-empty CR.
   have hd_iter_bne : (CodeReq.ofProg base rlp_phase2_long_iter_prog).Disjoint

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -34,20 +34,20 @@ open EvmAsm.Rv64
     fact is needed (the caller knows we exited via fall-through). -/
 @[irreducible]
 def rlp_phase2_long_loop_one_byte_post
-    (len ptr byte_zext word_val dwordAddr : Word) : Assertion :=
-  let length' := (len <<< 8) + byte_zext
+    (len ptr byteZext word_val dwordAddr : Word) : Assertion :=
+  let length' := (len <<< 8) + byteZext
   let ptr'    := ptr + 1
   (.x11 ↦ᵣ length') ** (.x13 ↦ᵣ ptr') ** (.x14 ↦ᵣ (0 : Word)) **
-    (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+    (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
     (dwordAddr ↦ₘ word_val)
 
 theorem rlp_phase2_long_loop_one_byte_post_unfold
-    (len ptr byte_zext word_val dwordAddr : Word) :
-    rlp_phase2_long_loop_one_byte_post len ptr byte_zext word_val dwordAddr =
-    ((.x11 ↦ᵣ ((len <<< 8) + byte_zext)) **
+    (len ptr byteZext word_val dwordAddr : Word) :
+    rlp_phase2_long_loop_one_byte_post len ptr byteZext word_val dwordAddr =
+    ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **
      (.x14 ↦ᵣ (0 : Word)) **
-     (.x12 ↦ᵣ byte_zext) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x12 ↦ᵣ byteZext) ** (.x0 ↦ᵣ (0 : Word)) **
      (dwordAddr ↦ₘ word_val)) := by
   delta rlp_phase2_long_loop_one_byte_post; rfl
 
@@ -64,13 +64,13 @@ theorem rlp_phase2_long_loop_one_byte_spec
     (base : Word) (back : BitVec 13)
     (halign : alignToDword ptr = dwordAddr)
     (hvalid : isValidByteAccess ptr = true) :
-    let byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+    let byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
     cpsTriple base (base + 24)
       (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
       ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (1 : Word)) **
        (.x12 ↦ᵣ v12_old) ** (.x0 ↦ᵣ (0 : Word)) **
        (dwordAddr ↦ₘ word_val))
-      (rlp_phase2_long_loop_one_byte_post len ptr byte_zext word_val
+      (rlp_phase2_long_loop_one_byte_post len ptr byteZext word_val
          dwordAddr) := by
   simp only [rlp_phase2_long_loop_one_byte_post_unfold]
   -- Body spec instantiated at cnt = 1.
@@ -82,9 +82,9 @@ theorem rlp_phase2_long_loop_one_byte_spec
   rw [hcnt'] at body
   -- The taken post carries `⌜(0 : Word) ≠ 0⌝`, which is False. Extract it
   -- via six layers of destructuring and derive the contradiction.
-  set byte_zext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
+  set byteZext := (extractByte word_val (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
-      rlp_phase2_long_loop_body_post len ptr (1 : Word) byte_zext word_val
+      rlp_phase2_long_loop_body_post len ptr (1 : Word) byteZext word_val
          dwordAddr ((0 : Word) ≠ 0) hp → False := by
     intro hp hpost
     simp only [rlp_phase2_long_loop_body_post_unfold] at hpost


### PR DESCRIPTION
## Summary
Renames let-bound locals \`byte_zext\` → \`byteZext\` and \`k_val\` → \`kVal\` across the RLP phase files (5 files, 104 occurrences).

Self-contained — these identifiers are local to \`Rv64/RLP/Phase*.lean\`.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)