### PR TITLE
refactor(EvmWordArith/Common): name shadowed haves in ult_one_eq_zero

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -29,10 +29,10 @@ theorem ult_one_eq_zero {x : Word} : BitVec.ult x 1 ↔ x = 0 := by
   · intro h
     have h1 := of_decide_eq_true h
     change x.toNat < (1 : Word).toNat at h1
-    have : (1 : Word).toNat = 1 := by decide
-    have : x.toNat = 0 := by omega
-    have : (0 : Word).toNat = 0 := by decide
-    exact BitVec.eq_of_toNat_eq (by omega)
+    apply BitVec.eq_of_toNat_eq
+    have h1eq : (1 : Word).toNat = 1 := by decide
+    have h0eq : (0 : Word).toNat = 0 := by decide
+    omega
   · intro h; subst h; decide
 
 theorem xor_eq_zero_imp {n : Nat} {x y : BitVec n} (h : x ^^^ y = 0) : x = y :=


### PR DESCRIPTION
## Summary

The forward direction of `ult_one_eq_zero` used three anonymous `have : _ := by decide` / `have : _ := by omega` bindings that shadowed each other, plus one redundant intermediate — the final `BitVec.eq_of_toNat_eq (by omega)` was recomputing `x.toNat = 0` anyway.

Rewrite to:
- `apply BitVec.eq_of_toNat_eq` up front (goal becomes `x.toNat = (0 : Word).toNat`).
- Name the two bitvec-toNat facts (`h1eq`, `h0eq`).
- Close with one `omega`.

Same proof strength, no new dependencies, just cleaner to read. Fits the spirit of issue #694 (eliminating anonymous/shadowing locals).

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)