### PR TITLE
refactor(SepLogic): flip holdsFor_pcFree_setPC s,v args to implicit

### DIFF
--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -92,7 +92,7 @@ theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · exact holdsFor_pcFree_setPC
-      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) _ _ hPR
+      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) hPR
 
 /-- BEQ when values are not equal: never taken (fall through to PC + 4).
     BEQ only modifies PC; all pcFree assertions are preserved. -/
@@ -117,7 +117,7 @@ theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · exact holdsFor_pcFree_setPC
-      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) _ _ hPR
+      (pcFree_sepConj (pcFree_sepConj (pcFree_regIs _ _) (pcFree_regIs _ _)) hR) hPR
 
 -- ============================================================================
 -- Per-limb Specs: SLT (MSB load + signed comparison)

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -110,7 +110,7 @@ theorem generic_lbu_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## LB generic spec
 
@@ -155,7 +155,7 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## SB generic spec
 
@@ -199,6 +199,6 @@ theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
       (v' := replaceByte wordOld (byteOffset (v_addr + signExtend12 offset)) (v_data.truncate 8)) h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     have h5 := holdsFor_sepConj_pull_second.mpr h4
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h5
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h5
 
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -249,7 +249,7 @@ theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
   refine ⟨1, s.setPC ((v + signExtend12 offset) &&& ~~~1), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep, hexec]; rfl
-  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ hPR
+  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hPR
 
 -- ============================================================================
 -- CPS specification for if_eq
@@ -317,7 +317,7 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
     · show (step s).bind (stepN 0) = some _
       rw [hstep', hexec']; rfl
     · -- Preserve assertions through setPC and add ⌜v1 = v2⌝
-      have hPR' := holdsFor_pcFree_setPC hpcfree s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpcfree (v := s.pc + 4) hPR
       -- Strengthen the aAnd part: add ⌜v1 = v2⌝ to inner sepConj
       obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨ha, hb, hda, hua, hinstr, haand⟩, hR2⟩ := hPR'
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -339,8 +339,8 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
     · show (step s).bind (stepN 0) = some _
       rw [hstep', hexec']; rfl
     · -- Preserve assertions through setPC and add ⌜v1 ≠ v2⌝
-      have hPR' := holdsFor_pcFree_setPC hpcfree s
-        (s.pc + signExtend13 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) hPR
+      have hPR' := holdsFor_pcFree_setPC hpcfree
+        (v := s.pc + signExtend13 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, ⟨ha, hb, hda, hua, hinstr, haand⟩, hR2⟩ := hPR'
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨ha, hb, hda, hua, hinstr, aAnd_mono_right (aAnd_mono_right (aAnd_pure_right_of_true heq)) hb haand⟩, hR2⟩
@@ -415,7 +415,7 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
     have hexec' : execInstrBr s (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) = s.setPC (s.pc + 4) := by
       simp only [execInstrBr, hrs1, hrs2, heq, bne_iff_ne, ne_eq, not_true_eq_false, ite_false]
     -- After BNE: all pcFree assertions preserved
-    have hPR1 := holdsFor_pcFree_setPC hpcfree_all s (s.pc + 4) hPR
+    have hPR1 := holdsFor_pcFree_setPC hpcfree_all (v := s.pc + 4) hPR
     -- Rearrange to (aand ** (bne ** jal ** R)), then strengthen aand with ⌜v1 = v2⌝
     have hPR1' : ((P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2) ⋒ ⌜v1 = v2⌝) **
         ((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
@@ -489,8 +489,8 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
         s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length) + 4 := by
       rw [hse]; bv_omega
     -- After BNE
-    have hPR1 := holdsFor_pcFree_setPC hpcfree_all s
-      (s.pc + signExtend13 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) hPR
+    have hPR1 := holdsFor_pcFree_setPC hpcfree_all
+      (v := s.pc + signExtend13 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) hPR
     -- Rearrange to (aand_ne ** (bne ** jal ** R))
     have hPR1' : ((P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2) ⋒ ⌜v1 ≠ v2⌝) **
         ((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -57,7 +57,7 @@ theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : W
     rw [hstep', hexec']; rfl
   · -- Postcondition
     have h1 := holdsFor_sepConj_regIs_setReg (v' := result) hrd_ne_x0 hPR
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h1
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h1
 
 -- ============================================================================
 -- Group 2: Two registers, rd ≠ rs1 (rs1 preserved, rd updated)
@@ -95,7 +95,7 @@ theorem generic_2reg_spec (instr : Instr) (rs rd : Reg)
     -- h1 : (rd ** (rs ** R))
     have h2 := holdsFor_sepConj_regIs_setReg (v' := result) hrd_ne_x0 h1
     have h3 := holdsFor_sepConj_pull_second.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 -- ============================================================================
 -- Group 3: Two registers, rd = rs1 (rd updated, rs2 preserved)
@@ -134,7 +134,7 @@ theorem generic_2reg_rd_eq_rs1_spec (instr : Instr) (rd rs2 : Reg)
     have h2 := holdsFor_sepConj_regIs_setReg (v' := result) hrd_ne_x0 h1a
     -- Rearrange back: (rd' ** (rs2 ** R)) → ((rd' ** rs2) ** R)
     have h3 := holdsFor_sepConj_assoc.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 -- ============================================================================
 -- Group 4: Three distinct registers (rs1, rs2 preserved, rd updated)
@@ -174,7 +174,7 @@ theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
     have h3 := holdsFor_sepConj_regIs_setReg (v' := result) hrd_ne_x0 h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     have h5 := holdsFor_sepConj_pull_second.mpr h4
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h5
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h5
 
 -- ============================================================================
 -- Group 5: NOP-like (just PC advance, no register/memory changes)
@@ -197,7 +197,7 @@ theorem generic_nop_spec (instr : Instr) (base exit_ : Word)
   refine ⟨1, s.setPC exit_, ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
-  · exact holdsFor_pcFree_setPC (pcFree_sepConj pcFree_emp hR) _ _ hPR
+  · exact holdsFor_pcFree_setPC (pcFree_sepConj pcFree_emp hR) hPR
 
 -- NOTE: LW/SW generic specs omitted for RV64.
 -- In RV64, LW uses getWord32 + signExtend and SW uses setWord32 + truncate,
@@ -241,7 +241,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
     · -- Add pure assertion ⌜v1 = v2⌝
       have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -255,7 +255,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -290,7 +290,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -304,7 +304,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -345,7 +345,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -359,7 +359,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -400,7 +400,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -414,7 +414,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -455,7 +455,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -469,7 +469,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -510,7 +510,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + 4) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + 4) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -524,7 +524,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       rw [hstep', hexec']; rfl
     · have hpc_free : (((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2)) ** R).pcFree :=
         pcFree_sepConj (by pcFree) hR
-      have hPR' := holdsFor_pcFree_setPC hpc_free s (s.pc + signExtend13 offset) hPR
+      have hPR' := holdsFor_pcFree_setPC hpc_free (v := s.pc + signExtend13 offset) hPR
       obtain ⟨hp, hcompat, h1, h2, hd, hu, hP1, hR2⟩ := hPR'
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
@@ -553,7 +553,7 @@ theorem generic_jal_spec (rd : Reg) (vOld : Word) (offset : BitVec 21) (base : W
   · show (step s).bind (stepN 0) = some _
     rw [hstep']; rfl
   · have h1 := holdsFor_sepConj_regIs_setReg (v' := s.pc + 4) hrd_ne_x0 hPR
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h1
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h1
 
 /-- Generic spec for JALR: rd := PC + 4, PC := (rs1 + sext(offset)) & ~1.
     Pre:  (rs1 ↦ᵣ v1) ** (rd ↦ᵣ vOld)
@@ -582,7 +582,7 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 vOld : Word) (offset : BitVec 12) (
     -- h1 : (rd ** (rs1 ** R))
     have h2 := holdsFor_sepConj_regIs_setReg (v' := s.pc + 4) hrd_ne_x0 h1
     have h3 := holdsFor_sepConj_pull_second.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 -- ============================================================================
 -- Group 11: LD (doubleword memory load)
@@ -628,7 +628,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr vOld memVal : Word)
     have h2 := holdsFor_sepConj_regIs_setReg (v' := memVal) hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 -- ============================================================================
 -- Group 12: SD (doubleword memory store)
@@ -672,7 +672,7 @@ theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data memOld : Word)
     have h3 := holdsFor_sepConj_memIs_setMem (v' := v_data) h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     have h5 := holdsFor_sepConj_pull_second.mpr h4
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h5
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h5
 
 -- ============================================================================
 -- Group 8: SD with x0 (stores 0, no x0 register in pre/post)
@@ -706,6 +706,6 @@ theorem generic_sd_x0_spec (rs1 : Reg) (v_addr memOld : Word)
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h2 := holdsFor_sepConj_memIs_setMem (v' := (0 : Word)) h1
     have h3 := holdsFor_sepConj_pull_second.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -97,7 +97,7 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## LH generic spec
 
@@ -141,7 +141,7 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## SH generic spec
 
@@ -185,6 +185,6 @@ theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
       (v' := replaceHalfword wordOld ((byteOffset (v_addr + signExtend12 offset)) / 2) (v_data.truncate 16)) h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     have h5 := holdsFor_sepConj_pull_second.mpr h4
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h5
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h5
 
 end EvmAsm.Rv64

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -260,7 +260,7 @@ theorem ld_spec_same (rd : Reg) (v_addr memVal : Word) (offset : BitVec 12) (bas
     have h2 := holdsFor_sepConj_regIs_setReg (v' := memVal) hrd_ne_x0 h1
     -- Reassociate: rd' ** (mem ** R) → (rd' ** mem) ** R
     have h3 := holdsFor_sepConj_assoc.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 /-- SD rs2, offset(rs1): mem[rs1 + sext(offset)] := rs2 (registers distinct) -/
 theorem sd_spec (rs1 rs2 : Reg) (v_addr v_data memOld : Word) (offset : BitVec 12) (base : Word) :
@@ -293,7 +293,7 @@ theorem sd_spec_same (rs : Reg) (v : Word) (memOld : Word) (offset : BitVec 12) 
   · have h1 := holdsFor_sepConj_pull_second.mp hPR
     have h2 := holdsFor_sepConj_memIs_setMem (v' := v) h1
     have h3 := holdsFor_sepConj_pull_second.mpr h2
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h3
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h3
 
 -- ============================================================================
 -- Branch Instructions (use cpsBranch for two exits)
@@ -325,7 +325,7 @@ theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   refine ⟨1, s.setPC (s.pc + signExtend13 offset), ?_, Or.inl ⟨rfl, ?_⟩⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
-  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ hPR
+  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hPR
 
 /-- BNE rs1, rs2, offset: branch if rs1 ≠ rs2 (registers distinct) -/
 theorem bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
@@ -353,7 +353,7 @@ theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   refine ⟨1, s.setPC (s.pc + 4), ?_, Or.inr ⟨rfl, ?_⟩⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
-  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ hPR
+  · exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hPR
 
 -- ============================================================================
 -- Branch Instructions: BGEU
@@ -407,7 +407,7 @@ theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Word)
   · show (step s).bind (stepN 0) = some _
     rw [hstep', hexec']; rfl
   · have h1 := holdsFor_sepConj_regIs_setReg (v' := s.pc + 4) hrd_ne_x0 hPR
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h1
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h1
 
 -- ============================================================================
 -- Pseudo Instructions

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1501,7 +1501,7 @@ theorem holdsFor_setReg {P : Assertion} {r : Reg} {v : Word} {s : MachineState}
   obtain ⟨h, hcompat, hp⟩ := hP
   exact ⟨h, PartialState.CompatibleWith_setReg hcompat (hP_no_r h hp), hp⟩
 
-theorem holdsFor_pcFree_setPC {P : Assertion} (hP : P.pcFree) (s : MachineState) (v : Word) :
+theorem holdsFor_pcFree_setPC {P : Assertion} (hP : P.pcFree) {s : MachineState} {v : Word} :
     P.holdsFor s → P.holdsFor (s.setPC v) := by
   intro ⟨h, hcompat, hp⟩
   have hpc_none := hP h hp

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -82,7 +82,7 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## LW generic spec
 
@@ -126,7 +126,7 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr vOld : Word)
       hrd_ne_x0 h1a
     have h3 := holdsFor_sepConj_assoc.mpr h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h4
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h4
 
 /-! ## SW generic spec
 
@@ -170,6 +170,6 @@ theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
       (v' := replaceWord32 wordOld ((byteOffset (v_addr + signExtend12 offset)) / 4) (v_data.truncate 32)) h2
     have h4 := holdsFor_sepConj_pull_second.mpr h3
     have h5 := holdsFor_sepConj_pull_second.mpr h4
-    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) _ _ h5
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) h5
 
 end EvmAsm.Rv64


### PR DESCRIPTION
## Summary

\`holdsFor_pcFree_setPC\` had \`{P} (hP) (s) (v)\` — the \`s\` and \`v\` arguments
were explicit but every external caller passed them as \`_ _\` or as redundant
concretes inferable from \`hPR\` and the goal type. Flip both to implicit so
callers can drop the underscore tail; the few sites that need to pin \`v\`
explicitly use the \`(v := …)\` named-arg style.

40+ call sites simplified across:
- \`Rv64/{ByteOps,HalfwordOps,WordOps,InstructionSpecs,GenericSpecs,ControlFlow}.lean\`
- \`Evm64/Compare/LimbSpec.lean\`

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)