### PR TITLE
refactor: extract shared word_toNat_0 lemma

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -29,6 +29,7 @@ import EvmAsm.Evm64.EvmWordArith.Val256ModBridge
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -78,7 +79,7 @@ theorem val256_denorm_eq_val256_mod_max_skip
   -- Using mulsubN4_val256_eq (normalized) + val256_normalize_general + val256_normalize.
   have h_un_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
   simp only [] at h_un_raw
-  rw [hc3_un_zero, show (0 : Word).toNat = 0 from by decide,
+  rw [hc3_un_zero, word_toNat_0,
       Nat.zero_mul, Nat.add_zero] at h_un_raw
   have h_n_raw := mulsubN4_val256_eq (signExtend12 4095) b0' b1' b2' b3' u0 u1 u2 u3
   simp only [] at h_n_raw

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -25,6 +25,7 @@ import EvmAsm.Evm64.DivMod.LoopSemantic
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -189,7 +190,7 @@ theorem u_top_eq_c3_n_max_skip
   -- Derive the 4 Euclidean-style hypotheses at Nat level.
   have h_un_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
   simp only [] at h_un_raw
-  rw [hc3_un_zero, show (0 : Word).toNat = 0 from by decide,
+  rw [hc3_un_zero, word_toNat_0,
       Nat.zero_mul, Nat.add_zero] at h_un_raw
   -- h_un_raw : val256(a) = val256(ms_un) + qHat * val256(b)
   have h_n_raw := mulsubN4_val256_eq (signExtend12 4095)

--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -19,6 +19,7 @@ import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -40,7 +41,7 @@ theorem val256_ms_un_eq_val256_mod_max_skip
   have hmulsub_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
   simp only [] at hmulsub_raw
   rw [show ms.2.2.2.2 = (0 : Word) from hc3_zero] at hmulsub_raw
-  rw [show (0 : Word).toNat = 0 from by decide, Nat.zero_mul, Nat.add_zero]
+  rw [word_toNat_0, Nat.zero_mul, Nat.add_zero]
     at hmulsub_raw
   -- Rearrange into the form expected by `remainder_lt_of_ge_floor`.
   have hmulsub : val256 a0 a1 a2 a3 =

--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -182,6 +182,10 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 @[rv64_addr, grind =] theorem bv6_toNat_62 : (62 : BitVec 6).toNat = 62 := by decide
 @[rv64_addr, grind =] theorem bv6_toNat_63 : (63 : BitVec 6).toNat = 63 := by decide
 
+/-- `(0 : Word).toNat = 0` — used by several Nat-level algebraic rewrites
+    in the EvmWordArith mod-bridge proofs. -/
+@[rv64_addr, grind =] theorem word_toNat_0 : (0 : Word).toNat = 0 := by decide
+
 -- ============================================================================
 -- `BitVec.ofNat 64 (4 * N)` evaluations (RV64 instruction stride × index)
 --


### PR DESCRIPTION
Three `show (0 : Word).toNat = 0 from by decide` inlines sat in `ModBridgeAssemble.lean`, `Val256ModBridge.lean`, and `ModBridgeUtop.lean`. Add a shared `word_toNat_0` theorem to `Rv64/AddrNorm.lean` (tagged `@[rv64_addr, grind =]` alongside the existing constant-toNat family) and reference it by name at the call sites.