### PR TITLE
feat(divmod): n4MaxDoubleAddbackSemanticHolds predicate (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -24,9 +24,10 @@
     `isAddbackBorrowN4CallEvm`. Each is a thin shim over the Word-level
     predicate plus a `_def` `rfl` lemma.
   * Semantic-correctness predicates: `n4MaxSkipSemanticHolds`,
-    `n4MaxAddbackSemanticHolds` — package the un-normalized `mulsubN4`-carry
-    hypotheses `n4_max_skip_div_mod_getLimbN` / `n4_max_addback_div_mod_getLimbN`
-    consume.
+    `n4MaxAddbackSemanticHolds`, `n4MaxDoubleAddbackSemanticHolds` — package
+    the un-normalized `mulsubN4`-carry hypotheses that
+    `n4_max_skip_div_mod_getLimbN` / `n4_max_addback_div_mod_getLimbN` /
+    `n4_max_double_addback_div_mod_getLimbN` consume.
   * Weakeners: `div_n4_max_skip_stack_weaken`, `mod_n4_max_skip_stack_weaken` —
     turn specific register values + `evmWordIs` operand atoms + `divScratchValues`
     into `divN4MaxSkipStackPost` / `modN4MaxSkipStackPost`.
@@ -198,6 +199,43 @@ theorem n4MaxAddbackSemanticHolds_def (a b : EvmWord) :
      ms.2.2.2.2 = 1 ∧
      addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 1) :=
+  rfl
+
+/-- Semantic-correctness precondition for the n=4 max+double-addback sub-path:
+    on **un-normalized** `a`, `b` limbs with the maximum trial quotient, the
+    mulsub carry is `1`, the *first* addback carry is `0` (first addback didn't
+    overflow the low 256 bits), and the *second* addback carry is `1`
+    (second addback did overflow). Together these three facts feed
+    `n4_max_double_addback_div_mod_getLimbN` to conclude the per-limb
+    `EvmWord.div` / `EvmWord.mod` equalities for the double-addback path.
+
+    This is distinct from `n4MaxAddbackSemanticHolds` (single-addback: c3=1 ∧
+    carry1=1) and fires on the complementary algorithm branch where the first
+    addback doesn't correct the borrow but the second one does. -/
+def n4MaxDoubleAddbackSemanticHolds (a b : EvmWord) : Prop :=
+  let ms := mulsubN4 (signExtend12 4095)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+  ms.2.2.2.2 = 1 ∧
+  addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 0 ∧
+  (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).toNat = 1
+
+theorem n4MaxDoubleAddbackSemanticHolds_def (a b : EvmWord) :
+    n4MaxDoubleAddbackSemanticHolds a b =
+    (let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+     let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+     ms.2.2.2.2 = 1 ∧
+     addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) = 0 ∧
+     (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).toNat = 1) :=
   rfl
 
 /-- Stack-level postcondition shape for the n=4 DIV max+skip path.


### PR DESCRIPTION
## Summary

Adds `n4MaxDoubleAddbackSemanticHolds` semantic-correctness predicate for the n=4 max+double-addback sub-path. Packages the three un-normalized carry facts that `n4_max_double_addback_div_mod_getLimbN` (PR #680) consumes:

- mulsub borrow c3 = 1
- first addback carry = 0 (first addback didn't overflow the low 256 bits)
- second addback carry = 1 (second addback did overflow)

Parallel to the existing `n4MaxAddbackSemanticHolds` (single-addback: c3=1 ∧ carry1=1). The two predicates fire on complementary algorithm branches of `fullDivN4MaxAddbackBeqPost`.

Phase C of the n=4 max+addback stack spec roadmap (Issue #61). Phase D (stack post bundles) and E/F (full-path wrappers + final stack spec) follow.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean (2.5s)
- [x] Full `lake build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)