### PR TITLE
refactor(DivMod/LoopBody): use rv64_addr for 5 private address theorems

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -18,7 +18,7 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_12 se13_156 se13_7736 se13_8044 se21_560)
+open EvmAsm.Rv64.AddrNorm (se13_7736)
 
 -- ============================================================================
 -- Section 1: CodeReq subsumption infrastructure for loop body instructions
@@ -509,7 +509,7 @@ theorem divK_mulsub_full_spec
 -- ============================================================================
 
 private theorem lb_beq_taken (base : Word) : (base + 728 : Word) + signExtend13 (156 : BitVec 13) = base + 884 := by
-  rw [se13_156]; bv_addr
+  rv64_addr
 
 private theorem lb_beq_ntaken (base : Word) : (base + 728 : Word) + 4 = base + 732 := by bv_addr
 
@@ -768,11 +768,11 @@ theorem divK_save_trial_load_spec
 
 -- Address normalization for trial quotient
 private theorem lb_bltu_taken (base : Word) : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
-  rw [se13_12]; bv_addr
+  rv64_addr
 private theorem lb_bltu_ntaken (base : Word) : (base + 500 : Word) + 4 = base + 504 := by bv_addr
 private theorem lb_trial_max_end (base : Word) : (base + 504 : Word) + 12 = base + 516 := by bv_addr
 private theorem lb_jal_target (base : Word) : (base + 512 : Word) + signExtend21 (560 : BitVec 21) = base + div128Off := by
-  rw [se21_560]; bv_addr
+  rv64_addr
 private theorem lb_jal_ret (base : Word) : (base + 512 : Word) + 4 = base + 516 := by bv_addr
 
 -- ============================================================================
@@ -891,7 +891,7 @@ theorem divK_trial_call_path_spec
 private theorem lb_sqj (base : Word) : (base + 884 : Word) + 16 = base + 900 := by bv_addr
 private theorem lb_lc_taken (base : Word) :
     (base + 900 : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
-  rw [se13_7736]; bv_addr
+  rv64_addr
 private theorem lb_lc_exit (base : Word) : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
 
 private theorem lb_beq_back_ntaken (base : Word) : (base + 880 : Word) + 4 = base + 884 := by bv_addr
@@ -918,8 +918,7 @@ theorem divK_beq_passthrough (carry : Word) (base : Word) (hne : carry ≠ 0) :
 -- Address normalization for BEQ taken (double-addback backward branch)
 private theorem lb_beq_back_taken (base : Word) :
     (base + 880 : Word) + signExtend13 (8044 : BitVec 13) = base + 732 := by
-  rw [se13_8044]
-  bv_addr
+  rv64_addr
 
 /-- Double-addback path at [108]: when first addback carry (x7) = 0, BEQ jumps back to [71]
     for a second addback pass. The second addback always produces carry ≠ 0, so BEQ at [108]


### PR DESCRIPTION
## Summary

Continues the rv64_addr migration. Migrates 5 private address-normalization theorems in `EvmAsm/Evm64/DivMod/LoopBody.lean` — `lb_beq_taken`, `lb_bltu_taken`, `lb_jal_target`, `lb_lc_taken`, `lb_beq_back_taken` — from `rw [seN_K]; bv_addr` to `by rv64_addr`.

With those sites migrated, the `open AddrNorm (…)` clause drops 4 now-unused names (se13_12, se13_156, se13_8044, se21_560). `se13_7736` is retained — 2 inline `rw [se13_7736]` sites at lines ~1173 and ~1259 still reference it directly (migration of those nested `rw [show … from by rw [se13_7736]; bv_addr, …]` sites left for a follow-up).

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)