### PR TITLE
refactor: migrate final cpsTriple_seq_with_perm_same_cr callers (#331)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -840,7 +840,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
       (fun h hq => by xperm_hyp hq)
       hphaseAB
   -- Final: Phase AB → Phase CD
-  exact cpsTriple_seq_with_perm_same_cr base (base + 56) (base + 180) _ _ _ _ _
+  exact cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
 
 -- ============================================================================

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -934,7 +934,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
       (fun h hq => by xperm_hyp hq)
       hphaseAB
   -- Final: Phase AB -> Phase CD
-  exact cpsTriple_seq_with_perm_same_cr base (base + 64) (base + 360) _ _ _ _ _
+  exact cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -1098,7 +1098,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
       (fun h hq => by xperm_hyp hq)
       hphaseAB
   -- Final: Phase AB -> Phase CD
-  exact cpsTriple_seq_with_perm_same_cr base (base + 64) (base + 380) _ _ _ _ _
+  exact cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -910,7 +910,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
       (fun h hq => by xperm_hyp hq)
       hphaseAB
   -- Final: Phase AB -> Phase CD
-  exact cpsTriple_seq_with_perm_same_cr base (base + 64) (base + 360) _ _ _ _ _
+  exact cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Partial #331. Replace the last four user call sites of the deprecated `cpsTriple_seq_with_perm_same_cr` (9 explicit positional args) with `cpsTriple_seq_perm_same_cr` (all positional/code/assertion args implicit).

Before:
```lean
exact cpsTriple_seq_with_perm_same_cr base (base + 56) (base + 180) _ _ _ _ _
  (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
```

After:
```lean
exact cpsTriple_seq_perm_same_cr
  (fun h hp => by xperm_hyp hp) hphaseAB' hphaseCD
```

Files: `Evm64/Byte/Spec.lean`, `Evm64/Shift/Compose.lean`, `Evm64/Shift/ShlCompose.lean`, `Evm64/Shift/SarCompose.lean`.

Three metacode references remain in `Rv64/Tactics/SeqFrame.lean` (`mkConst`/`mkAppN`); those need an Elab-aware rewrite and are left for a follow-up.

## Test plan
- [x] `lake build` succeeds
- [x] 4 `cpsTriple_seq_with_perm_same_cr` deprecation warnings removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)