### PR TITLE
refactor: remove deprecated cpsBranch_elim_{taken,ntaken} wrappers (#331)

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -296,16 +296,6 @@ theorem cpsBranch_takenPath {entry l_t l_f : Word} {cr : CodeReq}
   · obtain ⟨hp, hcompat, h1, h2, hd, hu, hQf, hR'⟩ := hQ_fR
     exact absurd hQf (h_absurd h1)
 
-/-- Explicit-argument variant of `cpsBranch_takenPath`. Kept for backwards
-    compatibility; prefer `cpsBranch_takenPath` in new code. -/
-@[deprecated cpsBranch_takenPath (since := "2026-04-19")]
-theorem cpsBranch_elim_taken (entry l_t l_f : Word) (cr : CodeReq)
-    (P Q_t Q_f : Assertion)
-    (hbr : cpsBranch entry cr P l_t Q_t l_f Q_f)
-    (h_absurd : ∀ hp, Q_f hp → False) :
-    cpsTriple entry l_t cr P Q_t :=
-  cpsBranch_takenPath hbr h_absurd
-
 /-- Extract the not-taken path from a cpsBranch when the taken postcondition
     is unsatisfiable (e.g., contains a contradictory pure fact).
     All position/code/pre/post arguments are implicit — unify from `hbr`. -/
@@ -320,16 +310,6 @@ theorem cpsBranch_ntakenPath {entry l_t l_f : Word} {cr : CodeReq}
   · obtain ⟨hp, hcompat, h1, h2, hd, hu, hQt, hR'⟩ := hQ_tR
     exact absurd hQt (h_absurd h1)
   · exact ⟨k, s', hstep, hpc_f, hQ_fR⟩
-
-/-- Explicit-argument variant of `cpsBranch_ntakenPath`. Kept for backwards
-    compatibility; prefer `cpsBranch_ntakenPath` in new code. -/
-@[deprecated cpsBranch_ntakenPath (since := "2026-04-19")]
-theorem cpsBranch_elim_ntaken (entry l_t l_f : Word) (cr : CodeReq)
-    (P Q_t Q_f : Assertion)
-    (hbr : cpsBranch entry cr P l_t Q_t l_f Q_f)
-    (h_absurd : ∀ hp, Q_t hp → False) :
-    cpsTriple entry l_f cr P Q_f :=
-  cpsBranch_ntakenPath hbr h_absurd
 
 /-- Eliminate the not-taken path from a cpsBranch AND strip the trailing pure fact
     from the taken postcondition (depth 2: A ** B ** ⌜P⌝ → A ** B). All arguments

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -57,7 +57,7 @@ theorem rlp_phase2_long_loop_one_byte_post_unfold
     Derived from `rlp_phase2_long_loop_body_spec` by observing that when
     `cnt = 1`, `cnt' = 1 + signExtend12 (-1) = 0`, so the taken-branch
     post `⌜cnt' ≠ 0⌝` collapses to `⌜(0 : Word) ≠ 0⌝ = False`. The
-    `cpsBranch_elim_ntaken` rule then turns the two-exit branch into a
+    `cpsBranch_ntakenPath` rule then turns the two-exit branch into a
     single-exit triple at the fall-through. -/
 theorem rlp_phase2_long_loop_one_byte_spec
     (len ptr v12Old wordVal dwordAddr : Word)
@@ -95,7 +95,7 @@ theorem rlp_phase2_long_loop_one_byte_spec
     obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
     obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
     exact hpost.2 rfl
-  -- `cpsBranch_elim_ntaken` drops the taken branch.
+  -- `cpsBranch_ntakenPath` drops the taken branch.
   have tri := cpsBranch_ntakenPath body h_absurd
   -- Weaken the post: unfold the `@[irreducible]` wrapper and strip the
   -- trailing `⌜(0 : Word) = 0⌝ = True` pure fact (via 5 `mono_right` wraps

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -100,7 +100,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
     obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
     obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
     exact absurd hpost.2 (by decide)
-  -- `cpsBranch_elim_taken` drops fall-through. Keeps taken exit (loops back).
+  -- `cpsBranch_takenPath` drops fall-through. Keeps taken exit (loops back).
   have tri1 := cpsBranch_takenPath body h_absurd
   -- Taken exit is `(base + 20) + signExtend13 back = base` by hback.
   rw [hback] at tri1


### PR DESCRIPTION
## Summary

Partial #331. Both wrappers were deprecated in favour of `cpsBranch_takenPath` / `cpsBranch_ntakenPath` (implicit-argument versions) and have no remaining callers — only three stale comment references in `RLP/Phase2LongLoopOne.lean` and `Phase2LongLoopTwo.lean`, which I updated to the new names.

Removing the wrappers trims 16 lines from `Rv64/CPSSpec.lean`.

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)