### PR TITLE
refactor(CPSSpec): flip cpsBranch_cons_cpsNBranch(_with_perm) positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -513,25 +513,19 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))
     _ (fun _ hp => hp)
   -- Chain step 2 + fallthrough (disjoint: cr_cs2 vs empty)
-  have n3 := cpsBranch_cons_cpsNBranch (base + 12) cr_cs2 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr_cs2)
-    _ e2 _ (base + 20) _ _ cs2 ft
+  have n3 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr_cs2) cs2 ft
   -- Helper: union with empty is identity
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain step 1 + n3 (disjoint: cr_cs1 vs cr_cs2.union empty)
   have hd_cs1_rest : cr_cs1.Disjoint (cr_cs2.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd_cs1_cs2
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 4) cr_cs1 (cr_cs2.union CodeReq.empty)
-    hd_cs1_rest
-    _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd_cs1_rest
     (fun h hp => by xperm_hyp hp) cs1 n3
   -- Chain step 0 + n2 (disjoint: cr_beq0 vs cr_cs1.union (cr_cs2.union empty))
   have hd_beq0_rest : cr_beq0.Disjoint (cr_cs1.union (cr_cs2.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd_beq0_cs1 hd_beq0_cs2
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr_beq0 (cr_cs1.union (cr_cs2.union CodeReq.empty))
-    hd_beq0_rest
-    _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd_beq0_rest
     (fun h hp => by xperm_hyp hp) beq0f n2
   -- The CR now is: cr_beq0.union (cr_cs1.union (cr_cs2.union empty))
   -- Simplify empty away and match the goal CR
@@ -661,22 +655,16 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain cs2_clean + ft
-  have n3 := cpsBranch_cons_cpsNBranch (base + 12) cr_cs2 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr_cs2)
-    _ e2 _ (base + 20) _ _ cs2_clean ft
+  have n3 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr_cs2) cs2_clean ft
   -- Chain cs1_clean + n3
   have hd_cs1_rest : cr_cs1.Disjoint (cr_cs2.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd_cs1_cs2
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 4) cr_cs1 (cr_cs2.union CodeReq.empty)
-    hd_cs1_rest
-    _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd_cs1_rest
     (fun h hp => by xperm_hyp hp) cs1_clean n3
   -- Chain beq0f + n2
   have hd_beq0_rest : cr_beq0.Disjoint (cr_cs1.union (cr_cs2.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd_beq0_cs1 hd_beq0_cs2
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr_beq0 (cr_cs1.union (cr_cs2.union CodeReq.empty))
-    hd_beq0_rest
-    _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd_beq0_rest
     (fun h hp => by xperm_hyp hp) beq0f n2
   -- Simplify CR and match goal
   have hcr_eq : cr_beq0.union (cr_cs1.union (cr_cs2.union CodeReq.empty)) = shr_phase_c_code base := by

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -600,22 +600,16 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain cs2_clean + ft
-  have n3 := cpsBranch_cons_cpsNBranch (base + 12) cr_cs2 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr_cs2)
-    _ e2 _ (base + 20) _ _ cs2_clean ft
+  have n3 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr_cs2) cs2_clean ft
   -- Chain cs1_clean + n3
   have hd_cs1_rest : cr_cs1.Disjoint (cr_cs2.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd_cs1_cs2
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 4) cr_cs1 (cr_cs2.union CodeReq.empty)
-    hd_cs1_rest
-    _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd_cs1_rest
     (fun h hp => by xperm_hyp hp) cs1_clean n3
   -- Chain beq0f + n2
   have hd_beq0_rest : cr_beq0.Disjoint (cr_cs1.union (cr_cs2.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd_beq0_cs1 hd_beq0_cs2
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr_beq0 (cr_cs1.union (cr_cs2.union CodeReq.empty))
-    hd_beq0_rest
-    _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd_beq0_rest
     (fun h hp => by xperm_hyp hp) beq0f n2
   -- Simplify CR and match goal
   have hcr_eq : cr_beq0.union (cr_cs1.union (cr_cs2.union CodeReq.empty)) = sar_phase_c_code base := by

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -631,24 +631,18 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)))
     _ (fun _ hp => hp)
   -- Chain step 2 + fallthrough
-  have n3 := cpsBranch_cons_cpsNBranch (base + 12) cr_cs2 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr_cs2)
-    _ e2 _ (base + 20) _ _ cs2 ft
+  have n3 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr_cs2) cs2 ft
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain step 1 + n3
   have hd_cs1_rest : cr_cs1.Disjoint (cr_cs2.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd_cs1_cs2
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 4) cr_cs1 (cr_cs2.union CodeReq.empty)
-    hd_cs1_rest
-    _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd_cs1_rest
     (fun h hp => by xperm_hyp hp) cs1 n3
   -- Chain step 0 + n2
   have hd_beq0_rest : cr_beq0.Disjoint (cr_cs1.union (cr_cs2.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd_beq0_cs1 hd_beq0_cs2
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr_beq0 (cr_cs1.union (cr_cs2.union CodeReq.empty))
-    hd_beq0_rest
-    _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd_beq0_rest
     (fun h hp => by xperm_hyp hp) beq0f n2
   -- Simplify CR and match goal
   have hcr_eq : cr_beq0.union (cr_cs1.union (cr_cs2.union CodeReq.empty)) = signext_phase_c_code base := by
@@ -802,18 +796,14 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
     _ (fun _ hp => hp)
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
-  have n3 := cpsBranch_cons_cpsNBranch (base + 12) cr_cs2 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr_cs2)
-    _ e2 _ (base + 20) _ _ cs2_clean ft
+  have n3 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr_cs2) cs2_clean ft
   have hd_cs1_rest : cr_cs1.Disjoint (cr_cs2.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd_cs1_cs2
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 4) cr_cs1 (cr_cs2.union CodeReq.empty)
-    hd_cs1_rest _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd_cs1_rest
     (fun h hp => by xperm_hyp hp) cs1_clean n3
   have hd_beq0_rest : cr_beq0.Disjoint (cr_cs1.union (cr_cs2.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd_beq0_cs1 hd_beq0_cs2
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr_beq0 (cr_cs1.union (cr_cs2.union CodeReq.empty))
-    hd_beq0_rest _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd_beq0_rest
     (fun h hp => by xperm_hyp hp) beq0f n2
   have hcr_eq : cr_beq0.union (cr_cs1.union (cr_cs2.union CodeReq.empty)) = signext_phase_c_code base := by
     simp only [hunion_empty]; rfl

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -748,11 +748,11 @@ theorem cpsTriple_seq_cpsBranch_with_perm (entry mid : Word) (cr1 cr2 : CodeReq)
 
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken (false) path.
     The taken path becomes a new exit prepended to the cpsNBranch exits. -/
-theorem cpsBranch_cons_cpsNBranch (entry : Word) (cr1 cr2 : CodeReq)
+theorem cpsBranch_cons_cpsNBranch {entry : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f : Assertion)
-    (exits : List (Word × Assertion))
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion}
+    {exit_f : Word} {Q_f : Assertion}
+    {exits : List (Word × Assertion)}
     (hbr : cpsBranch entry cr1 P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr2 Q_f exits) :
     cpsNBranch entry (cr1.union cr2) P ((exit_t, Q_t) :: exits) := by
@@ -768,11 +768,11 @@ theorem cpsBranch_cons_cpsNBranch (entry : Word) (cr1 cr2 : CodeReq)
            ex, List.Mem.tail _ hmem, hpc2, hER⟩
 
 /-- Compose a cpsBranch with a cpsNBranch, with permutation on the not-taken path. -/
-theorem cpsBranch_cons_cpsNBranch_with_perm (entry : Word) (cr1 cr2 : CodeReq)
+theorem cpsBranch_cons_cpsNBranch_with_perm {entry : Word} {cr1 cr2 : CodeReq}
     (hd : cr1.Disjoint cr2)
-    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f Q_f' : Assertion)
-    (exits : List (Word × Assertion))
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion}
+    {exit_f : Word} {Q_f Q_f' : Assertion}
+    {exits : List (Word × Assertion)}
     (hperm : ∀ h, Q_f h → Q_f' h)
     (hbr : cpsBranch entry cr1 P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr2 Q_f' exits) :

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -312,30 +312,22 @@ theorem rlp_phase1_classifier_spec (v5 v10 : Word) (base : Word)
             (.x10 ↦ᵣ ((0 : Word) + signExtend12 0xF8)))] :=
     cpsNBranch_refl e5 _ _ (fun _ hp => hp)
   -- Chain step 4 + fallthrough → cpsNBranch at base+24 with [e4, e5].
-  have n4 := cpsBranch_cons_cpsNBranch (base + 24) cr4 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr4)
-    _ e4 _ e5 _ _ cs4 ft
+  have n4 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr4) cs4 ft
   -- Chain step 3 + n4 → cpsNBranch at base+16 with [e3, e4, e5].
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   have hd3_rest : cr3.Disjoint (cr4.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd34
-  have n3 := cpsBranch_cons_cpsNBranch (base + 16) cr3 (cr4.union CodeReq.empty)
-    hd3_rest
-    _ e3 _ (base + 24) _ _ cs3 n4
+  have n3 := cpsBranch_cons_cpsNBranch hd3_rest cs3 n4
   -- Chain step 2 + n3 → cpsNBranch at base+8 with [e2, e3, e4, e5].
   have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
-  have n2 := cpsBranch_cons_cpsNBranch (base + 8) cr2
-    (cr3.union (cr4.union CodeReq.empty)) hd2_rest
-    _ e2 _ (base + 16) _ _ cs2 n3
+  have n2 := cpsBranch_cons_cpsNBranch hd2_rest cs2 n3
   -- Chain step 1 + n2 → cpsNBranch at base with [e1, e2, e3, e4, e5].
   have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
     rw [hunion_empty]
     exact CodeReq.Disjoint.union_right hd12 (CodeReq.Disjoint.union_right hd13 hd14)
-  have n1 := cpsBranch_cons_cpsNBranch base cr1
-    (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
-    _ e1 _ (base + 8) _ _ cs1 n2
+  have n1 := cpsBranch_cons_cpsNBranch hd1_rest cs1 n2
   -- The CR now is: cr1.union (cr2.union (cr3.union (cr4.union empty))).
   -- Simplify the trailing `empty` and match the goal's classifier_code.
   have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
@@ -443,32 +435,24 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
             ⌜¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)] :=
     cpsNBranch_refl e5 _ _ (fun _ hp => hp)
   -- Chain step 4 + fallthrough (no perm: step4.fall = ft.pre).
-  have n4 := cpsBranch_cons_cpsNBranch (base + 24) cr4 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr4)
-    _ e4 _ e5 _ _ cs4 ft
+  have n4 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr4) cs4 ft
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain step 3 + n4: strip `⌜¬ult v5 k3⌝` from step3.fall to match n4.pre.
   have hd3_rest : cr3.Disjoint (cr4.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd34
-  have n3 := cpsBranch_cons_cpsNBranch_with_perm (base + 16) cr3
-    (cr4.union CodeReq.empty) hd3_rest
-    _ e3 _ (base + 24) _ _ _
+  have n3 := cpsBranch_cons_cpsNBranch_with_perm hd3_rest
     (sepConj_strip_pure_end3 _ _ _ _) cs3 n4
   -- Chain step 2 + n3.
   have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 8) cr2
-    (cr3.union (cr4.union CodeReq.empty)) hd2_rest
-    _ e2 _ (base + 16) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm hd2_rest
     (sepConj_strip_pure_end3 _ _ _ _) cs2 n3
   -- Chain step 1 + n2.
   have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
     rw [hunion_empty]
     exact CodeReq.Disjoint.union_right hd12 (CodeReq.Disjoint.union_right hd13 hd14)
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr1
-    (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
-    _ e1 _ (base + 8) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm hd1_rest
     (sepConj_strip_pure_end3 _ _ _ _) cs1 n2
   -- Collapse the trailing `empty` and match the goal's classifier_code.
   have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
@@ -632,27 +616,20 @@ theorem rlp_phase1_classifier_spec_acc (v5 v10 : Word) (base : Word)
                ¬ BitVec.ult v5 ((0 : Word) + signExtend12 0xF8)⌝)] :=
     cpsNBranch_refl e5 _ _ (fun _ hp => hp)
   -- Chain step 4 + ft (no perm needed: cs4.fall matches ft.pre).
-  have n4 := cpsBranch_cons_cpsNBranch (base + 24) cr4 CodeReq.empty
-    (CodeReq.Disjoint.empty_right cr4)
-    _ e4 _ e5 _ _ cs4 ft
+  have n4 := cpsBranch_cons_cpsNBranch (CodeReq.Disjoint.empty_right cr4) cs4 ft
   have hunion_empty : ∀ (cr : CodeReq), cr.union CodeReq.empty = cr := by
     intro cr; funext a; simp only [CodeReq.union, CodeReq.empty]; cases cr a <;> rfl
   -- Chain remaining steps (no perm needed: each cs_i's fall matches cs_{i+1}'s pre).
   have hd3_rest : cr3.Disjoint (cr4.union CodeReq.empty) := by
     rw [hunion_empty]; exact hd34
-  have n3 := cpsBranch_cons_cpsNBranch (base + 16) cr3 (cr4.union CodeReq.empty)
-    hd3_rest _ e3 _ (base + 24) _ _ cs3 n4
+  have n3 := cpsBranch_cons_cpsNBranch hd3_rest cs3 n4
   have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
-  have n2 := cpsBranch_cons_cpsNBranch (base + 8) cr2
-    (cr3.union (cr4.union CodeReq.empty)) hd2_rest
-    _ e2 _ (base + 16) _ _ cs2 n3
+  have n2 := cpsBranch_cons_cpsNBranch hd2_rest cs2 n3
   have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
     rw [hunion_empty]
     exact CodeReq.Disjoint.union_right hd12 (CodeReq.Disjoint.union_right hd13 hd14)
-  have n1 := cpsBranch_cons_cpsNBranch base cr1
-    (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
-    _ e1 _ (base + 8) _ _ cs1 n2
+  have n1 := cpsBranch_cons_cpsNBranch hd1_rest cs1 n2
   have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
       rlp_phase1_classifier_code off1 off2 off3 off4 base := by
     simp only [hunion_empty]; rfl


### PR DESCRIPTION
## Summary

Continues the CPSSpec implicit-args arc (#797, #798, #800, #801).

Flips positional \`Word\`/\`CodeReq\`/\`Assertion\`/\`List\` arguments on
\`cpsBranch_cons_cpsNBranch\` and \`cpsBranch_cons_cpsNBranch_with_perm\` to
implicit. \`hd\`, \`hperm\`, \`hbr\`, \`h_rest\` remain explicit.

10+ call sites simplified across \`Rv64/RLP/Phase1.lean\`,
\`Evm64/Shift/LimbSpec.lean\`, \`Evm64/Shift/SarCompose.lean\`, and
\`Evm64/SignExtend/LimbSpec.lean\` — each previously carried a 7-to-10
underscore chain of inferable arguments.

Net: 35 insertions, 86 deletions.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)