### PR TITLE
refactor(Rv64/{Byte,Halfword,Word}Ops): drop redundant show from rfl

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -29,28 +29,28 @@ local macro "byte_algebra" : tactic =>
 
 private theorem erbs_0 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 0 b) 0 = b := by
-  simp only [extractByte, replaceByte, show (0 : Nat) * 8 = 0 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_1 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 1 b) 1 = b := by
-  simp only [extractByte, replaceByte, show (1 : Nat) * 8 = 8 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_2 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 2 b) 2 = b := by
-  simp only [extractByte, replaceByte, show (2 : Nat) * 8 = 16 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_3 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 3 b) 3 = b := by
-  simp only [extractByte, replaceByte, show (3 : Nat) * 8 = 24 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_4 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 4 b) 4 = b := by
-  simp only [extractByte, replaceByte, show (4 : Nat) * 8 = 32 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_5 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 5 b) 5 = b := by
-  simp only [extractByte, replaceByte, show (5 : Nat) * 8 = 40 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_6 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 6 b) 6 = b := by
-  simp only [extractByte, replaceByte, show (6 : Nat) * 8 = 48 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 private theorem erbs_7 (w : Word) (b : BitVec 8) :
     extractByte (replaceByte w 7 b) 7 = b := by
-  simp only [extractByte, replaceByte, show (7 : Nat) * 8 = 56 from rfl]; byte_algebra
+  simp only [extractByte, replaceByte]; byte_algebra
 
 theorem extractByte_replaceByte_same (w : Word) (pos : Fin 8) (b : BitVec 8) :
     extractByte (replaceByte w pos.val b) pos.val = b := by

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -21,16 +21,16 @@ local macro "halfword_algebra" : tactic =>
 
 private theorem erhs_0 (w : Word) (h : BitVec 16) :
     extractHalfword (replaceHalfword w 0 h) 0 = h := by
-  simp only [extractHalfword, replaceHalfword, show (0 : Nat) * 16 = 0 from rfl]; halfword_algebra
+  simp only [extractHalfword, replaceHalfword]; halfword_algebra
 private theorem erhs_1 (w : Word) (h : BitVec 16) :
     extractHalfword (replaceHalfword w 1 h) 1 = h := by
-  simp only [extractHalfword, replaceHalfword, show (1 : Nat) * 16 = 16 from rfl]; halfword_algebra
+  simp only [extractHalfword, replaceHalfword]; halfword_algebra
 private theorem erhs_2 (w : Word) (h : BitVec 16) :
     extractHalfword (replaceHalfword w 2 h) 2 = h := by
-  simp only [extractHalfword, replaceHalfword, show (2 : Nat) * 16 = 32 from rfl]; halfword_algebra
+  simp only [extractHalfword, replaceHalfword]; halfword_algebra
 private theorem erhs_3 (w : Word) (h : BitVec 16) :
     extractHalfword (replaceHalfword w 3 h) 3 = h := by
-  simp only [extractHalfword, replaceHalfword, show (3 : Nat) * 16 = 48 from rfl]; halfword_algebra
+  simp only [extractHalfword, replaceHalfword]; halfword_algebra
 
 theorem extractHalfword_replaceHalfword_same (w : Word) (pos : Fin 4) (h : BitVec 16) :
     extractHalfword (replaceHalfword w pos.val h) pos.val = h := by

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -21,10 +21,10 @@ local macro "word32_algebra" : tactic =>
 
 private theorem erws_0 (w : Word) (v : BitVec 32) :
     extractWord32 (replaceWord32 w 0 v) 0 = v := by
-  simp only [extractWord32, replaceWord32, show (0 : Nat) * 32 = 0 from rfl]; word32_algebra
+  simp only [extractWord32, replaceWord32]; word32_algebra
 private theorem erws_1 (w : Word) (v : BitVec 32) :
     extractWord32 (replaceWord32 w 1 v) 1 = v := by
-  simp only [extractWord32, replaceWord32, show (1 : Nat) * 32 = 32 from rfl]; word32_algebra
+  simp only [extractWord32, replaceWord32]; word32_algebra
 
 theorem extractWord32_replaceWord32_same (w : Word) (pos : Fin 2) (v : BitVec 32) :
     extractWord32 (replaceWord32 w pos.val v) pos.val = v := by


### PR DESCRIPTION
## Summary

Drops 14 redundant `show (N : Nat) * K = M from rfl` terms in `simp only [...]` args across three byte/halfword/word32 ops files:

- `Rv64/ByteOps.lean` — 8 `erbs_N` theorems (N ∈ 0..7, `N * 8`).
- `Rv64/HalfwordOps.lean` — 4 `erhs_N` theorems (N ∈ 0..3, `N * 16`).
- `Rv64/WordOps.lean` — 2 `erws_N` theorems (N ∈ 0..1, `N * 32`).

Each `show` was providing a kernel-level rfl-reducible rewrite into `simp only`. The subsequent `{byte,halfword,word32}_algebra` macro (`ext i; simp [...]; interval_cases i <;> simp_all`) closes the goal without needing the explicit rewrite.

Net: same tactic state, same proof term shape observable to consumers, cleaner proofs.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)