### PR TITLE
refactor(rlp): migrate cpsTriple_seq_with_perm_same_cr to seq_perm_same_cr (#331)

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -134,7 +134,7 @@ theorem rlp_phase2_long_loop_five_byte_spec
   have h_ptr_5 : (ptr + 1 : Word) + 4 = ptr + 5 := by bv_omega
   rw [h_ptr_2, h_ptr_3, h_ptr_4, h_ptr_5] at four_byte
   have composed :=
-    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+    cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) tri1' four_byte
   exact cpsTriple_weaken
     (fun _ hp => hp)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -128,7 +128,7 @@ theorem rlp_phase2_long_loop_four_byte_spec
   have h_ptr_4 : (ptr + 1 : Word) + 3 = ptr + 4 := by bv_omega
   rw [h_ptr_2, h_ptr_3, h_ptr_4] at three_byte
   have composed :=
-    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+    cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) tri1' three_byte
   exact cpsTriple_weaken
     (fun _ hp => hp)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -133,7 +133,7 @@ theorem rlp_phase2_long_loop_three_byte_spec
   have h_ptr_3 : (ptr + 1 : Word) + 2 = ptr + 3 := by bv_omega
   rw [h_ptr_2, h_ptr_3] at two_byte
   have composed :=
-    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+    cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) tri1' two_byte
   exact cpsTriple_weaken
     (fun _ hp => hp)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -131,7 +131,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
   -- Both CRs are the same (loop body prog at base), so use `_seq_same_cr`.
   -- Need to convert tri1''s post into one_byte's pre shape via consequence.
   have composed :=
-    cpsTriple_seq_with_perm_same_cr base base (base + 24) _ _ _ _ _
+    cpsTriple_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) tri1' one_byte
   -- Final post: rewrite `ptr + 1 + 1 = ptr + 2` and reshape.
   have h_ptr_2 : (ptr + 1 : Word) + 1 = ptr + 2 := by bv_omega


### PR DESCRIPTION
## Summary
Migrates 4 \`cpsTriple_seq_with_perm_same_cr\` callsites in the RLP phase-2 long-loop files (\`Phase2LongLoop{Two,Three,Four,Five}.lean\`) to the new implicit-arg form \`cpsTriple_seq_perm_same_cr\`.

Each call drops 5 redundant \`_\` arguments. Self-contained — these files aren't covered by other pending #189 PRs.

Continues the gradual #331 migration.

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds
- [x] No remaining \`cpsTriple_seq_with_perm_same_cr\` warnings in these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)