### PR TITLE
refactor(CPSSpec): flip cpsTriple_loop_with_perm positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -930,13 +930,15 @@ theorem cpsTriple_loop_simple
     : ∀ n, cpsTriple entry exit_ cr (inv n) Q :=
   cpsTriple_loop entry exit_ cr inv Q h_base h_step
 
-/-- Loop rule with permutation on back-edge and exit postconditions. -/
+/-- Loop rule with permutation on back-edge and exit postconditions.
+    All position/code/assertion arguments are implicit — inferred from
+    `h_base`/`h_step`/`hperm_*`. -/
 theorem cpsTriple_loop_with_perm
-    (entry exit_ : Word) (cr : CodeReq)
-    (inv : Nat → Assertion)
-    (Q : Assertion)
-    (inv' : Nat → Assertion)
-    (Q' : Assertion)
+    {entry exit_ : Word} {cr : CodeReq}
+    {inv : Nat → Assertion}
+    {Q : Assertion}
+    {inv' : Nat → Assertion}
+    {Q' : Assertion}
     (h_base : cpsTriple entry exit_ cr (inv 0) Q)
     (h_step : ∀ n, cpsBranch entry cr (inv (n + 1))
                               exit_ Q'


### PR DESCRIPTION
## Summary

Follow-up to #769 / #771 / #772 / #774 / #776 (implicit-arg convention pass). `cpsTriple_loop_with_perm`'s seven positional args (`entry`, `exit_`, `cr`, `inv`, `Q`, `inv'`, `Q'`) are all inferable from the hypothesis arguments (`h_base`, `h_step`, `hperm_inv`, `hperm_Q`).

Zero actual callers in the repo (only the definition and a docstring reference in a `LoopBody.lean` comment), so the signature flip is safe.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)