### PR TITLE
refactor: migrate cpsBranch_frame_left to cpsBranch_frameR (#331)

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -500,9 +500,7 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
         (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word)) h').1 hp').1) h hp)
       beq0_raw
   -- Frame BEQ with x10
-  have beq0f := cpsBranch_frame_left base cr_beq0
-    ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
-    e0 _ (base + 4) _
+  have beq0f := cpsBranch_frameR
     (.x10 ↦ᵣ v10) (by pcFree) beq0
   -- Step 1: cascade step at base+4 (CR = cr_cs1)
   have cs1 := shr_cascade_step_spec v5 v10 1 92 (base + 4) e1 hc1
@@ -824,11 +822,8 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       bne_raw
   -- Frame BNE with remaining state
-  have bne1f := cpsBranch_frame_left (base + 20) crBne
-    ((.x5 ↦ᵣ (s1 ||| s2 ||| s3)) ** (.x0 ↦ᵣ (0 : Word)))
-    zero_path _ (base + 24) _
-    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
-    (by pcFree) bne1
+  have bne1f := cpsBranch_frameR
+    ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) bne1
   -- Disjoint: crLinear vs crBne
   have hd_lin_bne : crLinear.Disjoint crBne :=
     CodeReq.Disjoint.union_left
@@ -890,11 +885,8 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       beq_raw
   -- Frame BEQ with remaining state
-  have beq1f := cpsBranch_frame_left (base + 32) crBeq
-    ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
-    zero_path _ (base + 36) _
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3))
-    (by pcFree) beq1
+  have beq1f := cpsBranch_frameR
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) beq1
   -- Disjoint: (crLd5 ∪ crSltiu) vs crBeq
   have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
     CodeReq.Disjoint.union_left

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -417,9 +417,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       bne_raw
-  have bne1f := cpsBranch_frame_left (base + 20) crBne
-    ((.x5 ↦ᵣ (b1 ||| b2 ||| b3)) ** (.x0 ↦ᵣ (0 : Word)))
-    done_path _ (base + 24) _
+  have bne1f := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) bne1
   have hd_lin_bne : crLinear.Disjoint crBne :=
@@ -473,9 +471,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
       beq_raw
-  have beq1f := cpsBranch_frame_left (base + 32) crBeq
-    ((.x10 ↦ᵣ sltiuVal) ** (.x0 ↦ᵣ (0 : Word)))
-    done_path _ (base + 36) _
+  have beq1f := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
     (by pcFree) beq1
   have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
@@ -652,9 +648,7 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
       (fun h hp => sepConj_mono_right
         (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word)) h').1 hp').1) h hp)
       beq0_raw
-  have beq0f := cpsBranch_frame_left base cr_beq0
-    ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)))
-    e0 _ (base + 4) _
+  have beq0f := cpsBranch_frameR
     (.x10 ↦ᵣ v10) (by pcFree) beq0
   -- Step 1: cascade step at base+4
   have cs1 := signext_cascade_step_spec v5 v10 1 60 (base + 4) e1 hc1

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -503,8 +503,7 @@ theorem rlp_phase1_step_spec_acc (Acc : Prop) (v5 v10 : Word)
          ⌜Acc ∧ ¬ BitVec.ult v5 kVal⌝) := by
   have h := rlp_phase1_step_spec v5 v10 k offset base target htarget
   -- Frame `rlp_phase1_step_spec` with `⌜Acc⌝` on the right.
-  have hf := cpsBranch_frame_left base _ _ target _ (base + 8) _
-    ⌜Acc⌝ (pcFree_pure Acc) h
+  have hf := cpsBranch_frameR ⌜Acc⌝ (pcFree_pure Acc) h
   -- hf has pre `(regs_3chain) ** ⌜Acc⌝`; target theorem has the 4-chain
   -- `regs ** ⌜Acc⌝`. Reshape via the associativity helper.
   exact cpsBranch_weaken


### PR DESCRIPTION
## Summary
Migrates all 7 remaining \`cpsBranch_frame_left\` callsites to the implicit-arg form \`cpsBranch_frameR\`:
- \`Evm64/SignExtend/LimbSpec.lean\` (3 sites)
- \`Evm64/Shift/LimbSpec.lean\` (3 sites)
- \`Rv64/RLP/Phase1.lean\` (1 site)

Each call drops 7 redundant explicit arguments. Drops 7 deprecation warnings.

The only remaining uses are the definition in \`Rv64/CPSSpec.lean\` and three docstring references in \`Rv64/SepLogic.lean\`.

## Test plan
- [x] Full \`lake build\` succeeds (3554 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)