### PR TITLE
feat(divmod): divScratchOwnCall — 19-cell call-path ownership bundle (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -391,6 +391,36 @@ instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
 theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
   rw [divScratchOwn_unfold]; pcFree
 
+/-- Value-agnostic counterpart to `divScratchValuesCall`: the same 19 cells
+    but with ownership only. Extends `divScratchOwn` with the 4 call-path
+    cells (at sp + 3968/3960/3952/3944).
+
+    Used for call-trial stack-spec postconditions that don't expose the
+    `div128` subroutine's internal state to callers. -/
+@[irreducible]
+def divScratchOwnCall (sp : Word) : Assertion :=
+  divScratchOwn sp **
+  memOwn (sp + signExtend12 3968) **
+  memOwn (sp + signExtend12 3960) **
+  memOwn (sp + signExtend12 3952) **
+  memOwn (sp + signExtend12 3944)
+
+/-- Named unfold for `divScratchOwnCall`. Parallel to `divScratchOwn_unfold`
+    and `divScratchValuesCall_unfold`. -/
+theorem divScratchOwnCall_unfold (sp : Word) :
+    divScratchOwnCall sp =
+    (divScratchOwn sp **
+     memOwn (sp + signExtend12 3968) **
+     memOwn (sp + signExtend12 3960) **
+     memOwn (sp + signExtend12 3952) **
+     memOwn (sp + signExtend12 3944)) := by
+  delta divScratchOwnCall; rfl
+
+/-- `divScratchOwnCall` is pc-free: all atoms are `memOwn` (chained from
+    `divScratchOwn` + 4 new `memOwn`). -/
+theorem pcFree_divScratchOwnCall (sp : Word) : (divScratchOwnCall sp).pcFree := by
+  rw [divScratchOwnCall_unfold, divScratchOwn_unfold]; pcFree
+
 instance pcFreeInst_divScratchOwn (sp : Word) :
     Assertion.PCFree (divScratchOwn sp) :=
   ⟨pcFree_divScratchOwn sp⟩

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -296,6 +296,35 @@ theorem divScratchValues_unfold_right (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
   rw [divScratchValues_unfold]
   iterate 14 rw [sepConj_assoc']
 
+/-- Extension of `divScratchValues` with the 4 additional call-path scratch
+    cells at `sp + signExtend12 3968/3960/3952/3944` — the `div128`-subroutine
+    return address, the normalized top-divisor limb `d = b3'`, its low 32
+    bits `dLo`, and the `u_top`-next-limb normalized halfword. Total: 19 cells.
+
+    Used by the call-trial paths (`evm_div_n4_full_call_{skip,addback}_spec`)
+    which need these 4 extra scratch slots for the `div128Quot` computation.
+    The max-trial paths use only the 15 cells of `divScratchValues`. -/
+@[irreducible]
+def divScratchValuesCall (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem **
+  ((sp + signExtend12 3968) ↦ₘ retMem) **
+  ((sp + signExtend12 3960) ↦ₘ dMem) **
+  ((sp + signExtend12 3952) ↦ₘ dloMem) **
+  ((sp + signExtend12 3944) ↦ₘ scratch_un0)
+
+/-- Named unfold for `divScratchValuesCall`. -/
+theorem divScratchValuesCall_unfold (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem **
+     ((sp + signExtend12 3968) ↦ₘ retMem) **
+     ((sp + signExtend12 3960) ↦ₘ dMem) **
+     ((sp + signExtend12 3952) ↦ₘ dloMem) **
+     ((sp + signExtend12 3944) ↦ₘ scratch_un0)) := by
+  delta divScratchValuesCall; rfl
+
 /-- Value-agnostic counterpart to `divScratchValues`: the same 15 cells but
     with ownership only (no commitment to specific values). Suitable for the
     postcondition of a stack-level DIV/MOD spec that doesn't want to expose


### PR DESCRIPTION
## Summary

Stacks on PR #768. Adds \`divScratchOwnCall\`: value-agnostic 19-cell ownership counterpart to \`divScratchValuesCall\`. Extends \`divScratchOwn\` with the 4 call-path cells at sp + 3968/3960/3952/3944.

Used for call-trial stack-spec postconditions that don't expose the \`div128\` subroutine's internal state to callers — parallel to the existing \`divScratchOwn\` used by the max-trial stack specs.

Includes \`divScratchOwnCall_unfold\` and \`pcFree_divScratchOwnCall\`.

## Why

Scaffolding for the forthcoming \`divN4StackPreCall\` bundle and \`evm_div_n4_full_call_skip_stack_pre_spec\` wrapper — the actual critical path for Issue #61 now that max-trial under \`hshift_nz\` is vacuous ([\`MaxTrialVacuity.lean\`](https://github.com/Verified-zkEVM/evm-asm/blob/main/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean)).

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Compose.Base\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)