### PR TITLE
refactor(CPSSpec): flip 4 cpsBranch/cpsTriple seq wrappers to implicit args

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -794,9 +794,9 @@ theorem cpsBranch_cons_cpsNBranch_with_perm (entry : Word) (cr1 cr2 : CodeReq)
 /-- Compose two sequential cpsBranch specs where the first's not-taken path leads
     to the second's entry, and both taken paths go to the same target.
     The two taken postconditions are merged into a common one via weakening functions. -/
-theorem cpsBranch_seq_cpsBranch (entry mid target exit_f : Word) (cr1 cr2 : CodeReq)
+theorem cpsBranch_seq_cpsBranch {entry mid target exit_f : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion)
+    {P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion}
     (h1 : cpsBranch entry cr1 P target Q_t1 mid Q_f1)
     (h2 : cpsBranch mid cr2 Q_f1 target Q_t2 exit_f Q_f2)
     (ht1 : ∀ h, Q_t1 h → Q_t h)
@@ -836,7 +836,7 @@ theorem cpsBranch_seq_cpsBranch_with_perm
     (ht1 : ∀ h, Q_t1 h → Q_t h)
     (ht2 : ∀ h, Q_t2 h → Q_t h) :
     cpsBranch entry (cr1.union cr2) P target Q_t exit_f Q_f2 :=
-  cpsBranch_seq_cpsBranch entry mid target exit_f cr1 cr2 hd P Q_t1 R Q_t2 Q_f2 Q_t
+  cpsBranch_seq_cpsBranch hd
     (cpsBranch_weaken (fun _ hp => hp) (fun _ hp => hp) hperm h1)
     h2 ht1 ht2
 
@@ -974,8 +974,8 @@ theorem cpsTriple_loop_with_perm
 -- ============================================================================
 
 /-- Like cpsBranch_seq_cpsBranch but with same CodeReq (no disjointness needed). -/
-theorem cpsBranch_seq_cpsBranch_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
-    (P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion)
+theorem cpsBranch_seq_cpsBranch_same_cr {entry mid target exit_f : Word} {cr : CodeReq}
+    {P Q_t1 Q_f1 Q_t2 Q_f2 Q_t : Assertion}
     (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
     (h2 : cpsBranch mid cr Q_f1 target Q_t2 exit_f Q_f2)
     (ht1 : ∀ h, Q_t1 h → Q_t h)
@@ -1008,14 +1008,14 @@ theorem cpsBranch_seq_cpsBranch_with_perm_same_cr
     (ht1 : ∀ h, Q_t1 h → Q_t h)
     (ht2 : ∀ h, Q_t2 h → Q_t h) :
     cpsBranch entry cr P target Q_t exit_f Q_f2 :=
-  cpsBranch_seq_cpsBranch_same_cr entry mid target exit_f cr P Q_t1 R Q_t2 Q_f2 Q_t
+  cpsBranch_seq_cpsBranch_same_cr
     (cpsBranch_weaken (fun _ hp => hp) (fun _ hp => hp) hperm h1)
     h2 ht1 ht2
 
 /-- Compose a cpsBranch (ntaken exit) with a cpsTriple, same CodeReq.
     The taken exit is passed through with a postcondition weakening. -/
-theorem cpsBranch_seq_cpsTriple_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
-    (P Q_t1 Q_f1 Q_f2 Q_t : Assertion)
+theorem cpsBranch_seq_cpsTriple_same_cr {entry mid target exit_f : Word} {cr : CodeReq}
+    {P Q_t1 Q_f1 Q_f2 Q_t : Assertion}
     (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
     (h2 : cpsTriple mid exit_f cr Q_f1 Q_f2)
     (ht1 : ∀ h, Q_t1 h → Q_t h) :
@@ -1033,14 +1033,14 @@ theorem cpsBranch_seq_cpsTriple_same_cr (entry mid target exit_f : Word) (cr : C
 
 /-- Like cpsBranch_seq_cpsTriple_same_cr but with a permutation between Q_f1 and the
     cpsTriple precondition. -/
-theorem cpsBranch_seq_cpsTriple_with_perm_same_cr (entry mid target exit_f : Word) (cr : CodeReq)
-    (P Q_t1 Q_f1 R Q_f2 Q_t : Assertion)
+theorem cpsBranch_seq_cpsTriple_with_perm_same_cr {entry mid target exit_f : Word} {cr : CodeReq}
+    {P Q_t1 Q_f1 R Q_f2 Q_t : Assertion}
     (h1 : cpsBranch entry cr P target Q_t1 mid Q_f1)
     (hperm : ∀ h, Q_f1 h → R h)
     (h2 : cpsTriple mid exit_f cr R Q_f2)
     (ht1 : ∀ h, Q_t1 h → Q_t h) :
     cpsBranch entry cr P target Q_t exit_f Q_f2 :=
-  cpsBranch_seq_cpsTriple_same_cr entry mid target exit_f cr P Q_t1 R Q_f2 Q_t
+  cpsBranch_seq_cpsTriple_same_cr
     (cpsBranch_weaken (fun _ hp => hp) (fun _ hp => hp) hperm h1)
     h2 ht1
 


### PR DESCRIPTION
## Summary

Continues the CPSSpec implicit-args arc (#797, #798, #800). Flips positional
\`Word\`/\`CodeReq\`/\`Assertion\` arguments to implicit on four wrappers:

- \`cpsBranch_seq_cpsBranch\`
- \`cpsBranch_seq_cpsBranch_same_cr\`
- \`cpsBranch_seq_cpsTriple_same_cr\`
- \`cpsBranch_seq_cpsTriple_with_perm_same_cr\`

\`hd\`, \`hperm\`, \`h1\`, \`h2\`, and the \`ht*\` weakening args stay explicit.
All four have only internal CPSSpec callers (the matching \`_with_perm\` wrappers
defined just below them); those call sites are simplified in the same commit.

Net: 11 insertions, 11 deletions (same line count, just \`(…)\`→\`{…}\` plus
three simplified internal call-sites).

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)