### PR TITLE
refactor: inline h3bv rename binding in Byte/Spec.lean (#694)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -604,13 +604,12 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hresult_high3 : getLimb result 3 = 0 :=
     byte_getLimb_high idx value (3 : Fin 4) (show (3 : Fin 4).val ≠ 0 by decide)
   have hresult_limb0 := byte_correct idx value hlt
-  have h3bv := bv6_toNat_3
   have hlimb_val : limbFromMsb.toNat = i0.toNat / 8 := by
     show (i0 >>> (3 : BitVec 6).toNat).toNat = i0.toNat / 8
-    rw [h3bv]; simp [BitVec.toNat_ushiftRight]; omega
+    rw [bv6_toNat_3]; simp [BitVec.toNat_ushiftRight]; omega
   have hbyte_shift_val : byteShift.toNat = (i0.toNat % 8) * 8 := by
     show (byteInLimb <<< (3 : BitVec 6).toNat).toNat = (i0.toNat % 8) * 8
-    rw [h3bv]
+    rw [bv6_toNat_3]
     simp only [byteInLimb, BitVec.toNat_shiftLeft, BitVec.toNat_and, se12_7,
                show (7 : Word).toNat = 7 from by decide]
     rw [Nat.and_two_pow_sub_one_eq_mod _ 3]


### PR DESCRIPTION
## Summary

Follow-up to #695 / #697 — this site was missed by earlier sweeps. The local `have h3bv := bv6_toNat_3` in `Evm64/Byte/Spec.lean:607` aliased the existing `bv6_toNat_3` lemma and was used only twice (`rw [h3bv]`). Inlining the lemma at the rewrite call removes the trivial rename.

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)