### PR TITLE
refactor(evm-asm): rename scratch-memory parameters to camelCase (#189)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -603,7 +603,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   -- The approach: frame Phase C, then merge with body+store per exit.
   -- Each body: bodyBase → base+136 (extended to evm_byte_code)
   -- Store: base+136 → base+180 (extended to evm_byte_code)
-  -- Compose body → store, frame with x0/x10/idx_mem, weaken regs, bridge via bv_srl_mask_eq + byte_correct
+  -- Compose body → store, frame with x0/x10/idxMem, weaken regs, bridge via bv_srl_mask_eq + byte_correct
   --
   -- Due to the different x10 values per Phase C exit and the complex memory layouts,
   -- the composition is done inline in the merge callback.

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -236,8 +236,8 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
     - `q0..q3` at `sp + signExtend12 4088/4080/4072/4064` — accumulated quotient digits
     - `u0..u4` at `sp + signExtend12 4056/4048/4040/4032/4024` — normalized dividend
     - `u5..u7` at `sp + signExtend12 4016/4008/4000` — overflow/scratch
-    - `shift_mem` at `sp + signExtend12 3992`, `n_mem` at `sp + signExtend12 3984`
-    - `j_mem` at `sp + signExtend12 3976`
+    - `shiftMem` at `sp + signExtend12 3992`, `n_mem` at `sp + signExtend12 3984`
+    - `jMem` at `sp + signExtend12 3976`
 
     This is the precondition shape — specific starting values for every cell.
     The full-path specs universally-quantify over these values since the program
@@ -245,33 +245,33 @@ theorem sharedDivModCode_sub_modCode (base : Word) :
     with fifteen `↦ₘ` lines at every call site. -/
 @[irreducible]
 def divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem : Word) : Assertion :=
+    shiftMem n_mem jMem : Word) : Assertion :=
   ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
   ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
   ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
   ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
   ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
   ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-  ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+  ((sp + signExtend12 3992) ↦ₘ shiftMem) **
   ((sp + signExtend12 3984) ↦ₘ n_mem) **
-  ((sp + signExtend12 3976) ↦ₘ j_mem)
+  ((sp + signExtend12 3976) ↦ₘ jMem)
 
 /-- Unfold `divScratchValues` into its 15 underlying memory atoms. The bundle
     is `@[irreducible]`, so `unfold` won't see through it — this named rewrite
     is the supported way in at call sites (parallel to `divScratchOwn_unfold`). -/
 theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem : Word) :
+    shiftMem n_mem jMem : Word) :
     divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shift_mem n_mem j_mem =
+        shiftMem n_mem jMem =
     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem) **
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
-     ((sp + signExtend12 3976) ↦ₘ j_mem)) := by
+     ((sp + signExtend12 3976) ↦ₘ jMem)) := by
   delta divScratchValues; rfl
 
 /-- Mid-tree variant of `divScratchValues_unfold`: threads a `Q` through the
@@ -281,18 +281,18 @@ theorem divScratchValues_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     composition where scratch atoms are scattered across the unfolded
     `fullDivN4MaxSkipPost` post. -/
 theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem : Word) (Q : Assertion) :
+    shiftMem n_mem jMem : Word) (Q : Assertion) :
     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+     ((sp + signExtend12 3992) ↦ₘ shiftMem) **
      ((sp + signExtend12 3984) ↦ₘ n_mem) **
-     ((sp + signExtend12 3976) ↦ₘ j_mem) ** Q) =
+     ((sp + signExtend12 3976) ↦ₘ jMem) ** Q) =
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shift_mem n_mem j_mem ** Q) := by
+      shiftMem n_mem jMem ** Q) := by
   rw [divScratchValues_unfold]
   iterate 14 rw [sepConj_assoc']
 
@@ -346,16 +346,16 @@ theorem divScratchOwn_unfold_right (sp : Word) (Q : Assertion) :
   rw [divScratchOwn_unfold]
 
 theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem : Word) :
+    shiftMem n_mem jMem : Word) :
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shift_mem n_mem j_mem).pcFree := by
+      shiftMem n_mem jMem).pcFree := by
   unfold divScratchValues; pcFree
 
-instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     Assertion.PCFree (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shift_mem n_mem j_mem) :=
+        shiftMem n_mem jMem) :=
   ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem⟩
+    shiftMem n_mem jMem⟩
 
 /-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
     through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
@@ -369,9 +369,9 @@ instance pcFreeInst_divScratchOwn (sp : Word) :
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
 theorem divScratchValues_implies_divScratchOwn
-    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     ∀ h, divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shift_mem n_mem j_mem h → divScratchOwn sp h := by
+        shiftMem n_mem jMem h → divScratchOwn sp h := by
   unfold divScratchValues divScratchOwn
   -- Weaken each of the 15 memIs cells to memOwn, left to right.
   iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -70,7 +70,7 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
     (by pcFree) hlde
-  -- 5. Frame BEQ exit with x12, x5, x7, x2, x10, shift_mem
+  -- 5. Frame BEQ exit with x12, x5, x7, x2, x10, shiftMem
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
      ((sp + signExtend12 3992) ↦ₘ shift))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -80,7 +80,7 @@ theorem evm_div_phaseAB_n4_clz_spec (sp base : Word)
     base → base+312. b[0..3] normalized in-place. -/
 theorem evm_div_n4_to_normB_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -93,22 +93,22 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
-  -- Frame AB+CLZ with x2 and shift_mem (not touched by AB or CLZ)
+  -- Frame AB+CLZ with x2 and shiftMem (not touched by AB or CLZ)
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   -- shift = (clzResult b3).1, need shift ≠ 0
   have hC2 := divK_phaseC2_ntaken_spec sp shift ((clzResult b3).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   -- Frame C2 with x5, x10, and all other memory
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
@@ -154,7 +154,7 @@ theorem evm_div_n4_to_normB_spec (sp base : Word)
     base → base+448. Normalizes b[] and a[], sets up loop parameters. -/
 theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -173,7 +173,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -188,7 +188,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: PhaseAB(n=4) + CLZ + PhaseC2 + NormB (base → base+312)
   have hNormB := evm_div_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem hbnz hb3nz hshift_nz
+    q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem hbnz hb3nz hshift_nz
 
   -- Frame NormB result with a[], u[] scratch, x1
   have hNormBf := cpsTriple_frameR
@@ -259,7 +259,7 @@ theorem evm_div_n4_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
@@ -278,7 +278,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
@@ -298,7 +298,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
   -- Step 1: PhaseAB(n=4) + CLZ (base → base+212)
   have hABCLZ := evm_div_phaseAB_n4_clz_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
-  -- Frame AB+CLZ with x2, x1, a[], u[0..4], shift_mem
+  -- Frame AB+CLZ with x2, x1, a[], u[0..4], shiftMem
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -307,11 +307,11 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396), shift = 0
   have hC2 := divK_phaseC2_taken_spec sp ((clzResult b3).1)
-    ((clzResult b3).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b3).2 >>> (63 : Nat)) shiftMem base hshift_z
   -- Frame C2 with everything not in C2's assertion
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
@@ -532,7 +532,7 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
   -- Step 2: Denorm + Epilogue (base+916 → base+1068)
   have hDE := evm_div_denorm_epilogue_spec sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
     q0 q1 q2 q3 m0 m8 m16 m24
-  -- Frame epilogue with shift_mem
+  -- Frame epilogue with shiftMem
   have hDEF := cpsTriple_frameR
     (((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hDE
@@ -602,7 +602,7 @@ theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
     (by pcFree) hlde
-  -- 5. Frame BEQ exit with x12, x5, x7, x2, x10, shift_mem
+  -- 5. Frame BEQ exit with x12, x5, x7, x2, x10, shiftMem
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
      ((sp + signExtend12 3992) ↦ₘ shift))
@@ -648,7 +648,7 @@ theorem evm_mod_preamble_denorm_epilogue_spec (sp base : Word)
   -- Step 2: Denorm + MOD Epilogue (base+916 → base+1068)
   have hDE := evm_mod_denorm_epilogue_spec sp base u0 u1 u2 u3 v2 v5 v7 v10 shift
     m0 m8 m16 m24
-  -- Frame epilogue with shift_mem
+  -- Frame epilogue with shiftMem
   have hDEF := cpsTriple_frameR
     (((sp + signExtend12 3992) ↦ₘ shift))
     (by pcFree) hDE
@@ -728,7 +728,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
     (by pcFree) hlde
-  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shift_mem
+  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shiftMem
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
      ((sp + signExtend12 3992) ↦ₘ shift))
@@ -747,7 +747,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
   have hEpi := divK_div_epilogue_spec sp base q0 q1 q2 q3
     v5 shift v7 v10 m0 m8 m16 m24
 
-  -- Frame epilogue with x2, x0, shift_mem
+  -- Frame epilogue with x2, x0, shiftMem
   have hEpiF := cpsTriple_frameR
     ((.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))
@@ -815,7 +815,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
     (by pcFree) hlde
-  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shift_mem
+  -- 5. Frame BEQ taken with x12, x5, x7, x2, x10, shiftMem
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
      ((sp + signExtend12 3992) ↦ₘ shift))
@@ -834,7 +834,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
   have hEpi := divK_mod_epilogue_spec sp base u0 u1 u2 u3
     v5 shift v7 v10 m0 m8 m16 m24
 
-  -- Frame epilogue with x2, x0, shift_mem
+  -- Frame epilogue with x2, x0, shiftMem
   have hEpiF := cpsTriple_frameR
     ((.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
      ((sp + signExtend12 3992) ↦ₘ shift))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1.lean
@@ -85,7 +85,7 @@ theorem evm_div_phaseAB_n1_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
@@ -104,7 +104,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b0).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -129,11 +129,11 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := divK_phaseC2_ntaken_spec sp shift ((clzResult b0).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -226,7 +226,7 @@ theorem evm_div_n1_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
@@ -245,7 +245,7 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (1 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b0).1) **
@@ -274,11 +274,11 @@ theorem evm_div_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := divK_phaseC2_taken_spec sp ((clzResult b0).1)
-    ((clzResult b0).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b0).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -124,7 +124,7 @@ def preloopN1UnifiedPost (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
 private theorem evm_div_n1_loop_unified_inst
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift anti_shift v0' v1' v2' v3' u0_s u1_s u2_s u3_s u4_s : Word)
-    (v10_val v11_old j_mem : Word)
+    (v10_val v11_old jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_3 : bltu_3 = BitVec.ult u4_s v0')
@@ -162,7 +162,7 @@ private theorem evm_div_n1_loop_unified_inst
       v0')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN1PreWithScratch sp j_mem (1 : Word) shift u0_s v10_val v11_old anti_shift
+      (loopN1PreWithScratch sp jMem (1 : Word) shift u0_s v10_val v11_old anti_shift
         v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
         u2_s u1_s u0_s (0 : Word) (0 : Word) (0 : Word) (0 : Word)
         ret_mem d_mem dlo_mem scratch_un0)
@@ -170,7 +170,7 @@ private theorem evm_div_n1_loop_unified_inst
         v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
         u2_s u1_s u0_s ret_mem d_mem dlo_mem scratch_un0) :=
   divK_loop_n1_unified_divCode bltu_3 bltu_2 bltu_1 bltu_0
-    sp j_mem (1 : Word) shift u0_s v10_val v11_old anti_shift
+    sp jMem (1 : Word) shift u0_s v10_val v11_old anti_shift
     v0' v1' v2' v3' u3_s u4_s (0 : Word) (0 : Word) (0 : Word)
     u2_s u1_s u0_s (0 : Word) (0 : Word) (0 : Word) (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0 base halign
@@ -192,7 +192,7 @@ private theorem evm_div_n1_loop_unified_inst
 theorem evm_div_n1_preloop_loop_unified_spec
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
@@ -222,8 +222,8 @@ theorem evm_div_n1_preloop_loop_unified_spec
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -233,13 +233,13 @@ theorem evm_div_n1_preloop_loop_unified_spec
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n1_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3z hb2z hb1z hshift_nz
 
 
-  -- Frame preloop with .x11, j_mem, scratch cells
+  -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) **
      (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -258,10 +258,10 @@ theorem evm_div_n1_preloop_loop_unified_spec
     ((a3 <<< (((clzResult b0).1).toNat % 64)) ||| (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64)))
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b0).1).toNat % 64))
-    v11_old j_mem
+    v11_old jMem
     ret_mem d_mem dlo_mem scratch_un0 halign
     hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
-  -- Frame loop with a[], shift_mem (no spare q/u for n=1)
+  -- Frame loop with a[], shiftMem (no spare q/u for n=1)
   have hLoopF := cpsTriple_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2.lean
@@ -88,7 +88,7 @@ theorem evm_div_phaseAB_n2_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
@@ -107,7 +107,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -132,11 +132,11 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := divK_phaseC2_ntaken_spec sp shift ((clzResult b1).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -229,7 +229,7 @@ theorem evm_div_n2_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
@@ -248,7 +248,7 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b1).1) **
@@ -277,11 +277,11 @@ theorem evm_div_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := divK_phaseC2_taken_spec sp ((clzResult b1).1)
-    ((clzResult b1).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b1).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -64,7 +64,7 @@ def fullDivN2_FFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FFT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -93,8 +93,8 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -118,7 +118,7 @@ theorem evm_div_n2_full_FFT_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false false true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -197,7 +197,7 @@ def fullDivN2_FTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FTF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -226,8 +226,8 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -251,7 +251,7 @@ theorem evm_div_n2_full_FTF_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false true false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -330,7 +330,7 @@ def fullDivN2_FTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_FTT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -359,8 +359,8 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -384,7 +384,7 @@ theorem evm_div_n2_full_FTT_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec false true true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -463,7 +463,7 @@ def fullDivN2_TFF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TFF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -492,8 +492,8 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -517,7 +517,7 @@ theorem evm_div_n2_full_TFF_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true false false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -596,7 +596,7 @@ def fullDivN2_TFT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TFT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -625,8 +625,8 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -650,7 +650,7 @@ theorem evm_div_n2_full_TFT_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true false true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -729,7 +729,7 @@ def fullDivN2_TTF_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TTF_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -758,8 +758,8 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -783,7 +783,7 @@ theorem evm_div_n2_full_TTF_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true true false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -862,7 +862,7 @@ def fullDivN2_TTT_Post (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 theorem evm_div_n2_full_TTT_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -891,8 +891,8 @@ theorem evm_div_n2_full_TTT_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -916,7 +916,7 @@ theorem evm_div_n2_full_TTT_spec (sp base : Word)
     u0_s r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   have hA := evm_div_n2_preloop_loop_unified_spec true true true sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -69,7 +69,7 @@ def fullDivN2AllMaxPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     Composes pre-loop + three-iteration loop + denorm + epilogue. -/
 theorem evm_div_n2_full_all_max_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -98,8 +98,8 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -125,7 +125,7 @@ theorem evm_div_n2_full_all_max_spec (sp base : Word)
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n2_preloop_loop_unified_spec false false false sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3z hb2z hb1nz hshift_nz halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -256,7 +256,7 @@ def fullDivN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
     Dispatches to per-case  lemmas via postcondition bridge. -/
 theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -285,8 +285,8 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -303,7 +303,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
       delta fullDivN2UnifiedPost fullDivN2AllMaxPost; rfl
     rw [h_eq]; exact evm_div_n2_full_all_max_spec sp base
       a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-      q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+      q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
       ret_mem d_mem dlo_mem scratch_un0
       hbnz hb3z hb2z hb1nz hshift_nz halign
       hbltu_2 hbltu_1 hbltu_0 hcarry2
@@ -313,7 +313,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FFT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FFT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -322,7 +322,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FTF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FTF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -331,7 +331,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_FTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_FTT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_FTT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -340,7 +340,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TFF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TFF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TFF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -349,7 +349,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TFT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TFT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TFT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -358,7 +358,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TTF_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TTF_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TTF_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign
@@ -367,7 +367,7 @@ theorem evm_div_n2_full_unified_spec (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Wo
           ret_mem d_mem dlo_mem scratch_un0 = fullDivN2_TTT_Post sp base a0 a1 a2 a3 b0 b1 b2 b3
           := by delta fullDivN2UnifiedPost fullDivN2_TTT_Post; rfl
        rw [h_eq]; exact evm_div_n2_full_TTT_spec sp base a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+          q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
           ret_mem d_mem dlo_mem scratch_un0 hbnz hb3z hb2z hb1nz hshift_nz
 
           halign

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -109,7 +109,7 @@ def preloopN2UnifiedPost (bltu_2 bltu_1 bltu_0 : Bool)
 private theorem evm_div_n2_loop_unified_inst
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift anti_shift v0' v1' v2' v3' u0_s u1_s u2_s u3_s u4_s : Word)
-    (v10_val v11_old j_mem : Word)
+    (v10_val v11_old jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_2 : bltu_2 = BitVec.ult u4_s v1')
@@ -124,7 +124,7 @@ private theorem evm_div_n2_loop_unified_inst
       v1')
     (hcarry2 : Carry2NzAll v0' v1' v2' v3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN2PreWithScratch sp j_mem (2 : Word) shift u0_s v10_val v11_old anti_shift
+      (loopN2PreWithScratch sp jMem (2 : Word) shift u0_s v10_val v11_old anti_shift
         v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
         u1_s u0_s (0 : Word) (0 : Word) (0 : Word)
         ret_mem d_mem dlo_mem scratch_un0)
@@ -132,7 +132,7 @@ private theorem evm_div_n2_loop_unified_inst
         v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
         u1_s u0_s ret_mem d_mem dlo_mem scratch_un0) :=
   divK_loop_n2_unified_divCode bltu_2 bltu_1 bltu_0
-    sp j_mem (2 : Word) shift u0_s v10_val v11_old anti_shift
+    sp jMem (2 : Word) shift u0_s v10_val v11_old anti_shift
     v0' v1' v2' v3' u2_s u3_s u4_s (0 : Word) (0 : Word)
     u1_s u0_s (0 : Word) (0 : Word) (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0 base halign
@@ -153,7 +153,7 @@ private theorem evm_div_n2_loop_unified_inst
 theorem evm_div_n2_preloop_loop_unified_spec
     (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
@@ -182,8 +182,8 @@ theorem evm_div_n2_preloop_loop_unified_spec
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -193,13 +193,13 @@ theorem evm_div_n2_preloop_loop_unified_spec
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n2_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3z hb2z hb1nz hshift_nz
 
 
-  -- Frame preloop with .x11, j_mem, scratch cells
+  -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) **
      (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -218,12 +218,12 @@ theorem evm_div_n2_preloop_loop_unified_spec
     ((a3 <<< (((clzResult b1).1).toNat % 64)) ||| (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64))
-    v11_old j_mem
+    v11_old jMem
     ret_mem d_mem dlo_mem scratch_un0
 
     halign
     hbltu_2 hbltu_1 hbltu_0 hcarry2
-  -- Frame loop with a[], spare q3, spare u7, shift_mem
+  -- Frame loop with a[], spare q3, spare u7, shiftMem
   have hLoopF := cpsTriple_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3.lean
@@ -88,7 +88,7 @@ theorem evm_div_phaseAB_n3_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
@@ -107,7 +107,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b2).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -132,11 +132,11 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := divK_phaseC2_ntaken_spec sp shift ((clzResult b2).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -229,7 +229,7 @@ theorem evm_div_n3_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
@@ -248,7 +248,7 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b2).1) **
@@ -277,11 +277,11 @@ theorem evm_div_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := divK_phaseC2_taken_spec sp ((clzResult b2).1)
-    ((clzResult b2).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b2).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -88,7 +88,7 @@ def preloopN3UnifiedPost (bltu_1 bltu_0 : Bool)
 private theorem evm_div_n3_loop_unified_inst
     (bltu_1 bltu_0 : Bool) (sp base : Word)
     (shift anti_shift b0' b1' b2' b3' u0 u1 u2 u3 u4 : Word)
-    (v10_old v11_old j_mem : Word)
+    (v10_old v11_old jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu_1 : bltu_1 = BitVec.ult u4 b2')
@@ -96,14 +96,14 @@ private theorem evm_div_n3_loop_unified_inst
       (iterN3 bltu_1 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
     (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
     cpsTriple (base + loopBodyOff) (base + denormOff) (divCode base)
-      (loopN3PreWithScratch sp j_mem (3 : Word) shift u0 v10_old v11_old anti_shift
+      (loopN3PreWithScratch sp jMem (3 : Word) shift u0 v10_old v11_old anti_shift
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
         ret_mem d_mem dlo_mem scratch_un0)
       (loopN3UnifiedPost bltu_1 bltu_0 sp base
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0
         ret_mem d_mem dlo_mem scratch_un0) :=
   divK_loop_n3_unified_divCode bltu_1 bltu_0
-    sp j_mem (3 : Word) shift u0 v10_old v11_old anti_shift
+    sp jMem (3 : Word) shift u0 v10_old v11_old anti_shift
     b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0 base halign
     hbltu_1 hbltu_0 hcarry2
@@ -118,7 +118,7 @@ private theorem evm_div_n3_loop_unified_inst
     Composes preloop (base→base+448) with unified loop (base+448→base+908). -/
 theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
@@ -146,8 +146,8 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        ((sp + signExtend12 3968) ↦ₘ ret_mem) **
        ((sp + signExtend12 3960) ↦ₘ d_mem) **
        ((sp + signExtend12 3952) ↦ₘ dlo_mem) **
@@ -157,11 +157,11 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
   -- 1. Pre-loop: base → base+448
   have hPre := evm_div_n3_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3z hb2nz hshift_nz
-  -- Frame preloop with .x11, j_mem, scratch cells
+  -- Frame preloop with .x11, jMem, scratch cells
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) **
      (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -180,11 +180,11 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
     ((a3 <<< ((clzResult b2).1.toNat % 64)) ||| (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
     (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))
     (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))
-    v11_old j_mem
+    v11_old jMem
     ret_mem d_mem dlo_mem scratch_un0
     halign
     hbltu_1 hbltu_0 hcarry2
-  -- Frame loop with a[], spare q[2..3], spare u[6..7], shift_mem
+  -- Frame loop with a[], spare q[2..3], spare u[6..7], shiftMem
   have hLoopF := cpsTriple_frameR
     (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
      ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -31,7 +31,7 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
 
 /-- Postcondition for pre-loop + max+skip loop body at n=4.
     Computes normalized b[], u[] from shift = clz(b3), then wraps loopBodyN4SkipPost
-    with frame atoms (a[], q[1-3]=0, padding, shift_mem). -/
+    with frame atoms (a[], q[1-3]=0, padding, shiftMem). -/
 @[irreducible]
 def preloopMaxSkipPostN4 (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
   let shift := (clzResult b3).1
@@ -123,7 +123,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm (sp base : Word)
 /-- n=4 pre-loop + max+skip loop body: base → base+904 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -145,8 +145,8 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isMaxTrialN4 at hbltu
   unfold isSkipBorrowN4Max at hborrow
@@ -163,15 +163,15 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem))
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_skip_j0_norm sp base
-    j_mem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
 
     hbltu
@@ -410,7 +410,7 @@ instance pcFreeInst_fullModN4MaxSkipPost
     Composes pre-loop + loop body + denorm + epilogue. -/
 theorem evm_div_n4_full_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -432,8 +432,8 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -450,7 +450,7 @@ theorem evm_div_n4_full_max_skip_spec (sp base : Word)
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_max_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     hbnz hb3nz hshift_nz
 
 
@@ -659,7 +659,7 @@ theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 /-- n=4 pre-loop + call+skip loop body: base → base+904 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
@@ -683,8 +683,8 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -703,17 +703,17 @@ theorem evm_div_n4_preloop_call_skip_spec (sp base : Word)
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
-    j_mem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0 halign
 
@@ -779,7 +779,7 @@ def fullDivN4CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+skip). -/
 theorem evm_div_n4_full_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
@@ -803,8 +803,8 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) **
        (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) **
@@ -828,7 +828,7 @@ theorem evm_div_n4_full_call_skip_spec (sp base : Word)
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_call_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3nz hshift_nz halign
     hbltu hborrow

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -189,7 +189,7 @@ def isAddbackCarry2NzN4MaxAb (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 /-- n=4 pre-loop + max+addback BEQ loop body: base → base+908 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -230,8 +230,8 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxAddbackBeqPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isMaxTrialN4 at hbltu
   unfold isAddbackBorrowN4Max at hborrow
@@ -253,15 +253,15 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
   have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem))
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_addback_j0_beq_norm sp base
-    j_mem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
 
     hbltu hcarry2_nz
@@ -344,7 +344,7 @@ def isAddbackCarry2NzN4CallAb (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 /-- n=4 pre-loop + call+addback BEQ loop body: base → base+908 (shift ≠ 0). -/
 theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
@@ -387,7 +387,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -411,17 +411,17 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
   have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_nz
 
 
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm sp base
-    j_mem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0
     hv_j hv_n hv_uhi hv_ulo hv_vtop hv_ret hv_d hv_dlo hv_scratch_un0 halign
@@ -549,7 +549,7 @@ def fullDivN4MaxAddbackBeqPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, max+addback BEQ). -/
 theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -590,8 +590,8 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullDivN4MaxAddbackBeqPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -619,7 +619,7 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   have hA := evm_div_n4_preloop_max_addback_beq_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     hbnz hb3nz hshift_nz
 
 
@@ -760,7 +760,7 @@ def fullDivN4CallAddbackBeqPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, call+addback BEQ). -/
 theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
@@ -803,7 +803,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (fullDivN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -837,7 +837,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
   let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
   have hA := evm_div_n4_preloop_call_addback_beq_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3nz hshift_nz
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -71,7 +71,7 @@ def preloopShift0CallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
 /-- n=4 pre-loop + call+skip loop body: base → base+904 (shift = 0). -/
 theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
@@ -94,8 +94,8 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -103,20 +103,20 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
   -- Pre-loop: base → base+448 (shift=0)
   have hPre := evm_div_n4_shift0_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_z
 
 
-  -- Frame preloop with x11, j_mem, ret_mem, d_mem, dlo_mem, scratch_un0
+  -- Frame preloop with x11, jMem, ret_mem, d_mem, dlo_mem, scratch_un0
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
      (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
      (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
     (by pcFree) hPre
   -- Loop body: base+448 → base+904, call+skip with v=b, u=a, u_top=0
   have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
   have hLoop := divK_loop_body_n4_call_skip_j0_norm sp base
-    j_mem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
+    jMem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
     v11_old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
     b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
     ret_mem d_mem dlo_mem scratch_un0 halign
@@ -228,7 +228,7 @@ def fullDivN4Shift0CallSkipPost (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Asser
     Composes pre-loop + loop body + shift=0 epilogue. -/
 theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
@@ -248,7 +248,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) ** ((sp + signExtend12 3976) ↦ₘ j_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
        (sp + signExtend12 3968 ↦ₘ ret_mem) ** (sp + signExtend12 3960 ↦ₘ d_mem) **
        (sp + signExtend12 3952 ↦ₘ dlo_mem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
       (fullDivN4Shift0CallSkipPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
@@ -257,7 +257,7 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
   -- 1. Pre-loop + loop body: base → base+904
   have hA := evm_div_n4_preloop_shift0_call_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     ret_mem d_mem dlo_mem scratch_un0
     hbnz hb3nz hshift_z halign hborrow
   -- 2. Post-loop: base+904 → base+1068 (shift=0 epilogue)

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPath.lean
@@ -122,7 +122,7 @@ theorem evm_mod_phaseAB_n4_clz_spec (sp base : Word)
     base → base+312. b[0..3] normalized in-place. -/
 theorem evm_mod_n4_to_normB_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -135,7 +135,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (normBPost sp (4 : Word) (clzResult b3).1 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -143,11 +143,11 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     q0 q1 q2 q3 u5 u6 u7 n_mem hbnz hb3nz
   have hABCLZf := cpsTriple_frameR
     ((.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- PhaseC2 ntaken
   have hC2 := mod_phaseC2_ntaken_spec sp shift ((clzResult b3).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
@@ -188,7 +188,7 @@ theorem evm_mod_n4_to_normB_spec (sp base : Word)
     base → base+448. Normalizes b[] and a[], sets up loop parameters. -/
 theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0) :
@@ -207,7 +207,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (4 : Word) (clzResult b3).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -222,7 +222,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
   let u0 := a0 <<< (shift.toNat % 64)
   -- Step 1: Through NormB (base → base+312)
   have hNormB := evm_mod_n4_to_normB_spec sp base b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u5 u6 u7 n_mem shift_mem hbnz hb3nz hshift_nz
+    q0 q1 q2 q3 u5 u6 u7 n_mem shiftMem hbnz hb3nz hshift_nz
 
   have hNormBf := cpsTriple_frameR
     ((.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
@@ -285,7 +285,7 @@ theorem evm_mod_n4_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_z : (clzResult b3).1 = 0) :
@@ -304,7 +304,7 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b3).1) ** (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b3).1) **
@@ -332,11 +332,11 @@ theorem evm_mod_n4_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := mod_phaseC2_taken_spec sp ((clzResult b3).1)
-    ((clzResult b3).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b3).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b3).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN1.lean
@@ -87,7 +87,7 @@ theorem evm_mod_phaseAB_n1_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_nz : (clzResult b0).1 ≠ 0) :
@@ -106,7 +106,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (1 : Word) (clzResult b0).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b0).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -131,11 +131,11 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := mod_phaseC2_ntaken_spec sp shift ((clzResult b0).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
@@ -228,7 +228,7 @@ theorem evm_mod_n1_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1z : b1 = 0)
     (hshift_z : (clzResult b0).1 = 0) :
@@ -247,7 +247,7 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (1 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b0).1) ** (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b0).1) **
@@ -276,11 +276,11 @@ theorem evm_mod_n1_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := mod_phaseC2_taken_spec sp ((clzResult b0).1)
-    ((clzResult b0).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b0).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b0).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b0).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN2.lean
@@ -90,7 +90,7 @@ theorem evm_mod_phaseAB_n2_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_nz : (clzResult b1).1 ≠ 0) :
@@ -109,7 +109,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (2 : Word) (clzResult b1).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b1).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -134,11 +134,11 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := mod_phaseC2_ntaken_spec sp shift ((clzResult b1).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
@@ -231,7 +231,7 @@ theorem evm_mod_n2_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
     (hshift_z : (clzResult b1).1 = 0) :
@@ -250,7 +250,7 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b1).1) ** (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b1).1) **
@@ -279,11 +279,11 @@ theorem evm_mod_n2_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := mod_phaseC2_taken_spec sp ((clzResult b1).1)
-    ((clzResult b1).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b1).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b1).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN3.lean
@@ -90,7 +90,7 @@ theorem evm_mod_phaseAB_n3_clz_spec (sp base : Word)
     base → base+448. -/
 theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_nz : (clzResult b2).1 ≠ 0) :
@@ -109,7 +109,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (loopSetupPost sp (3 : Word) (clzResult b2).1 a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b2).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -134,11 +134,11 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 ntaken (base+212 → base+228)
   have hC2 := mod_phaseC2_ntaken_spec sp shift ((clzResult b2).2 >>> (63 : Nat))
-    shift_mem base hshift_nz
+    shiftMem base hshift_nz
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
@@ -231,7 +231,7 @@ theorem evm_mod_n3_to_loopSetup_spec (sp base : Word)
     base → base+448. b[] already normalized, u[] = copy of a[]. -/
 theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
     (hshift_z : (clzResult b2).1 = 0) :
@@ -250,7 +250,7 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ (clzResult b2).1) ** (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x2 ↦ᵣ signExtend12 (0 : BitVec 12) - (clzResult b2).1) **
@@ -279,11 +279,11 @@ theorem evm_mod_n3_shift0_to_loopSetup_spec (sp base : Word)
      ((sp + signExtend12 4056) ↦ₘ u0_old) ** ((sp + signExtend12 4048) ↦ₘ u1_old) **
      ((sp + signExtend12 4040) ↦ₘ u2_old) ** ((sp + signExtend12 4032) ↦ₘ u3_old) **
      ((sp + signExtend12 4024) ↦ₘ u4_old) **
-     ((sp + signExtend12 3992) ↦ₘ shift_mem))
+     ((sp + signExtend12 3992) ↦ₘ shiftMem))
     (by pcFree) hABCLZ
   -- Step 2: PhaseC2 taken (base+212 → base+396)
   have hC2 := mod_phaseC2_taken_spec sp ((clzResult b2).1)
-    ((clzResult b2).2 >>> (63 : Nat)) shift_mem base hshift_z
+    ((clzResult b2).2 >>> (63 : Nat)) shiftMem base hshift_z
   have hC2f := cpsTriple_frameR
     ((.x5 ↦ᵣ (clzResult b2).2) ** (.x10 ↦ᵣ b3) **
      (.x7 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -26,7 +26,7 @@ open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
     and the DIV/MOD-specific loopSetup/loop-body theorems swapped. -/
 theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -48,8 +48,8 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   unfold isMaxTrialN4 at hbltu
   unfold isSkipBorrowN4Max at hborrow
@@ -66,13 +66,13 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
   let u0 := a0 <<< (shift.toNat % 64)
   have hPre := evm_mod_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem
     hbnz hb3nz hshift_nz
   have hPreF := cpsTriple_frameR
-    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ j_mem))
+    ((.x11 ↦ᵣ v11_old) ** ((sp + signExtend12 3976) ↦ₘ jMem))
     (by pcFree) hPre
   have hLoop := divK_loop_body_n4_max_skip_j0_norm_modCode sp base
-    j_mem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
+    jMem (4 : Word) shift u0 (a0 >>> (anti_shift.toNat % 64)) v11_old anti_shift
     b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
     hbltu hborrow
   have hLoopF := cpsTriple_frameR
@@ -106,7 +106,7 @@ theorem evm_mod_n4_preloop_max_skip_spec (sp base : Word)
     `modCode` and the MOD-specific post-loop composer. -/
 theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old : Word)
-    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem : Word)
+    (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
@@ -128,8 +128,8 @@ theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
        ((sp + signExtend12 4024) ↦ₘ u4_old) **
        ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
        ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem))
       (fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) := by
   let shift := (clzResult b3).1
   let anti_shift := signExtend12 (0 : BitVec 12) - shift
@@ -146,7 +146,7 @@ theorem evm_mod_n4_full_max_skip_spec (sp base : Word)
   -- 1. Pre-loop + loop body: base → base+denormOff
   have hA := evm_mod_n4_preloop_max_skip_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11_old
-    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shift_mem j_mem
+    q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7 n_mem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   -- 2. Post-loop: base+denormOff → base+nopOff (modCode)
   have hB := evm_mod_preamble_denorm_epilogue_spec sp base

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -43,26 +43,26 @@ private theorem beq_shift_sub_modCode (base : Word) :
 
 /-- Phase C2 body (base+212 -> base+224): store shift, compute anti_shift.
     Extends to modCode. Uses first 3 instructions of phaseC2. -/
-private theorem mod_phaseC2_body_modCode (sp shift v2 shift_mem : Word) (base : Word) :
+private theorem mod_phaseC2_body_modCode (sp shift v2 shiftMem : Word) (base : Word) :
     cpsTriple (base + phaseC2Off) (base + 224) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + phaseC2Off)
+  have hbody := divK_phaseC2_body_spec sp shift v2 shiftMem 172 (base + phaseC2Off)
   rw [show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_modCode base) hbody
 
 /-- Phase C2 when shift != 0: falls through to normB at base+228.
     MOD mirror of divK_phaseC2_ntaken_spec. -/
-theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
+theorem mod_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
     cpsTriple (base + phaseC2Off) (base + normBOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
+  have hbody := mod_phaseC2_body_modCode sp shift v2 shiftMem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
@@ -85,14 +85,14 @@ theorem mod_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
 
 /-- Phase C2 when shift = 0: branches to copyAU at base+396.
     MOD mirror of divK_phaseC2_taken_spec. -/
-theorem mod_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
+theorem mod_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_z : shift = 0) :
     cpsTriple (base + phaseC2Off) (base + copyAUOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := mod_phaseC2_body_modCode sp shift v2 shift_mem base
+  have hbody := mod_phaseC2_body_modCode sp shift v2 shiftMem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -37,26 +37,26 @@ private theorem beq_shift_sub_divCode (base : Word) :
 
 /-- Phase C2 body (base+212 → base+224): store shift, compute anti_shift.
     Extends to divCode. Uses first 3 instructions of phaseC2. -/
-private theorem divK_phaseC2_body_divCode (sp shift v2 shift_mem : Word) (base : Word) :
+private theorem divK_phaseC2_body_divCode (sp shift v2 shiftMem : Word) (base : Word) :
     cpsTriple (base + phaseC2Off) (base + 224) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem 172 (base + phaseC2Off)
+  have hbody := divK_phaseC2_body_spec sp shift v2 shiftMem 172 (base + phaseC2Off)
   rw [show (base + phaseC2Off : Word) + 12 = base + 224 from by bv_addr] at hbody
   exact cpsTriple_extend_code (divK_phaseC2_code_sub_divCode base) hbody
 
 /-- Phase C2 when shift ≠ 0: falls through to normB at base+228.
     Stores shift to scratch, computes anti_shift = -shift. -/
-theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
+theorem divK_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
     cpsTriple (base + phaseC2Off) (base + normBOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base
+  have hbody := divK_phaseC2_body_divCode sp shift v2 shiftMem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,
@@ -79,14 +79,14 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shift_mem : Word) (base : Word)
 
 /-- Phase C2 when shift = 0: branches to copyAU at base+396.
     Stores shift (=0) to scratch, computes anti_shift = 0. -/
-theorem divK_phaseC2_taken_spec (sp shift v2 shift_mem : Word) (base : Word)
+theorem divK_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_z : shift = 0) :
     cpsTriple (base + phaseC2Off) (base + copyAUOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  have hbody := divK_phaseC2_body_divCode sp shift v2 shift_mem base
+  have hbody := divK_phaseC2_body_divCode sp shift v2 shiftMem base
   have hbeq_raw := beq_spec_gen .x6 .x0 172 shift (0 : Word) (base + 224)
   rw [show (base + 224 : Word) + signExtend13 172 = base + copyAUOff from by
         rw [se13_172]; bv_addr,

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -34,18 +34,18 @@ abbrev divK_phaseC2_code (shift0_off : BitVec 13) (base : Word) : CodeReq :=
     Preserves x6 and x0 for the subsequent BEQ.
     The postcondition uses `signExtend12 (0 : BitVec 12) - shift` (= 0 - shift)
     to match the syntactic form produced by addi_x0_spec_gen + sub_spec_gen. -/
-theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
+theorem divK_phaseC2_body_spec (sp shift v2 shiftMem : Word)
     (shift0_off : BitVec 13) (base : Word) :
     let cr := divK_phaseC2_code shift0_off base
     cpsTriple base (base + 12) cr
       (
        (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       (
        (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   intro cr
-  have I0 := sd_spec_gen .x12 .x6 sp shift shift_mem 3992 base
+  have I0 := sd_spec_gen .x12 .x6 sp shift shiftMem 3992 base
   have I1 := addi_x0_spec_gen .x2 v2 0 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x2 .x6
     (signExtend12 (0 : BitVec 12)) shift (base + 8) (by nofun)
@@ -55,7 +55,7 @@ theorem divK_phaseC2_body_spec (sp shift v2 shift_mem : Word)
     Taken: shift = 0, skip normalization.
     Not taken: shift ≠ 0, proceed to normalize.
     anti_shift = signExtend12 0 - shift (= 0 - shift = negation of shift amount). -/
-theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
+theorem divK_phaseC2_spec (sp shift v2 shiftMem : Word)
     (shift0_off : BitVec 13) (base : Word) :
     let cr := divK_phaseC2_code shift0_off base
     let post :=
@@ -65,13 +65,13 @@ theorem divK_phaseC2_spec (sp shift v2 shift_mem : Word)
     cpsBranch base cr
       (
        (.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem))
+       ((sp + signExtend12 3992) ↦ₘ shiftMem))
       -- Taken: shift = 0
       ((base + 12) + signExtend13 shift0_off) post
       -- Not taken: shift ≠ 0
       (base + 16) post := by
   intro cr post
-  have hbody := divK_phaseC2_body_spec sp shift v2 shift_mem shift0_off base
+  have hbody := divK_phaseC2_body_spec sp shift v2 shiftMem shift0_off base
   have hbeq_raw := beq_spec_gen .x6 .x0 shift0_off shift (0 : Word) (base + 12)
   have ha1 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
   rw [ha1] at hbeq_raw

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -235,7 +235,7 @@ def divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) : Assertion :=
 def divN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) : Assertion :=
+     shiftMem n_mem jMem : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -243,30 +243,30 @@ def divN4StackPre (sp : Word) (a b : EvmWord)
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem
+    shiftMem n_mem jMem
 
 theorem pcFree_divN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem).pcFree := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem).pcFree := by
   delta divN4StackPre; pcFree
 
 instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     Assertion.PCFree (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem) :=
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem) :=
   ⟨pcFree_divN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem⟩
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem⟩
 
 /-- Named unfold for `divN4StackPre`. Restores access to the atomic
     components once `@[irreducible]` has made `delta` the only path in. -/
 theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) :
+     shiftMem n_mem jMem : Word) :
     divN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -274,7 +274,7 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shift_mem n_mem j_mem) := by
+       shiftMem n_mem jMem) := by
   delta divN4StackPre; rfl
 
 /-- Full-depth unfold of `divN4StackPre`: expands the bundle, both `evmWordIs`
@@ -285,9 +285,9 @@ theorem divN4StackPre_unfold (sp : Word) (a b : EvmWord)
 theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) :
+     shiftMem n_mem jMem : Word) :
     divN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -303,9 +303,9 @@ theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-      ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
       ((sp + signExtend12 3984) ↦ₘ n_mem) **
-      ((sp + signExtend12 3976) ↦ₘ j_mem))) := by
+      ((sp + signExtend12 3976) ↦ₘ jMem))) := by
   rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchValues_unfold]
 
@@ -317,7 +317,7 @@ theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
 def modN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) : Assertion :=
+     shiftMem n_mem jMem : Word) : Assertion :=
   (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
   (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
   (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -325,29 +325,29 @@ def modN4StackPre (sp : Word) (a b : EvmWord)
   (.x11 ↦ᵣ v11) **
   evmWordIs sp a ** evmWordIs (sp + 32) b **
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shift_mem n_mem j_mem
+    shiftMem n_mem jMem
 
 theorem pcFree_modN4StackPre (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem).pcFree := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem).pcFree := by
   delta modN4StackPre; pcFree
 
 instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word) :
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word) :
     Assertion.PCFree (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem) :=
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem) :=
   ⟨pcFree_modN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem⟩
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem⟩
 
 /-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
 theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) :
+     shiftMem n_mem jMem : Word) :
     modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -355,7 +355,7 @@ theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
      (.x11 ↦ᵣ v11) **
      evmWordIs sp a ** evmWordIs (sp + 32) b **
      divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shift_mem n_mem j_mem) := by
+       shiftMem n_mem jMem) := by
   delta modN4StackPre; rfl
 
 /-- Full-depth unfold of `modN4StackPre`: expands the bundle, both
@@ -364,9 +364,9 @@ theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
 theorem modN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shift_mem n_mem j_mem : Word) :
+     shiftMem n_mem jMem : Word) :
     modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem =
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
@@ -382,9 +382,9 @@ theorem modN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-      ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
       ((sp + signExtend12 3984) ↦ₘ n_mem) **
-      ((sp + signExtend12 3976) ↦ₘ j_mem))) := by
+      ((sp + signExtend12 3976) ↦ₘ jMem))) := by
   rw [modN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchValues_unfold]
 
@@ -545,7 +545,7 @@ theorem modN4MaxSkipStackPost_unfold_atoms_right (sp : Word) (a b : EvmWord)
     `divN4StackPre_unfold_atoms_right`. -/
 theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word)
     (Q : Assertion) :
     (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -562,11 +562,11 @@ theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
        ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))) ** Q) =
+       ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
     (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem ** Q) := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem ** Q) := by
   rw [modN4StackPre_unfold_atoms]
 
 /-- Mid-tree variant of `divN4StackPre_unfold_atoms`: threads a remainder
@@ -575,7 +575,7 @@ theorem modN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     fold variants. -/
 theorem divN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem : Word)
     (Q : Assertion) :
     (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -592,11 +592,11 @@ theorem divN4StackPre_unfold_atoms_right (sp : Word) (a b : EvmWord)
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
        ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3992) ↦ₘ shift_mem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
        ((sp + signExtend12 3984) ↦ₘ n_mem) **
-       ((sp + signExtend12 3976) ↦ₘ j_mem))) ** Q) =
+       ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
     (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem ** Q) := by
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem ** Q) := by
   rw [divN4StackPre_unfold_atoms]
 
 /-- Mid-tree variant of the `divN4MaxSkipStackPost_unfold_atoms` family:
@@ -676,7 +676,7 @@ theorem mod_n4_max_skip_stack_weaken
 theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11_old : Word)
     (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -690,7 +690,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
        (.x11 ↦ᵣ v11_old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValues sp q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old
-         u5 u6 u7 shift_mem n_mem j_mem)
+         u5 u6 u7 shiftMem n_mem jMem)
       (fullDivN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
@@ -701,7 +701,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v5 v6 v7 v10 v11_old
     q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-    n_mem shift_mem j_mem
+    n_mem shiftMem jMem
     hbnz' hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun h hp => by
@@ -738,7 +738,7 @@ theorem divScratchCellCount_pos : 0 < divScratchCellCount := by decide
 theorem evm_div_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -746,13 +746,13 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (hborrow : isSkipBorrowN4MaxEvm a b) :
     cpsTriple base (base + nopOff) (divCode base)
       (divN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
       (fullDivN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have h := evm_div_n4_full_max_skip_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    n_mem shift_mem j_mem hbnz hb3nz hshift_nz hbltu hborrow
+    n_mem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun _ hp => by rw [divN4StackPre_unfold] at hp; exact hp)
     (fun _ hq => hq)
@@ -871,7 +871,7 @@ theorem evm_mod_bzero_stack_spec (sp base : Word)
 theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11_old : Word)
     (q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -885,7 +885,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
        (.x11 ↦ᵣ v11_old) **
        evmWordIs sp a ** evmWordIs (sp + 32) b **
        divScratchValues sp q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old
-         u5 u6 u7 shift_mem n_mem j_mem)
+         u5 u6 u7 shiftMem n_mem jMem)
       (fullModN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
@@ -896,7 +896,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
     v5 v6 v7 v10 v11_old
     q0 q1 q2 q3 u0_old u1_old u2_old u3_old u4_old u5 u6 u7
-    n_mem shift_mem j_mem
+    n_mem shiftMem jMem
     hbnz' hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun h hp => by
@@ -913,7 +913,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
 theorem evm_mod_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -921,13 +921,13 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
     (hborrow : isSkipBorrowN4MaxEvm a b) :
     cpsTriple base (base + nopOff) (modCode base)
       (modN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
       (fullModN4MaxSkipPost sp
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have h := evm_mod_n4_full_max_skip_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    n_mem shift_mem j_mem hbnz hb3nz hshift_nz hbltu hborrow
+    n_mem shiftMem jMem hbnz hb3nz hshift_nz hbltu hborrow
   exact cpsTriple_weaken
     (fun _ hp => by rw [modN4StackPre_unfold] at hp; exact hp)
     (fun _ hq => hq)
@@ -991,7 +991,7 @@ theorem output_slot_to_evmWordIs_mod_n4_max_skip (sp : Word) (a b : EvmWord)
 theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -1000,10 +1000,10 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
     (hsem : n4MaxSkipSemanticHolds a b) :
     cpsTriple base (base + nopOff) (divCode base)
       (divN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
       (divN4MaxSkipStackPost sp a b) := by
   have h_pre := evm_div_n4_full_max_skip_stack_pre_spec_bundled sp base a b
-    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shift_mem j_mem
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3, _, _, _, _⟩ :=
     n4_max_skip_div_mod_getLimbN a b hb3nz hsem
@@ -1055,7 +1055,7 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
 theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
     (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     n_mem shift_mem j_mem : Word)
+     n_mem shiftMem jMem : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
@@ -1066,10 +1066,10 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
         2 ^ (64 - (clzResult (b.getLimbN 3)).1.toNat)) :
     cpsTriple base (base + nopOff) (modCode base)
       (modN4StackPre sp a b v5 v6 v7 v10 v11
-         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shift_mem n_mem j_mem)
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem n_mem jMem)
       (modN4MaxSkipStackPost sp a b) := by
   have h_pre := evm_mod_n4_full_max_skip_stack_pre_spec_bundled sp base a b
-    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shift_mem j_mem
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 n_mem shiftMem jMem
     hbnz hb3nz hshift_nz hbltu hborrow
   -- Shift bound: clzResult.1.toNat ≤ 63, and hshift_nz gives it > 0.
   have hshift_le_63 := clzResult_fst_toNat_le (b.getLimbN 3)

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -775,7 +775,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbody0 := cpsTriple_extend_code (body_0_sub_shrCode base)
     (shr_body_0_spec (sp + 32) limbShift sltiuVal bitShift antiShift mask
       v0 v1 v2 v3 (base + 240) (base + 360) 24 (shr_body0_exit base))
-  -- Frame each body with (x0=0 ** shift_mem)
+  -- Frame each body with (x0=0 ** shiftMem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody3

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -938,7 +938,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbody0 := cpsTriple_extend_code (sar_body_0_sub_sarCode base)
     (sar_body_0_spec (sp + 32) limbShift sltiuVal bitShift antiShift mask
       v0 v1 v2 v3 (base + 252) (base + 380) 32 (sar_body0_exit base))
-  -- Frame each body with (x0=0 ** shift_mem)
+  -- Frame each body with (x0=0 ** shiftMem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 380) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody3

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -750,7 +750,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbody0 := cpsTriple_extend_code (shl_body_0_sub_shlCode base)
     (shl_body_0_spec (sp + 32) limbShift sltiuVal bitShift antiShift mask
       v0 v1 v2 v3 (base + 240) (base + 360) 24 (shl_body0_exit base))
-  -- Frame each body with (x0=0 ** shift_mem)
+  -- Frame each body with (x0=0 ** shiftMem)
   have hbody3_f := cpsTriple_frame_left (base + 84) (base + 360) _ _ _
     ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hbody3

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -589,15 +589,15 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 v_old : Word) (offset : BitVec 12) 
 -- ============================================================================
 
 /-- Generic spec for LD: load doubleword from memory.
-    Pre:  (rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (addr ↦ₘ mem_val)
-    Post: (rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ mem_val) ** (addr ↦ₘ mem_val)
+    Pre:  (rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** (addr ↦ₘ memVal)
+    Post: (rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ memVal) ** (addr ↦ₘ memVal)
     where addr = v_addr + signExtend12 offset -/
-theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
+theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old memVal : Word)
     (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ mem_val) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val)) := by
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ memVal))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LD rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LD rd rs1 offset) s).mp hcr
@@ -606,7 +606,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
       (holdsFor_sepConj_elim_left hPR))
   have hmem_piece := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
     (holdsFor_sepConj_elim_left hPR))
-  have hmem : s.getMem (v_addr + signExtend12 offset) = mem_val :=
+  have hmem : s.getMem (v_addr + signExtend12 offset) = memVal :=
     holdsFor_memIs_getMem hmem_piece
   have hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess hmem_piece
@@ -614,9 +614,9 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
   have hstep' : step s = some (execInstrBr s (.LD rd rs1 offset)) :=
     step_ld s rd rs1 offset hfetch (hrs1 ▸ hvalid)
   -- execInstrBr s (.LD rd rs1 offset) = (s.setReg rd (s.getMem (s.getReg rs1 + signExtend12 offset))).setPC (s.pc + 4)
-  have hexec' : execInstrBr s (.LD rd rs1 offset) = (s.setReg rd mem_val).setPC (s.pc + 4) := by
+  have hexec' : execInstrBr s (.LD rd rs1 offset) = (s.setReg rd memVal).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, hmem]
-  refine ⟨1, (s.setReg rd mem_val).setPC (s.pc + 4), ?_, rfl, ?_⟩
+  refine ⟨1, (s.setReg rd memVal).setPC (s.pc + 4), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · -- Pull rd (position 2) to front: 1 pull_second + assoc
@@ -625,7 +625,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word)
     -- Need to separate rd from mem first
     have h1a := holdsFor_sepConj_assoc.mp h1
     -- h1a : (rd ** (mem ** (rs1 ** R)))
-    have h2 := holdsFor_sepConj_regIs_setReg (v' := mem_val) hrd_ne_x0 h1a
+    have h2 := holdsFor_sepConj_regIs_setReg (v' := memVal) hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -224,40 +224,40 @@ theorem auipc_spec (rd : Reg) (v_old : Word) (imm : BitVec 20) (base : Word)
 -- ============================================================================
 
 /-- LD rd, offset(rs1): rd := mem[rs1 + sext(offset)] (registers distinct) -/
-theorem ld_spec (rd rs1 : Reg) (v_addr v_old mem_val : Word) (offset : BitVec 12) (base : Word)
+theorem ld_spec (rd rs1 : Reg) (v_addr v_old memVal : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ mem_val) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val)) :=
-  generic_ld_spec rd rs1 v_addr v_old mem_val offset base hrd_ne_x0
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ memVal))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) :=
+  generic_ld_spec rd rs1 v_addr v_old memVal offset base hrd_ne_x0
 
 /-- LD rd, offset(rd): rd := mem[rd + sext(offset)] (same register) -/
-theorem ld_spec_same (rd : Reg) (v_addr mem_val : Word) (offset : BitVec 12) (base : Word)
+theorem ld_spec_same (rd : Reg) (v_addr memVal : Word) (offset : BitVec 12) (base : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple base (base + 4) (CodeReq.singleton base (.LD rd rd offset))
-      ((rd ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val))
-      ((rd ↦ᵣ mem_val) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val)) := by
+      ((rd ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ memVal))
+      ((rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LD rd rd offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LD rd rd offset) s).mp hcr
   have hrd : s.getReg rd = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hmem_piece := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
-  have hmem : s.getMem (v_addr + signExtend12 offset) = mem_val :=
+  have hmem : s.getMem (v_addr + signExtend12 offset) = memVal :=
     holdsFor_memIs_getMem hmem_piece
   have hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess hmem_piece
   have hstep' : step s = some (execInstrBr s (.LD rd rd offset)) :=
     step_ld s rd rd offset hfetch (hrd ▸ hvalid)
-  have hexec' : execInstrBr s (.LD rd rd offset) = (s.setReg rd mem_val).setPC (s.pc + 4) := by
+  have hexec' : execInstrBr s (.LD rd rd offset) = (s.setReg rd memVal).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrd, hmem]
-  refine ⟨1, (s.setReg rd mem_val).setPC (s.pc + 4), ?_, rfl, ?_⟩
+  refine ⟨1, (s.setReg rd memVal).setPC (s.pc + 4), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · -- Pre: (rd ** mem) ** R → assoc → rd ** (mem ** R)
     have h1 := holdsFor_sepConj_assoc.mp hPR
     -- Update rd: rd ** (mem ** R) → rd' ** (mem ** R)
-    have h2 := holdsFor_sepConj_regIs_setReg (v' := mem_val) hrd_ne_x0 h1
+    have h2 := holdsFor_sepConj_regIs_setReg (v' := memVal) hrd_ne_x0 h1
     -- Reassociate: rd' ** (mem ** R) → (rd' ** mem) ** R
     have h3 := holdsFor_sepConj_assoc.mpr h2
     exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -28,13 +28,13 @@ namespace EvmAsm.Rv64
 -- LD/SD specs (primary memory access for EVM64)
 -- ============================================================================
 
-@[spec_gen_rv64] theorem ld_spec_gen (rd rs1 : Reg) (v_addr v_old mem_val : Word)
+@[spec_gen_rv64] theorem ld_spec_gen (rd rs1 : Reg) (v_addr v_old memVal : Word)
     (offset : BitVec 12) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LD rd rs1 offset))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val))
-      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ mem_val) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val)) :=
-  generic_ld_spec rd rs1 v_addr v_old mem_val offset addr hrd_ne_x0
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ v_old) ** ((v_addr + signExtend12 offset) ↦ₘ memVal))
+      ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) :=
+  generic_ld_spec rd rs1 v_addr v_old memVal offset addr hrd_ne_x0
 
 @[spec_gen_rv64] theorem sd_spec_gen (rs1 rs2 : Reg) (v_addr v_data mem_old : Word)
     (offset : BitVec 12) (addr : Word) :
@@ -593,13 +593,13 @@ namespace EvmAsm.Rv64
 -- LD same register: LD rd, offset(rd) (rd = rs1)
 -- ============================================================================
 
-@[spec_gen_rv64] theorem ld_spec_gen_same (rd : Reg) (v_addr mem_val : Word)
+@[spec_gen_rv64] theorem ld_spec_gen_same (rd : Reg) (v_addr memVal : Word)
     (offset : BitVec 12) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
     cpsTriple addr (addr + 4) (CodeReq.singleton addr (.LD rd rd offset))
-      ((rd ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val))
-      ((rd ↦ᵣ mem_val) ** ((v_addr + signExtend12 offset) ↦ₘ mem_val)) :=
-  ld_spec_same rd v_addr mem_val offset addr hrd_ne_x0
+      ((rd ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ memVal))
+      ((rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) :=
+  ld_spec_same rd v_addr memVal offset addr hrd_ne_x0
 
 -- ============================================================================
 -- ORI specs


### PR DESCRIPTION
## Summary
Renames four scratch-memory parameters across 30 files (345 occurrences):
- \`idx_mem\` → \`idxMem\`
- \`j_mem\` → \`jMem\`
- \`shift_mem\` → \`shiftMem\`
- \`mem_val\` → \`memVal\`

Scope includes DivMod loop files, MulSub* LimbSpecs, Rv64 \`InstructionSpecs\`/\`SyscallSpecs\`, and Compose files.

Per Mathlib rule 4. Continues the gradual #189 migration.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)