### PR TITLE
refactor(rv64): rename sub_base/s1_base to camelCase (#189)

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -93,12 +93,12 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
     CodeReq.Disjoint.singleton (by bv_omega) _ _
   -- Step 1: SLLI x11, x11, 8 — use `slli_spec_gen_same` (rd = rs1),
   -- then frame with x12 to bring it into scope.
-  have s1_base := slli_spec_gen_same .x11 len 8 base (by nofun)
+  have s1Base := slli_spec_gen_same .x11 len 8 base (by nofun)
   have s1 : cpsTriple base (base + 4)
       (CodeReq.singleton base (.SLLI .x11 .x11 8))
       ((.x11 ↦ᵣ len) ** (.x12 ↦ᵣ byte))
       ((.x11 ↦ᵣ (len <<< (8 : BitVec 6).toNat)) ** (.x12 ↦ᵣ byte)) :=
-    cpsTriple_frameR (.x12 ↦ᵣ byte) (by pcFree) s1_base
+    cpsTriple_frameR (.x12 ↦ᵣ byte) (by pcFree) s1Base
   -- Step 2: ADD x11, x11, x12 — `add_spec_gen_rd_eq_rs1` (rd = rs1 = x11,
   -- rs2 = x12). No framing needed.
   have s2 := add_spec_gen_rd_eq_rs1 .x11 .x12

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2479,16 +2479,16 @@ theorem CodeReq.ofProg_mono_subrange (base : Word) (pre mid suf : List Instr)
     (by rwa [← List.append_assoc]) a i
     (CodeReq.ofProg_mono_append_left _ mid suf a i h)
 
-/-- Sub-range monotonicity with explicit offset: `ofProg sub_base sub ⊆ ofProg base full`
+/-- Sub-range monotonicity with explicit offset: `ofProg subBase sub ⊆ ofProg base full`
     when `sub` is a contiguous slice of `full` starting at instruction index `idx`
-    (byte offset `sub_base = base + 4*idx`). -/
-theorem CodeReq.ofProg_mono_sub (base sub_base : Word) (full sub : List Instr)
+    (byte offset `subBase = base + 4*idx`). -/
+theorem CodeReq.ofProg_mono_sub (base subBase : Word) (full sub : List Instr)
     (idx : Nat)
-    (h_addr : sub_base = base + BitVec.ofNat 64 (4 * idx))
+    (h_addr : subBase = base + BitVec.ofNat 64 (4 * idx))
     (h_slice : (full.drop idx).take sub.length = sub)
     (h_range : idx + sub.length ≤ full.length)
     (hbound : 4 * full.length < 2^64) :
-    ∀ a i, (CodeReq.ofProg sub_base sub) a = some i →
+    ∀ a i, (CodeReq.ofProg subBase sub) a = some i →
            (CodeReq.ofProg base full) a = some i := by
   intro a i h; rw [h_addr] at h
   -- Decompose: full.drop idx = sub ++ full.drop (idx + sub.length)


### PR DESCRIPTION
## Summary
Two small renames to lowerCamelCase per Mathlib rule 4:
- \`sub_base\` → \`subBase\` in \`EvmAsm/Rv64/SepLogic.lean\` (5 occurrences)
- \`s1_base\` → \`s1Base\` in \`EvmAsm/Rv64/RLP/Phase2LongAcc.lean\` (2 occurrences)

Self-contained — these files aren't covered by other pending #189 PRs.

## Test plan
- [x] Full \`lake build\` succeeds (3552 jobs)
- [x] Identifier-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)