### PR TITLE
refactor(SepLogic): flip sepConj_chain_push_outer and _merge_pure_and_end3 to implicit

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -507,9 +507,9 @@ theorem rlp_phase1_step_spec_acc (Acc : Prop) (v5 v10 : Word)
   -- hf has pre `(regs_3chain) ** ⌜Acc⌝`; target theorem has the 4-chain
   -- `regs ** ⌜Acc⌝`. Reshape via the associativity helper.
   exact cpsBranch_weaken
-    (sepConj_chain_push_outer _ _ _ _)
-    (sepConj_merge_pure_and_end3 _ _ _ _ _)
-    (sepConj_merge_pure_and_end3 _ _ _ _ _)
+    sepConj_chain_push_outer
+    sepConj_merge_pure_and_end3
+    sepConj_merge_pure_and_end3
     hf
 
 /-- Bundled exit postcondition with a single accumulated dispatch fact. -/

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1314,7 +1314,7 @@ theorem sepConj_extract_pure_end3 (A B C : Assertion) (P : Prop) :
 
     Useful to reconcile `cpsBranch_frameR` output with a theorem
     statement written in right-associated form. -/
-theorem sepConj_chain_push_outer (A B C D : Assertion) :
+theorem sepConj_chain_push_outer {A B C D : Assertion} :
     ∀ h, (A ** B ** C ** D) h → ((A ** B ** C) ** D) h := by
   intro h hp
   refine (sepConj_assoc _ _ _ _).mpr ?_
@@ -1329,7 +1329,7 @@ theorem sepConj_chain_push_outer (A B C D : Assertion) :
     The outer left-associated shape is what `cpsBranch_frameR` produces
     when framed with `⌜Q⌝`; the right-associated output is what downstream
     consumers with a single accumulated pure fact expect. -/
-theorem sepConj_merge_pure_and_end3 (A B C : Assertion) (P Q : Prop) :
+theorem sepConj_merge_pure_and_end3 {A B C : Assertion} {P Q : Prop} :
     ∀ h, ((A ** B ** C ** ⌜P⌝) ** ⌜Q⌝) h → (A ** B ** C ** ⌜Q ∧ P⌝) h := by
   intro h hp
   obtain ⟨hL, hR, _hdLR, huLR, hL_prop, ⟨eR, hQ⟩⟩ := hp


### PR DESCRIPTION
## Summary

Complements #807. Two more \`SepLogic\` helpers flip their positional
\`Assertion\` (and \`Prop\`) arguments to implicit:

- \`sepConj_chain_push_outer\` (\`A B C D : Assertion\`)
- \`sepConj_merge_pure_and_end3\` (\`A B C : Assertion, P Q : Prop\`)

Each is called exactly once in \`Rv64/RLP/Phase1.lean\` with \`_ _ _ _\` /
\`_ _ _ _ _\` — the implicit variants collapse each to the bare name.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)