### PR TITLE
refactor(DivMod/LimbSpec): use rv64_addr for se12_0 haddr identities

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/SubCarryStoreQj.lean
@@ -25,7 +25,6 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -85,7 +84,7 @@ theorem divK_store_qj_write_spec (qAddr qHat qOld : Word) (base : Word) :
       ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ qHat) ** (qAddr ↦ₘ qOld))
       ((.x7 ↦ᵣ qAddr) ** (.x11 ↦ᵣ qHat) ** (qAddr ↦ₘ qHat)) := by
   intro cr
-  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
+  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rv64_addr
   have I0 := sd_spec_gen .x7 .x11 qAddr qHat qOld 0 base
   rw [haddr] at I0
   runBlock I0

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -28,7 +28,6 @@ import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
 open EvmAsm.Rv64.AddrNorm (se21_8)
-open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -80,7 +79,7 @@ theorem divK_trial_load_u_spec (sp j n v5Old v7Old uHi uLo : Word)
        (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo)) := by
   intro jpn jpnX8 u0_base uAddr cr
-  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
+  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rv64_addr
   have I0 := ld_spec_gen .x5 .x12 sp v5Old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7Old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialStoreComposed.lean
@@ -23,7 +23,6 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Evm64.DivMod.AddrNorm (se12_0)
 
 namespace EvmAsm.Evm64
 
@@ -67,7 +66,7 @@ theorem divK_trial_load_spec
   let jpn := j + n
   let jpnX8 := jpn <<< (3 : BitVec 6).toNat
   let u0_base := sp + signExtend12 4056
-  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rw [se12_0]; bv_omega
+  have haddr0 : uAddr + signExtend12 (0 : BitVec 12) = uAddr := by rv64_addr
   have I0 := ld_spec_gen .x5 .x12 sp v5Old n 3984 base (by nofun)
   have I1 := add_spec_gen .x7 .x1 .x5 j n v7Old (base + 4) (by nofun)
   have I2 := slli_spec_gen_same .x7 jpn 3 (base + 8) (by nofun)
@@ -107,7 +106,7 @@ theorem divK_store_qj_spec (sp j qHat v5Old v7Old qOld : Word)
   have I0 := slli_spec_gen .x5 .x1 v5Old j 3 base (by nofun)
   have I1 := addi_spec_gen .x7 .x12 v7Old sp 4088 (base + 4) (by nofun)
   have I2 := sub_spec_gen_rd_eq_rs1 .x7 .x5 (sp + signExtend12 4088) jX8 (base + 8) (by nofun)
-  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rw [se12_0]; bv_omega
+  have haddr : qAddr + signExtend12 (0 : BitVec 12) = qAddr := by rv64_addr
   have I3 := sd_spec_gen .x7 .x11 qAddr qHat qOld 0 (base + 12)
   rw [haddr] at I3
   runBlock I0 I1 I2 I3


### PR DESCRIPTION
## Summary

Follow-up to #741 (which migrated the Byte/Spec address-normalization theorems to `rv64_addr`). Same mechanical migration for 4 inline `haddr` sites in the DivMod LimbSpec files:

- `SubCarryStoreQj.lean:88` (`divK_store_qj_write_spec`)
- `TrialQuotient.lean:83` (`divK_trial_load_spec`)
- `TrialStoreComposed.lean:70` (trial_store compose)
- `TrialStoreComposed.lean:110` (`divK_store_qj_spec`)

Each site was `have haddr : _ + signExtend12 (0 : BitVec 12) = _ := by rw [se12_0]; bv_omega`, now `by rv64_addr`. The grindset sees `se12_0` and `word_add_zero` via `@[grind =]`, collapsing the rewrite + bv_omega pair to one tactic call.

With every call site migrated, the `open AddrNorm (se12_0)` clause also drops from all three files.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)