### PR TITLE
feat(divmod): invert addbackN4_second_carry_one to derive hq_over (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -35,3 +35,4 @@ import EvmAsm.Evm64.EvmWordArith.Val256ModBridge
 import EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
+import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+
+  Inversion of `addbackN4_second_carry_one`: derive the trial-quotient
+  overestimate bound (`q ≤ ⌊u/v⌋ + 2`) from the second-addback carry = 1.
+
+  This unblocks the double-addback correctness path: the runtime
+  `isAddbackCarry2NzN4Max` check gives the algorithm a carry2 ≠ 0 witness
+  (combined with `carry2 < 2` to pin it to 1); from carry2 = 1 this file
+  proves the overestimate bound, which then feeds
+  `mulsub_double_addback_val256_combined` to get the Euclidean equation
+  `val256(u) = (q - 2) * val256(v) + val256(ab')`.
+
+  Foundation for `n4_max_double_addback_correct` (Phase A of the n=4
+  max+addback stack spec roadmap, Issue #61).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmWord EvmAsm.Rv64
+
+/-- Inversion: if the second-addback carry is 1 (double-addback path), the
+    trial quotient `q` overestimates `⌊val256(u)/val256(v)⌋` by at most 2.
+    Converse to `addbackN4_second_carry_one` — that theorem assumes
+    `hq_over` and proves `carry2 = 1`; this one uses `carry2 = 1` to
+    conclude `hq_over`. -/
+theorem hq_over_from_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_one : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry_zero : (addbackN4_carry
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+      v0 v1 v2 v3) = 0)
+    (hcarry2_one :
+      let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
+      (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3).toNat = 1) :
+    q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2 := by
+  simp only [] at hcarry2_one
+  -- From c3 = 1: val256(u) + 2^256 = val256(un) + q * val256(v)
+  have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
+  simp only [] at hmulsub
+  rw [show (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
+  have h1w : (1 : Word).toNat = 1 := by decide
+  rw [h1w] at hmulsub
+  -- First addback: val256(un) + val256(v) = val256(ab1) + 0 * 2^256 = val256(ab1)
+  set ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3 with hms_def
+  have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
+  simp only [] at hab1
+  have hc1_val : (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3).toNat = 0 := by
+    rw [hcarry_zero]; decide
+  rw [hc1_val] at hab1
+  -- Second addback: val256(ab1) + val256(v) = val256(ab') + 1 * 2^256
+  set ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3 with hab_def
+  have hab' := addbackN4_val256_eq ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3
+  simp only [] at hab'
+  rw [hcarry2_one] at hab'
+  -- Bounds
+  have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero v0 v1 v2 v3 hbnz
+  have hab'_bound := val256_bound
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.2.1
+    (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.2.2.1
+  -- From hab' + hab'_bound: val256(ab1) + val256(v) ≥ 2^256 + 1 > 2^256
+  -- Combined with hab1 (val256(un) + val256(v) = val256(ab1)):
+  --   val256(un) + 2 * val256(v) ≥ 2^256 + 1
+  -- From hmulsub: val256(un) = val256(u) + 2^256 - q * val256(v)
+  --   val256(u) + 2^256 - q * val256(v) + 2 * val256(v) ≥ 2^256 + 1
+  --   val256(u) + (2 - q) * val256(v) ≥ 1  (signed arithmetic)
+  --   val256(u) ≥ (q - 2) * val256(v)  (Nat subtraction handles q < 2 trivially)
+  -- Hence u/v ≥ q - 2, i.e., q ≤ u/v + 2.
+  have hq_v_le_plus : q.toNat * val256 v0 v1 v2 v3 ≤
+      val256 u0 u1 u2 u3 + 2 * val256 v0 v1 v2 v3 := by nlinarith
+  -- (q - 2) * v ≤ u
+  have hqm2_le : (q.toNat - 2) * val256 v0 v1 v2 v3 ≤ val256 u0 u1 u2 u3 := by
+    rcases Nat.lt_or_ge q.toNat 2 with hq_lt | hq_ge
+    · -- q < 2: q - 2 = 0, trivial
+      have : q.toNat - 2 = 0 := by omega
+      rw [this]; simp
+    · -- q ≥ 2
+      have hq_split : q.toNat * val256 v0 v1 v2 v3 =
+          (q.toNat - 2) * val256 v0 v1 v2 v3 + 2 * val256 v0 v1 v2 v3 := by
+        have : q.toNat = (q.toNat - 2) + 2 := by omega
+        nlinarith
+      linarith
+  -- u/v ≥ q - 2
+  have hdiv_ge : val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 ≥ q.toNat - 2 := by
+    exact Nat.le_div_iff_mul_le hv_pos |>.mpr (by linarith [Nat.mul_comm (q.toNat - 2) (val256 v0 v1 v2 v3)])
+  omega
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -253,4 +253,55 @@ theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     rw [hq_val, hq_hat''_toNat]; exact hcombined
   exact val256_euclidean_to_div_mod hbnz heuclid hab'_bound
 
+-- ============================================================================
+-- Per-limb and EvmWord-level bridges for the double-addback case
+-- ============================================================================
+
+/-- n=4 max+double-addback path: per-limb quotient/remainder equalities.
+    Direct consumer-facing form of `n4_max_double_addback_correct` —
+    parallels `n4_max_addback_div_mod_limbs`. The corrected quotient is
+    `q_hat'' = 3 * signExtend12 4095 = 2^64 - 3` in the low limb. -/
+theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hc3_one : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 1)
+    (hcarry1_zero : addbackN4_carry
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.1
+      b0 b1 b2 b3 = 0)
+    (hcarry2_one :
+      let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
+      (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 b0 b1 b2 b3).toNat = 1) :
+    let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0 b1 b2 b3
+    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+      signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    let a := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
+    let b := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
+    (EvmWord.div a b).getLimbN 0 = q_hat'' ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 ∧
+    (EvmWord.mod a b).getLimbN 0 = ab'.1 ∧
+    (EvmWord.mod a b).getLimbN 1 = ab'.2.1 ∧
+    (EvmWord.mod a b).getLimbN 2 = ab'.2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 3 = ab'.2.2.2.1 := by
+  intro ms ab ab' q_hat'' a b
+  have ⟨hq, hr⟩ := n4_max_double_addback_correct a0 a1 a2 a3 b0 b1 b2 b3
+    hb3nz hc3_one hcarry1_zero hcarry2_one
+  refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · rw [← hq]; exact getLimbN_fromLimbs_0 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_1 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_2 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_3 _ _ _ _
+  · rw [← hr]; exact getLimbN_fromLimbs_0 _ _ _ _
+  · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
+  · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
+  · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -93,4 +93,164 @@ theorem hq_over_from_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     exact Nat.le_div_iff_mul_le hv_pos |>.mpr (by linarith [Nat.mul_comm (q.toNat - 2) (val256 v0 v1 v2 v3)])
   omega
 
+-- ============================================================================
+-- Double-addback correctness: n=4 max trial, c3=1, carry1=0, carry2=1
+-- ============================================================================
+
+/-- Double-addback path (c3 = 1, carry1 = 0, carry2 = 1, max trial) at n=4:
+    the corrected quotient `q_hat - 2 = signExtend12 4095 * 3 = 2^64 - 3`
+    equals ⌊val256(a)/val256(b)⌋, and the second-addback remainder equals
+    `val256(a) mod val256(b)`.
+
+    Parallels `n4_max_addback_correct` (single-addback case); proof threads
+    `hq_over_from_second_carry_one` + `mulsub_double_addback_val256_combined`
+    + `val256_euclidean_to_div_mod`. -/
+theorem n4_max_double_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hc3_one : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 1)
+    (hcarry1_zero : addbackN4_carry
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.1
+      (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.1
+      b0 b1 b2 b3 = 0)
+    (hcarry2_one :
+      let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
+      (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 b0 b1 b2 b3).toNat = 1) :
+    let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2) b0 b1 b2 b3
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0 b1 b2 b3
+    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+      signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    let a := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => a0 | 1 => a1 | 2 => a2 | 3 => a3
+    let b := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3
+    let q := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => q_hat'' | 1 => (0 : Word) | 2 => (0 : Word) | 3 => (0 : Word)
+    let r := fromLimbs fun i : Fin 4 =>
+      match i with | 0 => ab'.1 | 1 => ab'.2.1 | 2 => ab'.2.2.1 | 3 => ab'.2.2.2.1
+    q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
+  intro ms ab ab' q_hat'' a b q r
+  have hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0 := by
+    intro h; exact hb3nz (BitVec.or_eq_zero_iff.mp h).2
+  -- Bridge: for any u_top, addbackN4's low-4 outputs are the same. So both
+  -- the algorithm's `ab` (u4_new = 0 - c3) and lemma's ab (u4_new = 0) share
+  -- low-4 limbs, and the second-addback low-4 outputs also match.
+  have h_ab_indep := addbackN4_fst4_u4_indep ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    ((0 : Word) - ms.2.2.2.2) 0 b0 b1 b2 b3
+  obtain ⟨hab_eq1, hab_eq21, hab_eq221, hab_eq2221⟩ := h_ab_indep
+  -- Abbreviate lemma's ab (with u4_new = 0): write it as `ab0` shorthand.
+  -- ab0.{1, 2.1, 2.2.1, 2.2.2.1} = ab.{…} by hab_eq{1,21,221,2221}.
+  -- Convert algorithm carry2 = 1 to the lemma's form via hab_eq*.
+  have hcarry2_lem : (addbackN4_carry
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      b0 b1 b2 b3).toNat = 1 := by
+    have := hcarry2_one
+    simp only [] at this
+    rw [← hab_eq1, ← hab_eq21, ← hab_eq221, ← hab_eq2221]
+    exact this
+  -- Derive hq_over from carry2 = 1.
+  have hq_over := hq_over_from_second_carry_one (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
+    hbnz hc3_one hcarry1_zero hcarry2_lem
+  -- q_hat ≥ 2: trivial.
+  have hq_hat_toNat : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2 ^ 64 - 1 := by decide
+  have hq_ge_2 : (signExtend12 (4095 : BitVec 12) : Word).toNat ≥ 2 := by
+    rw [hq_hat_toNat]; decide
+  -- Apply combined Euclidean lemma: val256(a) = (q-2)*val256(b) + val256(ab'_lem).
+  have hcombined := mulsub_double_addback_val256_combined
+    (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3 hbnz hq_over hc3_one hcarry1_zero hq_ge_2
+  simp only [] at hcombined
+  -- Bridge from lemma's ab' to algorithm's ab': both second addbacks compute
+  -- from the same low-4 ab limbs (low 4 are u_top-independent), and second
+  -- addback's low-4 outputs are themselves u_top-independent. So their
+  -- low-4 val256s match.
+  have h_ab'_alg_indep := addbackN4_fst4_u4_indep ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+    ab.2.2.2.2 0 b0 b1 b2 b3
+  obtain ⟨hab'_1, hab'_21, hab'_221, hab'_2221⟩ := h_ab'_alg_indep
+  -- Low-4 of algorithm's ab' = low-4 of lemma's ab' (via hab_eq* substitution).
+  have hab'_eq1 : ab'.1 = (addbackN4
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      0 b0 b1 b2 b3).1 := by
+    rw [show ab' = _ from rfl, hab'_1, hab_eq1, hab_eq21, hab_eq221, hab_eq2221]
+  have hab'_eq21 : ab'.2.1 = (addbackN4
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      0 b0 b1 b2 b3).2.1 := by
+    rw [show ab' = _ from rfl, hab'_21, hab_eq1, hab_eq21, hab_eq221, hab_eq2221]
+  have hab'_eq221 : ab'.2.2.1 = (addbackN4
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      0 b0 b1 b2 b3).2.2.1 := by
+    rw [show ab' = _ from rfl, hab'_221, hab_eq1, hab_eq21, hab_eq221, hab_eq2221]
+  have hab'_eq2221 : ab'.2.2.2.1 = (addbackN4
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      0 b0 b1 b2 b3).2.2.2.1 := by
+    rw [show ab' = _ from rfl, hab'_2221, hab_eq1, hab_eq21, hab_eq221, hab_eq2221]
+  -- Rewrite the combined equation to algorithm's ab'.
+  rw [← hab'_eq1, ← hab'_eq21, ← hab'_eq221, ← hab'_eq2221] at hcombined
+  -- Derive val256(ab') < val256(v) via the second-addback equation on lemma's form.
+  have hab'_bound_lem : val256
+      (addbackN4 (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+        0 b0 b1 b2 b3).1
+      (addbackN4 (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+        0 b0 b1 b2 b3).2.1
+      (addbackN4 (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+        0 b0 b1 b2 b3).2.2.1
+      (addbackN4 (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+        (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+        0 b0 b1 b2 b3).2.2.2.1
+      < val256 b0 b1 b2 b3 := by
+    have hab'_eq := addbackN4_val256_eq
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+      0 b0 b1 b2 b3
+    simp only [] at hab'_eq
+    rw [hcarry2_lem] at hab'_eq
+    have hab_lem_bound := val256_bound
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1
+      (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.2.1
+    linarith
+  -- Transport the bound to algorithm's ab'.
+  have hab'_bound : val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 < val256 b0 b1 b2 b3 := by
+    rw [hab'_eq1, hab'_eq21, hab'_eq221, hab'_eq2221]; exact hab'_bound_lem
+  -- Rewrite the Euclidean equation in val256_euclidean_to_div_mod's expected form.
+  have hq_hat''_toNat : q_hat''.toNat = (signExtend12 (4095 : BitVec 12) : Word).toNat - 2 := by
+    simp only [q_hat'']; decide
+  have hq_val : val256 q_hat'' 0 0 0 = q_hat''.toNat := val256_zero_upper_3 q_hat''
+  have heuclid : val256 a0 a1 a2 a3 =
+      val256 q_hat'' 0 0 0 * val256 b0 b1 b2 b3 +
+      val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 := by
+    rw [hq_val, hq_hat''_toNat]; exact hcombined
+  exact val256_euclidean_to_div_mod hbnz heuclid hab'_bound
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

- New `hq_over_from_second_carry_one` in `DivN4DoubleAddback.lean`: if the second addback carry is 1, the trial quotient `q` overestimates `⌊val256(u)/val256(v)⌋` by at most 2.
- Inverse of the existing `addbackN4_second_carry_one` (forward direction: `hq_over` ⇒ carry2 = 1).

## Why

Phase A of the n=4 max+addback stack spec roadmap (Issue #61). The algorithm's runtime `isAddbackCarry2NzN4Max` check gives `carry2 ≠ 0`; combined with `carry2 < 2` that pins `carry2 = 1`. This new inversion lemma then yields the `hq_over` hypothesis needed by `mulsub_double_addback_val256_combined` to derive

```
val256(u) = (q - 2) * val256(v) + val256(ab')
```

which is the Euclidean equation for the double-addback correctness theorem `n4_max_double_addback_correct` (forthcoming).

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback` — clean (3.5s)
- [x] `lake build` — full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)