### PR TITLE
refactor(calling-convention): migrate cpsTriple_frame_left to cpsTriple_frameR (#331)

### DIFF
--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -173,10 +173,7 @@ theorem callNear_function_spec
       ((CodeReq.singleton call_site (.JAL .x1 offset)).union cr_func)
       ((.x1 ↦ᵣ old_ra) ** P)
       ((.x1 ↦ᵣ (call_site + 4)) ** Q) := by
-  have hcall := cpsTriple_frame_left call_site (call_site + signExtend21 offset)
-    (CodeReq.singleton call_site (.JAL .x1 offset))
-    (.x1 ↦ᵣ old_ra) (.x1 ↦ᵣ (call_site + 4))
-    P hP (callNear_spec offset call_site old_ra)
+  have hcall := cpsTriple_frameR P hP (callNear_spec offset call_site old_ra)
   rw [hoff] at hcall
   exact cpsTriple_seq call_site func_entry ((call_site + 4) &&& ~~~1)
     (CodeReq.singleton call_site (.JAL .x1 offset)) cr_func hd


### PR DESCRIPTION
## Summary
Migrates the lone \`cpsTriple_frame_left\` callsite in \`EvmAsm/Evm64/CallingConvention.lean\` to \`cpsTriple_frameR\` (drops 5 explicit \`call_site\` / \`exit\` / \`cr\` / \`P\` / \`Q\` args).

Eliminates the last remaining \`cpsTriple_frame_left\` warning outside of the LimbSpec files (which are currently in-flight via other PRs).

## Test plan
- [x] \`lake build EvmAsm.Evm64.CallingConvention\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)