### PR TITLE
refactor(SepLogic): flip holdsFor_instrAt (a i s) args to implicit

### DIFF
--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -294,7 +294,7 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
   intro R hR s _hcr hPR hpc; subst hpc
   -- Extract instrAt from the precondition
   have hfetch : s.code s.pc = some (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) :=
-    (holdsFor_instrAt _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_instrAt.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   -- Extract register values from the aAnd part
   have haAnd := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
   have hrs1 : s.getReg rs1 = v1 :=
@@ -379,7 +379,7 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
   -- hPR : ((bne ** (jal ** aAnd)) ** R).holdsFor s
   -- Extract instrAt facts
   have hfetch_bne : s.code s.pc = some (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) :=
-    (holdsFor_instrAt _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_instrAt.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   -- Extract register values from the aAnd part
   have haAnd := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hrs1 : s.getReg rs1 = v1 :=

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1961,7 +1961,7 @@ end PartialState
 -- ============================================================================
 
 @[simp]
-theorem holdsFor_instrAt (a : Word) (i : Instr) (s : MachineState) :
+theorem holdsFor_instrAt {a : Word} {i : Instr} {s : MachineState} :
     (instrAt a i).holdsFor s ↔ s.code a = some i := by
   simp only [Assertion.holdsFor, instrAt]
   constructor
@@ -2605,7 +2605,7 @@ theorem CodeReq.singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState) 
 /-- An instrAt fact gives CodeReq.singleton satisfaction. -/
 theorem instrAt_singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState)
     (h : (instrAt a i).holdsFor s) : (CodeReq.singleton a i).SatisfiedBy s :=
-  (CodeReq.singleton_satisfiedBy a i s).mpr ((holdsFor_instrAt a i s).mp h)
+  (CodeReq.singleton_satisfiedBy a i s).mpr (holdsFor_instrAt.mp h)
 
 /-- Step preserves code (single step). -/
 theorem step_code_preserved (s s' : MachineState) (h : step s = some s') :

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -352,7 +352,7 @@ namespace EvmAsm.Rv64
       ((addr ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ exitCode)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some .ECALL :=
-    (holdsFor_instrAt _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
+    holdsFor_instrAt.mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hx5 : s.getReg .x5 = (0 : Word) :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)))


### PR DESCRIPTION
## Summary

Mirror of #819 for the code-fetch helper. \`holdsFor_instrAt\` had
\`(a : Word) (i : Instr) (s : MachineState)\` as explicit positional
arguments; every caller wrote \`(holdsFor_instrAt _ _ s).mp …\` or
\`(holdsFor_instrAt a i s).mp …\` where all three are inferable from
the consumer's \`hPR\`/sepConj-elim chain.

Flip to all-implicit so callers collapse to \`holdsFor_instrAt.mp …\`.

3 external + 1 internal call site simplified across:
- \`Rv64/SepLogic.lean\` (\`instrAt_singleton_satisfiedBy\` body)
- \`Rv64/SyscallSpecs.lean\`
- \`Rv64/ControlFlow.lean\` (2 sites)

\`@[simp]\` attribute preserved.

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)