### PR TITLE
feat(evm-word-arith): rv64_divu_toNat — Knuth B Step 1a (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -13,6 +13,7 @@
 
   Currently contains:
   - `val256_div_scale_invariant` (Step 0).
+  - `rv64_divu_toNat` (Step 1a — RV64 divu → Nat div bridge).
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -32,5 +33,20 @@ theorem val256_div_scale_invariant
     val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 := by
   have hpos : 0 < (2 : Nat)^s := by positivity
   rw [Nat.mul_div_mul_right _ _ hpos]
+
+/-- RV64 unsigned divide maps to Nat div on toNat (for nonzero divisor).
+
+    Entry-level bridge for reasoning about `div128Quot`, which composes two
+    `rv64_divu` calls with correction steps. The zero-divisor case returns
+    `BitVec.allOnes 64` and is handled separately at call sites. -/
+theorem rv64_divu_toNat (a b : Word) (hb : b ≠ 0) :
+    (rv64_divu a b).toNat = a.toNat / b.toNat := by
+  unfold rv64_divu
+  split
+  · rename_i hbeq
+    exfalso; apply hb
+    simp at hbeq
+    exact hbeq
+  · rw [BitVec.toNat_udiv]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Stacks on PR #756. Adds \`rv64_divu_toNat\`: the RV64 unsigned divide maps to Nat \`/\` on toNat (for nonzero divisor).

\`\`\`lean
theorem rv64_divu_toNat (a b : Word) (hb : b ≠ 0) :
    (rv64_divu a b).toNat = a.toNat / b.toNat
\`\`\`

Entry-level bridge for reasoning about \`div128Quot\` (\`LoopDefs/Iter.lean:130\`), which composes two \`rv64_divu\` calls with correction steps. The zero-divisor case (returns \`BitVec.allOnes 64\`) is handled at call sites.

## Why

**Step 1a** of the Knuth TAOCP Theorem B formalization plan. Next:
- Step 1b — first-round correctness of div128Quot's digit invariant.
- Step 1c — combination with second round into the 64-bit trial.

See [memory plan](https://github.com/Verified-zkEVM/evm-asm/blob/main/memory/project_knuth_theorem_b_plan.md) for the full breakdown.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)