### PR TITLE
refactor(SepLogic/Stack/CodeRegion): flip pcFree list-arg helpers to implicit

### DIFF
--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -124,19 +124,19 @@ theorem evmCodeIs_nonempty (base : Word) (bytes : List (BitVec 8)) (h : bytes �
     simp [numChunks]; omega
   rw [hstep]; rfl
 
-theorem pcFree_evmCodeIsAux (base : Word) (n : Nat) (bytes : List (BitVec 8)) :
+theorem pcFree_evmCodeIsAux {base : Word} {n : Nat} {bytes : List (BitVec 8)} :
     (evmCodeIsAux base n bytes).pcFree := by
   induction n generalizing base bytes with
   | zero => exact pcFree_emp
-  | succ n ih => exact pcFree_sepConj (pcFree_memIs _ _) (ih _ _)
+  | succ _ ih => exact pcFree_sepConj (pcFree_memIs _ _) ih
 
-theorem pcFree_evmCodeIs (base : Word) (bytes : List (BitVec 8)) :
+theorem pcFree_evmCodeIs {base : Word} {bytes : List (BitVec 8)} :
     (evmCodeIs base bytes).pcFree :=
-  pcFree_evmCodeIsAux base _ bytes
+  pcFree_evmCodeIsAux
 
 instance (base : Word) (bytes : List (BitVec 8)) :
     Assertion.PCFree (evmCodeIs base bytes) :=
-  ⟨pcFree_evmCodeIs base bytes⟩
+  ⟨pcFree_evmCodeIs⟩
 
 -- ============================================================================
 -- evmCodeIs_split_at: extract the doubleword containing byte k

--- a/EvmAsm/Evm64/Pop/Spec.lean
+++ b/EvmAsm/Evm64/Pop/Spec.lean
@@ -32,7 +32,7 @@ theorem evm_pop_stack_spec (sp base : Word)
       ((.x12 ↦ᵣ (sp + 32)) ** evmWordIs sp a ** evmStackIs (sp + 32) rest) :=
   cpsTriple_frameR
     (evmWordIs sp a ** evmStackIs (sp + 32) rest)
-    (pcFree_sepConj (pcFree_evmWordIs sp a) (pcFree_evmStackIs (sp + 32) rest))
+    (pcFree_sepConj pcFree_evmWordIs pcFree_evmStackIs)
     (evm_pop_spec sp base)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -48,7 +48,7 @@ theorem evm_push0_stack_spec (nsp base : Word)
     (fun h hq => by simp only [evmWordIs, EvmWord.getLimbN_zero]; xperm_hyp hq)
     (cpsTriple_frameR
       (evmStackIs (nsp + 32) rest)
-      (pcFree_evmStackIs (nsp + 32) rest)
+      pcFree_evmStackIs
       (evm_push0_spec nsp base d0 d1 d2 d3))
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -29,21 +29,21 @@ def evmStackIs (sp : Word) (values : List EvmWord) : Assertion :=
   | [] => empAssertion
   | v :: vs => evmWordIs sp v ** evmStackIs (sp + 32) vs
 
-theorem pcFree_evmWordIs (addr : Word) (v : EvmWord) :
+theorem pcFree_evmWordIs {addr : Word} {v : EvmWord} :
     (evmWordIs addr v).pcFree := by
   unfold evmWordIs; pcFree
 
-theorem pcFree_evmStackIs (sp : Word) (values : List EvmWord) :
+theorem pcFree_evmStackIs {sp : Word} {values : List EvmWord} :
     (evmStackIs sp values).pcFree := by
   induction values generalizing sp with
   | nil => exact pcFree_emp
-  | cons v vs ih => exact pcFree_sepConj (pcFree_evmWordIs sp v) (ih (sp + 32))
+  | cons _ _ ih => exact pcFree_sepConj pcFree_evmWordIs ih
 
 instance (addr : Word) (v : EvmWord) : Assertion.PCFree (evmWordIs addr v) :=
-  ⟨pcFree_evmWordIs addr v⟩
+  ⟨pcFree_evmWordIs⟩
 
 instance (sp : Word) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp values) :=
-  ⟨pcFree_evmStackIs sp values⟩
+  ⟨pcFree_evmStackIs⟩
 
 theorem evmStackIs_cons (sp : Word) (v : EvmWord) (vs : List EvmWord) :
     evmStackIs sp (v :: vs) = (evmWordIs sp v ** evmStackIs (sp + 32) vs) := rfl

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1028,11 +1028,11 @@ theorem holdsFor_publicValuesIs (vals : List (BitVec 8)) (s : MachineState) :
 -- pcFree for publicValuesIs
 -- ============================================================================
 
-theorem pcFree_publicValuesIs (vals : List (BitVec 8)) : (publicValuesIs vals).pcFree := by
+theorem pcFree_publicValuesIs {vals : List (BitVec 8)} : (publicValuesIs vals).pcFree := by
   intro h hp; rw [publicValuesIs] at hp; subst hp; rfl
 
 instance (vals : List (BitVec 8)) : Assertion.PCFree (publicValuesIs vals) :=
-  ⟨pcFree_publicValuesIs vals⟩
+  ⟨pcFree_publicValuesIs⟩
 
 -- ============================================================================
 -- Disjointness lemmas for publicValuesIs composition
@@ -1107,11 +1107,11 @@ theorem holdsFor_privateInputIs (vals : List (BitVec 8)) (s : MachineState) :
 -- pcFree for privateInputIs
 -- ============================================================================
 
-theorem pcFree_privateInputIs (vals : List (BitVec 8)) : (privateInputIs vals).pcFree := by
+theorem pcFree_privateInputIs {vals : List (BitVec 8)} : (privateInputIs vals).pcFree := by
   intro h hp; rw [privateInputIs] at hp; subst hp; rfl
 
 instance (vals : List (BitVec 8)) : Assertion.PCFree (privateInputIs vals) :=
-  ⟨pcFree_privateInputIs vals⟩
+  ⟨pcFree_privateInputIs⟩
 
 -- ============================================================================
 -- Disjointness lemmas for privateInputIs composition


### PR DESCRIPTION
## Summary

Continuing the pcFree-implicit cleanup (#811, #812). Flip six more \`pcFree_*\`
helpers that take positional \`List\`, \`addr/sp\`, or \`base/n/bytes\` arguments
to implicit. Every caller passes them by type unification or as redundant
explicit names:

- \`pcFree_publicValuesIs (vals)\` → implicit
- \`pcFree_privateInputIs (vals)\` → implicit
- \`pcFree_evmWordIs (addr v)\` → implicit
- \`pcFree_evmStackIs (sp values)\` → implicit
- \`pcFree_evmCodeIs (base bytes)\` → implicit
- \`pcFree_evmCodeIsAux (base n bytes)\` → implicit

Callers simplified:
- \`Evm64/Stack.lean\` instance terms + internal recursive \`pcFree_evmStackIs\` body
- \`Evm64/Pop/Spec.lean\`, \`Evm64/Push0/Spec.lean\` drop explicit name chains
- \`Evm64/CodeRegion.lean\` instance + internal \`pcFree_evmCodeIs\` body

Meta callers in \`Rv64/Tactics/SeqFrame.lean\` still use
\`mkApp pcFree_publicValuesIs arg\`; \`mkApp\` applies positional slots
regardless of implicit/explicit, so no change needed there.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)