### PR TITLE
feat(evm-word-arith): u_val256_eq_scaled_with_overflow — hnorm_u CLZ bridge (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -40,6 +40,8 @@
     `val256(b0', b1', b2', b3') = val256(b) * 2^clz(b3)`.
   - `u_val256_eq_scaled_with_overflow` — discharges `hnorm_u` for concrete CLZ
     shift: 4-limb normalized value + overflow = `val256(a) * 2^clz(b3)`.
+  - `knuth_theorem_b_from_clz` — **full Word-level Knuth B corollary** from raw
+    (a, b, hb3nz, hshift_nz, hcall). No normalization hypotheses needed.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -448,5 +450,56 @@ theorem u_val256_eq_scaled_with_overflow
     Nat.mod_eq_of_lt (by omega)
   rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
   exact val256_normalize_general h_shift_pos (by omega) a0 a1 a2 a3
+
+/-- **Knuth's Theorem B at the Word level — full CLZ-driven corollary.**
+
+    Under call-trial + CLZ-normalization hypotheses, the raw 2-limb trial
+    quotient `(u4 * 2^64 + un3) / b3'` overestimates the true quotient
+    `val256(a) / val256(b)` by at most 2:
+
+    ```
+      (u4.toNat * 2^64 + un3.toNat) / b3'.toNat ≤
+        val256(a) / val256(b) + 2
+    ```
+
+    Composes the discharge bridges (`u_val256_eq_scaled_with_overflow`,
+    `b3_prime_val256_eq_scaled`, `b3_prime_ge_pow63`, `isCallTrialN4_toNat_lt`)
+    with `knuth_theorem_b_val256`. This is the algorithm-facing conclusion
+    that downstream stack-spec reasoning consumes. -/
+theorem knuth_theorem_b_from_clz
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3) :
+    ((a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat * 2^64 +
+       ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+          (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat) /
+      ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+        (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat ≤
+    val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
+  have hnorm_u := u_val256_eq_scaled_with_overflow a0 a1 a2 a3 b3 hshift_nz
+  have hnorm_v := b3_prime_val256_eq_scaled b0 b1 b2 b3 hshift_nz
+  have hb3prime := b3_prime_ge_pow63 b3 b2 hb3nz
+    (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+  have hu4_lt := isCallTrialN4_toNat_lt a3 b2 b3 hcall
+  exact knuth_theorem_b_val256 a0 a1 a2 a3 b0 b1 b2 b3
+    (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))
+    (a0 <<< ((clzResult b3).1.toNat % 64))
+    ((a1 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((a2 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+       (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    (b0 <<< ((clzResult b3).1.toNat % 64))
+    ((b1 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((b2 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+       (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    (clzResult b3).1.toNat
+    (by linarith [hnorm_u])
+    hnorm_v hb3prime hu4_lt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -38,6 +38,8 @@
     hypotheses. Concludes `(u4 * B + un3) / b3' ≤ val256(a) / val256(b) + 2`.
   - `b3_prime_val256_eq_scaled` — discharges `hnorm_v` for concrete CLZ shift:
     `val256(b0', b1', b2', b3') = val256(b) * 2^clz(b3)`.
+  - `u_val256_eq_scaled_with_overflow` — discharges `hnorm_u` for concrete CLZ
+    shift: 4-limb normalized value + overflow = `val256(a) * 2^clz(b3)`.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -415,5 +417,36 @@ theorem b3_prime_val256_eq_scaled
   rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
   have hb3_bound := clzResult_fst_top_bound b3
   exact val256_normalize h_shift_pos (by omega) b0 b1 b2 b3 hb3_bound
+
+/-- Discharge of `hnorm_u` from `knuth_theorem_b_val256` using a concrete
+    CLZ-based shift: the algorithm's normalized dividend limbs plus the
+    overflow `a3 >>> antiShift` (scaled to `2^256`) equal `val256(a) * 2^shift`.
+
+    Parallel of `b3_prime_val256_eq_scaled`, but uses `val256_normalize_general`
+    (the overflow-including variant) since the dividend may overshoot 2^256. -/
+theorem u_val256_eq_scaled_with_overflow
+    (a0 a1 a2 a3 b3 : Word)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
+    val256
+      (a0 <<< ((clzResult b3).1.toNat % 64))
+      ((a1 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((a2 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+      ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+         (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)))
+    + (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat
+      * 2^256
+      = val256 a0 a1 a2 a3 * 2^(clzResult b3).1.toNat := by
+  have h_shift_le := clzResult_fst_toNat_le b3
+  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h | h
+    · exfalso; apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have hsmod : (clzResult b3).1.toNat % 64 = (clzResult b3).1.toNat :=
+    Nat.mod_eq_of_lt (by omega)
+  rw [hsmod, antiShift_toNat_mod_eq _ h_shift_pos h_shift_le]
+  exact val256_normalize_general h_shift_pos (by omega) a0 a1 a2 a3
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Parallel of \`b3_prime_val256_eq_scaled\` (#810) for the u (dividend) side. Discharges the \`hnorm_u\` hypothesis of \`knuth_theorem_b_val256\` (#806) for concrete CLZ-based shifts:

\`\`\`
val256 (a0 <<< shift%64)
       ((a1 <<< shift%64) ||| (a0 >>> antiShift%64))
       ((a2 <<< shift%64) ||| (a1 >>> antiShift%64))
       ((a3 <<< shift%64) ||| (a2 >>> antiShift%64))
+ (a3 >>> antiShift%64).toNat * 2^256
= val256 a0 a1 a2 a3 * 2^shift.toNat
\`\`\`

## Proof

Dual of \`b3_prime_val256_eq_scaled\` — same shift% and antiShift% simplification via \`antiShift_toNat_mod_eq\` (#803), then applies \`val256_normalize_general\` (the overflow-including variant in \`DenormLemmas.lean\`). No \`b3 < 2^(64-s)\` bound needed (the overflow limb handles dividend overshoot).

## Status

With both \`b3_prime_val256_eq_scaled\` and this theorem, all four hypotheses of \`knuth_theorem_b_val256\` can be discharged from a raw \`(a, b, hb3nz, hshift_nz, hcall)\` tuple. The next PR will compose them into \`knuth_theorem_b_from_clz\` — the full CLZ-driven Word-level corollary of Knuth B.

**Stacked on #810.**

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)