### PR TITLE
refactor: migrate cpsTriple_frame_left metacode + drop wrapper (#331)

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -853,8 +853,7 @@ theorem cpsNBranch_weaken_posts (entry : Word) (cr : CodeReq)
 
 /-- Frame a pcFree assertion `F` on the right of a cpsTriple: pre becomes
     `P ** F` and post becomes `Q ** F`. Position/code/pre/post args are all
-    implicit; prefer this over `cpsTriple_frame_left` (which takes five
-    explicit `_` arguments before the frame `F`). -/
+    implicit. -/
 theorem cpsTriple_frameR {entry exit_ : Word} {cr : CodeReq} {P Q : Assertion}
     (F : Assertion) (hF : F.pcFree)
     (h : cpsTriple entry exit_ cr P Q) :
@@ -863,16 +862,6 @@ theorem cpsTriple_frameR {entry exit_ : Word} {cr : CodeReq} {P Q : Assertion}
   have hPFR' := holdsFor_sepConj_assoc.mp hPFR
   obtain ⟨k, s', hstep, hpc', hpost⟩ := h (F ** R) (pcFree_sepConj hF hR) s hcr hPFR' hpc
   exact ⟨k, s', hstep, hpc', holdsFor_sepConj_assoc.mpr hpost⟩
-
-/-- Explicit-argument variant of `cpsTriple_frameR`. Kept for backwards
-    compatibility; prefer `cpsTriple_frameR` in new code. Note the name
-    is a misnomer — it adds `F` to the *right* of the sepConj chain. -/
-@[deprecated cpsTriple_frameR (since := "2026-04-19")]
-theorem cpsTriple_frame_left (entry exit_ : Word) (cr : CodeReq)
-    (P Q F : Assertion) (hF : F.pcFree)
-    (h : cpsTriple entry exit_ cr P Q) :
-    cpsTriple entry exit_ cr (P ** F) (Q ** F) :=
-  cpsTriple_frameR F hF h
 
 /-- Frame a pcFree assertion `F` on the left of a cpsTriple: pre becomes
     `F ** P` and post becomes `F ** Q`. Position/code/pre/post args are all

--- a/EvmAsm/Rv64/Tactics/RunBlock.lean
+++ b/EvmAsm/Rv64/Tactics/RunBlock.lean
@@ -423,7 +423,7 @@ private def frameFirstSpec (s1Expr : Expr) (goalPre : Expr) : MetaM Expr :=
   let pcFreeProof ← try buildPcFreeProof frameExpr
     catch _ => throwError "runBlock: could not prove pcFree for initial frame:\n  {frameExpr}"
   -- Frame s1: cpsTriple entry exit cr1 (P1 ** F) (Q1 ** F)
-  let s1Framed := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_frame_left)
+  let s1Framed := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_frameR)
     #[entry, exit_, cr1, preP1, postQ1, frameExpr, pcFreeProof, s1Expr]
   -- Permute precondition: goalPre → (P1 ** F)
   let p1StarFrame := mkApp2 (mkConst ``EvmAsm.Rv64.sepConj) preP1 frameExpr

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -17,7 +17,7 @@
 
   1. Extracts postcondition Q1 of h1 and precondition P2 of h2
   2. Computes frame F = Q1 \ P2 (atoms in Q1 not matched by P2)
-  3. Frames h2: `cpsTriple_frame_left` produces `cpsTriple mid exit (P2 ** F) (Q2 ** F)`
+  3. Frames h2: `cpsTriple_frameR` produces `cpsTriple mid exit (P2 ** F) (Q2 ** F)`
   4. Builds permutation proof Q1 → (P2 ** F)
   5. Composes via `cpsTriple_seq_with_perm`
 
@@ -902,7 +902,7 @@ def seqFrameCore (h1Expr h2Expr : Expr) : MetaM Expr :=
     catch _ => throwError "seqFrame: could not prove pcFree for frame:\n  {frameExpr}"
 
   -- h2Framed : cpsTriple mid exit_ cr2 (P2 ** F) (Q2 ** F)
-  let h2Framed := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_frame_left)
+  let h2Framed := mkAppN (mkConst ``EvmAsm.Rv64.cpsTriple_frameR)
     #[mid2, exit_, cr2, preP2, postQ2, frameExpr, pcFreeProof, h2Expr]
 
   -- When P2 = empAssertion, simplify (empAssertion ** F) to F and (Q2 ** F) similarly.


### PR DESCRIPTION
## Summary

Partial #331 follow-up. Replace the two metacode `mkAppN (mkConst \`\`cpsTriple_frame_left)` callers in `Rv64/Tactics/SeqFrame.lean` and `Rv64/Tactics/RunBlock.lean` with `cpsTriple_frameR` (same 8-slot arg layout; positional `mkAppN` fills implicit and explicit slots identically).

With the metacode migrated, the `@[deprecated]` `cpsTriple_frame_left` wrapper in `Rv64/CPSSpec.lean` has zero callers and is removed. One stale mention in the `SeqFrame.lean` docstring is updated to the successor name.

## Test plan
- [x] `lake build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)