### PR TITLE
refactor(DivMod/PhaseAB): use rv64_addr in BEQ/BNE cascade rewrites

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -14,9 +14,9 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Rv64.AddrNorm (se13_8 se13_16 se13_24 se13_1020
-  bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
-  bv64_4mul_14 bv64_4mul_15)
+open EvmAsm.Rv64.AddrNorm
+  (bv64_4mul_9 bv64_4mul_10 bv64_4mul_11 bv64_4mul_12 bv64_4mul_13
+   bv64_4mul_14 bv64_4mul_15)
 
 -- ============================================================================
 -- Section 5: CodeReq subsumption lemmas (via mono_unionAll / mono_sub_unionAll)
@@ -173,8 +173,7 @@ theorem evm_div_bzero_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
-        rw [se13_1020]; bv_addr,
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
@@ -231,8 +230,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
     (divK_phaseA_body_spec sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
   have hbeq_raw := beq_spec_gen .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by
-        rw [se13_1020]; bv_addr,
+  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
       show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
@@ -306,7 +304,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, phB_bne_4] at hbne_raw
+        rv64_addr, phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -547,7 +545,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
+        rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -582,7 +580,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
+        rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -691,7 +689,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
+        rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -726,7 +724,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
+        rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -761,7 +759,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [se13_8]; bv_addr, phB_step2_8] at hbne2_raw
+        rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -871,7 +869,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen .x10 .x0 24 b3 (0 : Word) (base + 72)
   rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
-        rw [se13_24]; bv_addr, phB_bne_4] at hbne0_raw
+        rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -906,7 +904,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen .x7 .x0 16 b2 (0 : Word) (base + 80)
   rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
-        rw [se13_16]; bv_addr, phB_step1_8] at hbne1_raw
+        rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -941,7 +939,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen .x6 .x0 8 b1 (0 : Word) (base + 88)
   rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
-        rw [se13_8]; bv_addr, phB_step2_8] at hbne2_raw
+        rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt


### PR DESCRIPTION
## Summary

DIV-side mirror of #749. Migrates 11 `rw [show … from by rw [seN_K]; bv_addr, …]` sites in `EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean` to use `by rv64_addr`:

- 2 sites — BEQ at Phase A entry (se13_1020).
- 9 sites — BNE cascades at phase B bodies (se13_8 ×2, se13_16 ×3, se13_24 ×4).

Each `rw [show … from by rw [seN_K]; bv_addr, <next>, …] at h` becomes `rw [show … from by rv64_addr, <next>, …] at h`.

With the migrations, the `open AddrNorm (…)` clause drops 4 now-unused names (se13_8, se13_16, se13_24, se13_1020). bv64_4mul_* imports are retained.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)