### PR TITLE
docs(OPCODE_TEMPLATE): replace stale _consequence with _unfold + cpsTriple_weaken

### DIFF
--- a/EvmAsm/Evm64/OPCODE_TEMPLATE.md
+++ b/EvmAsm/Evm64/OPCODE_TEMPLATE.md
@@ -77,11 +77,12 @@ Compose/
 DivMod retrofitted this under issue #266; MOD initially had a parallel clone
 of every DIV file, which doubled the LOC.
 
-### 2.3 `@[irreducible] def` + `_consequence` for large postconditions
+### 2.3 `@[irreducible] def` + `_unfold` for large postconditions
 
 Any postcondition with ≥3 `let` bindings — or any frame with ≥20 atoms —
 **must** be wrapped in `@[irreducible] def` with an accompanying `_unfold`
-(or `_consequence`) lemma. This is non-negotiable for scaling.
+lemma (callers peel back via `simp only [myPost_unfold]` or `delta myPost`
+inside a `cpsTriple_weaken` hook). This is non-negotiable for scaling.
 
 Reasons, both hit during the DivMod build-out:
 - Lean's WHNF elaboration at 25+ instruction atoms in a single theorem type


### PR DESCRIPTION
## Summary

Section 2.3 of `EvmAsm/Evm64/OPCODE_TEMPLATE.md` described the irreducible-postcondition pattern as "@[irreducible] def + _unfold (or _consequence) lemma". The `_consequence` wrapper was removed in the #331 deprecation cleanup — the live mechanism is now `cpsTriple_weaken` (the implicit-arg successor of the deprecated `cpsTriple_consequence`) paired with a per-def `_unfold` lemma.

Updates the section heading and body so new opcode subtrees don't adopt the stale idiom.

Doc-only change.

## Test plan

- [x] No build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)