### PR TITLE
refactor(DivMod/Spec): use shared word_toNat_0 instead of local have

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -54,7 +54,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (word_add_zero)
+open EvmAsm.Rv64.AddrNorm (word_add_zero word_toNat_0)
 
 /-- `evmWordIs addr (EvmWord.div a 0) = evmWordIs addr 0`. Specialized
     rewrite for the zero-divisor path, bundling `evmWordIs_congr` +
@@ -1361,7 +1361,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
     push Not at h
     apply hshift_nz
     apply BitVec.eq_of_toNat_eq
-    have h0 : (0 : Word).toNat = 0 := by decide
+    rw [word_toNat_0]
     omega
   have hshift_lt_64 : (clzResult (b.getLimbN 3)).1.toNat < 64 := by omega
   have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =


### PR DESCRIPTION
## Summary

Small call-site migration: in `evm_div_n4_max_path_stack_spec`'s `hshift_pos` derivation, replace the local `have h0 : (0 : Word).toNat = 0 := by decide` + `omega` with `rw [word_toNat_0]; omega`, sourcing the fact from the canonical `rv64_addr` grindset (`EvmAsm.Rv64.AddrNorm.word_toNat_0`) that this file already imports via `open AddrNorm (...)`.

## Rationale

Part of the incremental cleanup following PR #719 / #721 (extraction of `word_toNat_0` to the shared grindset). Each migrated site removes a one-off `have … := by decide` that re-proves a fact already canonicalised in `Rv64/AddrNorm.lean`.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)