### PR TITLE
refactor(SepLogic): flip pcFree_{regIs,memIs,regOwn,memOwn,instrAt,progAt} to implicit

### DIFF
--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -128,7 +128,7 @@ theorem pcFree_evmCodeIsAux (base : Word) (n : Nat) (bytes : List (BitVec 8)) :
     (evmCodeIsAux base n bytes).pcFree := by
   induction n generalizing base bytes with
   | zero => exact pcFree_emp
-  | succ n ih => exact pcFree_sepConj (pcFree_memIs _ _) (ih _ _)
+  | succ n ih => exact pcFree_sepConj pcFree_memIs (ih _ _)
 
 theorem pcFree_evmCodeIs (base : Word) (bytes : List (BitVec 8)) :
     (evmCodeIs base bytes).pcFree :=

--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -92,7 +92,7 @@ theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · exact holdsFor_pcFree_setPC
-      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) _ _ hPR
+      (pcFree_sepConj (pcFree_sepConj pcFree_regIs pcFree_regIs) hR) _ _ hPR
 
 /-- BEQ when values are not equal: never taken (fall through to PC + 4).
     BEQ only modifies PC; all pcFree assertions are preserved. -/
@@ -117,7 +117,7 @@ theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · exact holdsFor_pcFree_setPC
-      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) _ _ hPR
+      (pcFree_sepConj (pcFree_sepConj pcFree_regIs pcFree_regIs) hR) _ _ hPR
 
 -- ============================================================================
 -- Per-limb Specs: SLT (MSB load + signed comparison)

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -307,7 +307,7 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
   -- The entire precondition (P ** R form from cpsBranch) is pcFree
   have hpcfree : (((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
       (P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2))) ** R).pcFree :=
-    pcFree_sepConj (pcFree_sepConj (pcFree_instrAt _ _) (pcFree_aAnd hP (pcFree_aAnd (pcFree_regIs _ _) (pcFree_regIs _ _)))) hR
+    pcFree_sepConj (pcFree_sepConj pcFree_instrAt (pcFree_aAnd hP (pcFree_aAnd pcFree_regIs pcFree_regIs))) hR
   -- Case split on v1 = v2
   by_cases heq : v1 = v2
   · -- Not taken: v1 = v2 → PC = s.pc + 4 = thenEntry (exit_t)
@@ -393,13 +393,13 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
   have hpcfree_all : (((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
       ((s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length)) ↦ᵢ Instr.JAL Reg.x0 (BitVec.ofNat 21 (4 * else_body.length + 4))) **
       (P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2))) ** R).pcFree :=
-    pcFree_sepConj (pcFree_sepConj (pcFree_instrAt _ _)
-      (pcFree_sepConj (pcFree_instrAt _ _)
-        (pcFree_aAnd hP (pcFree_aAnd (pcFree_regIs _ _) (pcFree_regIs _ _))))) hR
+    pcFree_sepConj (pcFree_sepConj pcFree_instrAt
+      (pcFree_sepConj pcFree_instrAt
+        (pcFree_aAnd hP (pcFree_aAnd pcFree_regIs pcFree_regIs)))) hR
   -- Body-triple frame: bne ** jal ** R (pcFree)
   have hframe_pcfree : ((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
       ((s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length)) ↦ᵢ Instr.JAL Reg.x0 (BitVec.ofNat 21 (4 * else_body.length + 4))) ** R).pcFree :=
-    pcFree_sepConj (pcFree_instrAt _ _) (pcFree_sepConj (pcFree_instrAt _ _) hR)
+    pcFree_sepConj pcFree_instrAt (pcFree_sepConj pcFree_instrAt hR)
   -- Helper: rearranging ** chains
   -- (bne ** (jal ** aand)) ** R = (aand ** (bne ** (jal ** R))) as assertions
   have hassert_perm : (((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
@@ -445,7 +445,7 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
     -- Frame for jal_x0_spec_gen: the full (jal ** bne ** Q ** R) conjunction
     have hjal_pcfree : (((s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length)) ↦ᵢ Instr.JAL Reg.x0 (BitVec.ofNat 21 (4 * else_body.length + 4))) **
         ((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) ** Q ** R)).pcFree :=
-      pcFree_sepConj (pcFree_instrAt _ _) (pcFree_sepConj (pcFree_instrAt _ _) (pcFree_sepConj hQ hR))
+      pcFree_sepConj pcFree_instrAt (pcFree_sepConj pcFree_instrAt (pcFree_sepConj hQ hR))
     have hjal_cr : (CodeReq.singleton (s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length))
         (Instr.JAL Reg.x0 (BitVec.ofNat 21 (4 * else_body.length + 4)))).SatisfiedBy s2 :=
       instrAt_singleton_satisfiedBy _ _ _ (holdsFor_sepConj_elim_left hQR2')

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -565,17 +565,17 @@ theorem holdsFor_sepConj_elim_right {P Q : Assertion} {s : MachineState}
 -- pcFree lemmas
 -- ============================================================================
 
-theorem pcFree_regIs (r : Reg) (v : Word) : (regIs r v).pcFree := by
+theorem pcFree_regIs {r : Reg} {v : Word} : (regIs r v).pcFree := by
   intro h hp; rw [regIs] at hp; subst hp; rfl
 
-theorem pcFree_memIs (a : Word) (v : Word) : (memIs a v).pcFree := by
+theorem pcFree_memIs {a : Word} {v : Word} : (memIs a v).pcFree := by
   intro h ⟨hp, _⟩; subst hp; rfl
 
-theorem pcFree_regOwn (r : Reg) : (regOwn r).pcFree := by
-  intro h ⟨v, hv⟩; exact pcFree_regIs r v h hv
+theorem pcFree_regOwn {r : Reg} : (regOwn r).pcFree := by
+  intro h ⟨v, hv⟩; exact pcFree_regIs h hv
 
-theorem pcFree_memOwn (a : Word) : (memOwn a).pcFree := by
-  intro h ⟨v, hv⟩; exact pcFree_memIs a v h hv
+theorem pcFree_memOwn {a : Word} : (memOwn a).pcFree := by
+  intro h ⟨v, hv⟩; exact pcFree_memIs h hv
 
 theorem pcFree_emp : empAssertion.pcFree := by
   intro h hp; rw [empAssertion] at hp; subst hp; rfl
@@ -593,10 +593,10 @@ class Assertion.PCFree (P : Assertion) : Prop where
   proof : P.pcFree
 
 instance : Assertion.PCFree empAssertion             := ⟨pcFree_emp⟩
-instance : Assertion.PCFree (r ↦ᵣ v)                := ⟨pcFree_regIs r v⟩
-instance : Assertion.PCFree (a ↦ₘ v)                := ⟨pcFree_memIs a v⟩
-instance : Assertion.PCFree (regOwn r)               := ⟨pcFree_regOwn r⟩
-instance : Assertion.PCFree (memOwn a)               := ⟨pcFree_memOwn a⟩
+instance : Assertion.PCFree (r ↦ᵣ v)                := ⟨pcFree_regIs⟩
+instance : Assertion.PCFree (a ↦ₘ v)                := ⟨pcFree_memIs⟩
+instance : Assertion.PCFree (regOwn r)               := ⟨pcFree_regOwn⟩
+instance : Assertion.PCFree (memOwn a)               := ⟨pcFree_memOwn⟩
 @[reducible, instance] def instPCFreeSepConj [hP : Assertion.PCFree P] [hQ : Assertion.PCFree Q] :
     Assertion.PCFree (P ** Q)                        := ⟨pcFree_sepConj hP.proof hQ.proof⟩
 
@@ -1974,22 +1974,22 @@ theorem holdsFor_instrAt (a : Word) (i : Instr) (s : MachineState) :
 -- pcFree for code assertions
 -- ============================================================================
 
-theorem pcFree_instrAt (a : Word) (i : Instr) : (instrAt a i).pcFree := by
+theorem pcFree_instrAt {a : Word} {i : Instr} : (instrAt a i).pcFree := by
   intro h hp; rw [instrAt] at hp; subst hp; rfl
 
 theorem pcFree_programAt : ∀ prog, (programAt prog).pcFree
   | [] => pcFree_emp
-  | (a, i) :: rest =>
-    pcFree_sepConj (pcFree_instrAt a i) (pcFree_programAt rest)
+  | (_, _) :: rest =>
+    pcFree_sepConj pcFree_instrAt (pcFree_programAt rest)
 
-instance : Assertion.PCFree (instrAt a i) := ⟨pcFree_instrAt a i⟩
+instance : Assertion.PCFree (instrAt a i) := ⟨pcFree_instrAt⟩
 
 instance : Assertion.PCFree (programAt prog) := ⟨pcFree_programAt prog⟩
 
-theorem pcFree_progAt (base : Word) (prog : List Instr) : (progAt base prog).pcFree :=
+theorem pcFree_progAt {base : Word} {prog : List Instr} : (progAt base prog).pcFree :=
   pcFree_programAt (progIndexed base prog)
 
-instance : Assertion.PCFree (progAt base prog) := ⟨pcFree_progAt base prog⟩
+instance : Assertion.PCFree (progAt base prog) := ⟨pcFree_progAt⟩
 
 -- ============================================================================
 -- CodeReq: persistent code side-condition (for issue #35)
@@ -2733,11 +2733,11 @@ macro_rules
     | exact (inferInstance : Assertion.PCFree _).proof
     | repeat (first
       | apply pcFree_sepConj
-      | exact pcFree_instrAt _ _
-      | exact pcFree_regIs _ _
-      | exact pcFree_memIs _ _
-      | exact pcFree_regOwn _
-      | exact pcFree_memOwn _
+      | exact pcFree_instrAt
+      | exact pcFree_regIs
+      | exact pcFree_memIs
+      | exact pcFree_regOwn
+      | exact pcFree_memOwn
       | exact pcFree_emp
       | exact pcFree_pure _
       | exact pcFree_programAt _))


### PR DESCRIPTION
## Summary

Continuing the pcFree-implicit cleanup (#811). Flip the explicit positional
\`Reg\`/\`Word\`/\`Instr\`/\`List\` args on six \`pcFree_*\` primitives to implicit:

- \`pcFree_regIs (r v)\` → all implicit
- \`pcFree_memIs (a v)\` → all implicit
- \`pcFree_regOwn (r)\` → all implicit
- \`pcFree_memOwn (a)\` → all implicit
- \`pcFree_instrAt (a i)\` → all implicit
- \`pcFree_progAt (base prog)\` → all implicit

Every caller either passes them as underscores or is in a context where
unification drives them from the goal/hypothesis type.

Callers simplified:
- Internal \`SepLogic\` bodies (\`pcFree_regOwn\`, \`pcFree_programAt\`,
  the \`PCFree\` instance terms) drop redundant arguments.
- The \`pcFree\` macro (\`SepLogic.lean\`) drops the trailing \`_ _\` / \`_\` chains.
- \`Rv64/ControlFlow.lean\`, \`Evm64/Compare/LimbSpec.lean\`, \`Evm64/CodeRegion.lean\`
  drop paren-underscore noise at 5 call sites.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)