### PR TITLE
refactor(SepLogic): flip CodeReq.ofProg_disjoint_range positional args to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -41,7 +41,7 @@ theorem divK_modEpilogue_len : (divK_mod_epilogue 24).length = 10 := by decide
     Closes the disjointness goal using block length lemmas + bv_omega. -/
 macro "skipBlock" : tactic =>
   `(tactic| apply CodeReq.mono_union_right
-      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+      (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
         simp only [divK_phaseA_len, divK_phaseB_len, divK_clz_len, divK_phaseC2_len,
           divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
           divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len,

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -34,7 +34,7 @@ private theorem sub_modCode_of_phaseB_left (base : Word) (rest : CodeReq) :
       ((CodeReq.ofProg base (divK_phaseA 1020)).union
         ((CodeReq.ofProg (base + phaseBOff) divK_phaseB).union rest)) a = some i :=
   CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
+    (CodeReq.ofProg_disjoint_range
       (fun k1 k2 hk1 hk2 => by
         simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
     (CodeReq.union_mono_left _ _)

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -33,7 +33,7 @@ private theorem sub_divCode_of_phaseB_left (base : Word) (rest : CodeReq) :
       ((CodeReq.ofProg base (divK_phaseA 1020)).union
         ((CodeReq.ofProg (base + phaseBOff) divK_phaseB).union rest)) a = some i :=
   CodeReq.mono_union_right
-    (CodeReq.ofProg_disjoint_range _ _ _ _
+    (CodeReq.ofProg_disjoint_range
       (fun k1 k2 hk1 hk2 => by
         simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
     (CodeReq.union_mono_left _ _)

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -33,7 +33,7 @@ private theorem shr_body_0_prog_len : (shr_body_0_prog 24).length = 25 := by dec
 /-- Skip one ofProg block in a right-nested union via range disjointness. -/
 local macro "skipBlock" : tactic =>
   `(tactic| apply CodeReq.mono_union_right
-      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+      (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
         simp only [shr_phase_a_len, shr_phase_b_len, shr_phase_c_len,
           shr_body_3_prog_len, shr_body_2_prog_len, shr_body_1_prog_len,
           shr_body_0_prog_len, shr_zero_path_len] at hk1 hk2

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -39,7 +39,7 @@ private theorem sar_sign_fill_path_len : sar_sign_fill_path.length = 7 := by dec
 /-- Skip one ofProg block in a right-nested union via range disjointness. -/
 local macro "skipBlock" : tactic =>
   `(tactic| apply CodeReq.mono_union_right
-      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+      (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
         simp only [sar_phase_a_len, shr_phase_b_len, sar_phase_c_len,
           sar_body_3_prog_len, sar_body_2_prog_len, sar_body_1_prog_len,
           sar_body_0_prog_len, sar_sign_fill_path_len] at hk1 hk2

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -36,7 +36,7 @@ private theorem shl_body_0_prog_len : (shl_body_0_prog 24).length = 25 := by dec
 /-- Skip one ofProg block in a right-nested union via range disjointness. -/
 local macro "skipBlock" : tactic =>
   `(tactic| apply CodeReq.mono_union_right
-      (CodeReq.ofProg_disjoint_range _ _ _ _ (fun k1 k2 hk1 hk2 => by
+      (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
         simp only [shr_phase_a_len, shr_phase_b_len, shr_phase_c_len,
           shl_body_3_prog_len, shl_body_2_prog_len, shl_body_1_prog_len,
           shl_body_0_prog_len, shr_zero_path_len] at hk1 hk2

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2403,8 +2403,8 @@ theorem CodeReq.ofProg_some_range (base : Word) (prog : List Instr) (a : Word) (
 
 /-- Two ofProg blocks at non-overlapping address ranges are disjoint.
     Only requires the address-inequality predicate, not list expansion. -/
-theorem CodeReq.ofProg_disjoint_range (base1 : Word) (prog1 : List Instr)
-    (base2 : Word) (prog2 : List Instr)
+theorem CodeReq.ofProg_disjoint_range {base1 : Word} {prog1 : List Instr}
+    {base2 : Word} {prog2 : List Instr}
     (h : ∀ k1 k2, k1 < prog1.length → k2 < prog2.length →
       base1 + BitVec.ofNat 64 (4 * k1) ≠ base2 + BitVec.ofNat 64 (4 * k2)) :
     CodeReq.Disjoint (CodeReq.ofProg base1 prog1) (CodeReq.ofProg base2 prog2) := by
@@ -2429,7 +2429,7 @@ theorem CodeReq.ofProg_disjoint_range_len (base1 : Word) (prog1 : List Instr) (n
     (h : ∀ k1 k2, k1 < n1 → k2 < n2 →
       base1 + BitVec.ofNat 64 (4 * k1) ≠ base2 + BitVec.ofNat 64 (4 * k2)) :
     CodeReq.Disjoint (CodeReq.ofProg base1 prog1) (CodeReq.ofProg base2 prog2) :=
-  CodeReq.ofProg_disjoint_range base1 prog1 base2 prog2
+  CodeReq.ofProg_disjoint_range
     (fun k1 k2 hk1 hk2 => h k1 k2 (hlen1 ▸ hk1) (hlen2 ▸ hk2))
 
 -- ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

\`CodeReq.ofProg_disjoint_range\` had \`base1 prog1 base2 prog2\` as explicit
positional arguments. Every caller passes them as \`_ _ _ _\` since they
unify from the goal's \`Disjoint (ofProg base1 prog1) (ofProg base2 prog2)\`
shape. Flip to implicit so callers drop the underscore tail.

Internal caller \`ofProg_disjoint_range_len\` body simplified.

5 external call sites simplified across:
- \`Evm64/Shift/{ShlCompose,Compose,SarCompose}.lean\` (skipBlock macros)
- \`Evm64/DivMod/Compose/{Base,PhaseAB,ModPhaseB}.lean\`

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)