### PR TITLE
refactor(CPSSpec): rename cpsHaltTriple_consequence → cpsHaltTriple_weaken, implicit args

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -607,9 +607,10 @@ theorem cpsTriple_to_cpsHaltTriple (entry exit_ : Word) (cr : CodeReq)
   obtain ⟨k, s', hstep, hpc', hQR⟩ := h R hR s hcr hPR hpc
   exact ⟨k, s', hstep, hhalt R hR s' hQR hpc', hQR⟩
 
-/-- Consequence: strengthen precondition and weaken postcondition of a halt triple. -/
-theorem cpsHaltTriple_consequence (entry : Word) (cr : CodeReq)
-    (P P' Q Q' : Assertion)
+/-- Weaken: strengthen precondition and weaken postcondition of a halt triple.
+    Matches the `cpsTriple_weaken` / `cpsBranch_weaken` naming convention from #331. -/
+theorem cpsHaltTriple_weaken {entry : Word} {cr : CodeReq}
+    {P P' Q Q' : Assertion}
     (hpre  : ∀ h, P' h → P h)
     (hpost : ∀ h, Q h → Q' h)
     (h : cpsHaltTriple entry cr P Q) :


### PR DESCRIPTION
## Summary

The #331 renamings landed `cpsTriple_consequence` → `cpsTriple_weaken` and `cpsBranch_consequence` → `cpsBranch_weaken`, but the halt-triple variant was missed. `cpsHaltTriple_consequence` has zero callers in this repo (`grep -rn "cpsHaltTriple_consequence" EvmAsm/` finds only its own definition), so the rename is safe.

While here, flips the four `Assertion`-type params (`P P' Q Q'`) plus `entry`, `cr` to implicit — the same shape as `cpsTriple_weaken` — so future callers write `cpsHaltTriple_weaken hpre hpost h` instead of `cpsHaltTriple_consequence _ _ _ _ _ _ hpre hpost h`.

Docstring updated to note the post-#331 convention match.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).
- [x] `grep -rn "cpsHaltTriple_consequence" EvmAsm/` returns no callers (only the deleted defn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)