### PR TITLE
refactor: extract shared bv64_toNat_63 lemma

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -17,7 +17,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 bv64_toNat_63 word_add_zero)
 
 -- ============================================================================
 -- Section 1: shrCode definition and helpers
@@ -526,7 +526,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
   intro bs as_ mask; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
@@ -561,7 +561,7 @@ private theorem shr_bridge_last (value : EvmWord) (s0 : Word)
   intro bs; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_36 se13_100 se13_188 se13_320 se13_332 se21_32 se21_132 se21_212 se21_268
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 bv64_toNat_63 word_add_zero)
 
 -- ============================================================================
 -- Section 1: sarCode definition and helpers
@@ -660,7 +660,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
   intro bs as_ mask; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
@@ -697,7 +697,7 @@ private theorem sar_bridge_last (value : EvmWord) (s0 : Word)
   intro bs; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
@@ -723,7 +723,7 @@ private theorem sar_bridge_sign (value : EvmWord) (s0 : Word)
   -- Both give sign extension (all bits = MSB of x)
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     subst hbs; simp only [signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   simp only [getLimb]
   ext j

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -20,7 +20,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (se13_32 se13_92 se13_176 se13_308 se13_320 se21_24 se21_124 se21_200 se21_252
-  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 word_add_zero)
+  zero_add_se12_1_toNat zero_add_se12_2_toNat bv6_toNat_6 bv64_toNat_63 word_add_zero)
 
 -- ============================================================================
 -- Section 1: shlCode definition and helpers
@@ -492,7 +492,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
   intro bs as_ mask; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
@@ -531,7 +531,7 @@ private theorem shl_bridge_first (value : EvmWord) (s0 : Word)
   intro bs; rw [hresult]
   have hbs_val : bs.toNat = s0.toNat % 64 := by
     simp only [bs, signExtend12_63]
-    rw [BitVec.toNat_and, show (63 : BitVec 64).toNat = 63 from by decide]
+    rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -182,6 +182,8 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem bv6_toNat_62 : (62 : BitVec 6).toNat = 62 := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_63 : (63 : BitVec 6).toNat = 63 := by decide
 
+@[rv64_addr, grind =] theorem bv64_toNat_63 : (63 : BitVec 64).toNat = 63 := by decide
+
 -- ============================================================================
 -- `BitVec.ofNat 64 (4 * N)` evaluations (RV64 instruction stride × index)
 --


### PR DESCRIPTION
Seven `show (63 : BitVec 64).toNat = 63 from by decide` inlines were scattered across `Shift/Compose.lean`, `Shift/ShlCompose.lean`, and `Shift/SarCompose.lean`. Add a shared `bv64_toNat_63` theorem to `Rv64/AddrNorm.lean` (tagged `@[rv64_addr, grind =]` alongside the existing `bv6_toNat_*` family) and reference it by name at the call sites.