### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_cpsBranch_same_cr positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -96,6 +96,6 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
         simp only [CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega
         simp only [beq_iff_eq, h0, ↓reduceIte]))) hPR hpc
-  exact cpsTriple_seq_cpsBranch_same_cr _ _ _ _ _ _ _ _ _ hbody hbge_ext
+  exact cpsTriple_seq_cpsBranch_same_cr hbody hbge_ext
 
 end EvmAsm.Evm64

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -353,9 +353,10 @@ theorem cpsBranch_extend_code {entry : Word} {cr cr' : CodeReq}
   exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
 
 /-- Sequential composition: cpsTriple followed by cpsBranch, same CodeReq.
-    Unlike `cpsTriple_seq_cpsBranch`, does not require disjointness. -/
-theorem cpsTriple_seq_cpsBranch_same_cr (entry mid : Word) (cr : CodeReq)
-    (P Q : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
+    Unlike `cpsTriple_seq_cpsBranch`, does not require disjointness.
+    All position/code/assertion arguments are implicit — inferred from `h1`/`h2`. -/
+theorem cpsTriple_seq_cpsBranch_same_cr {entry mid : Word} {cr : CodeReq}
+    {P Q : Assertion} {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (h1 : cpsTriple entry mid cr P Q)
     (h2 : cpsBranch mid cr Q exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr P exit_t Q_t exit_f Q_f := by
@@ -374,7 +375,7 @@ theorem cpsTriple_seq_cpsBranch_perm_same_cr {entry mid : Word} {cr : CodeReq}
     (h1 : cpsTriple entry mid cr P Q1)
     (h2 : cpsBranch mid cr Q2 exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr P exit_t Q_t exit_f Q_f :=
-  cpsTriple_seq_cpsBranch_same_cr entry mid cr P Q2 exit_t Q_t exit_f Q_f
+  cpsTriple_seq_cpsBranch_same_cr
     (cpsTriple_weaken (fun _ hp => hp) hperm h1) h2
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Follow-up to #780. `cpsTriple_seq_cpsBranch_same_cr`'s nine positional args (`entry`, `mid`, `cr`, `P`, `Q`, `exit_t`, `Q_t`, `exit_f`, `Q_f`) are all inferable from `h1`/`h2`, matching the implicit-arg convention already used by the `_perm_same_cr` sibling.

Updates 1 consumer in `DivMod/LimbSpec/AddBackFinalLoopControl.lean` (from 9 underscores to just `hbody hbge_ext`) and the internal self-reference in `cpsTriple_seq_cpsBranch_perm_same_cr`.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)