### PR TITLE
refactor(CPSSpec): flip cpsBranch_to_cpsNBranch positional args to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -448,11 +448,12 @@ theorem cpsNBranch_to_cpsTriple {entry exit_ : Word} {cr : CodeReq}
   | head => exact ⟨k, s', hstep, hpc', hQR⟩
   | tail _ h => exact absurd h List.not_mem_nil
 
-/-- A 2-exit cpsBranch can be viewed as a cpsNBranch with two exits. -/
-theorem cpsBranch_to_cpsNBranch (entry : Word) (cr : CodeReq)
-    (P : Assertion)
-    (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f : Assertion)
+/-- A 2-exit cpsBranch can be viewed as a cpsNBranch with two exits.
+    All position/code/assertion arguments are implicit — inferred from `h`. -/
+theorem cpsBranch_to_cpsNBranch {entry : Word} {cr : CodeReq}
+    {P : Assertion}
+    {exit_t : Word} {Q_t : Assertion}
+    {exit_f : Word} {Q_f : Assertion}
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsNBranch entry cr P [(exit_t, Q_t), (exit_f, Q_f)] := by
   intro R hR s hcr hPR hpc

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -545,7 +545,7 @@ theorem if_eq_branch_step_n (rs1 rs2 : Reg) (v1 v2 : Word)
       [ (thenEntry, (base ↦ᵢ bneInstr) ** (P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2) ⋒ ⌜v1 = v2⌝)),
         (elseEntry, (base ↦ᵢ bneInstr) ** (P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2) ⋒ ⌜v1 ≠ v2⌝)) ] := by
   simp only
-  exact cpsBranch_to_cpsNBranch _ _ _ _ _ _ _
+  exact cpsBranch_to_cpsNBranch
     (if_eq_branch_step rs1 rs2 v1 v2 then_body base P hP ht_small)
 
 /-- Full N-exit CPS specification for if_eq, using cpsNBranch_merge.


### PR DESCRIPTION
## Summary

Follow-up to #782 (implicit-arg convention pass). `cpsBranch_to_cpsNBranch`'s seven positional args (`entry`, `cr`, `P`, `exit_t`, `Q_t`, `exit_f`, `Q_f`) are all inferable from `h`.

Updates the single consumer in `Rv64/ControlFlow.lean:548` from
  `cpsBranch_to_cpsNBranch _ _ _ _ _ _ _ (if_eq_branch_step …)`
to
  `cpsBranch_to_cpsNBranch (if_eq_branch_step …)`.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)