### PR TITLE
refactor(CPSSpec): flip cpsTriple_seq_cpsBranch_with_perm positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -391,7 +391,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
             (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
           s2_raw))
   -- Compose with disjoint CRs
-  exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
+  exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
 
 /-- Cascade step variant that preserves pure dispatch facts.
@@ -430,7 +430,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
-  exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
+  exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
 
 -- ============================================================================
@@ -824,8 +824,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _))
   -- Compose linear chain + BNE branch
-  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) crLinear crBne hd_lin_bne
-    _ _ _ zero_path _ (base + 24) _
+  have br1 := cpsTriple_seq_cpsBranch_with_perm hd_lin_bne
     (fun h hp => by xperm_hyp hp) c13 bne1f
   -- BR1 CR: crLinear ∪ crBne
   -- ── Part 3: Fall-through path (base+24..base+32): LD + SLTIU + BEQ ──
@@ -873,9 +872,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
   -- Compose LD+SLTIU chain with BEQ branch
-  have br2 := cpsTriple_seq_cpsBranch_with_perm (base + 24) (base + 32)
-    (crLd5.union crSltiu) crBeq hd_56_beq
-    _ _ _ zero_path _ (base + 36) _
+  have br2 := cpsTriple_seq_cpsBranch_with_perm hd_56_beq
     (fun h hp => by xperm_hyp hp) c56 beq1f
   -- BR2 CR: (crLd5 ∪ crSltiu) ∪ crBeq
   let crTail := (crLd5.union crSltiu).union crBeq

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -290,7 +290,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
           (fun h hp => sepConj_mono_right
             (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
           s2_raw))
-  exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
+  exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
 
 -- ============================================================================
@@ -415,8 +415,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.singleton (by bv_omega) _ _)
         (CodeReq.Disjoint.singleton (by bv_omega) _ _))
-  have br1 := cpsTriple_seq_cpsBranch_with_perm base (base + 20) crLinear crBne hd_lin_bne
-    _ _ _ done_path _ (base + 24) _
+  have br1 := cpsTriple_seq_cpsBranch_with_perm hd_lin_bne
     (fun h hp => by xperm_hyp hp) c13 bne1f
   -- ── Part 3: Fall-through path (base+24..base+32): LD + SLTIU + BEQ ──
   have lw5 := ld_spec_gen .x5 .x12 sp
@@ -455,9 +454,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
       (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-  have br2 := cpsTriple_seq_cpsBranch_with_perm (base + 24) (base + 32)
-    (crLd5.union crSltiu) crBeq hd_56_beq
-    _ _ _ done_path _ (base + 36) _
+  have br2 := cpsTriple_seq_cpsBranch_with_perm hd_56_beq
     (fun h hp => by xperm_hyp hp) c56 beq1f
   let crTail := (crLd5.union crSltiu).union crBeq
   -- ── Part 4: Combine br1 and br2 ──
@@ -707,7 +704,7 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
-  exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
+  exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
 
 -- ============================================================================

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -737,9 +737,9 @@ theorem cpsTriple_seq_cpsBranch {entry mid : Word} {cr1 cr2 : CodeReq}
   exact ⟨k1 + k2, s2, stepN_add_eq k1 k2 s s1 s2 hstep1 hstep2, hbranch⟩
 
 /-- Sequential composition with permutation: cpsTriple followed by cpsBranch. -/
-theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq)
+theorem cpsTriple_seq_cpsBranch_with_perm {entry mid : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q1 Q2 : Assertion) (exit_t : Word) (Q_t : Assertion) (exit_f : Word) (Q_f : Assertion)
+    {P Q1 Q2 : Assertion} {exit_t : Word} {Q_t : Assertion} {exit_f : Word} {Q_f : Assertion}
     (hperm : ∀ h, Q1 h → Q2 h)
     (h1 : cpsTriple entry mid cr1 P Q1)
     (h2 : cpsBranch mid cr2 Q2 exit_t Q_t exit_f Q_f) :

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -137,7 +137,7 @@ theorem rlp_phase1_step_spec (v5 v10 : Word)
       (fun h hp => by xperm_hyp hp)
       (fun h hp => by xperm_hyp hp)
       (cpsBranch_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s2_raw)
-  exact cpsTriple_seq_cpsBranch_with_perm _ _ _ _ hd _ _ _ target _ (base + 8) _
+  exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
 
 /-- Plain variant of `rlp_phase1_step_spec`: drops the `⌜…⌝` dispatch facts,


### PR DESCRIPTION
## Summary

Continues the CPSSpec positional-to-implicit refactor arc (#797, #798).

\`cpsTriple_seq_cpsBranch_with_perm\` had 11 explicit positional \`Word\`/\`CodeReq\`/\`Assertion\`
arguments: \`entry mid cr1 cr2 P Q1 Q2 exit_t Q_t exit_f Q_f\`. Every caller passes them
as underscores or redundant concretes unified from \`h1\`/\`h2\`. Flipping to implicit
collapses the calls. \`hd\`, \`hperm\`, \`h1\`, \`h2\` remain explicit.

9 call sites simplified across \`Rv64/RLP/Phase1.lean\`, \`Evm64/Shift/LimbSpec.lean\`,
and \`Evm64/SignExtend/LimbSpec.lean\` — each dropped a 12-element underscore chain.

Net: 11 insertions, 17 deletions.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)