### PR TITLE
refactor: migrate metacode cpsTriple_consequence → cpsTriple_weaken (#331)

### DIFF
--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -415,7 +415,7 @@ private def frameFirstSpec (s1Expr : Expr) (goalPre : Expr) : MetaM Expr :=
     -- P = preP1 (from s1), P' = goalPre (what we want), hpre : goalPre → preP1
     let prePermProof ← mkPermLambda goalPre preP1
     let postIdProof ← mkIdLambda postQ1
-    return mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_consequence)
+    return mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_weaken)
       #[entry, exit_, cr1, preP1, goalPre, postQ1, postQ1, prePermProof, postIdProof, s1Expr]
   -- Build frame expression
   let frameExpr ← buildSepConjChain frameAtoms
@@ -432,7 +432,7 @@ private def frameFirstSpec (s1Expr : Expr) (goalPre : Expr) : MetaM Expr :=
   let prePermProof ← mkPermLambda goalPre p1StarFrame
   let q1StarFrame := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) postQ1 frameExpr
   let postIdProof ← mkIdLambda q1StarFrame
-  return mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_consequence)
+  return mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_weaken)
     #[entry, exit_, cr1, p1StarFrame, goalPre, q1StarFrame, q1StarFrame,
       prePermProof, postIdProof, s1Framed]
 
@@ -993,7 +993,7 @@ elab "runBlock" specs:ident* : tactic => withMainContext do
       | throwError "runBlock: internal error — composed result is not a cpsTriple"
     let postPerm ← mkPermLambda resultPost goalPost
     let idPre ← mkIdLambda gPre
-    let permuted := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_consequence)
+    let permuted := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_weaken)
       #[gEntry, gExit, gCr, gPre, gPre, resultPost, goalPost, idPre, postPerm, finalResult]
     workingGoal.assign permuted
     replaceMainGoal []

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -938,7 +938,7 @@ def seqFrameCore (h1Expr h2Expr : Expr) : MetaM Expr :=
       let hpost ← mkIdLambda q2StarFrame
       Pure.pure (q2StarFrame, hpost)
     -- h2Simplified : cpsTriple mid exit_ cr2 F actualPost
-    let h2Simplified := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_consequence)
+    let h2Simplified := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_weaken)
       #[mid2, exit_, cr2, empStarFrame, frameExpr, q2StarFrame, actualPost,
         hpre, hpost, h2Framed]
     -- Permutation: Q1 = F (since frame = all Q1 atoms)
@@ -1006,7 +1006,7 @@ def assignOrPermute (goal : MVarId) (result : Expr) : MetaM Unit := do
       Pure.pure extended
   let postPerm ← mkPermLambda resultPost goalPost
   let idPre ← mkIdLambda gPre
-  goal.assign (mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_consequence)
+  goal.assign (mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_weaken)
     #[gEntry, gExit, gCr, gPre, gPre, resultPost, goalPost, idPre, postPerm, result'])
 
 /-- `seqFrame h1 h2` composes two `cpsTriple` hypotheses with automatic framing.


### PR DESCRIPTION
## Summary

Partial #331. Replace the five metacode `mkAppN (mkConst \`\`EvmAsm.Rv64.cpsTriple_consequence)` call sites in `Rv64/Tactics/RunBlock.lean` and `Rv64/Tactics/SeqFrame.lean` with the non-deprecated `cpsTriple_weaken`.

Both theorems share an identical argument arity (6 implicits + 3 proof args, 10 positional slots) and `cpsTriple_weaken` is just the body of `cpsTriple_consequence` with the type arguments made implicit — `mkAppN` happily fills all 10 slots positionally regardless, so the construction is equivalent.

This clears the last metacode references to the deprecated wrapper; combined with #699 (internal user-facing callers), `cpsTriple_consequence` can be removed after both land.

## Test plan
- [x] `lake build` succeeds
- [x] Full codebase recompiles — no proof regressions from the metacode change

🤖 Generated with [Claude Code](https://claude.com/claude-code)