### PR TITLE
refactor: inline hj_pos rename bindings in LoopIter (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -227,8 +227,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -351,8 +350,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -475,8 +473,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_3
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -221,8 +221,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -340,8 +339,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -459,8 +457,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base slt_jpos_3
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -178,8 +178,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_3
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -267,8 +266,7 @@ theorem divK_loop_body_n1_max_skip_j1_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -356,8 +354,7 @@ theorem divK_loop_body_n1_max_skip_j2_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -155,8 +155,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base slt_jpos_3
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -238,8 +237,7 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -321,8 +319,7 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -321,8 +321,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -439,8 +438,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -536,8 +534,7 @@ theorem divK_loop_body_n2_max_skip_j2_spec
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -654,8 +651,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -964,8 +960,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -1079,8 +1074,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -1170,8 +1164,7 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -1285,8 +1278,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have hj_pos := slt_jpos_2
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -326,8 +326,7 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   intro_lets at MCS
   have MCS0 := MCS hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+880 → base+448)
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   -- 4. Frame TF with mulsub cells
   have TFf := cpsTriple_frameR
@@ -455,8 +454,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   -- 3. Store + loop back j=1 (cpsTriple base+880 → base+448)
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
   intro_lets at SL
   -- 4. Frame TF (for n=3: v2, u2, u3 consumed by trial; v3, uTop in frame)
   have TFf := cpsTriple_frameR
@@ -778,8 +776,7 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop continue j=1 (cpsTriple base+884 → base+448)
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -901,8 +898,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
   -- 3. Store + loop back j=1 (cpsTriple base+884 → base+448)
-  have hj_pos := slt_jpos_1
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base hj_pos
+  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
   intro_lets at SL
   -- 4. Frame TF
   have TFf := cpsTriple_frameR


### PR DESCRIPTION
## Summary

Second batch for #694. Remove 24 local `have hj_pos := slt_jpos_N` aliases in the DivMod LoopIter files (LoopIterN1/{Max,MaxBeq,Call,CallBeq}, LoopIterN2, LoopIterN3). Each alias was used exactly once on the next line as the last argument to `divK_store_loop_jgt0_spec`; inlining `slt_jpos_N` at the call site removes the rename.

Before:
```lean
have hj_pos := slt_jpos_3
have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base hj_pos
```

After:
```lean
have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base slt_jpos_3
```

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)