### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_with_perm positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -767,8 +767,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Compose LD + LD/OR (need to frame + perm)
   have lw1f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ s0) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lw1
   have lor2f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lor2
-  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) crLd1 crLor2 hd_ld1_lor2
-    _ _ _ _
+  have c12 := cpsTriple_seq_with_perm hd_ld1_lor2
     (fun h hp => by xperm_hyp hp) lw1f lor2f
   -- Step 3: shr_ld_or_acc at base+12 (CR = crLor3, exit = (base+12)+8 = base+20)
   have lor3 := shr_ld_or_acc_spec sp (s1 ||| s2) s2 s3 24 (base + 12)
@@ -788,9 +787,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (CodeReq.Disjoint.union_right
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
-  have c13 := cpsTriple_seq_with_perm base (base + 12) (base + 20)
-    (crLd1.union crLor2) crLor3 hd_12_lor3
-    _ _ _ _
+  have c13 := cpsTriple_seq_with_perm hd_12_lor3
     (fun h hp => by xperm_hyp hp) c12 lor3f
   -- CR so far: (crLd1 ∪ crLor2) ∪ crLor3
   let crLinear := (crLd1.union crLor2).union crLor3
@@ -845,9 +842,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Frame and compose LD + SLTIU
   have lw5f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ s3) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lw5
   have sltiuf := cpsTriple_frameR ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) sltiu_raw
-  have c56 := cpsTriple_seq_with_perm (base + 24) (base + 28) (base + 32)
-    crLd5 crSltiu hd_ld5_sltiu
-    _ _ _ _
+  have c56 := cpsTriple_seq_with_perm hd_ld5_sltiu
     (fun h hp => by xperm_hyp hp) lw5f sltiuf
   -- Step 7: BEQ x10 x0 308 at base+32
   have beq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -364,8 +364,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
   have lw1f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ b0) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lw1
   have lor2f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lor2
-  have c12 := cpsTriple_seq_with_perm base (base + 4) (base + 12) crLd1 crLor2 hd_ld1_lor2
-    _ _ _ _
+  have c12 := cpsTriple_seq_with_perm hd_ld1_lor2
     (fun h hp => by xperm_hyp hp) lw1f lor2f
   have lor3 := signext_ld_or_acc_spec sp (b1 ||| b2) b2 b3 24 (base + 12)
   simp only [signExtend12_24] at lor3
@@ -383,9 +382,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
         (CodeReq.Disjoint.union_right
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)
           (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
-  have c13 := cpsTriple_seq_with_perm base (base + 12) (base + 20)
-    (crLd1.union crLor2) crLor3 hd_12_lor3
-    _ _ _ _
+  have c13 := cpsTriple_seq_with_perm hd_12_lor3
     (fun h hp => by xperm_hyp hp) c12 lor3f
   let crLinear := (crLd1.union crLor2).union crLor3
   -- ── Part 2: BNE at base+20 (first branch) ──
@@ -431,9 +428,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     CodeReq.Disjoint.singleton (by bv_omega) _ _
   have lw5f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lw5
   have sltiuf := cpsTriple_frameR ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) sltiu_raw
-  have c56 := cpsTriple_seq_with_perm (base + 24) (base + 28) (base + 32)
-    crLd5 crSltiu hd_ld5_sltiu
-    _ _ _ _
+  have c56 := cpsTriple_seq_with_perm hd_ld5_sltiu
     (fun h hp => by xperm_hyp hp) lw5f sltiuf
   have beq_raw := beq_spec_gen .x10 .x0 156 sltiuVal (0 : Word) (base + 32)
   rw [hdone2, ha32] at beq_raw

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -648,9 +648,9 @@ theorem cpsTriple_seq_halt {entry mid : Word} {cr1 cr2 : CodeReq}
     when Q1 and Q2 are AC-permutations (proved by hperm).
     Both Q1 and Q2 are fully determined by h1/h2, so the permutation
     obligation has no metavar ambiguity. -/
-theorem cpsTriple_seq_with_perm (s m e : Word) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_with_perm {s m e : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q1 Q2 R : Assertion)
+    {P Q1 Q2 R : Assertion}
     (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple s m cr1 P Q1)
     (h2 : cpsTriple m e cr2 Q2 R) :


### PR DESCRIPTION
## Summary

Continues the CPSSpec positional-to-implicit refactor arc.

\`cpsTriple_seq_with_perm\` had \`s m e : Word\`, \`cr1 cr2 : CodeReq\`, and
\`P Q1 Q2 R : Assertion\` as explicit positional arguments. Every non-meta
caller passes them as underscores (\`_ _ _ _ _\`) or redundant concretes that
are already unified from \`h1\`/\`h2\`. Flipping to implicit collapses the
calls. \`hd\`, \`hperm\`, \`h1\`, \`h2\` stay explicit.

Callers simplified: 3 sites in \`Evm64/Shift/LimbSpec.lean\` and 3 in
\`Evm64/SignExtend/LimbSpec.lean\`.

Meta callers in \`Rv64/Tactics/SeqFrame.lean\` use \`mkAppN\`, which passes all
args regardless of implicit/explicit — no change needed there.

Net: 8 insertions, 18 deletions.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)