### PR TITLE
refactor: migrate cpsTriple_seq_with_perm_same_cr to _perm_same_cr (#331)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -268,8 +268,7 @@ theorem evm_byte_zero_high_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_taken
   -- Compose OR-reduce → BNE(taken)
-  have hAB := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 160) _
-    _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) hOR_f hbne_framed
   -- Step 3: Zero path (base+160 → base+180) → extend to evm_byte_code
   have hzp := cpsTriple_extend_code (byte_zero_path_sub base)
@@ -282,8 +281,7 @@ theorem evm_byte_zero_high_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3))
     (by pcFree) hzp
   -- Compose AB → ZP: normalize addresses in perm callback
-  have hABZ := cpsTriple_seq_with_perm_same_cr base (base + 160) (base + 180) _
-    _ _ _ _
+  have hABZ := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) hAB hzp_framed
   -- Final: weaken regs to regOwn
   exact cpsTriple_weaken
@@ -345,8 +343,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
   -- Compose OR-reduce → BNE(ntaken)
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _
-    _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) hOR_f hbne_framed
   -- Step 3: LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (i1 ||| i2 ||| i3) i0 0 (base + 24) (by nofun)
@@ -368,11 +365,9 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h34 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h34 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   -- Compose h12 → h34
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h34
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h34
   -- Step 5: BEQ at base+32 → eliminate ntaken (sltiuVal = 0 since i0 ≥ 32)
   let sltiuVal := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 128 sltiuVal (0 : Word) (base + 32)
@@ -393,8 +388,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_taken
   -- Compose h1234 → BEQ(taken)
-  have h12345 := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 160) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 hbeq_framed
+  have h12345 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 hbeq_framed
   -- Step 6: Zero path (base+160 → base+180)
   have hzp := cpsTriple_extend_code (byte_zero_path_sub base)
     (byte_zero_path_spec sp v0 v1 v2 v3 (base + 160))
@@ -405,8 +399,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3))
     (by pcFree) hzp
   -- Compose → ZP: normalize addresses in perm callback
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 160) (base + 180) _
-    _ _ _ _
+  have hfull := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h12345 hzp_framed
   -- Final: weaken regs to regOwn
   exact cpsTriple_weaken
@@ -509,8 +502,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hOR_f hbne_framed
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hOR_f hbne_framed
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (i1 ||| i2 ||| i3) i0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -530,10 +522,8 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h34 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h34
+  have h34 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h34
   -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since i0<32, so 1=0 is absurd)
   let sltiuVal := (if BitVec.ult i0 (signExtend12 (32 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_i0]; decide
@@ -550,8 +540,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_ntaken
-  have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 hbeq_framed
+  have hphaseA := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 hbeq_framed
   -- Phase B: base+36 → base+56
   let byteInLimb := i0 &&& signExtend12 (7 : BitVec 12)
   let byteShift := byteInLimb <<< (3 : BitVec 6).toNat
@@ -565,8 +554,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseB
-  have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 56) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
+  have hphaseAB := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+56
   have hphaseC_raw := byte_phase_c_spec limbFromMsb byteShift (base + 56)
     (base + 124) (base + 108) (base + 92) (base + 76)
@@ -769,8 +757,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
       ((.x6 ↦ᵣ shiftAmount) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ x10v) **
        (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3))
       (by pcFree) hstore
-    have hbs := cpsTriple_seq_with_perm_same_cr bodyBase (base + 136) (base + 180) _ _ _ _ _
-      (fun h hp => by xperm_hyp hp) hbody_f hstore_f
+    have hbs := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hbody_f hstore_f
     exact cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hq => by xperm_hyp hq) hbs

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -265,16 +265,14 @@ theorem evm_shr_zero_high_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _
-    _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _
-    _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → extend to shrCode, eliminate ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
@@ -292,8 +290,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_taken
   -- Compose linear chain → BNE(taken)
-  have hAB := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 340) _
-    _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: Zero path (base+340 → base+360) → extend to shrCode
   have hzp := cpsTriple_extend_code (zero_path_sub_shrCode base)
@@ -312,8 +309,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
   have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose AB → ZP: normalize addresses in perm callback
-  have hABZ := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _
-    _ _ _ _
+  have hABZ := cpsTriple_seq_perm_same_cr 
     (fun h hp => by
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp) hAB hzp_framed
@@ -371,15 +367,13 @@ theorem evm_shr_zero_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → eliminate TAKEN (s1|||s2|||s3 = 0 contradicts ≠ 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shr_bne_target, shr_off_20] at hbne_raw
@@ -395,8 +389,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
   -- Compose linear → BNE(ntaken)
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: LD x5 x12 0 at base+24 → extend to shrCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -417,11 +410,9 @@ theorem evm_shr_zero_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   -- Compose h1234 → h56
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- Step 7: BEQ at base+32 → eliminate ntaken (sltiuVal = 0 since s0 ≥ 256)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)
@@ -442,8 +433,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_taken
   -- Compose h123456 → BEQ(taken)
-  have h1234567 := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 340) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have h1234567 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Zero path (base+340 → base+360)
   have hzp := cpsTriple_extend_code (zero_path_sub_shrCode base)
     (shr_zero_path_spec sp v0 v1 v2 v3 (base + 340))
@@ -460,8 +450,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose → ZP: normalize addresses in perm callback
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _ _ _ _ _
-    (fun h hp => by
+  have hfull := cpsTriple_seq_perm_same_cr (fun h hp => by
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp) h1234567 hzp_framed
   -- Final: normalize addresses back + weaken regs to regOwn
@@ -675,15 +664,13 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- BNE at base+20: eliminate TAKEN (s1|||s2|||s3=0 contradicts ne 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shr_bne_target, shr_off_20] at hbne_raw
@@ -697,8 +684,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -718,10 +704,8 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since s0<256, so 1=0 is absurd)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_s0]; decide
@@ -738,8 +722,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_ntaken
-  have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have hphaseA := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Phase B: base+36 -> base+64
   let bitShift := s0 &&& signExtend12 63
   let limbShift := s0 >>> (6 : BitVec 6).toNat
@@ -755,8 +738,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseB
-  have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 64) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
+  have hphaseAB := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+64 (with pure dispatch facts)
   have hphaseC_raw := shr_phase_c_spec_pure limbShift sltiuVal (base + 64)
     (base + 240) (base + 164) (base + 112) (base + 84)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -310,16 +310,14 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _
-    _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _
-    _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → extend to sarCode, eliminate ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 332 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
@@ -337,8 +335,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_taken
   -- Compose linear chain → BNE(taken)
-  have hAB := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 352) _
-    _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: Sign-fill path (base+352 → base+380) → extend to sarCode
   have hsfp := cpsTriple_extend_code (sign_fill_sub_sarCode base)
@@ -350,8 +347,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hsfp
   -- Compose AB → sign-fill: no address normalization needed (sign-fill uses sp+40 etc. directly)
-  have hABS := cpsTriple_seq_with_perm_same_cr base (base + 352) (base + 380) _
-    _ _ _ _
+  have hABS := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) hAB hsfp_framed
   -- Final: weaken regs to regOwn
   exact cpsTriple_weaken
@@ -408,15 +404,13 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 offset 332 → eliminate TAKEN (s1|||s2|||s3 = 0 contradicts ≠ 0)
   have hbne_raw := bne_spec_gen .x5 .x0 332 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [sar_bne_target, sar_off_20] at hbne_raw
@@ -432,8 +426,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
   -- Compose linear → BNE(ntaken)
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: LD x5 x12 0 at base+24 → extend to sarCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -454,11 +447,9 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   -- Compose h1234 → h56
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- Step 7: BEQ at base+32 offset 320 → eliminate ntaken (sltiuVal = 0 since s0 ≥ 256)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 320 sltiuVal (0 : Word) (base + 32)
@@ -479,8 +470,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_taken
   -- Compose h123456 → BEQ(taken)
-  have h1234567 := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 352) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have h1234567 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Sign-fill path (base+352 → base+380)
   have hsfp := cpsTriple_extend_code (sign_fill_sub_sarCode base)
     (sar_sign_fill_path_spec sp s0 sltiuVal v0 v1 v2 v3 (base + 352))
@@ -490,8 +480,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
     (by pcFree) hsfp
   -- Compose → SFP
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 352) (base + 380) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234567 hsfp_framed
+  have hfull := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234567 hsfp_framed
   -- Final: weaken regs to regOwn
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
@@ -838,15 +827,13 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- BNE at base+20: eliminate TAKEN (s1|||s2|||s3=0 contradicts ne 0)
   have hbne_raw := bne_spec_gen .x5 .x0 332 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [sar_bne_target, sar_off_20] at hbne_raw
@@ -860,8 +847,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -881,10 +867,8 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since s0<256, so 1=0 is absurd)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_s0]; decide
@@ -901,8 +885,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_ntaken
-  have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have hphaseA := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Phase B: base+36 -> base+64
   let bitShift := s0 &&& signExtend12 63
   let limbShift := s0 >>> (6 : BitVec 6).toNat
@@ -918,8 +901,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseB
-  have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 64) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
+  have hphaseAB := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+64 (with pure dispatch facts)
   have hphaseC_raw := sar_phase_c_spec_pure limbShift sltiuVal (base + 64)
     (base + 252) (base + 172) (base + 116) (base + 84)

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -254,16 +254,14 @@ theorem evm_shl_zero_high_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _
-    _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _
-    _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → extend to shlCode, eliminate ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
@@ -281,8 +279,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_taken
   -- Compose linear chain → BNE(taken)
-  have hAB := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 340) _
-    _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: Zero path (base+340 → base+360) → extend to shlCode
   have hzp := cpsTriple_extend_code (zero_path_sub_shlCode base)
@@ -301,8 +298,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
   have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose AB → ZP: normalize addresses in perm callback
-  have hABZ := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _
-    _ _ _ _
+  have hABZ := cpsTriple_seq_perm_same_cr 
     (fun h hp => by
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp) hAB hzp_framed
@@ -359,15 +355,13 @@ theorem evm_shl_zero_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → eliminate TAKEN (s1|||s2|||s3 = 0 contradicts ≠ 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
@@ -383,8 +377,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
   -- Compose linear → BNE(ntaken)
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: LD x5 x12 0 at base+24 → extend to shlCode
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -405,11 +398,9 @@ theorem evm_shl_zero_large_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
   -- Compose h1234 → h56
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- Step 7: BEQ at base+32 → eliminate ntaken (sltiuVal = 0 since s0 ≥ 256)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)
@@ -430,8 +421,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_taken
   -- Compose h123456 → BEQ(taken)
-  have h1234567 := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 340) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have h1234567 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Zero path (base+340 → base+360)
   have hzp := cpsTriple_extend_code (zero_path_sub_shlCode base)
     (shr_zero_path_spec sp v0 v1 v2 v3 (base + 340))
@@ -448,8 +438,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have ha48' : (sp + 32 : Word) + 16 = sp + 48 := by bv_omega
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   -- Compose → ZP: normalize addresses in perm callback
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 340) (base + 360) _ _ _ _ _
-    (fun h hp => by
+  have hfull := cpsTriple_seq_perm_same_cr (fun h hp => by
       simp only [ha40, ha48, ha56] at hp
       xperm_hyp hp) h1234567 hzp_framed
   -- Final: normalize addresses back + weaken regs to regOwn
@@ -650,15 +639,13 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- BNE at base+20: eliminate TAKEN (s1|||s2|||s3=0 contradicts ne 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
@@ -672,8 +659,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -693,10 +679,8 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- BEQ at base+32: eliminate TAKEN (sltiuVal=1 since s0<256, so 1=0 is absurd)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_s0]; decide
@@ -713,8 +697,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_ntaken
-  have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have hphaseA := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Phase B: base+36 -> base+64
   let bitShift := s0 &&& signExtend12 63
   let limbShift := s0 >>> (6 : BitVec 6).toNat
@@ -730,8 +713,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hphaseB
-  have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 64) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
+  have hphaseAB := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C: cascade dispatch at base+64 (with pure dispatch facts)
   have hphaseC_raw := shr_phase_c_spec_pure limbShift sltiuVal (base + 64)
     (base + 240) (base + 164) (base + 112) (base + 84)

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -225,16 +225,14 @@ theorem signext_nochange_high_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _
-    _ _ _ _
+  have h12 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _
-    _ _ _ _
+  have h123 := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → extend, eliminate ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
@@ -251,8 +249,7 @@ theorem signext_nochange_high_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_taken
   -- Compose → BNE
-  have hAB := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 188) _
-    _ _ _ _
+  have hAB := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: Done (base+188 → base+192) → extend
   have hdone := cpsTriple_extend_code (done_sub_signextCode base)
@@ -263,8 +260,7 @@ theorem signext_nochange_high_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hdone
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 188) (base + 192) _
-    _ _ _ _
+  have hfull := cpsTriple_seq_perm_same_cr 
     (fun h hp => by xperm_hyp hp) hAB hdone_framed
   -- Final: weaken regs to regOwn + perm
   exact cpsTriple_weaken
@@ -319,15 +315,13 @@ theorem signext_nochange_geq31_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) **
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- Step 4: BNE at base+20 → eliminate TAKEN (b1|||b2|||b3 = 0)
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [se_bne_target, se_off_20] at hbne_raw
@@ -341,8 +335,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbne_ntaken
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_framed
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: LD x5 x12 0 at base+24
   have hld_raw := ld_spec_gen .x5 .x12 sp (b1 ||| b2 ||| b3) b0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
@@ -362,10 +355,8 @@ theorem signext_nochange_geq31_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- Step 7: BEQ at base+32 → eliminate ntaken (sltiuVal = 0 since b0 >= 31)
   let sltiuVal := (if BitVec.ult b0 (signExtend12 (31 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 156 sltiuVal (0 : Word) (base + 32)
@@ -382,8 +373,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hbeq_taken
-  have h1234567 := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 188) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
+  have h1234567 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Done (base+188 → base+192)
   have hdone := cpsTriple_extend_code (done_sub_signextCode base)
     (signext_done_spec sp (base + 188))
@@ -393,8 +383,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
     (by pcFree) hdone
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 188) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234567 hdone_framed
+  have hfull := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234567 hdone_framed
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by
@@ -466,13 +455,11 @@ theorem signext_body_spec (sp base : Word)
   have h2f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) h2
-  have h12 := cpsTriple_seq_with_perm_same_cr base (base + 4) (base + 12) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1f h2f
+  have h12 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1f h2f
   have h3f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) h3
-  have h123 := cpsTriple_seq_with_perm_same_cr base (base + 12) (base + 20) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h12 h3f
+  have h123 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h12 h3f
   -- BNE ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 168 (b1 ||| b2 ||| b3) (0 : Word) (base + 20)
   rw [se_bne_target, se_off_20] at hbne_raw
@@ -482,8 +469,7 @@ theorem signext_body_spec (sp base : Word)
   have hbne_f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbne_nt
-  have h1234 := cpsTriple_seq_with_perm_same_cr base (base + 20) (base + 24) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123 hbne_f
+  have h1234 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123 hbne_f
   -- LD b0
   have hld_raw := ld_spec_gen .x5 .x12 sp (b1 ||| b2 ||| b3) b0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw; rw [word_add_zero, se_off_24] at hld_raw
@@ -498,10 +484,8 @@ theorem signext_body_spec (sp base : Word)
   have hsltiu_f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hsltiu
-  have h56 := cpsTriple_seq_with_perm_same_cr (base + 24) (base + 28) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
-  have h123456 := cpsTriple_seq_with_perm_same_cr base (base + 24) (base + 32) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h1234 h56
+  have h56 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hld_f hsltiu_f
+  have h123456 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h1234 h56
   -- BEQ ntaken (sltiuVal = 1 since b0 < 31)
   let sltiuVal := (if BitVec.ult b0 (signExtend12 (31 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hsmall]; decide
@@ -513,8 +497,7 @@ theorem signext_body_spec (sp base : Word)
   have hbeq_f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbeq_nt
-  have hphaseA := cpsTriple_seq_with_perm_same_cr base (base + 32) (base + 36) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) h123456 hbeq_f
+  have hphaseA := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_f
   -- Phase B: base+36 → base+56
   let byteInLimb := b0 &&& signExtend12 (7 : BitVec 12)
   let byteShift := byteInLimb <<< (3 : BitVec 6).toNat
@@ -526,8 +509,7 @@ theorem signext_body_spec (sp base : Word)
   have hphaseB_f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hphaseB
-  have hphaseAB := cpsTriple_seq_with_perm_same_cr base (base + 36) (base + 56) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
+  have hphaseAB := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseA hphaseB_f
   -- Phase C with pure dispatch facts
   have hphaseC_raw := signext_phase_c_spec_pure limbIdx byteShift (base + 56)
     (base + 156) (base + 124) (base + 96) (base + 76)
@@ -563,8 +545,7 @@ theorem signext_body_spec (sp base : Word)
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) **
      ((sp + 56) ↦ₘ (BitVec.sshiftRight (v3 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))))
     (by pcFree) hdone
-  have hbd3 := cpsTriple_seq_with_perm_same_cr (base + 76) (base + 188) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody3_f hdone3_f
+  have hbd3 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hbody3_f hdone3_f
   -- Body 2 + done
   have hdone2_f := cpsTriple_frameR
     ((.x5 ↦ᵣ (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))) **
@@ -575,8 +556,7 @@ theorem signext_body_spec (sp base : Word)
      ((sp + 48) ↦ₘ (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))) **
      ((sp + 56) ↦ₘ (BitVec.sshiftRight (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)))
     (by pcFree) hdone
-  have hbd2 := cpsTriple_seq_with_perm_same_cr (base + 96) (base + 188) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody2_f hdone2_f
+  have hbd2 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hbody2_f hdone2_f
   -- Body 1 + done
   have hdone1_f := cpsTriple_frameR
     ((.x5 ↦ᵣ (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))) **
@@ -588,8 +568,7 @@ theorem signext_body_spec (sp base : Word)
      ((sp + 48) ↦ₘ (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)) **
      ((sp + 56) ↦ₘ (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)))
     (by pcFree) hdone
-  have hbd1 := cpsTriple_seq_with_perm_same_cr (base + 124) (base + 188) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody1_f hdone1_f
+  have hbd1 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hbody1_f hdone1_f
   -- Body 0 + done
   have hdone0_f := cpsTriple_frameR
     ((.x5 ↦ᵣ (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))) **
@@ -601,8 +580,7 @@ theorem signext_body_spec (sp base : Word)
      ((sp + 48) ↦ₘ (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)) **
      ((sp + 56) ↦ₘ (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)))
     (by pcFree) hdone
-  have hbd0 := cpsTriple_seq_with_perm_same_cr (base + 156) (base + 188) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hbody0_f hdone0_f
+  have hbd0 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hbody0_f hdone0_f
   -- Address normalization: done spec produces signExtend12 32, goal needs 32
   have hse32 : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by rw [signExtend12_32]
   -- Helper: weaken body+done postconditions to regOwn + concrete mem values
@@ -855,8 +833,7 @@ theorem signext_body_spec (sp base : Word)
       (fun h hq => by xperm_hyp hq)
       hphaseAB
   -- Final: Phase AB -> Phase CD
-  have hfull := cpsTriple_seq_with_perm_same_cr base (base + 56) (base + 192) _ _ _ _ _
-    (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
+  have hfull := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
   -- Final consequence: permute to match goal shape
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary
Migrates ~90 deprecated \`cpsTriple_seq_with_perm_same_cr\` call-sites to the implicit-arg form \`cpsTriple_seq_perm_same_cr\` across 5 files:
- \`Evm64/SignExtend/Compose.lean\`
- \`Evm64/Shift/{Compose,SarCompose,ShlCompose}.lean\`
- \`Evm64/Byte/Spec.lean\`

Each call drops 8 redundant explicit arguments (3 \`Word\` positions + 5 \`Assertion\` underscores); the implicit-arg form infers them from the two Hoare triples that are the real content.

Net -90 LOC.

Continues the gradual #331 migration; leaves only the 4 usages in tactic metacode (\`SeqFrame.lean\`) and the wrapper defn in \`CPSSpec.lean\`.

## Test plan
- [x] Full \`lake build\` succeeds (3554 jobs)
- [x] Drops ~90 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)