### PR TITLE
refactor(DivMod/LimbSpec): use rv64_addr for CLZ + div128 branch-target haddr

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -29,7 +29,6 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_12)
 open EvmAsm.Evm64.DivMod.AddrNorm (bv6_toNat_63)
 
 namespace EvmAsm.Evm64
@@ -66,7 +65,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val K base (by nofun)
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR
@@ -120,7 +119,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   intro cr
   have I0 := srli_spec_gen .x7 .x5 v7 val K base (by nofun)
   have hbne_raw := bne_spec_gen .x7 .x0 (12 : BitVec 13) (val >>> K.toNat) (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR
@@ -190,7 +189,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
   simp only [bv6_toNat_63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [se13_8]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR
@@ -243,7 +242,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
   have I0 := srli_spec_gen .x7 .x5 v7 val 63 base (by nofun)
   simp only [bv6_toNat_63] at I0
   have hbne_raw := bne_spec_gen .x7 .x0 (8 : BitVec 13) (val >>> 63) (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rw [se13_8]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (8 : BitVec 13) = base + 12 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbne_raw
   have hbne_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -23,7 +23,6 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64.AddrNorm (se13_12)
 
 namespace EvmAsm.Evm64
 
@@ -54,7 +53,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat dHi v5Old : Word) (base : Word
        (.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ 0)) := by
     runBlock I0
   have hbeq_raw := beq_spec_gen .x5 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frameR
@@ -139,7 +138,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 dHi v1Old : Word) (base : Wor
     have I0 := srli_spec_gen .x1 .x5 v1Old q0 32 base (by nofun)
     runBlock I0
   have hbeq_raw := beq_spec_gen .x1 .x0 (12 : BitVec 13) hi (0 : Word) (base + 4)
-  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rw [se13_12]; bv_addr
+  have ha_t : (base + 4) + signExtend13 (12 : BitVec 13) = base + 16 := by rv64_addr
   have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
   rw [ha_t, ha_f] at hbeq_raw
   have hbeq_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -23,7 +23,7 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64.AddrNorm (se13_8 se21_12)
+open EvmAsm.Rv64.AddrNorm (se21_12)
 
 namespace EvmAsm.Evm64
 
@@ -67,7 +67,7 @@ theorem divK_div128_prodcheck1_merged_spec
     have I3 := or_spec_gen_rd_eq_rs1 .x1 .x11 (rhat <<< (32 : BitVec 6).toNat) un1 (base + 12) (by nofun)
     runBlock I0 I1 I2 I3
   have hbltu_raw := bltu_spec_gen .x1 .x5 (8 : BitVec 13) rhatUn1 qDlo (base + 16)
-  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rw [se13_8]; bv_addr
+  have ha_t : (base + 16) + signExtend13 (8 : BitVec 13) = base + 24 := by rv64_addr
   have ha_f : (base + 16 : Word) + 4 = base + 20 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   have hbltu_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -24,7 +24,7 @@ import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
-open EvmAsm.Rv64.AddrNorm (se13_8 se21_8)
+open EvmAsm.Rv64.AddrNorm (se21_8)
 
 namespace EvmAsm.Evm64
 
@@ -68,7 +68,7 @@ theorem divK_div128_prodcheck2_merged_spec
     have I4 := or_spec_gen_rd_eq_rs1 .x1 .x11 (rhat2 <<< (32 : BitVec 6).toNat) un0 (base + 16) (by nofun)
     runBlock I0 I1 I2 I3 I4
   have hbltu_raw := bltu_spec_gen .x1 .x7 (8 : BitVec 13) rhat2Un0 q0Dlo (base + 20)
-  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rw [se13_8]; bv_addr
+  have ha_t : (base + 20) + signExtend13 (8 : BitVec 13) = base + 28 := by rv64_addr
   have ha_f : (base + 20 : Word) + 4 = base + 24 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
   have hbltu_framed := cpsBranch_frameR


### PR DESCRIPTION
## Summary

Follow-up to the rv64_addr migration campaign (#741/#742/#743/#744/#745/#746). Migrates 8 `have ha_t` branch-target identities across 4 LimbSpec files from `rw [se13_K]; bv_addr` to `by rv64_addr`:

- `CLZ.lean` — 4 sites (stage taken/ntaken at K ∈ {8, 12}).
- `Div128Clamp.lean` — 2 sites (K=12 BEQ merge, both merged variants).
- `Div128ProdCheck1.lean` — 1 site (K=8 BLTU merge).
- `Div128ProdCheck2.lean` — 1 site (K=8 BLTU merge).

With every migrated site, the se13_8/se13_12 imports drop from each `open AddrNorm (…)` clause (se21_* imports retained where still used).

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)