### PR TITLE
refactor(DivMod/LoopBodyN2): inline single-use full rename (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -151,15 +151,13 @@ theorem divK_loop_body_n2_max_skip_spec
      ((uBase + signExtend12 4064) ↦ₘ u4_new) **
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
-  -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch)
-  have full := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  -- 8. Permute final cpsBranch to match target
+  -- 7. Compose pre_store (cpsTriple) with SLf (cpsBranch), then permute to match target
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf)
 
 -- ============================================================================
 -- Section 13n2: Full loop body cpsBranch for n=2, BLTU not-taken + BEQ addback
@@ -251,13 +249,12 @@ theorem divK_loop_body_n2_max_addback_spec
      (sp + signExtend12 3984 ↦ₘ (2 : Word)))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf)
 
 -- ============================================================================
 -- Section 14n2: Full loop body cpsBranch for n=2, BLTU taken + BEQ skip
@@ -406,13 +403,12 @@ theorem divK_loop_body_n2_call_skip_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf)
 
 -- ============================================================================
 -- Section 15n2: Full loop body cpsBranch for n=2, BLTU taken + BEQ addback
@@ -552,13 +548,12 @@ theorem divK_loop_body_n2_call_addback_spec
      (sp + signExtend12 3944 ↦ₘ div_un0))
     (by pcFree) SL
   -- 7. Compose
-  have full := cpsTriple_seq_cpsBranch_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
+    (cpsTriple_seq_cpsBranch_perm_same_cr
+      (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf)
 
 -- ============================================================================
 -- Section 16n2: Combined loop body cpsBranch for n=2 (all 4 paths unified)


### PR DESCRIPTION
## Summary

Follow-up to #793. Same `have full := cpsTriple_seq_cpsBranch_perm_same_cr ... → exact cpsBranch_weaken ... full`
→ inlined application pattern applied to the four occurrences in `LoopBodyN2.lean`
per issue #694.

Net: 9 insertions, 14 deletions.

`LoopBodyN3/N4.lean` follow the same pattern; those will land in follow-up PRs.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.LoopBodyN2` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)