### PR TITLE
refactor: migrate cpsBranch_consequence to cpsBranch_weaken (#331)

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -332,7 +332,7 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
   have cs1_composed := cpsTriple_seq_cpsBranch_with_perm_same_cr
     (base + 4) (base + 8) cr _ _ _ e1 _ (base + 12) _
     (fun h hp => by xperm_hyp hp) addi1f beq1f
-  -- Clean up cs1 to canonical form via cpsBranch_consequence
+  -- Clean up cs1 to canonical form via cpsBranch_weaken
   have cs1_clean : cpsBranch (base + 4) cr
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
       e1 ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 = (0 : Word) + signExtend12 1⌝)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -246,7 +246,7 @@ theorem divK_loop_body_n1_max_skip_spec
   have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   -- 8. Permute final cpsBranch to match target
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -338,7 +338,7 @@ theorem divK_loop_body_n1_max_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
@@ -469,7 +469,7 @@ theorem divK_loop_body_n1_call_skip_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
@@ -598,7 +598,7 @@ theorem divK_loop_body_n1_call_addback_spec
   -- 7. Compose
   have full := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+  exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
       delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -631,7 +631,7 @@ theorem divK_loop_body_n2_max_unified_spec
     have base_spec := divK_loop_body_n2_max_addback_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -642,7 +642,7 @@ theorem divK_loop_body_n2_max_unified_spec
     have base_spec := divK_loop_body_n2_max_skip_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -695,7 +695,7 @@ theorem divK_loop_body_n2_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -707,7 +707,7 @@ theorem divK_loop_body_n2_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -631,7 +631,7 @@ theorem divK_loop_body_n3_max_unified_spec
     have base_spec := divK_loop_body_n3_max_addback_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -642,7 +642,7 @@ theorem divK_loop_body_n3_max_unified_spec
     have base_spec := divK_loop_body_n3_max_skip_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -693,7 +693,7 @@ theorem divK_loop_body_n3_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -705,7 +705,7 @@ theorem divK_loop_body_n3_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -634,7 +634,7 @@ theorem divK_loop_body_n4_max_unified_spec
     have base_spec := divK_loop_body_n4_max_addback_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -645,7 +645,7 @@ theorem divK_loop_body_n4_max_unified_spec
     have base_spec := divK_loop_body_n4_max_skip_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -696,7 +696,7 @@ theorem divK_loop_body_n4_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu (hcarry (by decide)) hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
@@ -708,7 +708,7 @@ theorem divK_loop_body_n4_call_unified_spec
       sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
       base halign hbltu hborrow
-    exact cpsBranch_consequence _ _ _ _ _ _ _ _ _ _
+    exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)


### PR DESCRIPTION
## Summary
16 callsites of the deprecated \`cpsBranch_consequence\` in \`DivMod/LoopBodyN{1..4}.lean\` migrated to the implicit-arg form \`cpsBranch_weaken\`. Each drops 10 \`_\` placeholder arguments.

Also updates a docstring reference in \`Byte/LimbSpec.lean\`.

Leaves only the definition site in \`Rv64/CPSSpec.lean\`.

## Test plan
- [x] Full \`lake build\` succeeds (3554 jobs)
- [x] Drops 20 deprecation warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)