### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_halt positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -626,10 +626,11 @@ theorem cpsHaltTriple_weaken {entry : Word} {cr : CodeReq}
 
 /-- Sequence a `cpsTriple` followed by a `cpsHaltTriple`:
     if code reaches midpoint with Q, and from midpoint it halts with R, then
-    the composition halts with R. -/
-theorem cpsTriple_seq_halt (entry mid : Word) (cr1 cr2 : CodeReq)
+    the composition halts with R.
+    All position/code/assertion arguments are implicit — inferred from `h1`/`h2`. -/
+theorem cpsTriple_seq_halt {entry mid : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q R : Assertion)
+    {P Q R : Assertion}
     (h1 : cpsTriple entry mid cr1 P Q)
     (h2 : cpsHaltTriple mid cr2 Q R) :
     cpsHaltTriple entry (cr1.union cr2) P R := by


### PR DESCRIPTION
## Summary

Follow-up to #769 / #771 (implicit-arg convention pass). `cpsTriple_seq_halt`'s `entry`, `mid`, `cr1`, `cr2`, `P`, `Q`, `R` are all inferable from the hypotheses `h1 : cpsTriple entry mid cr1 P Q` and `h2 : cpsHaltTriple mid cr2 Q R`, so all seven are made implicit. `hd` stays explicit because it's the disjointness proof the caller supplies.

Zero callers today so the signature change is safe. Future callers write `cpsTriple_seq_halt hd h1 h2` instead of `cpsTriple_seq_halt _ _ _ _ hd _ _ _ h1 h2`.

Docstring gains a one-line note on the implicit-arg convention.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)