### PR TITLE
feat(divmod): divScratchValuesCall — 19-cell call-path scratch bundle (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -296,6 +296,35 @@ theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   rw [divScratchValues_unfold]
   iterate 14 rw [sepConj_assoc']
 
+/-- Extension of `divScratchValues` with the 4 additional call-path scratch
+    cells at `sp + signExtend12 3968/3960/3952/3944` — the `div128`-subroutine
+    return address, the normalized top-divisor limb `d = b3'`, its low 32
+    bits `dLo`, and the `u_top`-next-limb normalized halfword. Total: 19 cells.
+
+    Used by the call-trial paths (`evm_div_n4_full_call_{skip,addback}_spec`)
+    which need these 4 extra scratch slots for the `div128Quot` computation.
+    The max-trial paths use only the 15 cells of `divScratchValues`. -/
+@[irreducible]
+def divScratchValuesCall (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem **
+  ((sp + signExtend12 3968) ↦ₘ retMem) **
+  ((sp + signExtend12 3960) ↦ₘ dMem) **
+  ((sp + signExtend12 3952) ↦ₘ dloMem) **
+  ((sp + signExtend12 3944) ↦ₘ scratch_un0)
+
+/-- Named unfold for `divScratchValuesCall`. -/
+theorem divScratchValuesCall_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem **
+     ((sp + signExtend12 3968) ↦ₘ retMem) **
+     ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) **
+     ((sp + signExtend12 3944) ↦ₘ scratch_un0)) := by
+  delta divScratchValuesCall; rfl
+
 /-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
     with ownership only (no commitment to specific values). Suitable for the
     postcondition of a stack-level DIV/MOD spec that doesn't want to expose


### PR DESCRIPTION
## Summary

Adds \`divScratchValuesCall\` extending \`divScratchValues\` with the 4 additional call-path scratch cells at \`sp + signExtend12 3968/3960/3952/3944\`:
- \`retMem\` — div128 subroutine return address.
- \`dMem\` — normalized top-divisor limb \`d = b3'\`.
- \`dloMem\` — its low 32 bits.
- \`scratch_un0\` — the normalized u-next halfword.

Total 19 cells. Used by the call-trial full-path specs (\`evm_div_n4_full_call_{skip,addback}_spec\`) which need these extra slots for the \`div128Quot\` computation. The max-trial paths use only the 15 cells of \`divScratchValues\`.

## Why

Scaffolding for the forthcoming call-trial stack-spec wrappers (Phase E-analogs for the call paths) — the actual critical path for Issue #61 now that max-trial under \`hshift_nz\` is known vacuous ([\`MaxTrialVacuity.lean\`](https://github.com/Verified-zkEVM/evm-asm/blob/main/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean)). The semantic correctness bridge via Knuth TAOCP Theorem B is separately tracked in [memory plan](https://github.com/Verified-zkEVM/evm-asm/blob/main/memory/project_knuth_theorem_b_plan.md).

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Compose.Base\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)