### PR TITLE
refactor(CPSSpec): rename cpsHaltTriple_frame_left → cpsHaltTriple_frameR, implicit args

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -889,9 +889,10 @@ theorem cpsBranch_frameR {entry : Word} {cr : CodeReq} {P : Assertion}
     (fun ⟨hpc', hpost⟩ => Or.inl ⟨hpc', holdsFor_sepConj_assoc.mpr hpost⟩)
     (fun ⟨hpc', hpost⟩ => Or.inr ⟨hpc', holdsFor_sepConj_assoc.mpr hpost⟩)⟩
 
-/-- Frame on the right for cpsHaltTriple. -/
-theorem cpsHaltTriple_frame_left (entry : Word) (cr : CodeReq)
-    (P Q F : Assertion) (hF : F.pcFree)
+/-- Frame on the right for cpsHaltTriple (F appears on the right of P ** F).
+    Matches the `cpsTriple_frameR` / `cpsBranch_frameR` naming convention from #331. -/
+theorem cpsHaltTriple_frameR {entry : Word} {cr : CodeReq}
+    {P Q : Assertion} (F : Assertion) (hF : F.pcFree)
     (h : cpsHaltTriple entry cr P Q) :
     cpsHaltTriple entry cr (P ** F) (Q ** F) := by
   intro R hR s hcr hPFR hpc


### PR DESCRIPTION
## Summary

Continues the #331 naming-convention cleanup. The halt-triple variant was missed when `cpsTriple_frame_left` / `cpsBranch_frame_left` were renamed to `cpsTriple_frameR` / `cpsBranch_frameR`. Additionally, the old name was confusing: its docstring already said "Frame on the right" but the symbol was named `_frame_left`.

`cpsHaltTriple_frame_left` has zero callers in this repo (`grep` finds only its own definition — parallel to the #763 `cpsHaltTriple_consequence` rename), so the rename is safe.

Also flips `entry`, `cr`, `P`, `Q` to implicit params — the same shape as `cpsTriple_frameR` — so future callers write `cpsHaltTriple_frameR F hF h` instead of `cpsHaltTriple_frame_left _ _ _ _ F hF h`. `F` stays explicit because it's the frame the caller supplies.

Follow-up to #763 (`cpsHaltTriple_weaken` rename).

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)