### PR TITLE
feat(divmod): evm_{div,mod}_n4_max_addback_beq_stack_spec — Phase F closed (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1373,4 +1373,51 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   simp only [hmod_eq, hanti_toNat_mod] at hq
   xperm_hyp hq
 
+-- ============================================================================
+-- DIV/MOD: n=4 max+addback BEQ stack specs — vacuous under `hshift_nz`
+-- ============================================================================
+
+/-- EVM-stack-level DIV spec on the n=4 max+addback BEQ sub-path.
+
+    **Vacuous under `hshift_nz`**: by `isMaxTrialN4_false_of_shift_nz`
+    (`EvmWordArith/MaxTrialVacuity.lean`), `isMaxTrialN4Evm a b` (which
+    unfolds to `isMaxTrialN4` on b's top limb) cannot hold simultaneously
+    with non-zero shift. So the precondition set is unsatisfiable and
+    the spec is trivially provable via `exfalso`.
+
+    This closes Phase F of the n=4 max+addback stack spec roadmap
+    (Issue #61): the bridge chain I was planning is not needed, because
+    the runtime path this spec describes is dead code at runtime for
+    shift > 0. -/
+theorem evm_div_n4_max_addback_beq_stack_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hbltu : isMaxTrialN4Evm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      (divN4StackPre sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
+      (divN4MaxSkipStackPost sp a b) := by
+  exfalso
+  exact isMaxTrialN4_false_of_shift_nz (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+    hb3nz hshift_nz hbltu
+
+/-- MOD counterpart of `evm_div_n4_max_addback_beq_stack_spec` — also vacuous. -/
+theorem evm_mod_n4_max_addback_beq_stack_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem : Word)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hbltu : isMaxTrialN4Evm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      (modN4StackPre sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
+      (modN4MaxSkipStackPost sp a b) := by
+  exfalso
+  exact isMaxTrialN4_false_of_shift_nz (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
+    hb3nz hshift_nz hbltu
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Closes out **Phase F** of the n=4 max+addback stack spec roadmap (Issue #61) by leveraging the vacuity finding from the \`MaxTrialVacuity\` chain (#726, #729, #735): under \`hshift_nz\`, the max-trial condition cannot hold.

Both \`evm_div_n4_max_addback_beq_stack_spec\` and its MOD counterpart are proven via a **one-line** \`exfalso; exact isMaxTrialN4_false_of_shift_nz ... hbltu\` discharge. The specs' precondition sets are unsatisfiable under \`hshift_nz ∧ isMaxTrialN4Evm\`, so they describe dead runtime code.

## Why this is the right closure

The original Phase F plan (\`memory/project_branch_pinning_detailed_plan.md\`) proposed a 6-PR bridge chain to prove the algorithm's normalized carry matches un-normalized hsem — substantial math. The vacuity finding shows this bridge is **unnecessary**: the path doesn't exist at runtime.

## What's next (real critical path for Issue #61)

- **Call-trial stack specs for shift > 0**: where max-trial is vacuous, so the algorithm always goes call-trial. Needs Knuth Theorem B for the \`div128Quot\` overestimate — the major math gap remaining.
- **Shift = 0 stack specs**: currently only \`evm_div_n4_full_shift0_call_{skip,addback}_spec\` exist at the limb level; no shift=0 max-trial specs.

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Spec\` — clean
- [x] Full \`lake build\` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)