### PR TITLE
refactor(SignExtend/Compose): use rv64_addr for 8 address-normalization theorems

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -17,9 +17,9 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_24 se13_60 se13_100 se13_156 se13_168 se21_36 se21_68 se21_96
-  zero_add_se12_1_toNat zero_add_se12_2_toNat
-  se12_7 bv6_toNat_3 word_add_zero)
+open EvmAsm.Rv64.AddrNorm
+  (zero_add_se12_1_toNat zero_add_se12_2_toNat
+   se12_7 bv6_toNat_3 word_add_zero)
 
 -- ============================================================================
 -- Section 1: signextCode definition and helpers
@@ -164,24 +164,24 @@ private theorem se_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := 
 private theorem se_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
 private theorem se_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
 private theorem se_bne_target (base : Word) : (base + 20 : Word) + signExtend13 168 = base + 188 := by
-  rw [se13_168]; bv_omega
+  rv64_addr
 private theorem se_beq_target (base : Word) : (base + 32 : Word) + signExtend13 156 = base + 188 := by
-  rw [se13_156]; bv_omega
+  rv64_addr
 -- Phase C exit addresses
 private theorem se_c_e0 (base : Word) : (base + 56 : Word) + signExtend13 100 = base + 156 := by
-  rw [se13_100]; bv_omega
+  rv64_addr
 private theorem se_c_e1 (base : Word) : ((base + 56 : Word) + 8) + signExtend13 60 = base + 124 := by
-  rw [se13_60]; bv_omega
+  rv64_addr
 private theorem se_c_e2 (base : Word) : ((base + 56 : Word) + 16) + signExtend13 24 = base + 96 := by
-  rw [se13_24]; bv_omega
+  rv64_addr
 private theorem se_c_e3 (base : Word) : (base + 56 : Word) + 20 = base + 76 := by bv_omega
 -- Body exit addresses (JAL targets)
 private theorem se_body3_exit (base : Word) : ((base + 76 : Word) + 16) + signExtend21 96 = base + 188 := by
-  rw [se21_96]; bv_omega
+  rv64_addr
 private theorem se_body2_exit (base : Word) : ((base + 96 : Word) + 24) + signExtend21 68 = base + 188 := by
-  rw [se21_68]; bv_omega
+  rv64_addr
 private theorem se_body1_exit (base : Word) : ((base + 124 : Word) + 28) + signExtend21 36 = base + 188 := by
-  rw [se21_36]; bv_omega
+  rv64_addr
 private theorem se_done_exit (base : Word) : (base + 188 : Word) + 4 = base + 192 := by bv_omega
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Continues the migration from #741 (Byte/Spec), #743 (SHR), #744 (SHL), #745 (SAR). Migrates 8 private address-normalization theorems in `SignExtend/Compose.lean` — `se_bne_target`, `se_beq_target`, `se_c_e0..2`, `se_body{1,2,3}_exit` — from `rw [seN_K]; bv_omega` to `by rv64_addr`. Also prunes the 8 now-unused se13/se21 names from the `open AddrNorm (…)` clause.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)