### PR TITLE
cleanup: drop unused ite_true/ite_false simp args in comparison specs

### DIFF
--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -105,7 +105,7 @@ theorem evm_eq_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.eq_xor_or_reduce_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -116,7 +116,7 @@ theorem evm_gt_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.lt_borrow_chain_correct b a]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -84,7 +84,7 @@ theorem evm_iszero_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.iszero_or_reduce_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -116,7 +116,7 @@ theorem evm_lt_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.lt_borrow_chain_correct a b]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -156,7 +156,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.slt_result_correct b a]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -154,7 +154,7 @@ theorem evm_slt_stack_spec (sp base : Word)
       simp only [EvmWord.getLimbN_ite, EvmWord.getLimbN_zero,
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
-                 ite_true, ite_false, ite_self,
+                 ite_self,
                  ← EvmWord.slt_result_correct a b]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]


### PR DESCRIPTION
## Summary
The \`unusedSimpArgs\` linter flags 12 \`ite_true\`, \`ite_false\` arguments in \`simp only\` calls inside the comparison opcode specs (\`Eq\`, \`Gt\`, \`Lt\`, \`IsZero\`, \`Slt\`, \`Sgt\`). None of them actually fire. Removing them eliminates the warnings with zero behavioral change.

One-line change per file, 6 files.

## Test plan
- [x] Full \`lake build\` succeeds
- [x] All 12 unused-simp-arg warnings gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)