### PR TITLE
refactor(EvmWordArith): flip getLimbN_fromLimbs_{0,1,2,3,match} args to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -137,7 +137,7 @@ theorem ne_zero_iff_getLimbN_or (v : EvmWord) :
 /-- Construct an EvmWord from 4 Words via fromLimbs, with getLimbN round-trip.
     This is the key bridge for folding individual `↦ₘ` assertions back into
     `evmWordIs` in stack-level spec postconditions. -/
-theorem getLimbN_fromLimbs_match (w0 w1 w2 w3 : Word) :
+theorem getLimbN_fromLimbs_match {w0 w1 w2 w3 : Word} :
     let result := fromLimbs fun i : Fin 4 =>
       match i with | 0 => w0 | 1 => w1 | 2 => w2 | 3 => w3
     result.getLimbN 0 = w0 ∧ result.getLimbN 1 = w1 ∧
@@ -152,25 +152,25 @@ theorem getLimbN_fromLimbs_match (w0 w1 w2 w3 : Word) :
 
 /-- Variant: the getLimbN of fromLimbs equals the corresponding input word.
     Useful for rewriting individual limb assertions. -/
-theorem getLimbN_fromLimbs_0 (w0 w1 w2 w3 : Word) :
+theorem getLimbN_fromLimbs_0 {w0 w1 w2 w3 : Word} :
     (fromLimbs fun i : Fin 4 =>
       match i with | 0 => w0 | 1 => w1 | 2 => w2 | 3 => w3).getLimbN 0 = w0 :=
-  (getLimbN_fromLimbs_match w0 w1 w2 w3).1
+  getLimbN_fromLimbs_match.1
 
-theorem getLimbN_fromLimbs_1 (w0 w1 w2 w3 : Word) :
+theorem getLimbN_fromLimbs_1 {w0 w1 w2 w3 : Word} :
     (fromLimbs fun i : Fin 4 =>
       match i with | 0 => w0 | 1 => w1 | 2 => w2 | 3 => w3).getLimbN 1 = w1 :=
-  (getLimbN_fromLimbs_match w0 w1 w2 w3).2.1
+  getLimbN_fromLimbs_match.2.1
 
-theorem getLimbN_fromLimbs_2 (w0 w1 w2 w3 : Word) :
+theorem getLimbN_fromLimbs_2 {w0 w1 w2 w3 : Word} :
     (fromLimbs fun i : Fin 4 =>
       match i with | 0 => w0 | 1 => w1 | 2 => w2 | 3 => w3).getLimbN 2 = w2 :=
-  (getLimbN_fromLimbs_match w0 w1 w2 w3).2.2.1
+  getLimbN_fromLimbs_match.2.2.1
 
-theorem getLimbN_fromLimbs_3 (w0 w1 w2 w3 : Word) :
+theorem getLimbN_fromLimbs_3 {w0 w1 w2 w3 : Word} :
     (fromLimbs fun i : Fin 4 =>
       match i with | 0 => w0 | 1 => w1 | 2 => w2 | 3 => w3).getLimbN 3 = w3 :=
-  (getLimbN_fromLimbs_match w0 w1 w2 w3).2.2.2
+  getLimbN_fromLimbs_match.2.2.2
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -309,14 +309,14 @@ theorem n4_max_double_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   have ⟨hq, hr⟩ := n4_max_double_addback_correct a0 a1 a2 a3 b0 b1 b2 b3
     hb3nz hc3_one hcarry1_zero hcarry2_one
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · rw [← hq]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_3 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_0
+  · rw [← hq]; exact getLimbN_fromLimbs_1
+  · rw [← hq]; exact getLimbN_fromLimbs_2
+  · rw [← hq]; exact getLimbN_fromLimbs_3
+  · rw [← hr]; exact getLimbN_fromLimbs_0
+  · rw [← hr]; exact getLimbN_fromLimbs_1
+  · rw [← hr]; exact getLimbN_fromLimbs_2
+  · rw [← hr]; exact getLimbN_fromLimbs_3
 
 /-- n=4 max+double-addback path, EvmWord-level statement. Consumer form for
     stack specs: takes `a b : EvmWord`, works off `getLimbN`. Parallels

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -585,14 +585,14 @@ theorem n4_max_skip_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   intro ms a b
   have ⟨hq, hr⟩ := n4_max_skip_correct a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hc3_zero
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · rw [← hq]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_3 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_0
+  · rw [← hq]; exact getLimbN_fromLimbs_1
+  · rw [← hq]; exact getLimbN_fromLimbs_2
+  · rw [← hq]; exact getLimbN_fromLimbs_3
+  · rw [← hr]; exact getLimbN_fromLimbs_0
+  · rw [← hr]; exact getLimbN_fromLimbs_1
+  · rw [← hr]; exact getLimbN_fromLimbs_2
+  · rw [← hr]; exact getLimbN_fromLimbs_3
 
 /-- n=4 max+addback path: per-limb quotient/remainder equalities. Direct
     consumer-facing form of `n4_max_addback_correct` — the corrected quotient
@@ -624,14 +624,14 @@ theorem n4_max_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   intro ms ab qHat' a b
   have ⟨hq, hr⟩ := n4_max_addback_correct a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hc3_one hcarry_one
   refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · rw [← hq]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hq]; exact getLimbN_fromLimbs_3 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+  · rw [← hq]; exact getLimbN_fromLimbs_0
+  · rw [← hq]; exact getLimbN_fromLimbs_1
+  · rw [← hq]; exact getLimbN_fromLimbs_2
+  · rw [← hq]; exact getLimbN_fromLimbs_3
+  · rw [← hr]; exact getLimbN_fromLimbs_0
+  · rw [← hr]; exact getLimbN_fromLimbs_1
+  · rw [← hr]; exact getLimbN_fromLimbs_2
+  · rw [← hr]; exact getLimbN_fromLimbs_3
 
 -- ============================================================================
 -- EvmWord-level n=4 max bridges: state the skip/addback correctness directly

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -223,10 +223,10 @@ theorem denorm_limbN_eq_mod_max_skip
     hbnz hb3nz s hs0 hs hb3_bound hc3_un_zero hc3_n_le_u_top
   simp only [] at hr
   refine ⟨?_, ?_, ?_, ?_⟩
-  · rw [← hr]; exact getLimbN_fromLimbs_0 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_1 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_2 _ _ _ _
-  · rw [← hr]; exact getLimbN_fromLimbs_3 _ _ _ _
+  · rw [← hr]; exact getLimbN_fromLimbs_0
+  · rw [← hr]; exact getLimbN_fromLimbs_1
+  · rw [← hr]; exact getLimbN_fromLimbs_2
+  · rw [← hr]; exact getLimbN_fromLimbs_3
 
 /-- EvmWord-level form of `denorm_limbN_eq_mod_max_skip`. Mirrors the
     structure of `n4_max_skip_div_mod_getLimbN`: applies the Word-level


### PR DESCRIPTION
## Summary

Five \`fromLimbs\`/\`getLimbN\` round-trip lemmas in
\`Evm64/EvmWordArith/DivLimbBridge.lean\` had explicit positional
\`(w0 w1 w2 w3 : Word)\` arguments. All 28 call sites passed them as
\`_ _ _ _\` (e.g. \`exact getLimbN_fromLimbs_k _ _ _ _\` after a
\`rw [← hq]\` / \`rw [← hr]\`). Flip to implicit so callers drop the
4-underscore tail.

Internal callers in the four \`getLimbN_fromLimbs_{0,1,2,3}\` bodies also
drop the explicit args on their use of \`getLimbN_fromLimbs_match\`.

Files touched:
- \`Evm64/EvmWordArith/DivLimbBridge.lean\` (theorem signatures)
- \`Evm64/EvmWordArith/DivN4Overestimate.lean\` (16 call sites)
- \`Evm64/EvmWordArith/DivN4DoubleAddback.lean\` (8 call sites)
- \`Evm64/EvmWordArith/ModBridgeAssemble.lean\` (4 call sites)

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)