### PR TITLE
refactor(CPSSpec): flip cpsNBranch_merge positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -808,7 +808,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
       simp only [resultPost, hresult_high1, hresult_high2, hresult_high3]
       rw [← bridge v0 3 (derive_K_3 hd) (by omega) rfl]; exact hq)
   -- Merge Phase C with bodies
-  have hphaseCD := cpsNBranch_merge (base + 56) (base + 180) (evm_byte_code base) _ _ _ hphaseC_framed
+  have hphaseCD := cpsNBranch_merge hphaseC_framed
     (fun exit hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -902,7 +902,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
     (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- Merge Phase C + bodies. Phase C pure postconditions match body bridge preconditions.
-  have hphaseCD := cpsNBranch_merge (base + 64) (base + 360) (shrCode base) _ _ _ hphaseC_framed
+  have hphaseCD := cpsNBranch_merge hphaseC_framed
     (fun exit hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -1066,7 +1066,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
     (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- Merge Phase C + bodies
-  have hphaseCD := cpsNBranch_merge (base + 64) (base + 380) (sarCode base) _ _ _ hphaseC_framed
+  have hphaseCD := cpsNBranch_merge hphaseC_framed
     (fun exit hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -878,7 +878,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
     (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- Merge Phase C + bodies
-  have hphaseCD := cpsNBranch_merge (base + 64) (base + 360) (shlCode base) _ _ _ hphaseC_framed
+  have hphaseCD := cpsNBranch_merge hphaseC_framed
     (fun exit hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -803,7 +803,7 @@ theorem signext_body_spec (sp base : Word)
     (F := phaseC_frame) (by pcFree) hphaseC
   simp only [List.map] at hphaseC_framed
   -- Merge Phase C exits with body+done specs
-  have hphaseCD := cpsNBranch_merge (base + 56) (base + 192) (signextCode base) _ _ _ hphaseC_framed
+  have hphaseCD := cpsNBranch_merge hphaseC_framed
     (fun exit hmem => by
       simp only [List.mem_cons, List.mem_nil_iff, or_false] at hmem
       rcases hmem with ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩ | ⟨rfl, rfl⟩

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -491,9 +491,9 @@ theorem cpsNBranch_to_cpsBranch {entry : Word} {cr : CodeReq}
 /-- N-branch merge: if every exit leads to the same continuation,
     compose into a single cpsTriple. This is the main structural rule.
     Uses the same cr for all parts (simpler; use cpsTriple_extend_code to adapt). -/
-theorem cpsNBranch_merge (entry exit_ : Word) (cr : CodeReq)
-    (P R : Assertion)
-    (exits : List (Word × Assertion))
+theorem cpsNBranch_merge {entry exit_ : Word} {cr : CodeReq}
+    {P R : Assertion}
+    {exits : List (Word × Assertion)}
     (hbr : cpsNBranch entry cr P exits)
     (hall : ∀ exit ∈ exits, cpsTriple exit.1 exit_ cr exit.2 R) :
     cpsTriple entry exit_ cr P R := by


### PR DESCRIPTION
## Summary

Continues the CPSSpec implicit-args arc (#797, #798, #800, #801, #802).

\`cpsNBranch_merge\` had \`entry exit_\`, \`cr\`, \`P R\`, and \`exits\` as explicit
positional arguments. All six are inferable from \`hbr\` / \`hall\` / goal type.
Every caller already passed three underscores (\`_ _ _\`) before \`hbr\`; flipping
to implicit drops the 6-arg positional chain entirely.

\`hbr\` and \`hall\` remain explicit.

5 call sites simplified: \`Evm64/Shift/{ShlCompose,Compose,SarCompose}.lean\`,
\`Evm64/Byte/Spec.lean\`, \`Evm64/SignExtend/Compose.lean\`.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)