### PR TITLE
refactor: use shared word_toNat_0 in EvmWordArith arithmetic files

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
@@ -16,6 +16,7 @@ import EvmAsm.Evm64.EvmWordArith.DivAddbackLimb
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -228,7 +229,7 @@ theorem addback_register_4limb_val256
   have h3 := addback_limb_nat_word_eq un3 v3 co2 h2.1
   -- Simplify h0: carryIn = 0
   have h0' : un0.toNat + v0.toNat = co0.toNat * 2^64 + aun0.toNat := by
-    have := h0.2; simp only [show (0 : Word).toNat = 0 from rfl] at this; linarith
+    have := h0.2; simp only [word_toNat_0] at this; linarith
   -- Chain via addback_4limb_val256
   exact addback_4limb_val256 un0 un1 un2 un3 v0 v1 v2 v3 aun0 aun1 aun2 aun3
     co0.toNat co1.toNat co2.toNat co3.toNat h0' h1.2 h2.2 h3.2

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -20,6 +20,7 @@ import EvmAsm.Evm64.EvmWordArith.DivMulSubLimb
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -207,7 +208,7 @@ theorem mulsub_register_4limb_val256 (q v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
   have h3 := mulsub_limb_nat_word_eq q v3 u3 c2
   -- Simplify h0: carryIn = 0, so (0 : Word).toNat = 0
   have h0' : u0.toNat + c0.toNat * 2^64 = un0.toNat + q.toNat * v0.toNat := by
-    have := h0; simp only [show (0 : Word).toNat = 0 from rfl] at this; linarith
+    have := h0; simp only [word_toNat_0] at this; linarith
   -- Chain via mulsub_chain_nat
   exact mulsub_chain_nat q.toNat u0 u1 u2 u3 v0 v1 v2 v3 un0 un1 un2 un3
     c0.toNat c1.toNat c2.toNat c3.toNat h0' h1 h2 h3

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -16,10 +16,12 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (word_toNat_0)
 
 namespace EvmWord
 
@@ -235,7 +237,7 @@ theorem mulsub_4limb_euclidean_div (qNat : Nat)
   have hb : b.toNat = val256 v0 v1 v2 v3 := by
     show (fromLimbs _).toNat = _; rw [fromLimbs_toNat]; dsimp only []; unfold val256; norm_num
   have hq : q.toNat = qNat := by
-    show (fromLimbs _).toNat = qNat; rw [fromLimbs_toNat, show (0 : Word).toNat = 0 from rfl]
+    show (fromLimbs _).toNat = qNat; rw [fromLimbs_toNat, word_toNat_0]
     simp only [BitVec.toNat_ofNat]; omega
   have hr : r.toNat = val256 r0 r1 r2 r3 := by
     show (fromLimbs _).toNat = _; rw [fromLimbs_toNat]; dsimp only []; unfold val256; norm_num


### PR DESCRIPTION
Replaces three more `show (0 : Word).toNat = 0 from rfl` inlines with the shared `EvmAsm.Rv64.AddrNorm.word_toNat_0` lemma (landed in #717). Affected: `DivAddbackCarry.lean`, `DivMulSubCarry.lean`, `DivMulSubLimb.lean`.