### PR TITLE
feat(evm-word-arith): b3_prime_val256_eq_scaled — CLZ-shift normalization bridge (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -36,10 +36,13 @@
   - `knuth_theorem_b_val256` — val256-level corollary of Knuth B, assembling the
     abstract theorem with the Word→Nat bridges against provided normalization
     hypotheses. Concludes `(u4 * B + un3) / b3' ≤ val256(a) / val256(b) + 2`.
+  - `b3_prime_val256_eq_scaled` — discharges `hnorm_v` for concrete CLZ shift:
+    `val256(b0', b1', b2', b3') = val256(b) * 2^clz(b3)`.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
+import EvmAsm.Evm64.EvmWordArith.DenormLemmas
 
 namespace EvmAsm.Evm64
 
@@ -378,5 +381,39 @@ theorem knuth_theorem_b_val256
   -- Rewrite u_nat / v_nat via scale invariance
   rw [hu_nat_def, hv_nat_def, val256_div_scale_invariant] at h_abs
   exact h_abs
+
+/-- Discharge of `hnorm_v` from `knuth_theorem_b_val256` using a concrete
+    CLZ-based shift: the algorithm's normalized divisor limbs compute to
+    `val256(b) * 2^shift`.
+
+    Combines:
+    - `Nat.mod_eq_of_lt` to simplify `shift.toNat % 64 = shift.toNat`.
+    - `antiShift_toNat_mod_eq` to convert antiShift's `% 64` form to `64 - s`.
+    - `clzResult_fst_top_bound` for the `b3 < 2^(64-s)` bound.
+    - `val256_normalize` (overflow-free variant, since normalization ensures
+      `b3 < 2^(64-s)` with `s = clz(b3)`). -/
+theorem b3_prime_val256_eq_scaled
+    (b0 b1 b2 b3 : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    val256
+      (b0 <<< ((clzResult b3).1.toNat % 64))
+      ((b1 <<< ((clzResult b3).1.toNat % 64)) |||
+         (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((b2 <<< ((clzResult b3).1.toNat % 64)) |||
+         (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+         (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      = val256 b0 b1 b2 b3 * 2^(clzResult b3).1.toNat := by
+  have h_shift_le := clzResult_fst_toNat_le b3
+  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h | h
+    · exfalso; apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have hsmod : (clzResult b3).1.toNat % 64 = (clzResult b3).1.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
+  have hb3_bound := clzResult_fst_top_bound b3
+  exact val256_normalize h_shift_pos (by omega) b0 b1 b2 b3 hb3_bound
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -40,6 +40,8 @@
     `val256(b0', b1', b2', b3') = val256(b) * 2^clz(b3)`.
   - `u_val256_eq_scaled_with_overflow` — discharges `hnorm_u` for concrete CLZ
     shift: 4-limb normalized value + overflow = `val256(a) * 2^clz(b3)`.
+  - `knuth_theorem_b_from_clz` — **full Word-level Knuth B corollary** from raw
+    (a, b, hb3nz, hshift_nz, hcall). No normalization hypotheses needed.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -448,5 +450,56 @@ theorem u_val256_eq_scaled_with_overflow
     Nat.mod_eq_of_lt (by omega)
   rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
   exact val256_normalize_general h_shift_pos (by omega) a0 a1 a2 a3
+
+/-- **Knuth's Theorem B at the Word level — full CLZ-driven corollary.**
+
+    Under call-trial + CLZ-normalization hypotheses, the raw 2-limb trial
+    quotient `(u4 * 2^64 + un3) / b3'` overestimates the true quotient
+    `val256(a) / val256(b)` by at most 2:
+
+    ```
+      (u4.toNat * 2^64 + un3.toNat) / b3'.toNat ≤
+        val256(a) / val256(b) + 2
+    ```
+
+    Composes the discharge bridges (`u_val256_eq_scaled_with_overflow`,
+    `b3_prime_val256_eq_scaled`, `b3_prime_ge_pow63`, `isCallTrialN4_toNat_lt`)
+    with `knuth_theorem_b_val256`. This is the algorithm-facing conclusion
+    that downstream stack-spec reasoning consumes. -/
+theorem knuth_theorem_b_from_clz
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3) :
+    ((a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat * 2^64 +
+       ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+          (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat) /
+      ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+        (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat ≤
+    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
+  have hnorm_u := u_val256_eq_scaled_with_overflow a0 a1 a2 a3 b3 hshift_nz
+  have hnorm_v := b3_prime_val256_eq_scaled b0 b1 b2 b3 hshift_nz
+  have hb3prime := b3_prime_ge_pow63 b3 b2 hb3nz
+    (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+  have hu4_lt := isCallTrialN4_toNat_lt a3 b2 b3 hcall
+  exact knuth_theorem_b_val256 a0 a1 a2 a3 b0 b1 b2 b3
+    (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))
+    (a0 <<< ((clzResult b3).1.toNat % 64))
+    ((a1 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((a2 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    (b0 <<< ((clzResult b3).1.toNat % 64))
+    ((b1 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((b2 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    (clzResult b3).1.toNat
+    (by linarith [hnorm_u])
+    hnorm_v hb3prime hu4_lt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -38,6 +38,8 @@
     hypotheses. Concludes `(u4 * B + un3) / b3' ≤ val256(a) / val256(b) + 2`.
   - `b3_prime_val256_eq_scaled` — discharges `hnorm_v` for concrete CLZ shift:
     `val256(b0', b1', b2', b3') = val256(b) * 2^clz(b3)`.
+  - `u_val256_eq_scaled_with_overflow` — discharges `hnorm_u` for concrete CLZ
+    shift: 4-limb normalized value + overflow = `val256(a) * 2^clz(b3)`.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -415,5 +417,36 @@ theorem b3_prime_val256_eq_scaled
   rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
   have hb3_bound := clzResult_fst_top_bound b3
   exact val256_normalize h_shift_pos (by omega) b0 b1 b2 b3 hb3_bound
+
+/-- Discharge of `hnorm_u` from `knuth_theorem_b_val256` using a concrete
+    CLZ-based shift: the algorithm's normalized dividend limbs plus the
+    overflow `a3 >>> antiShift` (scaled to `2^256`) equal `val256(a) * 2^shift`.
+
+    Parallel of `b3_prime_val256_eq_scaled`, but uses `val256_normalize_general`
+    (the overflow-including variant) since the dividend may overshoot 2^256. -/
+theorem u_val256_eq_scaled_with_overflow
+    (a0 a1 a2 a3 b3 : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    val256
+      (a0 <<< ((clzResult b3).1.toNat % 64))
+      ((a1 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((a2 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    + (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat
+      * 2^256
+      = val256 a0 a1 a2 a3 * 2^(clzResult b3).1.toNat := by
+  have h_shift_le := clzResult_fst_toNat_le b3
+  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h | h
+    · exfalso; apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have hsmod : (clzResult b3).1.toNat % 64 = (clzResult b3).1.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
+  exact val256_normalize_general h_shift_pos (by omega) a0 a1 a2 a3
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Discharges the \`hnorm_v\` hypothesis of \`knuth_theorem_b_val256\` (from #806) for concrete CLZ-based shifts. States that the algorithm's normalized divisor limbs compute to \`val256(b) * 2^clz(b3)\`:

\`\`\`
val256 (b0 <<< shift%64)
       ((b1 <<< shift%64) ||| (b0 >>> antiShift%64))
       ((b2 <<< shift%64) ||| (b1 >>> antiShift%64))
       ((b3 <<< shift%64) ||| (b2 >>> antiShift%64))
= val256 b0 b1 b2 b3 * 2^shift.toNat
\`\`\`

## Proof chain
1. \`clzResult_fst_toNat_le\` + \`hshift_nz\` give \`1 ≤ shift ≤ 63\`.
2. \`Nat.mod_eq_of_lt\` converts \`shift%64 → shift\`.
3. \`antiShift_toNat_mod_eq\` (#803) converts \`antiShift%64 → 64 - shift\`.
4. \`clzResult_fst_top_bound\` supplies \`b3 < 2^(64-shift)\`.
5. \`val256_normalize\` (overflow-free variant in \`DenormLemmas.lean\`) closes.

Adds \`DenormLemmas\` to the imports of \`KnuthTheoremB\`.

## Next

The analogous \`u_val256_eq_scaled_with_overflow\` using \`val256_normalize_general\` (which includes the \`u4\` overflow limb) is the remaining piece to fully discharge \`hnorm_u\` for \`knuth_theorem_b_val256\`.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)