### PR TITLE
chore: drop redundant `by exact` wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -628,6 +628,6 @@ theorem x1_val_n4 : signExtend12 (4 : BitVec 12) - (4 : Word) = (0 : Word) := by
 /-- When b ≠ 0, 0 < b in unsigned ordering (BitVec.ult). -/
 theorem ult_zero_of_ne {b : Word} (h : b ≠ 0) : BitVec.ult 0 b := by
   unfold BitVec.ult; simp
-  exact Nat.pos_of_ne_zero (fun h0 => h (by exact BitVec.eq_of_toNat_eq h0))
+  exact Nat.pos_of_ne_zero (fun h0 => h (BitVec.eq_of_toNat_eq h0))
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -48,7 +48,7 @@ theorem evm_push0_stack_spec (nsp base : Word)
     (fun h hq => by simp only [evmWordIs, EvmWord.getLimbN_zero]; xperm_hyp hq)
     (cpsTriple_frameR
       (evmStackIs (nsp + 32) rest)
-      (by exact pcFree_evmStackIs (nsp + 32) rest)
+      (pcFree_evmStackIs (nsp + 32) rest)
       (evm_push0_spec nsp base d0 d1 d2 d3))
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Two spots wrapped a direct term in `by exact …`. Both are already at the expected type; the tactic shim adds no value.

- `Evm64/Push0/Spec.lean:51` — `(by exact pcFree_evmStackIs …)` → `(pcFree_evmStackIs …)`
- `Evm64/DivMod/Compose/Base.lean:631` — `(by exact BitVec.eq_of_toNat_eq h0)` → `(BitVec.eq_of_toNat_eq h0)`