### PR TITLE
docs: update deprecated cpsTriple_consequence refs in comments

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -661,7 +661,7 @@ theorem divK_correction_addback_spec
     ntaken_framedAB
 
 /-- Variant of correction_addback_spec with addbackN4/addbackN4_carry in postcondition.
-    Same proof via cpsTriple_consequence (definitional equality). -/
+    Same proof via cpsTriple_weaken (definitional equality). -/
 theorem divK_correction_addback_named_spec
     (sp u_base borrow q_hat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5_old v2_old : Word) (base : Word)

--- a/EvmAsm/Rv64/Tactics/LiftSpec.lean
+++ b/EvmAsm/Rv64/Tactics/LiftSpec.lean
@@ -14,7 +14,7 @@
 
   1. The goal should be `cpsTriple entry exit goalPre goalPost`
   2. `h_main` should be `cpsTriple entry exit mainPre mainPost`
-  3. Applies `cpsTriple_consequence` with `h_main`
+  3. Applies `cpsTriple_weaken` with `h_main`
   4. In the pre/post lambdas: unfolds `evmWordIs`/`evmStackIs`, normalizes
      addresses via `BitVec.add_assoc`, then permutes via `xperm_hyp`
 -/


### PR DESCRIPTION
## Summary
Two-line docstring fix — points \`LiftSpec.lean\` and \`LoopBody.lean\` comments at the non-deprecated name \`cpsTriple_weaken\` instead of the deprecated \`cpsTriple_consequence\`.

The tactic metacode in \`RunBlock.lean\` / \`SeqFrame.lean\` still references \`cpsTriple_consequence\` via \`mkConst\`; migrating those needs an implicit-arg-aware \`mkAppM\` rewrite and is out of scope.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Comment-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)