### PR TITLE
docs(SeqFrame): note rv64_addr as preferred successor to bv_addr

### DIFF
--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -1070,7 +1070,15 @@ elab "crMono" : tactic => do
 /-- Lightweight address arithmetic: proves `(a + k₁) + k₂ = a + k₃` via
     BitVec associativity + constant folding. Generates much smaller kernel
     proof terms than `bv_omega` (one `add_assoc` rewrite + `rfl` vs full
-    Presburger arithmetic proof). -/
+    Presburger arithmetic proof).
+
+    **Prefer `rv64_addr`** (in `EvmAsm/Rv64/AddrNorm.lean`) for new code:
+    it subsumes `bv_addr` via its simp fallback and additionally handles
+    goals that mix `signExtend13`/`signExtend21` evaluations on the
+    common branch/jump offsets — shapes this macro cannot close. `bv_addr`
+    remains here because >400 existing call-sites are still pure
+    associativity and migrating them is net-neutral churn; pick `rv64_addr`
+    only when a `signExtend` is in the goal. -/
 macro "bv_addr" : tactic =>
   `(tactic| (simp only [BitVec.add_assoc]; rfl))
 


### PR DESCRIPTION
## Summary

Adds a note to the `bv_addr` macro docstring in `EvmAsm/Rv64/Tactics/SeqFrame.lean` pointing future readers at `rv64_addr` (`EvmAsm/Rv64/AddrNorm.lean`) as the preferred alternative for new code.

`rv64_addr` was introduced as the GRIND.md Phase 3 successor — its `simp only [rv64_addr, BitVec.add_assoc]; rfl` fallback subsumes `bv_addr`'s exact proof shape, and its `grind` branch additionally handles goals that mix `signExtend1?` evaluations on the common branch/jump offsets.

`bv_addr` remains because >400 existing call-sites are pure associativity and mass migration would be net-neutral churn. The note steers new sites (and any future bulk sweep) toward the richer macro.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)