### PR TITLE
refactor(SepLogic): flip sepConj_strip/extract_pure_end{2,3} args to implicit

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -355,8 +355,8 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
       -- ntaken: combine ⌜v5 ≠ 0⌝ ∧ ⌜v5 ≠ 1⌝
       (fun h hp => by
         have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne1 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne1 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1_framed
@@ -403,8 +403,8 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
       -- ntaken: combine ⌜v5≠0 ∧ v5≠1⌝ ∧ ⌜v5≠2⌝
       (fun h hp => by
         have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne2 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne2 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2_framed

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -620,8 +620,8 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
         -- hp : ((x5 ** x0 ** x10 ** ⌜v5 ≠ 1⌝) ** ⌜v5 ≠ 0⌝) h
         have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
         -- hinner : (x5 ** x0 ** x10 ** ⌜v5 ≠ 1⌝) h
-        have hne1 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne1 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         -- Reconstruct: regs ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
@@ -649,8 +649,8 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => by
         -- hp : ((x5 ** x0 ** x10 ** ⌜v5 ≠ 2⌝) ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝) h
         have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne2 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne2 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -569,8 +569,8 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
       (fun h hp => by
         have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne1 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne1 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1f
@@ -588,8 +588,8 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
       (fun h hp => by
         have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne2 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne2 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -769,8 +769,8 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
       (fun h hp => by
         have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne1 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne1 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1f
@@ -788,8 +788,8 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
       (fun h hp => by
         have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
-        have hne2 := sepConj_extract_pure_end3 _ _ _ _ h hinner
-        have hregs := sepConj_strip_pure_end3 _ _ _ _ h hinner
+        have hne2 := sepConj_extract_pure_end3 h hinner
+        have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
           ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -285,7 +285,7 @@ theorem cpsBranch_takenStripPure2
     cpsTriple entry l_t cr P (A ** B) :=
   cpsTriple_weaken
     (fun _ hp => hp)
-    (sepConj_strip_pure_end2 A B Prop_t)
+    sepConj_strip_pure_end2
     (cpsBranch_takenPath hbr h_absurd)
 
 /-- Eliminate the not-taken path from a cpsBranch AND strip the trailing pure fact
@@ -298,7 +298,7 @@ theorem cpsBranch_takenStripPure3
     cpsTriple entry l_t cr P (A ** B ** C) :=
   cpsTriple_weaken
     (fun _ hp => hp)
-    (sepConj_strip_pure_end3 A B C Prop_t)
+    sepConj_strip_pure_end3
     (cpsBranch_takenPath hbr h_absurd)
 
 /-- Eliminate the taken path from a cpsBranch AND strip the trailing pure fact
@@ -311,7 +311,7 @@ theorem cpsBranch_ntakenStripPure2
     cpsTriple entry l_f cr P (A ** B) :=
   cpsTriple_weaken
     (fun _ hp => hp)
-    (sepConj_strip_pure_end2 A B Prop_f)
+    sepConj_strip_pure_end2
     (cpsBranch_ntakenPath hbr h_absurd)
 
 /-- Eliminate the taken path from a cpsBranch AND strip the trailing pure fact
@@ -324,7 +324,7 @@ theorem cpsBranch_ntakenStripPure3
     cpsTriple entry l_f cr P (A ** B ** C) :=
   cpsTriple_weaken
     (fun _ hp => hp)
-    (sepConj_strip_pure_end3 A B C Prop_f)
+    sepConj_strip_pure_end3
     (cpsBranch_ntakenPath hbr h_absurd)
 
 /-- A cpsTriple with zero steps: if entry = exit and P implies Q, trivially holds.

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -154,8 +154,8 @@ theorem rlp_phase1_step_spec_plain (v5 v10 : Word)
       (base + 8) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal)) :=
   cpsBranch_weaken
     (fun _ hp => hp)
-    (sepConj_strip_pure_end3 _ _ _ _)
-    (sepConj_strip_pure_end3 _ _ _ _)
+    sepConj_strip_pure_end3
+    sepConj_strip_pure_end3
     (rlp_phase1_step_spec v5 v10 k offset base target htarget)
 
 -- ============================================================================
@@ -454,14 +454,14 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
   have n3 := cpsBranch_cons_cpsNBranch_with_perm (base + 16) cr3
     (cr4.union CodeReq.empty) hd3_rest
     _ e3 _ (base + 24) _ _ _
-    (sepConj_strip_pure_end3 _ _ _ _) cs3 n4
+    sepConj_strip_pure_end3 cs3 n4
   -- Chain step 2 + n3.
   have hd2_rest : cr2.Disjoint (cr3.union (cr4.union CodeReq.empty)) := by
     rw [hunion_empty]; exact CodeReq.Disjoint.union_right hd23 hd24
   have n2 := cpsBranch_cons_cpsNBranch_with_perm (base + 8) cr2
     (cr3.union (cr4.union CodeReq.empty)) hd2_rest
     _ e2 _ (base + 16) _ _ _
-    (sepConj_strip_pure_end3 _ _ _ _) cs2 n3
+    sepConj_strip_pure_end3 cs2 n3
   -- Chain step 1 + n2.
   have hd1_rest : cr1.Disjoint (cr2.union (cr3.union (cr4.union CodeReq.empty))) := by
     rw [hunion_empty]
@@ -469,7 +469,7 @@ theorem rlp_phase1_classifier_spec_pure (v5 v10 : Word) (base : Word)
   have n1 := cpsBranch_cons_cpsNBranch_with_perm base cr1
     (cr2.union (cr3.union (cr4.union CodeReq.empty))) hd1_rest
     _ e1 _ (base + 8) _ _ _
-    (sepConj_strip_pure_end3 _ _ _ _) cs1 n2
+    sepConj_strip_pure_end3 cs1 n2
   -- Collapse the trailing `empty` and match the goal's classifier_code.
   have hcr_eq : cr1.union (cr2.union (cr3.union (cr4.union CodeReq.empty))) =
       rlp_phase1_classifier_code off1 off2 off3 off4 base := by

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1281,25 +1281,25 @@ theorem sepConj_mono {P P' Q Q' : Assertion} (hp : ∀ h, P h → P' h) (hq : �
 -- ============================================================================
 
 /-- Strip a pure fact at depth 2: A ** B ** ⌜P⌝ → A ** B -/
-theorem sepConj_strip_pure_end2 (A B : Assertion) (P : Prop) :
+theorem sepConj_strip_pure_end2 {A B : Assertion} {P : Prop} :
     ∀ h, (A ** B ** ⌜P⌝) h → (A ** B) h :=
   fun h hp => sepConj_mono_right
     (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp
 
 /-- Strip a pure fact at depth 3: A ** B ** C ** ⌜P⌝ → A ** B ** C -/
-theorem sepConj_strip_pure_end3 (A B C : Assertion) (P : Prop) :
+theorem sepConj_strip_pure_end3 {A B C : Assertion} {P : Prop} :
     ∀ h, (A ** B ** C ** ⌜P⌝) h → (A ** B ** C) h :=
   fun h hp => sepConj_mono_right (sepConj_mono_right
     (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
 
 /-- Strip a pure fact at depth 3 (middle position): A ** B ** C ** ⌜P⌝ ** D → A ** B ** C ** D -/
-theorem sepConj_strip_pure_depth3 (A B C D : Assertion) (P : Prop) :
+theorem sepConj_strip_pure_depth3 {A B C D : Assertion} {P : Prop} :
     ∀ h, (A ** B ** C ** ⌜P⌝ ** D) h → (A ** B ** C ** D) h :=
   fun h hp => sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
     (fun hd hpd => ((sepConj_pure_left P D hd).1 hpd).2))) h hp
 
 /-- Extract the pure fact at depth 3: A ** B ** C ** ⌜P⌝ → P -/
-theorem sepConj_extract_pure_end3 (A B C : Assertion) (P : Prop) :
+theorem sepConj_extract_pure_end3 {A B C : Assertion} {P : Prop} :
     ∀ h, (A ** B ** C ** ⌜P⌝) h → P :=
   fun h hp => by
     obtain ⟨_, _, _, _, _, h2⟩ := hp


### PR DESCRIPTION
## Summary

Continues the implicit-args arc by targeting the \`SepLogic\` pure-fact stripping
helpers. Flip \`A B (C) : Assertion\` and \`P : Prop\` on four theorems to implicit,
since every caller already passes them as underscores or relies on unification:

- \`sepConj_strip_pure_end2\`
- \`sepConj_strip_pure_end3\`
- \`sepConj_strip_pure_depth3\`
- \`sepConj_extract_pure_end3\`

Callers simplified:
- 4 sites in \`Rv64/CPSSpec.lean\` (internal \`cpsBranch_*StripPure{2,3}\` wrappers
  drop the explicit \`A B C Prop_*\` rehashes)
- 5 sites in \`Rv64/RLP/Phase1.lean\`
- 8 \`sepConj_extract_pure_end3 _ _ _ _ h hinner\` sites + 8 matching
  \`sepConj_strip_pure_end3 _ _ _ _ h hinner\` sites across
  \`Evm64/Shift/{LimbSpec,SarCompose}.lean\`, \`Evm64/Byte/LimbSpec.lean\`,
  \`Evm64/SignExtend/LimbSpec.lean\`

Net: 29 insertions, 29 deletions (same line count, but drops the positional
underscore chains — diff is \`(… _ _ _ _)\` → bare name).

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)