### PR TITLE
refactor(CPSSpec): flip cpsBranch_merge_same_cr positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -238,9 +238,10 @@ theorem cpsBranch_merge (entry l_t l_f exit_ : Word) (cr1 cr_t cr_f : CodeReq)
     exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hR⟩
 
 /-- Like cpsBranch_merge but with the same CodeReq for all three specs.
-    No disjointness needed since code requirements are shared. -/
-theorem cpsBranch_merge_same_cr (entry l_t l_f exit_ : Word) (cr : CodeReq)
-    (P Q_t Q_f R : Assertion)
+    No disjointness needed since code requirements are shared.
+    All position/code/assertion arguments are implicit — inferred from `hbr`/`h_t`/`h_f`. -/
+theorem cpsBranch_merge_same_cr {entry l_t l_f exit_ : Word} {cr : CodeReq}
+    {P Q_t Q_f R : Assertion}
     (hbr   : cpsBranch entry cr P l_t Q_t l_f Q_f)
     (h_t   : cpsTriple l_t exit_ cr Q_t R)
     (h_f   : cpsTriple l_f exit_ cr Q_f R) :


### PR DESCRIPTION
## Summary

Follow-up to #769 (`cpsBranch_swap` implicit-arg flip). `cpsBranch_merge_same_cr`'s nine positional args (`entry`, `l_t`, `l_f`, `exit_`, `cr`, `P`, `Q_t`, `Q_f`, `R`) are all inferable from the three hypothesis arguments, matching the implicit-arg pattern already used by `cpsTriple_weaken`, `cpsBranch_takenPath`, `cpsBranch_ntakenPath`, `cpsBranch_takenStripPure{2,3}`, `cpsBranch_ntakenStripPure{2,3}`, and `cpsBranch_extend_code`.

Zero callers today (`grep -rn "cpsBranch_merge_same_cr" EvmAsm/` finds only the definition) so the signature change is safe. Future callers write `cpsBranch_merge_same_cr hbr h_t h_f` instead of `cpsBranch_merge_same_cr _ _ _ _ _ _ _ _ _ hbr h_t h_f`.

Docstring gains a one-line note on the implicit-arg convention.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)