### PR TITLE
refactor(CPSSpec): flip cpsNBranch_weaken_{pre,posts} positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -541,7 +541,7 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
   -- Rewrite CR, weaken pre, and weaken post
   intro code
   have n1_rw := hcr_eq ▸ n1
-  exact cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun h hp => by xperm_hyp hp) n1_rw)
+  exact cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun h hp => by xperm_hyp hp) n1_rw)
     (fun ex hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
@@ -683,7 +683,7 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
     simp only [hunion_empty]; rfl
   intro code
   have n1_rw := hcr_eq ▸ n1
-  exact cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun h hp => by xperm_hyp hp) n1_rw)
+  exact cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun h hp => by xperm_hyp hp) n1_rw)
     (fun ex hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -622,7 +622,7 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
     simp only [hunion_empty]; rfl
   intro code
   have n1_rw := hcr_eq ▸ n1
-  exact cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun h hp => by xperm_hyp hp) n1_rw)
+  exact cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun h hp => by xperm_hyp hp) n1_rw)
     (fun ex hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -662,7 +662,7 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
     simp only [hunion_empty]; rfl
   intro code
   have n1_rw := hcr_eq ▸ n1
-  exact cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun h hp => by xperm_hyp hp) n1_rw)
+  exact cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun h hp => by xperm_hyp hp) n1_rw)
     (fun ex hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩
@@ -826,7 +826,7 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
     simp only [hunion_empty]; rfl
   intro code
   have n1_rw := hcr_eq ▸ n1
-  exact cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun h hp => by xperm_hyp hp) n1_rw)
+  exact cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun h hp => by xperm_hyp hp) n1_rw)
     (fun ex hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -498,10 +498,11 @@ theorem cpsNBranch_merge (entry exit_ : Word) (cr : CodeReq)
   obtain ⟨k2, s2, hstep2, hpc2, hRF⟩ := hall ex hmem F hF s1 hcr1 hQF hpc1
   exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hpc2, hRF⟩
 
-/-- Consequence: strengthen the precondition of an N-branch. -/
-theorem cpsNBranch_weaken_pre (entry : Word) (cr : CodeReq)
-    (P P' : Assertion)
-    (exits : List (Word × Assertion))
+/-- Consequence: strengthen the precondition of an N-branch.
+    All position/code/assertion arguments are implicit — inferred from `h`/`hpre`/goal type. -/
+theorem cpsNBranch_weaken_pre {entry : Word} {cr : CodeReq}
+    {P P' : Assertion}
+    {exits : List (Word × Assertion)}
     (hpre : ∀ h, P' h → P h) (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr P' exits := by
   intro R hR s hcr hP'R hpc
@@ -829,9 +830,10 @@ theorem cpsBranch_seq_cpsBranch_with_perm
     (cpsBranch_weaken (fun _ hp => hp) (fun _ hp => hp) hperm h1)
     h2 ht1 ht2
 
-/-- Weaken postconditions of all exits in a cpsNBranch. -/
-theorem cpsNBranch_weaken_posts (entry : Word) (cr : CodeReq)
-    (P : Assertion) (exits exits' : List (Word × Assertion))
+/-- Weaken postconditions of all exits in a cpsNBranch.
+    All position/code/assertion arguments are implicit — inferred from `h`/goal type. -/
+theorem cpsNBranch_weaken_posts {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exits exits' : List (Word × Assertion)}
     (h : cpsNBranch entry cr P exits)
     (hmap : ∀ ex ∈ exits, ∃ ex' ∈ exits', ex'.1 = ex.1 ∧ ∀ h, ex.2 h → ex'.2 h) :
     cpsNBranch entry cr P exits' := by


### PR DESCRIPTION
## Summary

Follow-up to #784 (implicit-arg convention pass). Both cpsNBranch weaken wrappers have their position/code/assertion args inferable from `h` and the goal type:

- `cpsNBranch_weaken_pre` — `entry`, `cr`, `P`, `P'`, `exits` ← `h`/`hpre`/goal
- `cpsNBranch_weaken_posts` — `entry`, `cr`, `P`, `exits`, `exits'` ← `h`/goal

Updates 5 consumer sites across `SignExtend/LimbSpec`, `Shift/{LimbSpec,SarCompose}`:

```
cpsNBranch_weaken_posts _ _ _ _ _ (cpsNBranch_weaken_pre _ _ _ _ _ (fun …) n1_rw)
```
becomes
```
cpsNBranch_weaken_posts (cpsNBranch_weaken_pre (fun …) n1_rw)
```

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)