### PR TITLE
refactor(Execution): flip step_l*/step_s* memory-helper args to implicit

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -94,7 +94,7 @@ theorem generic_lbu_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LBU rd rs1 offset)) :=
-    step_lbu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lbu s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LBU rd rs1 offset) =
       (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getByte_eq]; rw [halign, hmem]
@@ -139,7 +139,7 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LB rd rs1 offset)) :=
-    step_lb s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lb s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LB rd rs1 offset) =
       (s.setReg rd ((extractByte wordVal (byteOffset (v_addr + signExtend12 offset))).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getByte_eq]; rw [halign, hmem]
@@ -184,7 +184,7 @@ theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.SB rs1 rs2 offset)) :=
-    step_sb s rs1 rs2 offset hfetch (hrs1 ▸ hvalid)
+    step_sb s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.SB rs1 rs2 offset) =
       (s.setMem dwordAddr (replaceByte wordOld (byteOffset (v_addr + signExtend12 offset)) (v_data.truncate 8))).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, hrs2, setByte_eq]; rw [halign, hmem]

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -429,7 +429,7 @@ def step (s : MachineState) : Option MachineState :=
   unfold step; rw [hfetch]; cases i <;> simp_all [Instr.isMemAccess]
 
 /-- step for LD with valid dword memory access. -/
-theorem step_ld (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_ld (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LD rd rs1 offset))
     (hvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LD rd rs1 offset)) := by
@@ -437,7 +437,7 @@ theorem step_ld (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SD with valid dword memory access. -/
-theorem step_sd (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sd (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SD rs1 rs2 offset))
     (hvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.SD rs1 rs2 offset)) := by
@@ -445,7 +445,7 @@ theorem step_sd (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LD with invalid dword memory access (trap). -/
-theorem step_ld_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_ld_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LD rd rs1 offset))
     (hinvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -453,7 +453,7 @@ theorem step_ld_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SD with invalid dword memory access (trap). -/
-theorem step_sd_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sd_trap (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SD rs1 rs2 offset))
     (hinvalid : isValidDwordAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -461,7 +461,7 @@ theorem step_sd_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LW with valid memory access. -/
-theorem step_lw (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lw (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LW rd rs1 offset))
     (hvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LW rd rs1 offset)) := by
@@ -469,7 +469,7 @@ theorem step_lw (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SW with valid memory access. -/
-theorem step_sw (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sw (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SW rs1 rs2 offset))
     (hvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.SW rs1 rs2 offset)) := by
@@ -477,7 +477,7 @@ theorem step_sw (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LW with invalid memory access (trap). -/
-theorem step_lw_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lw_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LW rd rs1 offset))
     (hinvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -485,7 +485,7 @@ theorem step_lw_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SW with invalid memory access (trap). -/
-theorem step_sw_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sw_trap (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SW rs1 rs2 offset))
     (hinvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -493,7 +493,7 @@ theorem step_sw_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LWU with valid memory access. -/
-theorem step_lwu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lwu (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LWU rd rs1 offset))
     (hvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LWU rd rs1 offset)) := by
@@ -501,7 +501,7 @@ theorem step_lwu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LWU with invalid memory access (trap). -/
-theorem step_lwu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lwu_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LWU rd rs1 offset))
     (hinvalid : isValidMemAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -509,7 +509,7 @@ theorem step_lwu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LB with valid byte access. -/
-theorem step_lb (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lb (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LB rd rs1 offset))
     (hvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LB rd rs1 offset)) := by
@@ -517,7 +517,7 @@ theorem step_lb (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LB with invalid byte access (trap). -/
-theorem step_lb_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lb_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LB rd rs1 offset))
     (hinvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -525,7 +525,7 @@ theorem step_lb_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LBU with valid byte access. -/
-theorem step_lbu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lbu (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LBU rd rs1 offset))
     (hvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LBU rd rs1 offset)) := by
@@ -533,7 +533,7 @@ theorem step_lbu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LBU with invalid byte access (trap). -/
-theorem step_lbu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lbu_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LBU rd rs1 offset))
     (hinvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -541,7 +541,7 @@ theorem step_lbu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LH with valid halfword access. -/
-theorem step_lh (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lh (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LH rd rs1 offset))
     (hvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LH rd rs1 offset)) := by
@@ -549,7 +549,7 @@ theorem step_lh (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LH with invalid halfword access (trap). -/
-theorem step_lh_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lh_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LH rd rs1 offset))
     (hinvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -557,7 +557,7 @@ theorem step_lh_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LHU with valid halfword access. -/
-theorem step_lhu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lhu (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LHU rd rs1 offset))
     (hvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.LHU rd rs1 offset)) := by
@@ -565,7 +565,7 @@ theorem step_lhu (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for LHU with invalid halfword access (trap). -/
-theorem step_lhu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
+theorem step_lhu_trap (s : MachineState) {rd rs1 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.LHU rd rs1 offset))
     (hinvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -573,7 +573,7 @@ theorem step_lhu_trap (s : MachineState) (rd rs1 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SB with valid byte access. -/
-theorem step_sb (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sb (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SB rs1 rs2 offset))
     (hvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.SB rs1 rs2 offset)) := by
@@ -581,7 +581,7 @@ theorem step_sb (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SB with invalid byte access (trap). -/
-theorem step_sb_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sb_trap (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SB rs1 rs2 offset))
     (hinvalid : isValidByteAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by
@@ -589,7 +589,7 @@ theorem step_sb_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SH with valid halfword access. -/
-theorem step_sh (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sh (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SH rs1 rs2 offset))
     (hvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = true) :
     step s = some (execInstrBr s (.SH rs1 rs2 offset)) := by
@@ -597,7 +597,7 @@ theorem step_sh (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
   omega
 
 /-- step for SH with invalid halfword access (trap). -/
-theorem step_sh_trap (s : MachineState) (rs1 rs2 : Reg) (offset : BitVec 12)
+theorem step_sh_trap (s : MachineState) {rs1 rs2 : Reg} {offset : BitVec 12}
     (hfetch : s.code s.pc = some (.SH rs1 rs2 offset))
     (hinvalid : isValidHalfwordAccess (s.getReg rs1 + signExtend12 offset) = false) :
     step s = none := by

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -612,7 +612,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr vOld memVal : Word)
     holdsFor_memIs_isValidDwordAccess hmem_piece
   -- Step proof using step_ld
   have hstep' : step s = some (execInstrBr s (.LD rd rs1 offset)) :=
-    step_ld s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_ld s hfetch (hrs1 ▸ hvalid)
   -- execInstrBr s (.LD rd rs1 offset) = (s.setReg rd (s.getMem (s.getReg rs1 + signExtend12 offset))).setPC (s.pc + 4)
   have hexec' : execInstrBr s (.LD rd rs1 offset) = (s.setReg rd memVal).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, hmem]
@@ -657,7 +657,7 @@ theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data memOld : Word)
       (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)))
   -- Step proof using step_sd
   have hstep' : step s = some (execInstrBr s (.SD rs1 rs2 offset)) :=
-    step_sd s rs1 rs2 offset hfetch (hrs1 ▸ hvalid)
+    step_sd s hfetch (hrs1 ▸ hvalid)
   -- execInstrBr: setMem then setPC
   have hexec' : execInstrBr s (.SD rs1 rs2 offset) =
       (s.setMem (v_addr + signExtend12 offset) v_data).setPC (s.pc + 4) := by
@@ -696,7 +696,7 @@ theorem generic_sd_x0_spec (rs1 : Reg) (v_addr memOld : Word)
     holdsFor_memIs_isValidDwordAccess (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.SD rs1 .x0 offset)) :=
-    step_sd s rs1 .x0 offset hfetch (hrs1 ▸ hvalid)
+    step_sd s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.SD rs1 .x0 offset) =
       (s.setMem (v_addr + signExtend12 offset) 0).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1]; rfl

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -81,7 +81,7 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LHU rd rs1 offset)) :=
-    step_lhu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lhu s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LHU rd rs1 offset) =
       (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getHalfword_eq]; rw [halign, hmem]
@@ -125,7 +125,7 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LH rd rs1 offset)) :=
-    step_lh s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lh s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LH rd rs1 offset) =
       (s.setReg rd ((extractHalfword wordVal ((byteOffset (v_addr + signExtend12 offset)) / 2)).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getHalfword_eq]; rw [halign, hmem]
@@ -170,7 +170,7 @@ theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.SH rs1 rs2 offset)) :=
-    step_sh s rs1 rs2 offset hfetch (hrs1 ▸ hvalid)
+    step_sh s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.SH rs1 rs2 offset) =
       (s.setMem dwordAddr (replaceHalfword wordOld ((byteOffset (v_addr + signExtend12 offset)) / 2) (v_data.truncate 16))).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, hrs2, setHalfword_eq]; rw [halign, hmem]

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -248,7 +248,7 @@ theorem ld_spec_same (rd : Reg) (v_addr memVal : Word) (offset : BitVec 12) (bas
   have hvalid : isValidDwordAccess (v_addr + signExtend12 offset) = true :=
     holdsFor_memIs_isValidDwordAccess hmem_piece
   have hstep' : step s = some (execInstrBr s (.LD rd rd offset)) :=
-    step_ld s rd rd offset hfetch (hrd ▸ hvalid)
+    step_ld s hfetch (hrd ▸ hvalid)
   have hexec' : execInstrBr s (.LD rd rd offset) = (s.setReg rd memVal).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrd, hmem]
   refine ⟨1, (s.setReg rd memVal).setPC (s.pc + 4), ?_, rfl, ?_⟩
@@ -283,7 +283,7 @@ theorem sd_spec_same (rs : Reg) (v : Word) (memOld : Word) (offset : BitVec 12) 
     holdsFor_memIs_isValidDwordAccess (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.SD rs rs offset)) :=
-    step_sd s rs rs offset hfetch (hrs ▸ hvalid)
+    step_sd s hfetch (hrs ▸ hvalid)
   have hexec' : execInstrBr s (.SD rs rs offset) =
       (s.setMem (v + signExtend12 offset) v).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs]

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -66,7 +66,7 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LWU rd rs1 offset)) :=
-    step_lwu s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lwu s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LWU rd rs1 offset) =
       (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).zeroExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getWord32_eq]; rw [halign, hmem]
@@ -110,7 +110,7 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr vOld : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.LW rd rs1 offset)) :=
-    step_lw s rd rs1 offset hfetch (hrs1 ▸ hvalid)
+    step_lw s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.LW rd rs1 offset) =
       (s.setReg rd ((extractWord32 wordVal ((byteOffset (v_addr + signExtend12 offset)) / 4)).signExtend 64)).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, getWord32_eq]; rw [halign, hmem]
@@ -155,7 +155,7 @@ theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
     holdsFor_memIs_getMem (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR)))
   have hstep' : step s = some (execInstrBr s (.SW rs1 rs2 offset)) :=
-    step_sw s rs1 rs2 offset hfetch (hrs1 ▸ hvalid)
+    step_sw s hfetch (hrs1 ▸ hvalid)
   have hexec' : execInstrBr s (.SW rs1 rs2 offset) =
       (s.setMem dwordAddr (replaceWord32 wordOld ((byteOffset (v_addr + signExtend12 offset)) / 4) (v_data.truncate 32))).setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs1, hrs2, setWord32_eq]; rw [halign, hmem]


### PR DESCRIPTION
## Summary

Mirror of #823 for the per-instruction memory step helpers
(\`step_l{b,bu,h,hu,w,wu,d}\`, \`step_s{b,h,w,d}\`, plus their \`_trap\`
variants — 22 theorems total). Each had \`(rd rs1 : Reg) (offset : BitVec 12)\`
(or \`rs1 rs2\`) explicit; every caller passes them positionally with values
that are determined by \`hfetch\`'s type. Flip to implicit so callers
collapse from \`step_lbu s rd rs1 offset hfetch …\` to
\`step_lbu s hfetch …\`.

15 call sites simplified across:
- \`Rv64/{ByteOps,HalfwordOps,WordOps,InstructionSpecs,GenericSpecs}.lean\`

\`s\` stays explicit (often passed concretely, not always inferable).

## Test plan
- [x] \`lake build\` succeeds (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)