### PR TITLE
refactor(DivMod/LoopBody): use rv64_addr for 2 inline BGE loop-back rewrites

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1168,9 +1168,7 @@ theorem divK_store_loop_j0_spec
     exact lb_sub base 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
   have hbge_raw := bge_spec_gen .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
-  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
-        rw [se13_7736]
-        bv_addr,
+  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by
     exact lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
@@ -1254,9 +1252,7 @@ theorem divK_store_loop_jgt0_spec
     exact lb_sub base 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
   have hbge_raw := bge_spec_gen .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
-  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by
-        rw [se13_7736]
-        bv_addr,
+  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
       show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranch_extend_code (hmono := by
     exact lb_sub base 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw


### PR DESCRIPTION
## Summary

Follow-up to #748 (the private-theorem migration in the same file). Migrates the 2 remaining `rw [se13_7736]; bv_addr` sites in `DivMod/LoopBody.lean`:

- Line 1171 — normal-path BGE loop-back at base+904 → base+loopBodyOff.
- Line 1257 — double-addback-path BGE loop-back at the same PC.

Each `rw [show … from by rw [se13_7736]; bv_addr, …]` becomes `rw [show … from by rv64_addr, …]`.

`se13_7736` remains in the `open AddrNorm (…)` clause (imported by #748) until that PR lands; once both merge, a follow-up can drop the now-empty import.

## Test plan

- [x] `lake build` passes (full repo, 3557 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)