### PR TITLE
refactor(DivMod): redesign per-j iter spec unification via Fin+if-then-else (#283)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -640,17 +640,19 @@ theorem divK_loop_body_n1_call_iter_spec (j : Fin 4)
 -- Single `(j : Fin 4) (bltu : Bool)` iter spec for n=1
 -- ============================================================================
 
-/-- Unified iter spec for n=1: one theorem covering all 16 original path combinations. -/
+/-- Unified iter spec for n=1: one theorem covering all 16 original path combinations.
+    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
+    need vacuous dischargers — they pass the reduced hypothesis directly. -/
 theorem divK_loop_body_n1_iter_spec (j : Fin 4) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
-    (halign : bltu = true → ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu_max : bltu = false → ¬BitVec.ult u1 v0)
-    (hbltu_call : bltu = true → BitVec.ult u1 v0)
-    (hcarry_max : bltu = false → isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry_call : bltu = true → isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (halign : if bltu then ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516
+              else True)
+    (hbltu : if bltu then BitVec.ult u1 v0 else ¬BitVec.ult u1 v0)
+    (hcarry : if bltu then isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+              else isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
     cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
       (match bltu with
@@ -664,22 +666,19 @@ theorem divK_loop_body_n1_iter_spec (j : Fin 4) (bltu : Bool)
       (loopIterPostN1 bltu sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro exit_addr
   cases bltu
-  · simp only []
-    have hbltu' := hbltu_max rfl
-    have hcarry := hcarry_max rfl
+  · -- false (max): halign reduces to True, hbltu to ¬ult, hcarry to max variant
+    rw [if_neg (by decide)] at hbltu hcarry
     have H := divK_loop_body_n1_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => by unfold loopIterPostN1; simp only []; rw [sepConj_emp_right']; exact hp)
       H
-  · simp only []
-    have hbltu' := hbltu_call rfl
-    have halign' := halign rfl
-    have hcarry := hcarry_call rfl
+  · -- true (call): halign, hbltu, hcarry reduce to call-path types
+    rw [if_pos rfl] at halign hbltu hcarry
     have H := divK_loop_body_n1_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign' hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -805,17 +805,18 @@ theorem divK_loop_body_n2_call_iter_spec (j : Fin 3)
 -- ============================================================================
 
 /-- Unified iter spec for n=2: one theorem covering all 12 original path combinations.
-    Uses `preIterN2 (bltu : Bool)` which dispatches precondition shape. -/
+    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
+    need vacuous dischargers — they pass the reduced hypothesis directly. -/
 theorem divK_loop_body_n2_iter_spec (j : Fin 3) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
-    (halign : bltu = true → ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu_max : bltu = false → ¬BitVec.ult u2 v1)
-    (hbltu_call : bltu = true → BitVec.ult u2 v1)
-    (hcarry_max : bltu = false → isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry_call : bltu = true → isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (halign : if bltu then ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516
+              else True)
+    (hbltu : if bltu then BitVec.ult u2 v1 else ¬BitVec.ult u2 v1)
+    (hcarry : if bltu then isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+              else isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
     cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
       (match bltu with
@@ -830,23 +831,18 @@ theorem divK_loop_body_n2_iter_spec (j : Fin 3) (bltu : Bool)
   intro exit_addr
   cases bltu
   · -- false (max)
-    simp only []
-    have hbltu' := hbltu_max rfl
-    have hcarry := hcarry_max rfl
+    rw [if_neg (by decide)] at hbltu hcarry
     have H := divK_loop_body_n2_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => by unfold loopIterPostN2; simp only []; rw [sepConj_emp_right']; exact hp)
       H
   · -- true (call)
-    simp only []
-    have hbltu' := hbltu_call rfl
-    have halign' := halign rfl
-    have hcarry := hcarry_call rfl
+    rw [if_pos rfl] at halign hbltu hcarry
     have H := divK_loop_body_n2_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign' hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -758,17 +758,19 @@ theorem divK_loop_body_n3_call_iter_spec (j : Fin 2)
 -- Single `(j : Fin 2) (bltu : Bool)` iter spec for n=3
 -- ============================================================================
 
-/-- Unified iter spec for n=3: one theorem covering all 8 original path combinations. -/
+/-- Unified iter spec for n=3: one theorem covering all 8 original path combinations.
+    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
+    need vacuous dischargers — they pass the reduced hypothesis directly. -/
 theorem divK_loop_body_n3_iter_spec (j : Fin 2) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
-    (halign : bltu = true → ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu_max : bltu = false → ¬BitVec.ult u3 v2)
-    (hbltu_call : bltu = true → BitVec.ult u3 v2)
-    (hcarry_max : bltu = false → isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry_call : bltu = true → isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
+    (halign : if bltu then ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516
+              else True)
+    (hbltu : if bltu then BitVec.ult u3 v2 else ¬BitVec.ult u3 v2)
+    (hcarry : if bltu then isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+              else isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
     let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
     cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
       (match bltu with
@@ -782,22 +784,17 @@ theorem divK_loop_body_n3_iter_spec (j : Fin 2) (bltu : Bool)
       (loopIterPostN3 bltu sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
   intro exit_addr
   cases bltu
-  · simp only []
-    have hbltu' := hbltu_max rfl
-    have hcarry := hcarry_max rfl
+  · rw [if_neg (by decide)] at hbltu hcarry
     have H := divK_loop_body_n3_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
       (fun _ hp => by unfold loopIterPostN3; simp only []; rw [sepConj_emp_right']; exact hp)
       H
-  · simp only []
-    have hbltu' := hbltu_call rfl
-    have halign' := halign rfl
-    have hcarry := hcarry_call rfl
+  · rw [if_pos rfl] at halign hbltu hcarry
     have H := divK_loop_body_n3_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign' hbltu' hcarry
+      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
     intro_lets at H
     exact cpsTriple_weaken
       (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -505,17 +505,20 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
 -- ============================================================================
 
 /-- Unified iter spec for n=4: one theorem covering 4 original path combinations
-    (max/call × skip/addback). Uses `preIterN4 bltu` for precondition shape. -/
+    (max/call × skip/addback). Uses `if bltu then ... else ...` hypothesis API so
+    concrete-bltu call sites don't need vacuous dischargers. -/
 theorem divK_loop_body_n4_iter_spec (j : Fin 1) (bltu borrow_zero : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
     (ret_mem d_mem dlo_mem scratch_un0 : Word)
     (base : Word)
-    (halign : bltu = true → ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu_max : bltu = false → ¬BitVec.ult u_top v3)
-    (hbltu_call : bltu = true → BitVec.ult u_top v3)
-    (hcarry_max : bltu = false → borrow_zero = false → isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
-    (hcarry_call : bltu = true → borrow_zero = false → isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    (halign : if bltu then ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516
+              else True)
+    (hbltu : if bltu then BitVec.ult u_top v3 else ¬BitVec.ult u_top v3)
+    (hcarry : borrow_zero = false →
+      if bltu then isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 u_top
+      else isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 u_top)
+    -- hborrow kept split to avoid WHNF timeout on nested `let q_hat := if bltu then ... else ...`
     (hborrow_max : bltu = false →
       (if borrow_zero
        then (if BitVec.ult u_top (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -553,17 +556,17 @@ theorem divK_loop_body_n4_iter_spec (j : Fin 1) (bltu borrow_zero : Bool)
   intro q_hat_max q_hat_call q_hat
   fin_cases j
   cases bltu
-  · -- bltu = false (max path)
-    simp only []
-    have hbltu' := hbltu_max rfl
+  · -- bltu = false (max path): halign → True, hbltu → ¬ult, hcarry → max variant
+    rw [if_neg (by decide)] at hbltu
     have hborrow' := hborrow_max rfl
     cases borrow_zero
     · -- borrow_zero = false (addback path)
       simp only [loopBodyUnifiedPost_false]
       rw [if_neg (by decide)] at hborrow'
-      have hcarry := hcarry_max rfl rfl
+      have hcarry_inner := hcarry rfl
+      rw [if_neg (by decide)] at hcarry_inner
       have H := divK_loop_body_n4_max_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu' hcarry
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry_inner
       intro_lets at H
       have Hout := H hborrow'
       exact cpsTriple_weaken
@@ -574,26 +577,25 @@ theorem divK_loop_body_n4_iter_spec (j : Fin 1) (bltu borrow_zero : Bool)
       simp only [loopBodyUnifiedPost_true]
       rw [if_pos rfl] at hborrow'
       have H := divK_loop_body_n4_max_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu'
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu
       intro_lets at H
       have Hout := H hborrow'
       exact cpsTriple_weaken
         (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
         (fun _ hp => hp)
         Hout
-  · -- bltu = true (call path)
-    simp only []
-    have hbltu' := hbltu_call rfl
-    have halign' := halign rfl
+  · -- bltu = true (call path): halign → align_req, hbltu → ult, hcarry → call variant
+    rw [if_pos rfl] at halign hbltu
     have hborrow' := hborrow_call rfl
     cases borrow_zero
     · -- borrow_zero = false (addback)
       simp only [loopBodyUnifiedPost_false]
       rw [if_neg (by decide)] at hborrow'
-      have hcarry := hcarry_call rfl rfl
+      have hcarry_inner := hcarry rfl
+      rw [if_pos rfl] at hcarry_inner
       have H := divK_loop_body_n4_call_addback_j0_beq_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
-        halign' hbltu' hcarry
+        halign hbltu hcarry_inner
       intro_lets at H
       have Hout := H hborrow'
       exact cpsTriple_weaken
@@ -605,7 +607,7 @@ theorem divK_loop_body_n4_iter_spec (j : Fin 1) (bltu borrow_zero : Bool)
       rw [if_pos rfl] at hborrow'
       have H := divK_loop_body_n4_call_skip_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
         v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base
-        halign' hbltu'
+        halign hbltu
       intro_lets at H
       have Hout := H hborrow'
       exact cpsTriple_weaken


### PR DESCRIPTION
Towards #283. 

## Summary 
Redesigns the divK_loop_body_n{k}_iter_spec family with 4 Fin-parametric entry points using an if-then-else hypothesis API that eliminates vacuous dischargers at concrete-bltu call sites.

## Test plan

- [x] `lake build` — 3555/3555 jobs
