### PR TITLE
refactor: add bv64_4mul_0 to rv64_addr grindset

### DIFF
--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -208,6 +208,7 @@ theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
 -- Migrating those sites to the `rv64_addr` grindset localizes the knowledge.
 -- ============================================================================
 
+@[rv64_addr, grind =] theorem bv64_4mul_0  : BitVec.ofNat 64 (4 * 0)  = (0  : Word) := by decide
 @[rv64_addr, grind =] theorem bv64_4mul_1  : BitVec.ofNat 64 (4 * 1)  = (4  : Word) := by decide
 @[rv64_addr, grind =] theorem bv64_4mul_3  : BitVec.ofNat 64 (4 * 3)  = (12 : Word) := by decide
 @[rv64_addr, grind =] theorem bv64_4mul_5  : BitVec.ofNat 64 (4 * 5)  = (20 : Word) := by decide


### PR DESCRIPTION
## Summary

Adds `bv64_4mul_0 : BitVec.ofNat 64 (4 * 0) = (0 : Word)` as `@[rv64_addr, grind =]` in `Rv64/AddrNorm.lean`. The existing family covers N ∈ {1, 3, 5, 9, 10, 11, 12, 13, 14, 15, 17, 20, 21}.

## Motivation

N=0 is the only remaining `(4 * N)` index that appears in consumer sites without a grindset entry. Two uses today both close via `from by bv_addr`:
- `EvmAsm/Evm64/DivMod/Compose/CLZ.lean:66`
- `EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean:63`

Having the lemma lets any future migration of those sites to `by rv64_addr` / `by grind` work uniformly with the N ≥ 1 cases. Pure addition — no call sites migrated in this PR.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)