### PR TITLE
refactor: extend rv64_addr grindset with word_toNat_{1,2,3,4}

### DIFF
--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -187,6 +187,10 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 /-- `(n : Word).toNat = n` evaluations used by the Byte spec and by the
     EvmWordArith mod-bridge proofs. -/
 @[rv64_addr, grind =] theorem word_toNat_0   : (0   : Word).toNat = 0   := by decide
+@[rv64_addr, grind =] theorem word_toNat_1   : (1   : Word).toNat = 1   := by decide
+@[rv64_addr, grind =] theorem word_toNat_2   : (2   : Word).toNat = 2   := by decide
+@[rv64_addr, grind =] theorem word_toNat_3   : (3   : Word).toNat = 3   := by decide
+@[rv64_addr, grind =] theorem word_toNat_4   : (4   : Word).toNat = 4   := by decide
 @[rv64_addr, grind =] theorem word_toNat_7   : (7   : Word).toNat = 7   := by decide
 @[rv64_addr, grind =] theorem word_toNat_32  : (32  : Word).toNat = 32  := by decide
 @[rv64_addr, grind =] theorem word_toNat_255 : (255 : Word).toNat = 255 := by decide


### PR DESCRIPTION
## Summary

- Adds `word_toNat_{1,2,3,4}` as `@[rv64_addr, grind =]` lemmas in `EvmAsm/Rv64/AddrNorm.lean`, alongside the existing `word_toNat_{0,7,32,255}`.
- Pure addition; no call sites migrated in this PR.

## Motivation

Ad-hoc `have h : (N : Word).toNat = N := by decide` locals for `N ∈ {0,1}` appear 10+ times across:
- `EvmAsm/Evm64/EvmWordArith/Common.lean`
- `EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean` (6 sites)
- `EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean`
- `EvmAsm/Evm64/DivMod/Spec.lean`

Registering these on the shared grindset lets future `grind` / `rv64_addr` invocations discharge them uniformly, and opens a path to incremental inlining of the locals without each caller re-proving the same `by decide`.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)