### PR TITLE
docs: clarify hypothesis vs let-binding naming in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,8 +42,8 @@ We follow the [Mathlib4 naming guide](https://leanprover-community.github.io/con
 
 **Local variables inside proofs** (bound by `have`, `intro`, `let`) follow the same rules by extension:
 
-- Proof/hypothesis names (most `have`/`intro`) — `snake_case` (rule 1). Short forms like `h`, `hx`, `h1`, `hab` are standard. Descriptive forms like `carry_in`, `u_plus_carry` are fine.
-- `let`-bound values of `Type`s — `lowerCamelCase` (rule 4). e.g. `let midPoint := ...`.
+- Proof/hypothesis names (most `have`/`intro`) — `snake_case` (rule 1). Short forms like `h`, `hx`, `h1`, `hab` are standard. Descriptive forms like `h_carry_pos`, `add_lt_aux` are fine.
+- `let`-bound values of `Type`s — `lowerCamelCase` (rule 4). e.g. `let midPoint := ...`, `let carryIn := ...`. A Word-valued local called `carryIn` is a Type term (rule 4), not a Prop term (rule 1) — even though the underlying computation is carry arithmetic.
 
 ## Git Workflow
 


### PR DESCRIPTION
## Summary
The previous examples under "hypothesis names" (\`carry_in\`, \`u_plus_carry\`) were misleading: in the actual codebase those are Word-valued parameters / \`let\`-bound locals, i.e. Type terms (Mathlib rule 4, \`lowerCamelCase\`), not Prop hypothesis names (rule 1, snake_case).

Replace the examples with clearly-Prop-flavored names (\`h_carry_pos\`, \`add_lt_aux\`) and add an explicit note that a Word-valued \`carryIn\` follows rule 4 even though the meaning is "carry arithmetic."

Motivated by the running #189 migration — contributors (and automated renamers) were getting mixed signals about which identifiers should stay snake_case.

## Test plan
- [x] Doc-only change

🤖 Generated with [Claude Code](https://claude.com/claude-code)