### PR TITLE
refactor: inline h6 rename bindings in Shift Compose files (#694)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -530,8 +530,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
       getLimbN_lt value (i.val + L) hiL,
       getLimbN_lt value (i.val + L + 1) hiL1]
@@ -565,8 +564,7 @@ private theorem shr_bridge_last (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div, hiL,
       getLimbN_lt value 3 (by omega), getLimbN_ge value 4 (by omega)]
   simp [show bs.toNat % 64 = s0.toNat % 64 from by omega]
@@ -581,8 +579,7 @@ private theorem shr_bridge_zero (value : EvmWord) (s0 : Word)
     getLimb result i = 0 := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
       getLimbN_ge value (i.val + L) (by omega),
       getLimbN_ge value (i.val + L + 1) (by omega)]
@@ -871,10 +868,9 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         show value >>> shift.toNat = value >>> s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 := bv6_toNat_6
         have hlt4 : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
-          rw [h6]; simp [BitVec.toNat_ushiftRight]; omega
+          rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
         have hn0 : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
         have hn1 : limbShift.toNat ≠ 1 :=

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -664,8 +664,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- sshiftRight agrees with ushiftRight for merge limbs
   rw [getLimb_sshiftRight_eq_ushiftRight value s0.toNat i (by omega)]
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
@@ -701,8 +700,7 @@ private theorem sar_bridge_last (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_sshiftRight_last value s0.toNat i (by omega)]
   congr 1; omega
 
@@ -718,8 +716,7 @@ private theorem sar_bridge_sign (value : EvmWord) (s0 : Word)
     getLimb result i := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- getLimb (sshiftRight value n) i = sshiftRight (getLimb value 3) 63 for sign limbs
   rw [getLimb_sshiftRight_sign' value s0.toNat i (by omega)]
   -- sshiftRight (sshiftRight x bs) 63 = sshiftRight x 63 when bs < 64
@@ -1035,10 +1032,9 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 := bv6_toNat_6
         have hlt4 : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
-          rw [h6]; simp [BitVec.toNat_ushiftRight]; omega
+          rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
         have hn0 : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
         have hn1 : limbShift.toNat ≠ 1 :=

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -496,8 +496,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft: i*64 >= s0.toNat since i >= L+1 and s0.toNat = L*64 + bs < (L+1)*64
   rw [getLimb_shiftLeft value s0.toNat i (by omega), hL_div,
       getLimbN_lt value (i.val - L) hiLsub,
@@ -535,8 +534,7 @@ private theorem shl_bridge_first (value : EvmWord) (s0 : Word)
     rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_eq_div: i.val = n / 64
   rw [getLimb_shiftLeft_eq_div value s0.toNat i (by omega)]
   -- getLimbN v 0 = getLimb v ⟨0, _⟩
@@ -554,8 +552,7 @@ private theorem shl_bridge_zero (value : EvmWord) (s0 : Word)
     getLimb result i = 0 := by
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
-    have h6 := bv6_toNat_6
-    rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_low: (i+1)*64 <= s0.toNat since i < L and s0.toNat >= L*64
   exact getLimb_shiftLeft_low value s0.toNat i (by omega)
 
@@ -847,10 +844,9 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         show value <<< shift.toNat = value <<< s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have h6 := bv6_toNat_6
         have hlt4 : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
-          rw [h6]; simp [BitVec.toNat_ushiftRight]; omega
+          rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
         have hn0 : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
         have hn1 : limbShift.toNat ≠ 1 :=


### PR DESCRIPTION
## Summary

Third batch for #694. Remove 12 local `have h6 := bv6_toNat_6` aliases across `Shift/Compose`, `Shift/ShlCompose`, and `Shift/SarCompose`. Each alias was used exactly once on the following `rw` line; inlining the lemma name eliminates the trivial rename.

Before:
```lean
have hL_div : s0.toNat / 64 = L := by
  have h6 := bv6_toNat_6
  rw [← hL, h6]; simp [BitVec.toNat_ushiftRight]; omega
```

After:
```lean
have hL_div : s0.toNat / 64 = L := by
  rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
```

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)