### PR TITLE
refactor(CPSSpec): flip cpsBranch_cons_cpsNBranch(_with_perm)_same_cr to implicit

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -416,15 +416,12 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
     intro R hR s _hcr hPR hpc
     exact ⟨0, s, rfl, (e3, _), List.Mem.head _, he3 ▸ hpc, hPR⟩
   -- Chain cs2_final + ft → exits [e2, e3]
-  have n3 := cpsBranch_cons_cpsNBranch_same_cr (base + 12) cr
-    _ e2 _ (base + 20) _ _ cs2_final ft
+  have n3 := cpsBranch_cons_cpsNBranch_same_cr cs2_final ft
   -- Chain cs1_final + n3 → exits [e1, e2, e3]
-  have n2 := cpsBranch_cons_cpsNBranch_with_perm_same_cr (base + 4) cr
-    _ e1 _ (base + 12) _ _ _
+  have n2 := cpsBranch_cons_cpsNBranch_with_perm_same_cr
     (fun h hp => by xperm_hyp hp) cs1_final n3
   -- Chain beq0f + n2 → exits [e0, e1, e2, e3]
-  have n1 := cpsBranch_cons_cpsNBranch_with_perm_same_cr base cr
-    _ e0 _ (base + 4) _ _ _
+  have n1 := cpsBranch_cons_cpsNBranch_with_perm_same_cr
     (fun h hp => by xperm_hyp hp) beq0f n2
   exact n1
 

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -1045,10 +1045,10 @@ theorem cpsBranch_seq_cpsTriple_with_perm_same_cr (entry mid target exit_f : Wor
     h2 ht1
 
 /-- Compose a cpsBranch with a cpsNBranch on the not-taken path, same CodeReq. -/
-theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Word) (cr : CodeReq)
-    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f : Assertion)
-    (exits : List (Word × Assertion))
+theorem cpsBranch_cons_cpsNBranch_same_cr {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion}
+    {exit_f : Word} {Q_f : Assertion}
+    {exits : List (Word × Assertion)}
     (hbr : cpsBranch entry cr P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr Q_f exits) :
     cpsNBranch entry cr P ((exit_t, Q_t) :: exits) := by
@@ -1062,10 +1062,10 @@ theorem cpsBranch_cons_cpsNBranch_same_cr (entry : Word) (cr : CodeReq)
            ex, List.Mem.tail _ hmem, hpc2, hER⟩
 
 /-- Compose a cpsBranch with a cpsNBranch, with permutation on the not-taken path, same CodeReq. -/
-theorem cpsBranch_cons_cpsNBranch_with_perm_same_cr (entry : Word) (cr : CodeReq)
-    (P : Assertion) (exit_t : Word) (Q_t : Assertion)
-    (exit_f : Word) (Q_f Q_f' : Assertion)
-    (exits : List (Word × Assertion))
+theorem cpsBranch_cons_cpsNBranch_with_perm_same_cr {entry : Word} {cr : CodeReq}
+    {P : Assertion} {exit_t : Word} {Q_t : Assertion}
+    {exit_f : Word} {Q_f Q_f' : Assertion}
+    {exits : List (Word × Assertion)}
     (hperm : ∀ h, Q_f h → Q_f' h)
     (hbr : cpsBranch entry cr P exit_t Q_t exit_f Q_f)
     (h_rest : cpsNBranch exit_f cr Q_f' exits) :


### PR DESCRIPTION
## Summary

Continues the CPSSpec implicit-args arc (#797, #798, #800, #801, #802, #804).

The \`same_cr\` variants of \`cpsBranch_cons_cpsNBranch\` still had \`entry\`,
\`cr\`, \`P\`, \`exit_t\`, \`Q_t\`, \`exit_f\`, \`Q_f\` (and \`Q_f'\` for the perm
variant), \`exits\` as explicit positional arguments. Flip to implicit.

3 call sites in \`Evm64/Byte/LimbSpec.lean\` simplified — each previously
carried a 7-element underscore chain.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)