### PR TITLE
cleanup: replace inline decidable signExtend12 rewrites with named lemmas

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -299,7 +299,7 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
   have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
-      rw [show signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) from by decide] at hp
+      rw [x1_val_n4] at hp
       xperm_hyp hp) hPreF hLoopF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -457,7 +457,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
   have hFull := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       delta loopSetupPost at hp
-      rw [show signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) from by decide] at hp
+      rw [x1_val_n4] at hp
       xperm_hyp hp) hPreF hLoopF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1281,7 +1281,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   -- the Lemma G adapter uses.
   have h0se12 : signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1 =
       -((clzResult (b.getLimbN 3)).1) := by
-    rw [show signExtend12 (0 : BitVec 12) = (0 : Word) from by decide]
+    rw [signExtend12_0]
     simp
   have hanti_toNat_mod :
       (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64 =


### PR DESCRIPTION
## Summary
Three \`rw [show ... from by decide]\` call-sites replaced with the already-existing named lemmas:
- \`x1_val_n4\` (= \`signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word)\`) — 2 sites in \`FullPathN4Beq.lean\`
- \`signExtend12_0\` (@[simp], already in \`Rv64/Instructions.lean\`) — 1 site in \`DivMod/Spec.lean\`

Slight noise reduction; makes the intent clearer.

## Test plan
- [x] \`lake build\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)