### PR TITLE
refactor(CPSSpec): flip cpsBranch_swap's positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -154,9 +154,10 @@ theorem cpsBranch_weaken {entry : Word} {cr : CodeReq}
       obtain ⟨hp, hcompat, hpq⟩ := hQR_f
       exact ⟨hp, hcompat, sepConj_mono_left hpost_f hp hpq⟩⟩⟩
 
-/-- Swap the two branch targets of a cpsBranch. -/
-theorem cpsBranch_swap (entry : Word) (cr : CodeReq) (P : Assertion)
-    (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
+/-- Swap the two branch targets of a cpsBranch.
+    All position/code/assertion arguments are implicit — inferred from `h`. -/
+theorem cpsBranch_swap {entry : Word} {cr : CodeReq} {P : Assertion}
+    {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr P exit_f Q_f exit_t Q_t := by
   intro R hR s hcr hPR hpc


### PR DESCRIPTION
## Summary

Completes the #331 implicit-arg convention pass. `cpsBranch_swap` was the last `cpsBranch_*` wrapper still taking `entry cr P exit_t Q_t exit_f Q_f` as explicit positional args. All seven are inferable from the hypothesis, matching the pattern already used by `cpsBranch_weaken`, `cpsBranch_takenPath`, `cpsBranch_ntakenPath`, `cpsBranch_extend_code`, and `cpsBranch_{taken,ntaken}StripPure{2,3}`.

Zero callers today (`grep -rn "cpsBranch_swap" EvmAsm/` finds only the definition) so the signature change is safe. Future callers write `cpsBranch_swap h` instead of `cpsBranch_swap _ _ _ _ _ _ _ h`.

Docstring gains a one-line note on the implicit-arg convention for discoverability.

Follow-up to #763 / #765 / #766 / #767.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)