### PR TITLE
refactor(EvmWordArith): use fin4_val_{0,1,2,3} in Common/Arithmetic

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -116,7 +116,7 @@ theorem add_carry_chain_correct (a b : EvmWord) :
     simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow]; rw [hS]; norm_num
   have key3 : ((a + b).getLimb 3).toNat = S % 2^256 / 2^192 % 2^64 := by
     simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow,
-      show (3 : Fin 4).val = 3 from rfl]; rw [hS]
+      fin4_val_3]; rw [hS]
   -- Factor S at each limb boundary using ring, then omega handles div/mod
   set W := (2 : Nat) ^ 64
   have hW : 0 < W := by positivity
@@ -361,7 +361,7 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
     simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow]; rw [hD]; norm_num
   have key3 : ((a - b).getLimb 3).toNat = D % 2^256 / 2^192 % W := by
     simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow,
-      show (3 : Fin 4).val = 3 from rfl]; rw [hD]
+      fin4_val_3]; rw [hD]
   -- Factor D using omega (ring doesn't work for Nat subtraction)
   have hD0 : D = (a0.toNat + W - b0.toNat) +
     (a1.toNat + W - 1 - b1.toNat + (a2.toNat + W - 1 - b2.toNat +

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -49,8 +49,7 @@ theorem toNat_eq_limb_sum (v : EvmWord) :
     v.toNat = (v.getLimb 0).toNat + (v.getLimb 1).toNat * 2^64 +
               (v.getLimb 2).toNat * 2^128 + (v.getLimb 3).toNat * 2^192 := by
   simp only [getLimb, BitVec.extractLsb'_toNat,
-    show (0 : Fin 4).val = 0 from rfl, show (1 : Fin 4).val = 1 from rfl,
-    show (2 : Fin 4).val = 2 from rfl, show (3 : Fin 4).val = 3 from rfl,
+    fin4_val_0, fin4_val_1, fin4_val_2, fin4_val_3,
     Nat.zero_mul, Nat.shiftRight_zero]
   have hv := v.isLt  -- v.toNat < 2^256
   omega


### PR DESCRIPTION
## Summary

Follow-up to #723 (which introduced the shared `fin4_val_{0,1,2,3}` lemmas in `Evm64/Basic.lean`). Four call sites in `EvmWordArith/{Common,Arithmetic}.lean` still used the inline `show (N : Fin 4).val = N from rfl` idiom — migrated to reference the shared lemmas:

- `Common.lean:toNat_eq_limb_sum` — all 4 indices in one `simp only`.
- `Arithmetic.lean` add-path `key3`.
- `Arithmetic.lean` sub-path `key3`.

Semantically equivalent (the lemmas are `rfl`); this just removes the ad-hoc `show`s in favour of the single source of truth in `Basic.lean`.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)