### PR TITLE
refactor(DivMod/ModPhaseB): use rv64_addr in the BNE cascade rewrites

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4 se12_4095)
-open EvmAsm.Rv64.AddrNorm (se13_24 se12_32
+open EvmAsm.Rv64.AddrNorm (se12_32
   bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
   bv64_4mul_14 bv64_4mul_15)
 
@@ -154,8 +154,8 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   seqFrame hinit1fhinit2 haddi
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne_raw
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+      mod_phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -8,7 +8,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_1 se12_2 se12_3 se12_4)
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se12_32)
+open EvmAsm.Rv64.AddrNorm (se12_32)
 
 -- ============================================================================
 -- MOD Phase B n=2 (b[3]=b[2]=0, b[1]≠0)
@@ -81,8 +81,8 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+      mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -116,8 +116,8 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+      mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -151,8 +151,8 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [se13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
+  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by rv64_addr,
+      mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -262,8 +262,8 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+      mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -297,8 +297,8 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+      mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -332,8 +332,8 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [se13_8]; bv_addr, mod_phB_step2_8] at hbne2_raw
+  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by rv64_addr,
+      mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -8,7 +8,7 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_3 se12_4)
-open EvmAsm.Rv64.AddrNorm (se13_16 se13_24 se12_32)
+open EvmAsm.Rv64.AddrNorm (se12_32)
 
 -- ============================================================================
 -- MOD Phase B n=3 (b[3]=0, b[2]≠0)
@@ -80,8 +80,8 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, mod_phB_bne_4] at hbne0_raw
+  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+      mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -115,8 +115,8 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, mod_phB_step1_8] at hbne1_raw
+  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+      mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf


### PR DESCRIPTION
## Summary

Migrates 9 `rw [se13_K]; bv_addr` sites inside `rw [show …, mod_phB_…]` cascades across three ModPhaseB files to `by rv64_addr`:

- `ModPhaseB.lean` (1 site: se13_24)
- `ModPhaseBn3.lean` (2 sites: se13_16, se13_24)
- `ModPhaseBn21.lean` (6 sites: se13_8 ×2, se13_16 ×2, se13_24 ×2)

Each `rw [show … from by rw [seN_K]; bv_addr, mod_phB_…]` becomes `rw [show … from by rv64_addr, mod_phB_…]`.

With the migrations, the `open AddrNorm (…)` clauses drop 6 now-unused names (se13_24 from ModPhaseB.lean; se13_16 + se13_24 from ModPhaseBn3; se13_8 + se13_16 + se13_24 from ModPhaseBn21). se12_32 and bv64_4mul_* imports are retained where still used.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)