### PR TITLE
refactor(EvmWordArith): inline bare word_toNat_1 renames (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -60,8 +60,7 @@ theorem hq_over_from_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
   simp only [] at hmulsub
   rw [show (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
-  have h1w := word_toNat_1
-  rw [h1w] at hmulsub
+  rw [word_toNat_1] at hmulsub
   -- First addback: val256(un) + val256(v) = val256(ab1) + 0 * 2^256 = val256(ab1)
   set ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3 with hms_def
   have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -117,8 +117,7 @@ theorem mulsub_addback_val256_combined (q v0 v1 v2 v3 u0 u1 u2 u3 u4_new : Word)
   -- Substitute c3 = 1 and carry = 1
   rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
   rw [hcarry_one] at haddback
-  have h1 := word_toNat_1
-  rw [h1] at hmulsub haddback
+  rw [word_toNat_1] at hmulsub haddback
   -- hmulsub: val256 u + 1 * 2^256 = val256 un + q * val256 v
   -- haddback: val256 un + val256 v = val256 aun + 1 * 2^256
   -- Add both: cancel val256 un and 2^256
@@ -189,8 +188,7 @@ theorem n4_max_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     have hmulsub_raw := mulsubN4_val256_eq (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     simp only [] at hmulsub_raw
     rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub_raw
-    have h1 := word_toNat_1
-    rw [h1] at hmulsub_raw
+    rw [word_toNat_1] at hmulsub_raw
     -- hmulsub_raw: val256 u + 1 * 2^256 = val256 un + qHat * val256 v
     -- So qHat * val256 v ≥ val256 u + 1 (since 2^256 > val256 un)
     have hv_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
@@ -353,8 +351,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
   simp only [] at hmulsub
   rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
-  have h1w := word_toNat_1
-  rw [h1w] at hmulsub
+  rw [word_toNat_1] at hmulsub
   -- First addback: val256(un) + val256(v) = val256(ab1) + carry1 * 2^256
   have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
   simp only [] at hab1
@@ -448,8 +445,7 @@ theorem mulsub_double_addback_val256_combined (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
   simp only [] at hmulsub
   rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
-  have h1w := word_toNat_1
-  rw [h1w] at hmulsub
+  rw [word_toNat_1] at hmulsub
   -- First addback with carry = 0
   have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
   simp only [] at hab1
@@ -496,8 +492,7 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
   simp only [] at hmulsub
   rw [show ms.2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
-  have h1w := word_toNat_1
-  rw [h1w] at hmulsub
+  rw [word_toNat_1] at hmulsub
   -- hmulsub: val256(u) + 1 * 2^256 = val256(un) + q * val256(v)
   -- First addback equation
   have hab := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3


### PR DESCRIPTION
## Summary

Six places in \`DivN4Overestimate\` and \`DivN4DoubleAddback\` bound
\`word_toNat_1\` to a local (\`h1\` / \`h1w\`) and immediately used it once as
\`rw [h1] at …\`. Inlined to \`rw [word_toNat_1] at …\` per the bare-rename
scope clarified in issue #694.

Net: 6 insertions, 12 deletions.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.DivN4Overestimate EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)