### PR TITLE
chore: replace `show (if true = true …) = … from by decide` with `if_pos rfl`

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -541,7 +541,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
     simp [hmod0, hmask, show bs.toNat % 64 = 0 from by omega]
   · have hmask : mask = BitVec.allOnes 64 := by
       simp only [mask]; have : BitVec.ult (0 : Word) bs = true := by simp [BitVec.ult]; omega
-      rw [this, show (if true = true then (1 : Word) else 0) = 1 from by decide]
+      rw [this, if_pos rfl]
       show (0 : Word) - 1 = BitVec.allOnes 64; decide
     rw [show bs.toNat % 64 = s0.toNat % 64 from by omega,
         show as_.toNat % 64 = 64 - s0.toNat % 64 from by

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -677,7 +677,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
     simp [hmod0, hmask, show bs.toNat % 64 = 0 from by omega]
   · have hmask : mask = BitVec.allOnes 64 := by
       simp only [mask]; have : BitVec.ult (0 : Word) bs = true := by simp [BitVec.ult]; omega
-      rw [this, show (if true = true then (1 : Word) else 0) = 1 from by decide]
+      rw [this, if_pos rfl]
       show (0 : Word) - 1 = BitVec.allOnes 64; decide
     rw [show bs.toNat % 64 = s0.toNat % 64 from by omega,
         show as_.toNat % 64 = 64 - s0.toNat % 64 from by

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -511,7 +511,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
   · -- bs > 0 case: mask = allOnes 64, helper mask = allOnes 64
     have hmask : mask = BitVec.allOnes 64 := by
       simp only [mask]; have : BitVec.ult (0 : Word) bs = true := by simp [BitVec.ult]; omega
-      rw [this, show (if true = true then (1 : Word) else 0) = 1 from by decide]
+      rw [this, if_pos rfl]
       show (0 : Word) - 1 = BitVec.allOnes 64; decide
     rw [show bs.toNat % 64 = s0.toNat % 64 from by omega,
         show as_.toNat % 64 = 64 - s0.toNat % 64 from by


### PR DESCRIPTION
Three sites in the Shift Compose files inlined a `show`/`decide` wrapper to prove `(if true = true then (1 : Word) else 0) = 1`. `if_pos rfl` is the idiomatic reflexivity proof — shorter and produces a smaller proof term.