### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_cpsBranch (base) positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -705,10 +705,11 @@ theorem cpsTriple_seq_cpsNBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq
 
 /-- Sequential composition: cpsTriple followed by cpsBranch.
     If code reaches mid with Q, and from mid it branches, then the
-    composition branches from entry. -/
-theorem cpsTriple_seq_cpsBranch (entry mid : Word) (cr1 cr2 : CodeReq)
+    composition branches from entry.
+    All position/code/assertion arguments are implicit — inferred from `h1`/`h2`. -/
+theorem cpsTriple_seq_cpsBranch {entry mid : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
+    {P Q : Assertion} {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (h1 : cpsTriple entry mid cr1 P Q)
     (h2 : cpsBranch mid cr2 Q exit_t Q_t exit_f Q_f) :
     cpsBranch entry (cr1.union cr2) P exit_t Q_t exit_f Q_f := by
@@ -728,7 +729,7 @@ theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq)
     (h1 : cpsTriple entry mid cr1 P Q1)
     (h2 : cpsBranch mid cr2 Q2 exit_t Q_t exit_f Q_f) :
     cpsBranch entry (cr1.union cr2) P exit_t Q_t exit_f Q_f :=
-  cpsTriple_seq_cpsBranch entry mid cr1 cr2 hd P Q2 exit_t Q_t exit_f Q_f
+  cpsTriple_seq_cpsBranch hd
     (cpsTriple_weaken (fun _ hp => hp) hperm h1) h2
 
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken (false) path.

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -200,6 +200,6 @@ theorem rlp_phase2_long_loop_body_spec
             CodeReq.empty a = _
         simp only [CodeReq.union, hcr])
       bne_framed
-  exact cpsTriple_seq_cpsBranch _ _ _ _ hd_iter_bne _ _ _ _ _ _ iter' bne_ext
+  exact cpsTriple_seq_cpsBranch hd_iter_bne iter' bne_ext
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Follow-up to #779 (implicit-arg convention pass). `cpsTriple_seq_cpsBranch` (the base sequence-then-branch composition without permutation) has `entry`, `mid`, `cr1`, `cr2`, `P`, `Q`, `exit_t`, `Q_t`, `exit_f`, `Q_f` all inferable from `h1`/`h2` — flip to implicit. `hd` stays explicit.

Updates the single consumer in `Rv64/RLP/Phase2LongLoopBody.lean:203` from
  `cpsTriple_seq_cpsBranch _ _ _ _ hd_iter_bne _ _ _ _ _ _ iter' bne_ext`
to
  `cpsTriple_seq_cpsBranch hd_iter_bne iter' bne_ext`.

The `_with_perm` variant is intentionally left explicit-arg — it has 9 callers across SignExtend/Shift LimbSpec files + Phase1, which would need a consumer-side sweep.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)