### PR TITLE
feat(evm-word-arith): val256 helpers for Knuth B abstract proof (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -16,6 +16,10 @@
   - `rv64_divu_toNat` (Step 1a — RV64 divu → Nat div bridge).
   - `val256_ge_pow255_of_normalized` — normalized divisor ≥ 2^255.
   - `val256_split_hi2` — split val256 into (hi2-limb * 2^128 + lo2-limb) form.
+  - `knuth_u_hat_mul_pow192_le` — trial-numerator * 2^192 ≤ u_nat.
+  - `knuth_v_nat_lt_v_top_succ_mul_pow192` — v_nat < (v_top + 1) * 2^192.
+  - `knuth_v_nat_ge_pow255_abstract` — Nat-level v_nat ≥ 2^255.
+  - `knuth_q_hat_clamp_le_div` / `knuth_q_hat_clamp_lt_pow64` — min-clamp bounds.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -73,5 +77,55 @@ theorem val256_split_hi2 (a0 a1 a2 a3 : Word) :
       (a3.toNat * 2^64 + a2.toNat) * 2^128 +
       (a1.toNat * 2^64 + a0.toNat) := by
   unfold val256; ring
+
+/-- Knuth B — trial numerator scales up to at most the full numerator.
+    `u_nat = u_top * 2^256 + u_next * 2^192 + u_rest` implies
+    `(u_top * 2^64 + u_next) * 2^192 ≤ u_nat` since `u_rest ≥ 0` and
+    `2^64 * 2^192 = 2^256`. -/
+theorem knuth_u_hat_mul_pow192_le
+    (u_nat u_top u_next u_rest : Nat)
+    (h_u_split : u_top * 2^256 + u_next * 2^192 + u_rest = u_nat) :
+    (u_top * 2^64 + u_next) * 2^192 ≤ u_nat := by
+  have hpow : (2:Nat)^64 * 2^192 = 2^256 := by rw [← pow_add]
+  have h1 : (u_top * 2^64 + u_next) * 2^192 = u_top * 2^256 + u_next * 2^192 := by
+    rw [Nat.add_mul, Nat.mul_assoc, hpow]
+  omega
+
+/-- Knuth B — full divisor is strictly less than `(v_top + 1) * 2^192`.
+    Follows from `v_rest < 2^192`. -/
+theorem knuth_v_nat_lt_v_top_succ_mul_pow192
+    (v_nat v_top v_rest : Nat)
+    (h_v_split : v_nat = v_top * 2^192 + v_rest)
+    (h_v_rest : v_rest < 2^192) :
+    v_nat < (v_top + 1) * 2^192 := by
+  have : (v_top + 1) * 2^192 = v_top * 2^192 + 2^192 := by ring
+  omega
+
+/-- Knuth B — Nat-level version of `v_nat ≥ 2^255` under normalization.
+    Abstract counterpart of `val256_ge_pow255_of_normalized`. -/
+theorem knuth_v_nat_ge_pow255_abstract
+    (v_nat v_top v_rest : Nat)
+    (h_v_norm : v_top ≥ 2^63)
+    (h_v_split : v_nat = v_top * 2^192 + v_rest) :
+    v_nat ≥ 2^255 := by
+  have h1 : v_top * 2^192 ≥ 2^63 * 2^192 := Nat.mul_le_mul_right _ h_v_norm
+  have h2 : (2:Nat)^63 * 2^192 = 2^255 := by rw [← pow_add]
+  omega
+
+/-- Knuth B — the min-clamp quotient `q_hat = min((u_top*B + u_next)/v_top, B-1)`
+    is at most the raw trial quotient. Trivial from `min_le_left`. -/
+theorem knuth_q_hat_clamp_le_div (u_top u_next v_top q_hat : Nat)
+    (hq : q_hat = min ((u_top * 2^64 + u_next) / v_top) (2^64 - 1)) :
+    q_hat ≤ (u_top * 2^64 + u_next) / v_top := by
+  rw [hq]; exact Nat.min_le_left _ _
+
+/-- Knuth B — the min-clamp quotient is strictly less than `2^64`. -/
+theorem knuth_q_hat_clamp_lt_pow64 (u_top u_next v_top q_hat : Nat)
+    (hq : q_hat = min ((u_top * 2^64 + u_next) / v_top) (2^64 - 1)) :
+    q_hat < 2^64 := by
+  rw [hq]
+  have := Nat.min_le_right ((u_top * 2^64 + u_next) / v_top) (2^64 - 1)
+  have hpow : (0:Nat) < 2^64 := by positivity
+  omega
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -14,6 +14,8 @@
   Currently contains:
   - `val256_div_scale_invariant` (Step 0).
   - `rv64_divu_toNat` (Step 1a — RV64 divu → Nat div bridge).
+  - `val256_ge_pow255_of_normalized` — normalized divisor ≥ 2^255.
+  - `val256_split_hi2` — split val256 into (hi2-limb * 2^128 + lo2-limb) form.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -48,5 +50,28 @@ theorem rv64_divu_toNat (a b : Word) (hb : b ≠ 0) :
     simp at hbeq
     exact hbeq
   · rw [BitVec.toNat_udiv]
+
+/-- Under the normalization precondition `b3.toNat ≥ 2^63`, the 4-limb
+    divisor is at least `2^255` (i.e. the top bit of the 256-bit value
+    is set). Used by Knuth B to bound `v_nat` from below.
+
+    Proof: `val256 ≥ b3.toNat * 2^192 ≥ 2^63 * 2^192 = 2^255`. -/
+theorem val256_ge_pow255_of_normalized
+    (b0 b1 b2 b3 : Word) (hb3 : b3.toNat ≥ 2^63) :
+    val256 b0 b1 b2 b3 ≥ 2^255 := by
+  unfold val256
+  have h : b3.toNat * 2^192 ≥ 2^63 * 2^192 := Nat.mul_le_mul_right _ hb3
+  have hpow : (2:Nat)^63 * 2^192 = 2^255 := by norm_num
+  nlinarith
+
+/-- Split a 4-limb value into its high-2-limb half and low-2-limb half:
+    `val256 a0 a1 a2 a3 = (a3*B + a2) * B^2 + (a1*B + a0)` where `B = 2^64`.
+    Used by Knuth B to express the "trial quotient" in terms of
+    `u_top * 2^64 + u3` (the high pair) and `u2 * 2^64 + u1` (the low pair). -/
+theorem val256_split_hi2 (a0 a1 a2 a3 : Word) :
+    val256 a0 a1 a2 a3 =
+      (a3.toNat * 2^64 + a2.toNat) * 2^128 +
+      (a1.toNat * 2^64 + a0.toNat) := by
+  unfold val256; ring
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -20,6 +20,7 @@
   - `knuth_v_nat_lt_v_top_succ_mul_pow192` — v_nat < (v_top + 1) * 2^192.
   - `knuth_v_nat_ge_pow255_abstract` — Nat-level v_nat ≥ 2^255.
   - `knuth_q_hat_clamp_le_div` / `knuth_q_hat_clamp_lt_pow64` — min-clamp bounds.
+  - `knuth_core_ineq` — `x * z < y + 2 * z → x ≤ y / z + 2` (Knuth overshoot step).
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -127,5 +128,28 @@ theorem knuth_q_hat_clamp_lt_pow64 (u_top u_next v_top q_hat : Nat)
   have := Nat.min_le_right ((u_top * 2^64 + u_next) / v_top) (2^64 - 1)
   have hpow : (0:Nat) < 2^64 := by positivity
   omega
+
+/-- Knuth B core overshoot inequality (Nat-abstract):
+    `x * z < y + 2 * z` plus `0 < z` implies `x ≤ y / z + 2`.
+
+    This is the final combinator for the "q_hat ≤ q_true + 2" step. After
+    accumulating `q_hat_raw * v_nat < u_nat + 2 * v_nat` (from the trial
+    remainder bookkeeping + the `v_nat ≥ 2^255` normalization lower bound),
+    applying this lemma yields `q_hat_raw ≤ u_nat / v_nat + 2 = q_true + 2`.
+
+    Proof: by contradiction. If `x ≥ y / z + 3`, then
+    `(y/z + 3) * z ≤ x * z < y + 2 * z`, so `(y/z) * z + 3*z < y + 2*z`,
+    i.e. `(y/z) * z + z < y`. But `y = (y/z) * z + y%z` and `y%z < z`, so
+    `y < (y/z) * z + z`. Contradiction. -/
+theorem knuth_core_ineq (x y z : Nat) (hz : 0 < z)
+    (h : x * z < y + 2 * z) :
+    x ≤ y / z + 2 := by
+  by_contra hgt
+  push Not at hgt
+  have h3 : y / z + 3 ≤ x := hgt
+  have h4 : (y / z + 3) * z ≤ x * z := Nat.mul_le_mul_right z h3
+  have hd : z * (y / z) + y % z = y := Nat.div_add_mod y z
+  have hm : y % z < z := Nat.mod_lt y hz
+  nlinarith
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds two small standalone Word→Nat helper lemmas that feed into the abstract Knuth TAOCP Vol 2 §4.3.1 Theorem B proof for the call-trial DIV/MOD stack specs.

- \`val256_ge_pow255_of_normalized\`: under \`b3.toNat ≥ 2^63\` (CLZ-normalized divisor), the 4-limb value is at least 2^255. Used to bound \`v_nat\` from below in Knuth's bookkeeping.
- \`val256_split_hi2\`: \`val256 a0 a1 a2 a3 = (a3*B + a2) * B^2 + (a1*B + a0)\` where \`B = 2^64\`. Used to express Knuth's trial \`q̂\` in terms of the top pair \`u_top * 2^64 + u3\` and bottom pair \`u2 * 2^64 + u1\`.

Both proofs are one-liners (\`nlinarith\` / \`ring\`). Each advances Step 2 of the plan in \`memory/project_knuth_theorem_b_plan.md\` by providing the val256-level identities needed before the Nat-level Knuth argument kicks in.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` succeeds
- [x] Axiom check: nothing beyond \`propext\`/\`Classical.choice\`/\`Quot.sound\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)