### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -175,10 +175,7 @@ theorem callNear_function_spec
       ((.x1 ↦ᵣ (call_site + 4)) ** Q) := by
   have hcall := cpsTriple_frameR P hP (callNear_spec offset call_site old_ra)
   rw [hoff] at hcall
-  exact cpsTriple_seq call_site func_entry ((call_site + 4) &&& ~~~1)
-    (CodeReq.singleton call_site (.JAL .x1 offset)) cr_func hd
-    ((.x1 ↦ᵣ old_ra) ** P) ((.x1 ↦ᵣ (call_site + 4)) ** P) ((.x1 ↦ᵣ (call_site + 4)) ** Q)
-    hcall (hfunc (call_site + 4))
+  exact cpsTriple_seq hd hcall (hfunc (call_site + 4))
 
 -- ============================================================================
 -- Prologue-body-epilogue composition
@@ -213,10 +210,6 @@ theorem nonleaf_function_spec
       ((.x2 ↦ᵣ sp_val) ** (.x1 ↦ᵣ ra_val) ** ((sp_val - 8) ↦ₘ ra_val) ** Q) := by
   rw [← hprol_exit] at hbody
   rw [← hbody_exit] at hepi
-  exact cpsTriple_seq prol_base body_exit (ra_val &&& ~~~1)
-    (cr_prol.union cr_body) cr_epi hd2
-    _ _ _
-    (cpsTriple_seq prol_base (prol_base + 8) body_exit cr_prol cr_body hd1 _ _ _ hprol hbody)
-    hepi
+  exact cpsTriple_seq hd2 (cpsTriple_seq hd1 hprol hbody) hepi
 
 end EvmAsm.Evm64

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -63,9 +63,9 @@ def cpsBranch (entry : Word) (cr : CodeReq) (P : Assertion)
 -- ============================================================================
 
 /-- Sequence: compose two CPS triples sharing a midpoint. -/
-theorem cpsTriple_seq (l1 l2 l3 : Word) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq {l1 l2 l3 : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q R : Assertion)
+    {P Q R : Assertion}
     (h1 : cpsTriple l1 l2 cr1 P Q)
     (h2 : cpsTriple l2 l3 cr2 Q R) :
     cpsTriple l1 l3 (cr1.union cr2) P R := by
@@ -655,8 +655,7 @@ theorem cpsTriple_seq_with_perm (s m e : Word) (cr1 cr2 : CodeReq)
     (h1 : cpsTriple s m cr1 P Q1)
     (h2 : cpsTriple m e cr2 Q2 R) :
     cpsTriple s e (cr1.union cr2) P R :=
-  cpsTriple_seq s m e cr1 cr2 hd P Q2 R
-    (cpsTriple_weaken (fun _ hp => hp) hperm h1) h2
+  cpsTriple_seq hd (cpsTriple_weaken (fun _ hp => hp) hperm h1) h2
 
 /-- Sequence with same CodeReq: compose two CPS triples sharing the same CodeReq.
     Unlike `cpsTriple_seq`, does not require disjointness (same cr on both sides).

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -106,7 +106,7 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at s2
   -- Compose. `(8 : BitVec 6).toNat = 8` so the result matches.
   rw [bv6_toNat_8] at s1
-  exact cpsTriple_seq _ _ _ _ _ hd _ _ _ s1 s2
+  exact cpsTriple_seq hd s1 s2
 
 /-! ## Concrete sanity checks -/
 

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -287,9 +287,9 @@ theorem rlp_phase2_long_iter_spec
         simp only [CodeReq.union, hcr])
       s5
   -- Chain bottom up.
-  have t45 := cpsTriple_seq _ _ _ _ _ hd4 _ _ _ s4 s5_ext
-  have t345 := cpsTriple_seq _ _ _ _ _ hd3 _ _ _ s3 t45
-  have t2345 := cpsTriple_seq _ _ _ _ _ hd2 _ _ _ s2 t345
-  exact cpsTriple_seq _ _ _ _ _ hd1 _ _ _ s1 t2345
+  have t45 := cpsTriple_seq hd4 s4 s5_ext
+  have t345 := cpsTriple_seq hd3 s3 t45
+  have t2345 := cpsTriple_seq hd2 s2 t345
+  exact cpsTriple_seq hd1 s1 t2345
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -134,6 +134,6 @@ theorem rlp_phase2_long_load_acc_spec (len ptr v12Old wordVal dwordAddr : Word)
       (fun h hp => by xperm_hyp hp)
       (cpsTriple_frameR
         ((.x13 ↦ᵣ ptr) ** (dwordAddr ↦ₘ wordVal)) (by pcFree) acc)
-  exact cpsTriple_seq _ _ _ _ _ hd _ _ _ lbu_framed acc_framed
+  exact cpsTriple_seq hd lbu_framed acc_framed
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Continues the \`CPSSpec\` positional-to-implicit refactor arc (PRs #776–#789).

\`cpsTriple_seq\` had \`l1 l2 l3 : Word\`, \`cr1 cr2 : CodeReq\`, and \`P Q R : Assertion\`
as explicit positional arguments — but every caller either passes underscores
(\`_ _ _ _ _ hd _ _ _ h1 h2\`) or redundant concretes that were already being
unified from \`h1\`/\`h2\`. Making them implicit collapses the calls.

\`hd\`, \`h1\`, \`h2\` stay explicit.

## Callers simplified
- \`cpsTriple_seq_with_perm\` (in \`CPSSpec.lean\`)
- \`Rv64/RLP/Phase2LongIter.lean\` (4 sites)
- \`Rv64/RLP/Phase2LongLoad.lean\`, \`Rv64/RLP/Phase2LongAcc.lean\` (1 each)
- \`Evm64/CallingConvention.lean\` (2 sites, including a nested one)

Net: 11 insertions, 19 deletions.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)