### PR TITLE
refactor(DivMod): flip 10 pcFree_* helpers in DivMod bundles to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -374,8 +374,8 @@ theorem divScratchOwn_unfold_right (sp : Word) (Q : Assertion) :
     (divScratchOwn sp ** Q) := by
   rw [divScratchOwn_unfold]
 
-theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem : Word) :
+theorem pcFree_divScratchValues {sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem : Word} :
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem).pcFree := by
   unfold divScratchValues; pcFree
@@ -383,12 +383,11 @@ theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
 instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem) :=
-  ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem⟩
+  ⟨pcFree_divScratchValues⟩
 
 /-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
     through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
-theorem pcFree_divScratchOwn (sp : Word) : (divScratchOwn sp).pcFree := by
+theorem pcFree_divScratchOwn {sp : Word} : (divScratchOwn sp).pcFree := by
   rw [divScratchOwn_unfold]; pcFree
 
 /-- Value-agnostic counterpart to `divScratchValuesCall`: the same 19 cells
@@ -418,12 +417,12 @@ theorem divScratchOwnCall_unfold (sp : Word) :
 
 /-- `divScratchOwnCall` is pc-free: all atoms are `memOwn` (chained from
     `divScratchOwn` + 4 new `memOwn`). -/
-theorem pcFree_divScratchOwnCall (sp : Word) : (divScratchOwnCall sp).pcFree := by
+theorem pcFree_divScratchOwnCall {sp : Word} : (divScratchOwnCall sp).pcFree := by
   rw [divScratchOwnCall_unfold, divScratchOwn_unfold]; pcFree
 
 instance pcFreeInst_divScratchOwn (sp : Word) :
     Assertion.PCFree (divScratchOwn sp) :=
-  ⟨pcFree_divScratchOwn sp⟩
+  ⟨pcFree_divScratchOwn⟩
 
 /-- Weakening: any concrete scratch state implies ownership of the same 15
     cells. This lets a stack spec hide the scratch values on exit. -/
@@ -501,14 +500,14 @@ theorem loopSetupPost_unfold (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   delta loopSetupPost; rfl
 
 /-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_loopSetupPost (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem pcFree_loopSetupPost {sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
   rw [loopSetupPost_unfold]; pcFree
 
 instance pcFreeInst_loopSetupPost
     (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3⟩
+  ⟨pcFree_loopSetupPost⟩
 
 -- ============================================================================
 -- Postcondition bundles for denorm + epilogue paths
@@ -550,13 +549,13 @@ theorem denormDivPost_unfold (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
   delta denormDivPost; rfl
 
 /-- `denormDivPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
+theorem pcFree_denormDivPost {sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word} :
     (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3).pcFree := by
   rw [denormDivPost_unfold]; pcFree
 
 instance pcFreeInst_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
     Assertion.PCFree (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
-  ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
+  ⟨pcFree_denormDivPost⟩
 
 /-- Postcondition for MOD denorm + epilogue (shift ≠ 0).
     Encapsulates antiShift and denormalized u'[0..3]. -/
@@ -590,13 +589,13 @@ theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
   delta denormModPost; rfl
 
 /-- `denormModPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormModPost (sp shift u0 u1 u2 u3 : Word) :
+theorem pcFree_denormModPost {sp shift u0 u1 u2 u3 : Word} :
     (denormModPost sp shift u0 u1 u2 u3).pcFree := by
   rw [denormModPost_unfold]; pcFree
 
 instance pcFreeInst_denormModPost (sp shift u0 u1 u2 u3 : Word) :
     Assertion.PCFree (denormModPost sp shift u0 u1 u2 u3) :=
-  ⟨pcFree_denormModPost sp shift u0 u1 u2 u3⟩
+  ⟨pcFree_denormModPost⟩
 
 -- ============================================================================
 -- Postcondition bundle for normB (PhaseAB + CLZ + PhaseC2 + NormB)
@@ -642,13 +641,13 @@ theorem normBPost_unfold (sp nVal shift b0 b1 b2 b3 : Word) :
   delta normBPost; rfl
 
 /-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
+theorem pcFree_normBPost {sp nVal shift b0 b1 b2 b3 : Word} :
     (normBPost sp nVal shift b0 b1 b2 b3).pcFree := by
   rw [normBPost_unfold]; pcFree
 
 instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
     Assertion.PCFree (normBPost sp nVal shift b0 b1 b2 b3) :=
-  ⟨pcFree_normBPost sp nVal shift b0 b1 b2 b3⟩
+  ⟨pcFree_normBPost⟩
 
 -- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -310,7 +310,7 @@ theorem fullDivN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     `regIs` / `memIs`. Proof goes through `delta` since the bundle is
     `@[irreducible]`; the inner `denormDivPost` is handled by its
     own `Assertion.PCFree` instance. -/
-theorem pcFree_fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem pcFree_fullDivN4MaxSkipPost {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
   delta fullDivN4MaxSkipPost
   pcFree
@@ -318,7 +318,7 @@ theorem pcFree_fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 instance pcFreeInst_fullDivN4MaxSkipPost
     (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3⟩
+  ⟨pcFree_fullDivN4MaxSkipPost⟩
 
 -- ============================================================================
 -- Full n=4 MOD path postcondition (max+skip, shift≠0)
@@ -396,7 +396,7 @@ theorem fullModN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 
 /-- `fullModN4MaxSkipPost` is pc-free. Mirror of
     `pcFree_fullDivN4MaxSkipPost`. -/
-theorem pcFree_fullModN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem pcFree_fullModN4MaxSkipPost {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
   delta fullModN4MaxSkipPost
   pcFree
@@ -404,7 +404,7 @@ theorem pcFree_fullModN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
 instance pcFreeInst_fullModN4MaxSkipPost
     (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3⟩
+  ⟨pcFree_fullModN4MaxSkipPost⟩
 
 /-- Full n=4 DIV path: base → base+1068 (shift ≠ 0, max+skip).
     Composes pre-loop + loop body + denorm + epilogue. -/

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -310,9 +310,9 @@ def divN4StackPre (sp : Word) (a b : EvmWord)
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shiftMem nMem jMem
 
-theorem pcFree_divN4StackPre (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
+theorem pcFree_divN4StackPre {sp : Word} {a b : EvmWord}
+    {v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word} :
     (divN4StackPre sp a b v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem).pcFree := by
   delta divN4StackPre; pcFree
@@ -321,8 +321,7 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (divN4StackPre sp a b v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem) :=
-  ⟨pcFree_divN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
+  ⟨pcFree_divN4StackPre⟩
 
 /-- Named unfold for `divN4StackPre`. Restores access to the atomic
     components once `@[irreducible]` has made `delta` the only path in. -/
@@ -392,9 +391,9 @@ def modN4StackPre (sp : Word) (a b : EvmWord)
   divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     shiftMem nMem jMem
 
-theorem pcFree_modN4StackPre (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
+theorem pcFree_modN4StackPre {sp : Word} {a b : EvmWord}
+    {v5 v6 v7 v10 v11 : Word}
+    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word} :
     (modN4StackPre sp a b v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem).pcFree := by
   delta modN4StackPre; pcFree
@@ -403,8 +402,7 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
     (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (modN4StackPre sp a b v5 v6 v7 v10 v11
       q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem) :=
-  ⟨pcFree_modN4StackPre sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
+  ⟨pcFree_modN4StackPre⟩
 
 /-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
 theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
@@ -493,13 +491,13 @@ theorem divN4MaxSkipStackPost_unfold_atoms (sp : Word) (a b : EvmWord) :
   rw [divN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchOwn_unfold]
 
-theorem pcFree_divN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+theorem pcFree_divN4MaxSkipStackPost {sp : Word} {a b : EvmWord} :
     (divN4MaxSkipStackPost sp a b).pcFree := by
   rw [divN4MaxSkipStackPost_unfold]; pcFree
 
 instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (divN4MaxSkipStackPost sp a b) :=
-  ⟨pcFree_divN4MaxSkipStackPost sp a b⟩
+  ⟨pcFree_divN4MaxSkipStackPost⟩
 
 /-- Weakening bridge from a concrete post state (specific register values +
     concrete scratch cells via `divScratchValues`) to `divN4MaxSkipStackPost`.
@@ -690,13 +688,13 @@ theorem divN4MaxSkipStackPost_unfold_atoms_right (sp : Word) (a b : EvmWord)
     (divN4MaxSkipStackPost sp a b ** Q) := by
   rw [divN4MaxSkipStackPost_unfold_atoms]
 
-theorem pcFree_modN4MaxSkipStackPost (sp : Word) (a b : EvmWord) :
+theorem pcFree_modN4MaxSkipStackPost {sp : Word} {a b : EvmWord} :
     (modN4MaxSkipStackPost sp a b).pcFree := by
   rw [modN4MaxSkipStackPost_unfold]; pcFree
 
 instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (modN4MaxSkipStackPost sp a b) :=
-  ⟨pcFree_modN4MaxSkipStackPost sp a b⟩
+  ⟨pcFree_modN4MaxSkipStackPost⟩
 
 -- ============================================================================
 -- pcFree for DivMod post bundles


### PR DESCRIPTION
## Summary

Continuing the pcFree-implicit cleanup (#811, #812, #814). Flip positional
args on ten DivMod-domain \`pcFree_*\` helpers to implicit. Each has exactly
one caller (its paired \`PCFree\` instance directly below) and that instance
just forwards all the args explicitly, so flipping collapses the instance
bodies to the bare theorem name.

Theorems flipped:
- \`Evm64/DivMod/Compose/Base.lean\`: \`pcFree_divScratchValues\`,
  \`pcFree_divScratchOwn\`, \`pcFree_divScratchOwnCall\`, \`pcFree_loopSetupPost\`,
  \`pcFree_denormDivPost\`, \`pcFree_denormModPost\`, \`pcFree_normBPost\`
- \`Evm64/DivMod/Spec.lean\`: \`pcFree_divN4StackPre\`, \`pcFree_modN4StackPre\`,
  \`pcFree_divN4MaxSkipStackPost\`, \`pcFree_modN4MaxSkipStackPost\`
- \`Evm64/DivMod/Compose/FullPathN4.lean\`: \`pcFree_fullDivN4MaxSkipPost\`,
  \`pcFree_fullModN4MaxSkipPost\`

Net: 30 insertions, 33 deletions.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)