### PR TITLE
refactor(SepLogic): flip holdsFor_regIs (r v s) args to implicit

### DIFF
--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -81,9 +81,9 @@ theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   have hfetch : s.code s.pc = some (.BEQ rs1 rs2 offset) :=
     hcr s.pc (.BEQ rs1 rs2 offset) (CodeReq.singleton_get s.pc (.BEQ rs1 rs2 offset))
   have hrs1 : s.getReg rs1 = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
@@ -106,9 +106,9 @@ theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   have hfetch : s.code s.pc = some (.BEQ rs1 rs2 offset) :=
     hcr s.pc (.BEQ rs1 rs2 offset) (CodeReq.singleton_get s.pc (.BEQ rs1 rs2 offset))
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + 4) := by

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -88,7 +88,7 @@ theorem generic_lbu_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LBU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LBU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -133,7 +133,7 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LB rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LB rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -175,10 +175,10 @@ theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
   have hfetch : s.code s.pc = some (.SB rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SB rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v_data :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hmem : s.getMem dwordAddr = wordOld :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -241,7 +241,7 @@ theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
   have hfetch : s.code s.pc = some (.JALR .x0 rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.JALR .x0 rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hexec : execInstrBr s (.JALR .x0 rs1 offset) = s.setPC ((v + signExtend12 offset) &&& ~~~1) := by
     rw [execInstrBr_jalr_x0, hrs1]
   have hstep : step s = some (execInstrBr s (.JALR .x0 rs1 offset)) :=
@@ -298,9 +298,9 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
   -- Extract register values from the aAnd part
   have haAnd := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).1
+    holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).1
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
+    holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
   -- Execute the BNE instruction
   have hstep' : step s = some (execInstrBr s (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)))) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -383,9 +383,9 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
   -- Extract register values from the aAnd part
   have haAnd := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).1
+    holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).1
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
+    holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
   -- Execute BNE
   have hstep' : step s = some (execInstrBr s (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)))) :=
     step_non_ecall_non_mem s _ hfetch_bne (by nofun) (by nofun) (by rfl)

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -46,7 +46,7 @@ theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : W
   have hfetch : s.code s.pc = some instr :=
     (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
   have hrd : s.getReg rd = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   -- Compute next state
   have hexec' := hexec s rfl hrd
   have hstep' := hstep s hfetch
@@ -80,10 +80,10 @@ theorem generic_2reg_spec (instr : Instr) (rs rd : Reg)
   have hfetch : s.code s.pc = some instr :=
     (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
   have hrs : s.getReg rs = v_src :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrd : s.getReg rd = vOld :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hexec' := hexec s rfl hrs hrd
   have hstep' := hstep s hfetch
@@ -118,10 +118,10 @@ theorem generic_2reg_rd_eq_rs1_spec (instr : Instr) (rd rs2 : Reg)
   have hfetch : s.code s.pc = some instr :=
     (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
   have hrd : s.getReg rd = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hexec' := hexec s rfl hrd hrs2
   have hstep' := hstep s hfetch
@@ -157,10 +157,10 @@ theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
   have hfetch : s.code s.pc = some instr :=
     (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hexec' := hexec s rfl hrs1 hrs2
   have hstep' := hstep s hfetch
@@ -223,10 +223,10 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
   have hfetch : s.code s.pc = some (.BNE rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BNE rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BNE rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -274,10 +274,10 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
   have hfetch : s.code s.pc = some (.BEQ rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BEQ rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -329,10 +329,10 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
   have hfetch : s.code s.pc = some (.BLTU rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BLTU rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BLTU rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -384,10 +384,10 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
   have hfetch : s.code s.pc = some (.BGE rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BGE rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BGE rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -439,10 +439,10 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
   have hfetch : s.code s.pc = some (.BLT rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BLT rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BLT rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -494,10 +494,10 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
   have hfetch : s.code s.pc = some (.BGEU rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BGEU rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v2 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BGEU rs1 rs2 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -567,7 +567,7 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 vOld : Word) (offset : BitVec 12) (
   have hfetch : s.code s.pc = some (.JALR rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.JALR rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.JALR rd rs1 offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
@@ -602,7 +602,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr vOld memVal : Word)
   have hfetch : s.code s.pc = some (.LD rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LD rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem_piece := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
     (holdsFor_sepConj_elim_left hPR))
@@ -647,10 +647,10 @@ theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data memOld : Word)
   have hfetch : s.code s.pc = some (.SD rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SD rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v_data :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess (holdsFor_sepConj_elim_right
@@ -690,7 +690,7 @@ theorem generic_sd_x0_spec (rs1 : Reg) (v_addr memOld : Word)
   have hfetch : s.code s.pc = some (.SD rs1 .x0 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SD rs1 .x0 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess (holdsFor_sepConj_elim_right

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -75,7 +75,7 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LHU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LHU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -119,7 +119,7 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LH rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LH rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -161,10 +161,10 @@ theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
   have hfetch : s.code s.pc = some (.SH rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SH rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v_data :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hmem : s.getMem dwordAddr = wordOld :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -241,7 +241,7 @@ theorem ld_spec_same (rd : Reg) (v_addr memVal : Word) (offset : BitVec 12) (bas
   have hfetch : s.code s.pc = some (.LD rd rd offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LD rd rd offset) s).mp hcr
   have hrd : s.getReg rd = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hmem_piece := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
   have hmem : s.getMem (v_addr + signExtend12 offset) = memVal :=
     holdsFor_memIs_getMem hmem_piece
@@ -278,7 +278,7 @@ theorem sd_spec_same (rs : Reg) (v : Word) (memOld : Word) (offset : BitVec 12) 
   have hfetch : s.code s.pc = some (.SD rs rs offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SD rs rs offset) s).mp hcr
   have hrs : s.getReg rs = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hvalid : isValidDwordAccess (v + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
@@ -317,7 +317,7 @@ theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   have hfetch : s.code s.pc = some (.BEQ rs rs offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BEQ rs rs offset) s).mp hcr
   have hrs : s.getReg rs = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BEQ rs rs offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs rs offset) = s.setPC (s.pc + signExtend13 offset) := by
@@ -345,7 +345,7 @@ theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   have hfetch : s.code s.pc = some (.BNE rs rs offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.BNE rs rs offset) s).mp hcr
   have hrs : s.getReg rs = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BNE rs rs offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BNE rs rs offset) = s.setPC (s.pc + 4) := by
@@ -397,7 +397,7 @@ theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Word)
   have hfetch : s.code s.pc = some (.JALR rd rd offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.JALR rd rd offset) s).mp hcr
   have hrd : s.getReg rd = v :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.JALR rd rd offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.JALR rd rd offset) =

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -401,7 +401,7 @@ def Assertion.pcFree (P : Assertion) : Prop := ∀ h, P h → h.pc = none
 -- ============================================================================
 
 @[simp]
-theorem holdsFor_regIs (r : Reg) (v : Word) (s : MachineState) :
+theorem holdsFor_regIs {r : Reg} {v : Word} {s : MachineState} :
     (regIs r v).holdsFor s ↔ s.getReg r = v := by
   simp only [Assertion.holdsFor, regIs]
   constructor

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -354,7 +354,7 @@ namespace EvmAsm.Rv64
   have hfetch : s.code s.pc = some .ECALL :=
     (holdsFor_instrAt _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hx5 : s.getReg .x5 = (0 : Word) :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)))
   refine ⟨0, s, rfl, ?_, hPR⟩
   simp only [isHalted, step_ecall_halt s hfetch hx5, Option.isNone]

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -60,7 +60,7 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LWU rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LWU rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -104,7 +104,7 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr vOld : Word)
   have hfetch : s.code s.pc = some (.LW rd rs1 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.LW rd rs1 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hmem : s.getMem dwordAddr = wordVal :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
@@ -146,10 +146,10 @@ theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
   have hfetch : s.code s.pc = some (.SW rs1 rs2 offset) :=
     (CodeReq.singleton_satisfiedBy s.pc (.SW rs1 rs2 offset) s).mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hrs2 : s.getReg rs2 = v_data :=
-    (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hmem : s.getMem dwordAddr = wordOld :=
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right


### PR DESCRIPTION
## Summary

\`holdsFor_regIs\` had \`(r : Reg) (v : Word) (s : MachineState)\` as explicit
positional arguments. Every caller wrote \`(holdsFor_regIs _ _ s).mp …\` —
all three are inferable from the consumer's \`hPR\`/sepConj-elim chain. Flip
to all-implicit so callers collapse to \`holdsFor_regIs.mp …\`.

50+ call sites simplified across:
- \`Rv64/{ByteOps,ControlFlow,GenericSpecs,HalfwordOps,InstructionSpecs,SyscallSpecs,WordOps}.lean\`
- \`Evm64/Compare/LimbSpec.lean\`

\`@[simp]\` attribute preserved — simp uses the LHS pattern, so the
implicit/explicit distinction doesn't affect matching.

Net: 52 insertions, 52 deletions (same line count, just \`(holdsFor_regIs _ _ s)\` → \`holdsFor_regIs\` paren removal).

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)