### PR TITLE
feat(evm-word-arith): val256_div_scale_invariant — Knuth B Step 0 (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -39,3 +39,4 @@ import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.AddbackBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.AddbackPinning
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
+import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -1,0 +1,36 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
+
+  Toward Knuth's TAOCP Vol 2 §4.3.1 Theorem B for the n=4 max-trial
+  call path: `div128Quot u_top u3 b3'` overestimates the true quotient
+  `⌊val256(a) / val256(b)⌋` by at most 2.
+
+  This is the major remaining math gap for call-trial DIV/MOD stack
+  specs (the real shift > 0 runtime path, after max-trial under
+  `hshift_nz` was shown vacuous in `MaxTrialVacuity.lean`).
+
+  See `memory/project_knuth_theorem_b_plan.md` for the 6-PR breakdown.
+
+  Currently contains:
+  - `val256_div_scale_invariant` (Step 0).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64 EvmWord
+
+/-- Scale invariance of integer division on val256: multiplying both operands
+    by `2^s` doesn't change the quotient. Entry point for lifting normalized
+    val256 computations back to un-normalized quotients.
+
+    Trivial from `Nat.mul_div_mul_right`. -/
+theorem val256_div_scale_invariant
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (s : Nat) :
+    (val256 a0 a1 a2 a3 * 2^s) / (val256 b0 b1 b2 b3 * 2^s) =
+    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by
+  have hpos : 0 < (2 : Nat)^s := by positivity
+  rw [Nat.mul_div_mul_right _ _ hpos]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

**Step 0** of the Knuth TAOCP Vol 2 §4.3.1 Theorem B formalization plan (see [memory note](https://github.com/Verified-zkEVM/evm-asm/blob/main/memory/project_knuth_theorem_b_plan.md)).

New \`EvmWordArith/KnuthTheoremB.lean\` with \`val256_div_scale_invariant\`:
\`\`\`
(val256 a * 2^s) / (val256 b * 2^s) = val256 a / val256 b
\`\`\`

Trivial from \`Nat.mul_div_mul_right\`, but provides the entry point for lifting normalized val256 computations back to un-normalized quotients — needed throughout the call-trial DIV/MOD stack spec chain (the real shift > 0 runtime path now that max-trial under \`hshift_nz\` is known vacuous via \`MaxTrialVacuity.lean\`).

## Why

Major math gap remaining for Issue #61. Plan breakdown:
- **Step 0** (this PR): scale invariance helper (~30 lines).
- **Step 1**: \`div128Quot\` unfolding to \`(u_top * B + u3) / b3'\` form (~40 lines).
- **Step 2**: Knuth's two-case bound \`q̂ ≤ q_true + 2\` (~100 lines).
- **Step 3**: \`n4_call_{skip,addback}_div_mod_getLimbN\` bridge lemmas (~120 lines).

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)