### PR TITLE
refactor(CPSSpec): flip cpsBranch_seq_cpsBranch_with_perm positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -912,9 +912,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       -- crBne
       (sd_tail (base + 20) _ (by bv_omega) (by bv_omega) (by bv_omega))
   have combined := cpsBranch_seq_cpsBranch_with_perm
-    base (base + 24) zero_path (base + 36)
-    (crLinear.union crBne) crTail hd_br1_br2
-    _ _ _ _ _ _ _
+    hd_br1_br2
     br1 (fun h hp => by xperm_hyp hp) br2
     -- ht1: weaken first taken path (BNE taken: x5 = s1|||s2|||s3, x10 = s3)
     (fun h hp => by

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -493,9 +493,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       hd_bne_tail
   -- Combine: br1 (taken → done_path, ntaken → base+24) with br2 (base+24 → done_path or base+36)
   have combined := cpsBranch_seq_cpsBranch_with_perm
-    base (base + 24) done_path (base + 36)
-    (crLinear.union crBne) crTail hd_br1_br2
-    _ _ _ _ _ _ _
+    hd_br1_br2
     br1 (fun h hp => by xperm_hyp hp) br2
     -- ht1: weaken BNE taken path (x5 = b1|||b2|||b3, x10 = b3) → regOwn
     (fun h hp => by

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -814,11 +814,12 @@ theorem cpsBranch_seq_cpsBranch (entry mid target exit_f : Word) (cr1 cr2 : Code
       exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2,
              Or.inr ⟨hpc_f2, hQ_f2R⟩⟩
 
-/-- Like `cpsBranch_seq_cpsBranch` but with a permutation between Q_f1 and R. -/
+/-- Like `cpsBranch_seq_cpsBranch` but with a permutation between Q_f1 and R.
+    All position/code/assertion arguments are implicit — inferred from `h1`/`h2`/`hperm`/`ht*`/goal. -/
 theorem cpsBranch_seq_cpsBranch_with_perm
-    (entry mid target exit_f : Word) (cr1 cr2 : CodeReq)
+    {entry mid target exit_f : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q_t1 Q_f1 R Q_t2 Q_f2 Q_t : Assertion)
+    {P Q_t1 Q_f1 R Q_t2 Q_f2 Q_t : Assertion}
     (h1 : cpsBranch entry cr1 P target Q_t1 mid Q_f1)
     (hperm : ∀ h, Q_f1 h → R h)
     (h2 : cpsBranch mid cr2 R target Q_t2 exit_f Q_f2)


### PR DESCRIPTION
## Summary

Follow-up to #787 (implicit-arg convention pass). `cpsBranch_seq_cpsBranch_with_perm`'s 13 positional args (`entry`, `mid`, `target`, `exit_f`, `cr1`, `cr2`, `P`, `Q_t1`, `Q_f1`, `R`, `Q_t2`, `Q_f2`, `Q_t`) are all inferable from `h1`/`h2`/`hperm`/`ht*` and the goal type. `hd` stays explicit.

Updates 2 consumer sites — `SignExtend/LimbSpec.lean:495` and `Shift/LimbSpec.lean:914` — dropping 13 explicit positional args each.

## Test plan

- [x] `lake build` passes (full repo, 3558 jobs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)