### PR TITLE
refactor: remove unused deprecated wrappers (#331)

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -434,17 +434,6 @@ theorem cpsTriple_seq_cpsBranch_perm_same_cr {entry mid : Word} {cr : CodeReq}
   cpsTriple_seq_cpsBranch_same_cr entry mid cr P Q2 exit_t Q_t exit_f Q_f
     (cpsTriple_consequence entry mid cr P P Q1 Q2 (fun _ hp => hp) hperm h1) h2
 
-/-- Explicit-argument variant of `cpsTriple_seq_cpsBranch_perm_same_cr`. Deprecated;
-    prefer `cpsTriple_seq_cpsBranch_perm_same_cr` in new code. -/
-@[deprecated cpsTriple_seq_cpsBranch_perm_same_cr (since := "2026-04-19")]
-theorem cpsTriple_seq_cpsBranch_with_perm_same_cr (entry mid : Word) (cr : CodeReq)
-    (P Q1 Q2 : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
-    (hperm : ∀ h, Q1 h → Q2 h)
-    (h1 : cpsTriple entry mid cr P Q1)
-    (h2 : cpsBranch mid cr Q2 exit_t Q_t exit_f Q_f) :
-    cpsBranch entry cr P exit_t Q_t exit_f Q_f :=
-  cpsTriple_seq_cpsBranch_perm_same_cr hperm h1 h2
-
 -- ============================================================================
 -- N-exit CPS specifications
 -- ============================================================================
@@ -957,8 +946,7 @@ theorem cpsTriple_frameL {entry exit_ : Word} {cr : CodeReq} {P Q : Assertion}
   exact ⟨k, s', hstep, hpc', holdsFor_sepConj_pull_second.mpr hpost⟩
 
 /-- Frame for cpsBranch: add `F` on the right. Position/code/pre/post args
-    are all implicit; prefer this over `cpsBranch_frame_left` (which takes
-    seven explicit `_` arguments before the frame `F`). -/
+    are all implicit. -/
 theorem cpsBranch_frameR {entry : Word} {cr : CodeReq} {P : Assertion}
     {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (F : Assertion) (hF : F.pcFree)
@@ -970,17 +958,6 @@ theorem cpsBranch_frameR {entry : Word} {cr : CodeReq} {P : Assertion}
   exact ⟨k, s', hstep, hcase.elim
     (fun ⟨hpc', hpost⟩ => Or.inl ⟨hpc', holdsFor_sepConj_assoc.mpr hpost⟩)
     (fun ⟨hpc', hpost⟩ => Or.inr ⟨hpc', holdsFor_sepConj_assoc.mpr hpost⟩)⟩
-
-/-- Explicit-argument variant of `cpsBranch_frameR`. Kept for backwards
-    compatibility; prefer `cpsBranch_frameR` in new code. -/
-@[deprecated cpsBranch_frameR (since := "2026-04-19")]
-theorem cpsBranch_frame_left (entry : Word) (cr : CodeReq)
-    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f : Assertion)
-    (F : Assertion) (hF : F.pcFree)
-    (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
-    cpsBranch entry cr (P ** F) exit_t (Q_t ** F) exit_f (Q_f ** F) :=
-  cpsBranch_frameR F hF h
 
 /-- Frame on the right for cpsHaltTriple. -/
 theorem cpsHaltTriple_frame_left (entry : Word) (cr : CodeReq)

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1308,11 +1308,11 @@ theorem sepConj_extract_pure_end3 (A B C : Assertion) (P : Prop) :
 
 /-- Push the outer atom of a 4-chain left-associated `(3-chain) ** D`
     into the right-associated 4-chain — the inverse of the tree shape
-    `cpsBranch_frame_left` produces when framing a 3-atom pre with a
+    `cpsBranch_frameR` produces when framing a 3-atom pre with a
     single-atom frame:
     `A ** B ** C ** D → (A ** B ** C) ** D`.
 
-    Useful to reconcile `cpsBranch_frame_left` output with a theorem
+    Useful to reconcile `cpsBranch_frameR` output with a theorem
     statement written in right-associated form. -/
 theorem sepConj_chain_push_outer (A B C D : Assertion) :
     ∀ h, (A ** B ** C ** D) h → ((A ** B ** C) ** D) h := by
@@ -1326,7 +1326,7 @@ theorem sepConj_chain_push_outer (A B C D : Assertion) :
     swapping the order:
     `(A ** B ** C ** ⌜P⌝) ** ⌜Q⌝ → A ** B ** C ** ⌜Q ∧ P⌝`.
 
-    The outer left-associated shape is what `cpsBranch_frame_left` produces
+    The outer left-associated shape is what `cpsBranch_frameR` produces
     when framed with `⌜Q⌝`; the right-associated output is what downstream
     consumers with a single accumulated pure fact expect. -/
 theorem sepConj_merge_pure_and_end3 (A B C : Assertion) (P Q : Prop) :


### PR DESCRIPTION
## Summary

Partial #331. Remove two deprecated wrappers that have no callers:

1. `cpsTriple_seq_cpsBranch_with_perm_same_cr` — deprecated in favor of `cpsTriple_seq_cpsBranch_perm_same_cr` (implicit args).
2. `cpsBranch_frame_left` — deprecated in favor of `cpsBranch_frameR` (implicit args).

Both have no call sites. Doc-comment mentions in `Rv64/SepLogic.lean` and one `Rv64/CPSSpec.lean` comment updated to point at the successors.

Net: 24 lines removed from `CPSSpec.lean`, 3 outdated comment references updated in `SepLogic.lean`.

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)