### PR TITLE
refactor(DivMod/LimbSpec): inline single-use composed rename (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -101,12 +101,11 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
       exact CodeReq.ofProg_lookup base (divK_loopSetup bltOff) 3
         (by omega) (by omega)
     · simp at h) hblt_framed
-  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hbody hblt_ext
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
-    composed
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hbody hblt_ext)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -104,14 +104,12 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
     exact CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
       (by decide) (by decide)
     ) hbeq_framed
-  -- 5. Compose body → BEQ with permutation (same CR)
-  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
-  -- 6. Final permutation of postconditions
+  -- 5. Compose body → BEQ with permutation (same CR) and clean up postconditions
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
-    composed
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hbody hbeq_ext)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -87,13 +87,12 @@ theorem divK_phaseB_cascade_step_spec (nVal : BitVec 12) (rx : Reg) (check v5 : 
       have h0 : ¬(base + 4 = base) := by bv_omega
       simp only [beq_iff_eq, h0, ↓reduceIte]
     · simp at h) hbne_framed
-  -- 5. Compose
-  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hbody hbne_ext
+  -- 5. Compose and clean up postconditions
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
-    composed
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hbody hbne_ext)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -104,12 +104,11 @@ theorem divK_phaseC2_spec (sp shift v2 shiftMem : Word)
       exact CodeReq.ofProg_lookup base (divK_phaseC2 shift0_off) 3
         (by omega) (by omega)
     · simp at h) hbeq_framed
-  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hbody hbeq_ext
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
-    composed
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by xperm_hyp hp) hbody hbeq_ext)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Four LimbSpec files (`LoopSetup`, `PhaseA`, `PhaseBCascade`, `PhaseC2`) had a
`have composed := cpsTriple_seq_cpsBranch_perm_same_cr ...` whose only use was
as the final argument to `cpsBranch_weaken`. Inlining the application removes
the rename-only local per issue #694.

Net: 10 insertions, 15 deletions.

Other `composed` / `cs?_composed` / `full` locals were left alone because they
are used more than once (taken + ntaken paths) or because the sharing is a
non-trivial elaboration saving — those can be revisited separately if desired.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.LimbSpec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)