### PR TITLE
docs: update 3 stale cpsTriple_seq_with_perm references in README + PLAN

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -191,7 +191,7 @@ All deleted spec files have been recreated. See **Pending: Recreate Deleted Spec
 ## Pending: Recreate Deleted Spec Files
 
 Five Evm64 spec files were deleted because their CodeReq migration was
-incomplete (manual `cpsTriple_seq_with_perm` calls lacked the `hd :
+incomplete (manual `cpsTriple_seq_perm_same_cr` calls lacked the `hd :
 cr1.Disjoint cr2` argument added during the migration, and CR tree shapes
 didn't match goals). The program definitions and tests remain in the
 corresponding non-Spec files.
@@ -270,9 +270,9 @@ corresponding non-Spec files.
 
 - Use `runBlock` auto mode wherever possible (handles CR extension, address
   normalization, and composition automatically).
-- For manual compositions with different CRs, use `cpsTriple_seq_with_perm`
+- For manual compositions with different CRs, use `cpsTriple_seq_perm`
   with `(by crDisjoint)` for the `hd` argument, or extend to a common CR
-  first and use `_same_cr` variants.
+  first and use `_same_cr` variants (`cpsTriple_seq_perm_same_cr`).
 - All `_code` abbrevs should be `CodeReq` — prefer `CodeReq.ofProg base prog`
   over chains of `singleton.union`. See MultiplySpec.lean for the current pattern.
 - Theorem statements use 5-arg `cpsTriple base exit cr P Q` with no

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ This is a **prototype** demonstrating the approach. Current state:
     frame parameter and tactics instantiate it during composition.
   - The instruction specs with explicit frame in `compiler/src/compiler/GoFlatToRiscv.v`
     (lines 439-546) informed the design of composing instruction specs with
-    `cpsTriple_frameR` + `cpsTriple_seq_with_perm`.
+    `cpsTriple_frameR` + `cpsTriple_seq_perm_same_cr`.
 - Knuth, D.E. (1997). *The Art of Computer Programming, Volume 2:
   Seminumerical Algorithms* (3rd ed.), §4.3.1 "The Classical Algorithms."
   Addison-Wesley. Algorithm D is used for the DIV/MOD opcodes in `Evm64/DivMod.lean`.


### PR DESCRIPTION
## Summary

Complements #725 and #758: three more references to the deprecated `cpsTriple_seq_with_perm` (removed in the #331 cleanup in favor of `cpsTriple_seq_perm_same_cr` / `cpsTriple_seq_perm`):

- `README.md` acknowledgments (bedrock2 inspiration bullet) — replace with `cpsTriple_seq_perm_same_cr`.
- `PLAN.md` "Pending: Recreate Deleted Spec Files" — update migration-failure description to the live name.
- `PLAN.md` CodeReq-migration guidance — replace with `cpsTriple_seq_perm` and explicitly name the `_same_cr` variant.

Doc-only; no build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)