### PR TITLE
feat(evm-word-arith): antiShift_toNat_mod_eq — antiShift arithmetic helper (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -31,6 +31,8 @@
     (directly feeds abstract Knuth B's `h_v_norm`).
   - `isCallTrialN4_toNat_lt` — Word→Nat bridge converting `BitVec.ult u4 b3'`
     to the Nat comparison needed by abstract Knuth B's `hu_top_lt`.
+  - `antiShift_toNat_mod_eq` — `(signExtend12 0 - shift).toNat % 64 = 64 - shift.toNat`
+    for `1 ≤ shift.toNat ≤ 63` (the antiShift arithmetic helper).
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -300,5 +302,28 @@ theorem isCallTrialN4_toNat_lt (a3 b2 b3 : Word)
         (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat := by
   unfold isCallTrialN4 at h
   exact (EvmWord.ult_iff _ _).mp h
+
+/-- Antishift arithmetic: under `1 ≤ shift.toNat ≤ 63`, the algorithm's
+    `antiShift = signExtend12 0 - shift` satisfies `antiShift.toNat % 64 =
+    64 - shift.toNat`.
+
+    This reconciles the algorithm's `%64` modular form with `val256_normalize_general`'s
+    direct `64 - s` form — a prerequisite for lifting abstract Knuth B to Word-level
+    normalized limb values. Same proof pattern as in `u_top_lt_pow63_of_shift_nz`
+    (MaxTrialVacuity.lean), extracted as a reusable lemma. -/
+theorem antiShift_toNat_mod_eq (shift : Word)
+    (h1 : 1 ≤ shift.toNat) (h63 : shift.toNat ≤ 63) :
+    (signExtend12 (0 : BitVec 12) - shift).toNat % 64 = 64 - shift.toNat := by
+  have h0 : (signExtend12 (0 : BitVec 12) : Word) = 0 := by decide
+  rw [h0]
+  have hshift_toNat : ((0 : Word) - shift).toNat = 2^64 - shift.toNat := by
+    rw [BitVec.toNat_sub]; simp; omega
+  rw [hshift_toNat]
+  have hsplit : 2^64 - shift.toNat = (2^64 - 64) + (64 - shift.toNat) := by omega
+  rw [hsplit, Nat.add_mod]
+  have hmod64 : (2^64 - 64) % 64 = 0 := by decide
+  rw [hmod64]
+  simp
+  omega
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Small reusable helper extracted from the antiShift manipulation inside \`u_top_lt_pow63_of_shift_nz\` (\`MaxTrialVacuity.lean\`). States:

\`\`\`
1 ≤ shift.toNat ≤ 63  →
(signExtend12 0 - shift).toNat % 64 = 64 - shift.toNat
\`\`\`

Reconciles the algorithm's modular \`%64\` form with \`val256_normalize_general\`'s direct \`64 - s\` form — a prerequisite for lifting abstract Knuth B (\`knuth_theorem_b_abstract\`) to Word-level normalized limb values.

## Context

This is the **prerequisite PR** for **Piece A** of the Knuth B plan: the Word-level corollary that combines the abstract Knuth B theorem with the existing val256 normalization lemmas and the 3 Word→Nat bridges (#791 / #795 / #799). See \`memory/project_knuth_theorem_b_plan.md\` (updated in this session) for the full breakdown.

Proof is ~10 lines using \`BitVec.toNat_sub\`, Nat arithmetic on \`2^64 - shift.toNat\`, and \`omega\`. Same structure as the embedded version in \`u_top_lt_pow63_of_shift_nz\`, extracted for reuse.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)