### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_cpsNBranch positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -681,10 +681,11 @@ theorem cpsTriple_seq_perm_same_cr {s m e : Word} {cr : CodeReq}
 
 /-- Sequential composition: cpsTriple followed by cpsNBranch.
     If code reaches mid with Q, and from mid it branches to one of exits,
-    then code branches from entry to one of exits. -/
-theorem cpsTriple_seq_cpsNBranch (entry mid : Word) (cr1 cr2 : CodeReq)
+    then code branches from entry to one of exits.
+    All position/code/assertion arguments are implicit — inferred from `h1`/`h2`. -/
+theorem cpsTriple_seq_cpsNBranch {entry mid : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q : Assertion) (exits : List (Word × Assertion))
+    {P Q : Assertion} {exits : List (Word × Assertion)}
     (h1 : cpsTriple entry mid cr1 P Q)
     (h2 : cpsNBranch mid cr2 Q exits) :
     cpsNBranch entry (cr1.union cr2) P exits := by
@@ -705,7 +706,7 @@ theorem cpsTriple_seq_cpsNBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq
     (h1 : cpsTriple entry mid cr1 P Q1)
     (h2 : cpsNBranch mid cr2 Q2 exits) :
     cpsNBranch entry (cr1.union cr2) P exits :=
-  cpsTriple_seq_cpsNBranch entry mid cr1 cr2 hd P Q2 exits
+  cpsTriple_seq_cpsNBranch hd
     (cpsTriple_weaken (fun _ hp => hp) hperm h1) h2
 
 /-- Sequential composition: cpsTriple followed by cpsBranch.


### PR DESCRIPTION
## Summary

Follow-up to #780 / #781 (implicit-arg convention pass). `cpsTriple_seq_cpsNBranch`'s six positional args (`entry`, `mid`, `cr1`, `cr2`, `P`, `Q`, `exits`) are all inferable from `h1`/`h2`; flip them to implicit. `hd` stays explicit as the caller-supplied disjointness witness.

The only caller is the internal self-reference in `cpsTriple_seq_cpsNBranch_with_perm` (updated to the new call shape `cpsTriple_seq_cpsNBranch hd …`). No external consumers.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)