### PR TITLE
refactor: inline single-use base_spec bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -628,25 +628,23 @@ theorem divK_loop_body_n2_max_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN2, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n2_max_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n2_max_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN2, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n2_max_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n2_max_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
 
 /-- Unified loop body (BLTU taken, call path) for n=2, parameterized by borrow condition.
     `borrow_zero = true` → skip path; `borrow_zero = false` → addback+BEQ path.
@@ -691,26 +689,24 @@ theorem divK_loop_body_n2_call_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN2, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n2_call_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n2_call_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN2, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n2_call_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n2_call_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu hborrow)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -628,25 +628,23 @@ theorem divK_loop_body_n3_max_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN3, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n3_max_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n3_max_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN3, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n3_max_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n3_max_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
 
 /-- Unified loop body (BLTU taken, call path) for n=3, parameterized by borrow condition. -/
 theorem divK_loop_body_n3_call_unified_spec
@@ -689,26 +687,24 @@ theorem divK_loop_body_n3_call_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN3, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n3_call_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n3_call_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN3, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n3_call_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n3_call_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu hborrow)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -631,25 +631,23 @@ theorem divK_loop_body_n4_max_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN4, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n4_max_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n4_max_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN4, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n4_max_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n4_max_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
 
 /-- Unified loop body (BLTU taken, call path) for n=4, parameterized by borrow condition. -/
 theorem divK_loop_body_n4_call_unified_spec
@@ -692,26 +690,24 @@ theorem divK_loop_body_n4_call_unified_spec
   · -- false (addback+BEQ path)
     rw [if_neg (by decide)] at hborrow
     simp only [loopBodyUnifiedPostN4, loopBodyUnifiedPost_false]
-    have base_spec := divK_loop_body_n4_call_addback_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu (hcarry (by decide)) hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n4_call_addback_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu (hcarry (by decide)) hborrow)
   · -- true (skip path)
     rw [if_pos rfl] at hborrow
     simp only [loopBodyUnifiedPostN4, loopBodyUnifiedPost_true]
-    have base_spec := divK_loop_body_n4_call_skip_spec
-      sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
-      base halign hbltu hborrow
     exact cpsBranch_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => hp)
       (fun _ hp => hp)
-      base_spec
+      (divK_loop_body_n4_call_skip_spec
+        sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0
+        base halign hbltu hborrow)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Remove 12 local \`have base_spec := divK_loop_body_n{2,3,4}_*_spec ...\` bindings where \`base_spec\` is used only as the final argument to \`cpsBranch_weaken\`. Inlining the spec call at the argument position drops the intermediate alias per #694.

The two n=1 sites keep the binding because they additionally rewrite via \`simp only [...] at base_spec\` before exposing it.

## Test plan
- [x] \`lake build\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)