### PR TITLE
refactor(CPSSpec): rename cpsNBranch_frame_left → cpsNBranch_frameR

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -194,7 +194,7 @@ private theorem byte_store_exit_eq (base : Word) :
 
 -- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
--- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `cpsNBranch_extend_code` and `cpsNBranch_frameR` live in
 -- `Rv64/CPSSpec.lean` (shared).
 
 -- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
@@ -687,7 +687,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     cpsTriple_weaken
       (fun h hp => by xperm_hyp hp) (fun h hq => by xperm_hyp hq) hb0_val_f
   -- Frame Phase C and merge with bodies+store
-  have hphaseC_framed := cpsNBranch_frame_left
+  have hphaseC_framed := cpsNBranch_frameR
     (F := (.x6 ↦ᵣ shiftAmount) ** (.x12 ↦ᵣ sp) **
           (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -477,7 +477,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
 -- Section 5: Body path composition
 -- ============================================================================
 
--- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `cpsNBranch_extend_code` and `cpsNBranch_frameR` live in
 -- `Rv64/CPSSpec.lean` (shared).
 
 -- ============================================================================
@@ -895,7 +895,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
            ((sp + 48) ↦ₘ getLimb result 2) ** ((sp + 56) ↦ₘ getLimb result 3)) h
       rw [← eq0, eq1, eq2, eq3]; exact hq)
   -- Frame Phase C and merge with body specs
-  have hphaseC_framed := cpsNBranch_frame_left
+  have hphaseC_framed := cpsNBranch_frameR
     (F := (.x6 ↦ᵣ bitShift) ** (.x7 ↦ᵣ antiShift) ** (.x11 ↦ᵣ mask) ** (.x12 ↦ᵣ (sp + 32)) **
           (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -635,7 +635,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
 -- Section 6: Helpers for body path composition
 -- ============================================================================
 
--- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `cpsNBranch_extend_code` and `cpsNBranch_frameR` live in
 -- `Rv64/CPSSpec.lean` (shared).
 
 -- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
@@ -1059,7 +1059,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
            ((sp + 48) ↦ₘ getLimb result 2) ** ((sp + 56) ↦ₘ getLimb result 3)) h
       rw [← eq0, ← eq1, ← eq2, ← eq3]; exact hq)
   -- Frame Phase C and merge with body specs
-  have hphaseC_framed := cpsNBranch_frame_left
+  have hphaseC_framed := cpsNBranch_frameR
     (F := (.x6 ↦ᵣ bitShift) ** (.x7 ↦ᵣ antiShift) ** (.x11 ↦ᵣ mask) ** (.x12 ↦ᵣ (sp + 32)) **
           (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -467,7 +467,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
 
 -- Helpers for extending code requirements to cpsNBranch
 
--- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `cpsNBranch_extend_code` and `cpsNBranch_frameR` live in
 -- `Rv64/CPSSpec.lean` (shared).
 
 -- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
@@ -871,7 +871,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
            ((sp + 48) ↦ₘ getLimb result 2) ** ((sp + 56) ↦ₘ getLimb result 3)) h
       rw [← eq3, eq0, eq1, eq2]; exact hq)
   -- Frame Phase C and merge with body specs
-  have hphaseC_framed := cpsNBranch_frame_left
+  have hphaseC_framed := cpsNBranch_frameR
     (F := (.x6 ↦ᵣ bitShift) ** (.x7 ↦ᵣ antiShift) ** (.x11 ↦ᵣ mask) ** (.x12 ↦ᵣ (sp + 32)) **
           (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
           ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3))

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -409,7 +409,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
 
 -- `cpsTriple_strip_pure_and_convert` lives in `Rv64/CPSSpec.lean` (shared).
 
--- `cpsNBranch_extend_code` and `cpsNBranch_frame_left` live in
+-- `cpsNBranch_extend_code` and `cpsNBranch_frameR` live in
 -- `Rv64/CPSSpec.lean` (shared across Evm64 opcode compositions).
 
 -- ============================================================================
@@ -799,7 +799,7 @@ theorem signext_body_spec (sp base : Word)
   -- Frame Phase C with the full frame
   let phaseC_frame := (.x6 ↦ᵣ shiftAmount) ** (.x12 ↦ᵣ sp) ** bmem **
     ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)
-  have hphaseC_framed := cpsNBranch_frame_left
+  have hphaseC_framed := cpsNBranch_frameR
     (F := phaseC_frame) (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- Merge Phase C exits with body+done specs

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -544,7 +544,7 @@ theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
     becomes `P ** F` and each exit assertion in the list becomes `ex.2 ** F`.
     Shared across Evm64 opcode compositions — previously 5× `private theorem`
     duplicates. -/
-theorem cpsNBranch_frame_left {entry : Word} {cr : CodeReq}
+theorem cpsNBranch_frameR {entry : Word} {cr : CodeReq}
     {P : Assertion} {exits : List (Word × Assertion)} {F : Assertion}
     (hF : F.pcFree) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr (P ** F) (exits.map (fun ex => (ex.1, ex.2 ** F))) := by


### PR DESCRIPTION
## Summary

Continues the #331 naming-convention cleanup. The N-branch variant was missed when `cpsTriple_frame_left` / `cpsBranch_frame_left` were renamed to `cpsTriple_frameR` / `cpsBranch_frameR`. Parallel to #765 (`cpsHaltTriple_frameR` rename).

Unlike the halt-triple case, this theorem has 10 active callers across 5 files:

- `Evm64/Byte/Spec.lean`
- `Evm64/Shift/Compose.lean`
- `Evm64/Shift/ShlCompose.lean`
- `Evm64/Shift/SarCompose.lean`
- `Evm64/SignExtend/Compose.lean`

All signatures were already implicit-arg — the rename is purely textual. Signature and semantics unchanged.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)