### PR TITLE
refactor: inline trivial rename have-bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -188,11 +188,9 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
               (.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word))) := by
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
-  have h63 := bv6_toNat_63
-  simp only [h63] at I0
+  simp only [bv6_toNat_63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have hsig := se13_8
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [se13_8]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR
@@ -243,11 +241,9 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
               (.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
-  have h63 := bv6_toNat_63
-  simp only [h63] at I0
+  simp only [bv6_toNat_63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have hsig := se13_8
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [hsig]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [se13_8]; bv_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -100,10 +100,9 @@ theorem sar_body_3_spec (sp : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result0) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ signExt) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
-  have h63 := bv6_toNat_63
   have LL := sar_last_limb_spec 0 sp v3 v0 v5 bit_shift base
   have SR := srai_spec_gen .x10 .x5 v10 (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63 (base + 12) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp (BitVec.sshiftRight (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63) v1 8 (base + 16)
   have S1 := sd_spec_gen .x12 .x10 sp (BitVec.sshiftRight (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63) v2 16 (base + 20)
   have S2 := sd_spec_gen .x12 .x10 sp (BitVec.sshiftRight (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63) v3 24 (base + 24)
@@ -134,7 +133,6 @@ theorem sar_body_2_spec (sp : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result1) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ signExt) ** ((sp + 24) ↦ₘ signExt)) := by
-  have h63 := bv6_toNat_63
   have MM := shr_merge_limb_spec 16 24 0 sp v2 v3 v0 v5 v10 bit_shift antiShift mask base
   have LL := sar_last_limb_spec 8 sp v3 v1
     ((v2 >>> (bit_shift.toNat % 64)) ||| ((v3 <<< (antiShift.toNat % 64)) &&& mask))
@@ -142,7 +140,7 @@ theorem sar_body_2_spec (sp : Word)
   have SR := srai_spec_gen .x10 .x5
     ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63 (base + 40) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
     (BitVec.sshiftRight (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63) v2 16 (base + 44)
   have S1 := sd_spec_gen .x12 .x10 sp
@@ -175,7 +173,6 @@ theorem sar_body_1_spec (sp : Word)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result2) ** (.x6 ↦ᵣ bit_shift) **
        (.x7 ↦ᵣ antiShift) ** (.x10 ↦ᵣ signExt) ** (.x11 ↦ᵣ mask) **
        (sp ↦ₘ result0) ** ((sp + 8) ↦ₘ result1) ** ((sp + 16) ↦ₘ result2) ** ((sp + 24) ↦ₘ signExt)) := by
-  have h63 := bv6_toNat_63
   have MM1 := shr_merge_limb_spec 8 16 0 sp v1 v2 v0 v5 v10 bit_shift antiShift mask base
   have MM2 := shr_merge_limb_spec 16 24 8 sp v2 v3 v1
     ((v1 >>> (bit_shift.toNat % 64)) ||| ((v2 <<< (antiShift.toNat % 64)) &&& mask))
@@ -187,7 +184,7 @@ theorem sar_body_1_spec (sp : Word)
   have SR := srai_spec_gen .x10 .x5
     ((v3 <<< (antiShift.toNat % 64)) &&& mask)
     (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63 (base + 68) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
     (BitVec.sshiftRight (BitVec.sshiftRight v3 (bit_shift.toNat % 64)) 63) v3 24 (base + 72)
   have JL := jal_x0_spec_gen jal_off (base + 76)
@@ -265,10 +262,9 @@ theorem sar_sign_fill_path_spec (sp : Word)
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ signExt) ** (.x10 ↦ᵣ v10) **
        ((sp + 32) ↦ₘ signExt) ** ((sp + 40) ↦ₘ signExt) ** ((sp + 48) ↦ₘ signExt) ** ((sp + 56) ↦ₘ signExt)) := by
-  have h63 := bv6_toNat_63
   have LD0 := ld_spec_gen .x5 .x12 sp v5 v3 56 base (by nofun)
   have SR := srai_spec_gen_same .x5 v3 63 (base + 4) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have AD := addi_spec_gen_same .x12 sp 32 (base + 8) (by nofun)
   simp only [signExtend12_32] at AD
   have S0 := sd_spec_gen .x12 .x5 (sp + 32) (BitVec.sshiftRight v3 63) v0 0 (base + 12)

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -99,12 +99,11 @@ theorem signext_body_2_spec (sp : Word)
        ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 48) ↦ₘ result) ** ((sp + 56) ↦ₘ signFill)) := by
-  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 48 sp v2 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
     (BitVec.sshiftRight (BitVec.sshiftRight (v2 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v3 56 (base + 20)
@@ -131,12 +130,11 @@ theorem signext_body_1_spec (sp : Word)
        ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 40) ↦ₘ result) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
-  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 40 sp v1 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
     (BitVec.sshiftRight (BitVec.sshiftRight (v1 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v2 48 (base + 20)
@@ -166,12 +164,11 @@ theorem signext_body_0_spec (sp : Word)
        ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ result) ** (.x6 ↦ᵣ shiftAmount) ** (.x10 ↦ᵣ signFill) **
        ((sp + 32) ↦ₘ result) ** ((sp + 40) ↦ₘ signFill) ** ((sp + 48) ↦ₘ signFill) ** ((sp + 56) ↦ₘ signFill)) := by
-  have h63 := bv6_toNat_63
   have IP := signext_inplace_spec 32 sp v0 v5 shiftAmount base
   have SR := srai_spec_gen .x10 .x5 v10
     (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64))
     63 (base + 16) (by nofun)
-  simp only [h63] at SR
+  simp only [bv6_toNat_63] at SR
   have S0 := sd_spec_gen .x12 .x10 sp
     (BitVec.sshiftRight (BitVec.sshiftRight (v0 <<< (shiftAmount.toNat % 64)) (shiftAmount.toNat % 64)) 63)
     v1 40 (base + 20)

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -105,8 +105,7 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
     (len <<< (8 : BitVec 6).toNat) byte (base + 4) (by nofun)
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at s2
   -- Compose. `(8 : BitVec 6).toNat = 8` so the result matches.
-  have heq := bv6_toNat_8
-  rw [heq] at s1
+  rw [bv6_toNat_8] at s1
   exact cpsTriple_seq _ _ _ _ _ hd _ _ _ s1 s2
 
 /-! ## Concrete sanity checks -/

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -125,26 +125,23 @@ theorem rlp_phase2_long_iter_spec
   simp only [rlp_phase2_long_iter_post_unfold]
   rw [iter_code_split]
   -- Helpers: `signExtend12 1 = 1` and `signExtend12 0 = 0`.
-  have h_se1 := se12_1
-  have h_se0 := se12_0
-  have h_shamt := bv6_toNat_8
   -- Distinct-addresses plumbing.
   obtain ⟨h01, h02, h03, h04, h12, h13, h14, h23, h24, h34⟩ :=
     iter_addrs_distinct base
   set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   -- Step 1: LBU x12, x13, 0.
   have halign0 : alignToDword (ptr + signExtend12 (0 : BitVec 12)) = dwordAddr := by
-    rw [h_se0]; simpa using halign
+    rw [se12_0]; simpa using halign
   have hvalid0 : isValidByteAccess (ptr + signExtend12 (0 : BitVec 12)) = true := by
-    rw [h_se0]; simpa using hvalid
+    rw [se12_0]; simpa using hvalid
   have lbu_raw := generic_lbu_spec .x12 .x13 ptr v12Old 0 base dwordAddr wordVal
     (by nofun) halign0 hvalid0
   rw [show ptr + signExtend12 (0 : BitVec 12) = ptr from by
-        rw [h_se0]; bv_omega] at lbu_raw
+        rw [se12_0]; bv_omega] at lbu_raw
   -- Step 2: SLLI x11, x11, 8.
   have slli_raw := slli_spec_gen_same .x11 len 8 (base + 4) (by nofun)
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at slli_raw
-  rw [h_shamt] at slli_raw
+  rw [bv6_toNat_8] at slli_raw
   -- Step 3: ADD x11, x11, x12.
   have add_raw := add_spec_gen_rd_eq_rs1 .x11 .x12 (len <<< 8) byteZext
     (base + 8) (by nofun)
@@ -152,7 +149,7 @@ theorem rlp_phase2_long_iter_spec
   -- Step 4: ADDI x13, x13, 1.
   have addi_ptr_raw := addi_spec_gen_same .x13 ptr 1 (base + 12) (by nofun)
   rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega] at addi_ptr_raw
-  rw [h_se1] at addi_ptr_raw
+  rw [se12_1] at addi_ptr_raw
   -- Step 5: ADDI x14, x14, -1.
   have addi_cnt_raw := addi_spec_gen_same .x14 cnt (-1) (base + 16) (by nofun)
   rw [show (base + 16 : Word) + 4 = base + 20 from by bv_omega] at addi_cnt_raw


### PR DESCRIPTION
## Summary

Closes part of #694: remove local `have X := lemma` aliases that rename an existing lemma without adding information. Each use site now references the lemma directly.

Before:
```lean
have h63 := bv6_toNat_63
...
simp only [h63] at SR
```

After:
```lean
simp only [bv6_toNat_63] at SR
```

Aliases removed: `h63`, `hsig`, `h_se0`, `h_se1`, `h_shamt`, `heq` (local) across 5 files.

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)