### PR TITLE
feat(divmod): output-slot reshape lemmas for max+addback single (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1163,6 +1163,52 @@ theorem output_slot_to_evmWordIs_mod_n4_max_skip (sp : Word) (a b : EvmWord)
   rw [evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _
       hmod0 hmod1 hmod2 hmod3]
 
+/-- Max+addback (single) DIV output-slot reshape: the four sp+32..sp+56 atoms
+    written by `denormDivPost` with `q_out = signExtend12 4095 +
+    signExtend12 4095` and upper q-limbs zero fold into
+    `evmWordIs (sp+32) (EvmWord.div a b)` under the semantic-correctness
+    precondition `n4MaxAddbackSemanticHolds`. Parallel to
+    `output_slot_to_evmWordIs_div_n4_max_skip`. -/
+theorem output_slot_to_evmWordIs_div_n4_max_addback_single (sp : Word)
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0) (hsem : n4MaxAddbackSemanticHolds a b) :
+    (((sp + 32) ↦ₘ (signExtend12 4095 + signExtend12 4095 : Word)) **
+     ((sp + 40) ↦ₘ (0 : Word)) **
+     ((sp + 48) ↦ₘ (0 : Word)) **
+     ((sp + 56) ↦ₘ (0 : Word))) =
+    evmWordIs (sp + 32) (EvmWord.div a b) := by
+  obtain ⟨hc3_one, hcarry_one⟩ := hsem
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3, _, _, _, _⟩ :=
+    n4_max_addback_div_mod_getLimbN a b hb3nz hc3_one hcarry_one
+  rw [evmWordIs_sp32_limbs_eq sp (EvmWord.div a b) _ _ _ _
+      hdiv0 hdiv1 hdiv2 hdiv3]
+
+/-- Max+addback (single) MOD output-slot reshape: the four sp+32..sp+56 atoms
+    carrying the un-normalized first-addback low-4 limbs fold into
+    `evmWordIs (sp+32) (EvmWord.mod a b)` under `n4MaxAddbackSemanticHolds`.
+    The stack spec itself threads an additional CLZ top-limb bound when
+    denormalizing (as in the max+skip MOD stack spec) — here we assert
+    only the per-limb equalities at the un-normalized level. -/
+theorem output_slot_to_evmWordIs_mod_n4_max_addback_single (sp : Word)
+    (a b : EvmWord)
+    (hb3nz : b.getLimbN 3 ≠ 0) (hsem : n4MaxAddbackSemanticHolds a b) :
+    let ms := mulsubN4 (signExtend12 4095)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 ((0 : Word) - ms.2.2.2.2)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    (((sp + 32) ↦ₘ ab.1) **
+     ((sp + 40) ↦ₘ ab.2.1) **
+     ((sp + 48) ↦ₘ ab.2.2.1) **
+     ((sp + 56) ↦ₘ ab.2.2.2.1)) =
+    evmWordIs (sp + 32) (EvmWord.mod a b) := by
+  obtain ⟨hc3_one, hcarry_one⟩ := hsem
+  obtain ⟨_, _, _, _, hmod0, hmod1, hmod2, hmod3⟩ :=
+    n4_max_addback_div_mod_getLimbN a b hb3nz hc3_one hcarry_one
+  intro _ _
+  rw [evmWordIs_sp32_limbs_eq sp (EvmWord.mod a b) _ _ _ _
+      hmod0 hmod1 hmod2 hmod3]
+
 -- ============================================================================
 -- DIV: n=4 max+skip stack spec
 -- ============================================================================


### PR DESCRIPTION
## Summary

Adds two reshape lemmas parallel to `output_slot_to_evmWordIs_{div,mod}_n4_max_skip`, specialized for the single-addback branch of the n=4 max+addback BEQ path:

1. **`output_slot_to_evmWordIs_div_n4_max_addback_single`**: the four sp+32..sp+56 atoms with values `(signExtend12 4095 + signExtend12 4095, 0, 0, 0)` (from `denormDivPost` when `carry ≠ 0` in `fullDivN4MaxAddbackBeqPost`) fold into `evmWordIs (sp+32) (EvmWord.div a b)` under `n4MaxAddbackSemanticHolds`.

2. **`output_slot_to_evmWordIs_mod_n4_max_addback_single`**: the four sp+32..sp+56 atoms carrying the un-normalized first-addback low-4 limbs `ab.{1, 2.1, 2.2.1, 2.2.2.1}` fold into `evmWordIs (sp+32) (EvmWord.mod a b)` under the same semantic precondition.

Both proofs thread `n4_max_addback_div_mod_getLimbN` to get per-limb `EvmWord.div` / `EvmWord.mod` equalities, then rewrite via `evmWordIs_sp32_limbs_eq`.

## Why

Phase F sublemmas for the single-addback branch of the n=4 max+addback stack spec roadmap (Issue #61). Complements `fullDivN4MaxAddbackBeqPost_unfold` (PR #684). Remaining for Phase F: double-addback reshapes + the final stack spec with carry1 case analysis.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` — clean
- [x] Full `lake build` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)