### PR TITLE
feat(divmod): n4_max_double_addback_div_mod_getLimbN — Phase B (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -21,6 +21,20 @@ namespace EvmAsm.Evm64
 
 open EvmWord EvmAsm.Rv64
 
+/-- Local copy of `EvmWord.fromLimbs_match_getLimbN_id` with the match
+    expression elaborated in this file's context, so that the auxiliary
+    `match` function identity matches the one produced for our new lemmas'
+    `fromLimbs fun i => match i with ...` patterns. Needed because
+    `rewrite` requires syntactic identity of the match-auxiliary function,
+    and Lean generates these per-file. -/
+private theorem fromLimbs_match_getLimbN_id_local (v : EvmWord) :
+    (EvmWord.fromLimbs fun i : Fin 4 =>
+      match i with
+      | 0 => v.getLimbN 0
+      | 1 => v.getLimbN 1
+      | 2 => v.getLimbN 2
+      | 3 => v.getLimbN 3) = v := EvmWord.fromLimbs_match_getLimbN_id v
+
 /-- Inversion: if the second-addback carry is 1 (double-addback path), the
     trial quotient `q` overestimates `⌊val256(u)/val256(v)⌋` by at most 2.
     Converse to `addbackN4_second_carry_one` — that theorem assumes
@@ -303,5 +317,59 @@ theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
   · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
   · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+
+/-- n=4 max+double-addback path, EvmWord-level statement. Consumer form for
+    stack specs: takes `a b : EvmWord`, works off `getLimbN`. Parallels
+    `n4_max_addback_div_mod_getLimbN`. -/
+theorem n4_max_double_addback_div_mod_getLimbN (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hc3_one : (mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 1)
+    (hcarry1_zero : addbackN4_carry
+      (mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).1
+      (mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.1
+      (mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.1
+      (mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.1
+      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 0)
+    (hcarry2_one :
+      let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).toNat = 1) :
+    let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    let q_hat'' : Word := signExtend12 (4095 : BitVec 12) +
+      signExtend12 (4095 : BitVec 12) + signExtend12 (4095 : BitVec 12)
+    (EvmWord.div a b).getLimbN 0 = q_hat'' ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 ∧
+    (EvmWord.mod a b).getLimbN 0 = ab'.1 ∧
+    (EvmWord.mod a b).getLimbN 1 = ab'.2.1 ∧
+    (EvmWord.mod a b).getLimbN 2 = ab'.2.2.1 ∧
+    (EvmWord.mod a b).getLimbN 3 = ab'.2.2.2.1 := by
+  have hraw := n4_max_double_addback_div_mod_limbs
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    hb3nz hc3_one hcarry1_zero hcarry2_one
+  rw [fromLimbs_match_getLimbN_id_local a, fromLimbs_match_getLimbN_id_local b] at hraw
+  exact hraw
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds `n4_max_double_addback_div_mod_getLimbN` — the EvmWord-level form of the double-addback correctness theorem from PR #679. Takes `a b : EvmWord` and returns eight per-limb `getLimbN` equalities for `EvmWord.div` / `EvmWord.mod` on the double-addback path. Parallels `n4_max_addback_div_mod_getLimbN` (single-addback form).

Phase B of the n=4 max+addback stack spec roadmap (Issue #61), unblocking Phase C (semantic predicates) and beyond.

## Gotcha: match-auxiliary file-locality

The implementation requires a local copy (`private theorem fromLimbs_match_getLimbN_id_local`) of `EvmWord.fromLimbs_match_getLimbN_id`. The `rewrite` tactic needs syntactic identity of the `match`-auxiliary function, but Lean 4 generates these per-file. The LHS pattern in the original lemma (in `DivN4Overestimate.lean`) uses a different aux function than the match expressions produced for our new lemmas in `DivN4DoubleAddback.lean`, even though they're structurally identical. The local copy is definitionally equal (`EvmWord.fromLimbs_match_getLimbN_id v`) but has its LHS match expression elaborated in this file's context, so the aux function identity matches and `rewrite` succeeds.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback` — clean (4.3s)
- [x] Full `lake build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)