### PR TITLE
refactor(SepLogic): flip CodeReq.singleton_satisfiedBy (a i s) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -90,7 +90,7 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
       ((base + 4) + signExtend13 loop_back_off) ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))
       (base + 8) ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0)) :=
     fun R hR s hcr hPR hpc =>
-      hbge R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbge R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show CodeReq.union (CodeReq.singleton base (.ADDI .x1 .x1 4095))
           (CodeReq.singleton (base + 4) (.BGE .x1 .x0 loop_back_off)) (base + 4) = _
         simp only [CodeReq.union, CodeReq.singleton]

--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -81,7 +81,7 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
         (((.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜val >>> K.toNat = 0⌝) **
          ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))) :=
     fun R hR s hcr hPR hpc =>
-      hbne_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbne_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show divK_clz_stage_code K M_s M_a base (base + 4) = _
         simp only [divK_clz_stage_code, divK_clz_stage_prog,
           CodeReq.ofProg_cons, CodeReq.ofProg_nil,
@@ -134,7 +134,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
         (((.x7 ↦ᵣ (val >>> K.toNat)) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜val >>> K.toNat = 0⌝) **
          ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))) :=
     fun R hR s hcr hPR hpc =>
-      hbne_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbne_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show divK_clz_stage_code K M_s M_a base (base + 4) = _
         simp only [divK_clz_stage_code, divK_clz_stage_prog,
           CodeReq.ofProg_cons, CodeReq.ofProg_nil,
@@ -204,7 +204,7 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
         (((.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜val >>> 63 = 0⌝) **
          ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))) :=
     fun R hR s hcr hPR hpc =>
-      hbne_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbne_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show divK_clz_last_code base (base + 4) = _
         simp only [divK_clz_last_code, divK_clz_last_prog,
           CodeReq.ofProg_cons, CodeReq.ofProg_nil,
@@ -257,7 +257,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
         (((.x7 ↦ᵣ (val >>> 63)) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜val >>> 63 = 0⌝) **
          ((.x5 ↦ᵣ val) ** (.x6 ↦ᵣ count))) :=
     fun R hR s hcr hPR hpc =>
-      hbne_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbne_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show divK_clz_last_code base (base + 4) = _
         simp only [divK_clz_last_code, divK_clz_last_prog,
           CodeReq.ofProg_cons, CodeReq.ofProg_nil,

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -69,7 +69,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat dHi v5Old : Word) (base : Word
         (((.x5 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
          ((.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x6 ↦ᵣ dHi))) :=
     fun R hR s hcr hPR hpc =>
-      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbeq_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show cr (base + 4) = _
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega
@@ -154,7 +154,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 dHi v1Old : Word) (base : Wor
         (((.x1 ↦ᵣ hi) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜hi ≠ 0⌝) **
          ((.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ rhat2) ** (.x6 ↦ᵣ dHi))) :=
     fun R hR s hcr hPR hpc =>
-      hbeq_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbeq_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show cr (base + 4) = _
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 4 = base) := by bv_omega

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -87,7 +87,7 @@ theorem divK_div128_prodcheck1_merged_spec
          ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
           (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) :=
     fun R hR s hcr hPR hpc =>
-      hbltu_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbltu_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show cr (base + 16) = _
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 16 = base) := by bv_omega

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -88,7 +88,7 @@ theorem divK_div128_prodcheck2_merged_spec
          ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))) :=
     fun R hR s hcr hPR hpc =>
-      hbltu_framed R hR s ((CodeReq.singleton_satisfiedBy _ _ s).mpr (hcr _ _ (by
+      hbltu_framed R hR s (CodeReq.singleton_satisfiedBy.mpr (hcr _ _ (by
         show cr (base + 20) = _
         simp only [cr, CodeReq.union, CodeReq.singleton]
         have h0 : ¬(base + 20 = base) := by bv_omega

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -86,7 +86,7 @@ theorem generic_lbu_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LBU rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LBU rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -131,7 +131,7 @@ theorem generic_lb_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LB rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LB rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -173,7 +173,7 @@ theorem generic_sb_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
        (dwordAddr ↦ₘ replaceByte wordOld (byteOffset (v_addr + signExtend12 offset)) (v_data.truncate 8))) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SB rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SB rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -239,7 +239,7 @@ theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
       (rs1 ↦ᵣ v) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.JALR .x0 rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.JALR .x0 rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
   have hexec : execInstrBr s (.JALR .x0 rs1 offset) = s.setPC ((v + signExtend12 offset) &&& ~~~1) := by

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -44,7 +44,7 @@ theorem generic_1reg_spec (instr : Instr) (rd : Reg) (v result : Word) (base : W
   intro R hR s hcr hPR hpc; subst hpc
   -- Extract code fetch from CodeReq
   have hfetch : s.code s.pc = some instr :=
-    (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrd : s.getReg rd = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
   -- Compute next state
@@ -78,7 +78,7 @@ theorem generic_2reg_spec (instr : Instr) (rs rd : Reg)
       ((rs ↦ᵣ v_src) ** (rd ↦ᵣ result)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some instr :=
-    (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs : s.getReg rs = v_src :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -116,7 +116,7 @@ theorem generic_2reg_rd_eq_rs1_spec (instr : Instr) (rd rs2 : Reg)
       ((rd ↦ᵣ result) ** (rs2 ↦ᵣ v2)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some instr :=
-    (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrd : s.getReg rd = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -155,7 +155,7 @@ theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ result)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some instr :=
-    (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -191,7 +191,7 @@ theorem generic_nop_spec (instr : Instr) (base exit_ : Word)
       empAssertion := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some instr :=
-    (CodeReq.singleton_satisfiedBy s.pc instr s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hexec' := hexec s rfl
   have hstep' := hstep s hfetch
   refine ⟨1, s.setPC exit_, ?_, rfl, ?_⟩
@@ -221,7 +221,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜v1 = v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BNE rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BNE rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -272,7 +272,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜v1 ≠ v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BEQ rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BEQ rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -327,7 +327,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜¬BitVec.ult v1 v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BLTU rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BLTU rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -382,7 +382,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜BitVec.slt v1 v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BGE rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BGE rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -437,7 +437,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜¬BitVec.slt v1 v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BLT rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BLT rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -492,7 +492,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
         ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** ⌜BitVec.ult v1 v2⌝) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BGEU rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BGEU rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -545,7 +545,7 @@ theorem generic_jal_spec (rd : Reg) (vOld : Word) (offset : BitVec 21) (base : W
       (rd ↦ᵣ (base + 4)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.JAL rd offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.JAL rd offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hstep' : step s = some (execInstrBr s (.JAL rd offset)) :=
     step_non_ecall_non_mem s _ hfetch (by nofun) (by nofun) (by rfl)
   -- execInstrBr s (.JAL rd offset) = (s.setReg rd (s.pc + 4)).setPC (s.pc + signExtend21 offset)
@@ -565,7 +565,7 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 vOld : Word) (offset : BitVec 12) (
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (base + 4))) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.JALR rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.JALR rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v1 :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -600,7 +600,7 @@ theorem generic_ld_spec (rd rs1 : Reg) (v_addr vOld memVal : Word)
       ((rs1 ↦ᵣ v_addr) ** (rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LD rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LD rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -645,7 +645,7 @@ theorem generic_sd_spec (rs1 rs2 : Reg) (v_addr v_data memOld : Word)
       ((rs1 ↦ᵣ v_addr) ** (rs2 ↦ᵣ v_data) ** ((v_addr + signExtend12 offset) ↦ₘ v_data)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SD rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SD rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -688,7 +688,7 @@ theorem generic_sd_x0_spec (rs1 : Reg) (v_addr memOld : Word)
       ((rs1 ↦ᵣ v_addr) ** ((v_addr + signExtend12 offset) ↦ₘ (0 : Word))) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SD rs1 .x0 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SD rs1 .x0 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -73,7 +73,7 @@ theorem generic_lhu_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LHU rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LHU rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -117,7 +117,7 @@ theorem generic_lh_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LH rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LH rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -159,7 +159,7 @@ theorem generic_sh_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
        (dwordAddr ↦ₘ replaceHalfword wordOld ((byteOffset (v_addr + signExtend12 offset)) / 2) (v_data.truncate 16))) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SH rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SH rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -239,7 +239,7 @@ theorem ld_spec_same (rd : Reg) (v_addr memVal : Word) (offset : BitVec 12) (bas
       ((rd ↦ᵣ memVal) ** ((v_addr + signExtend12 offset) ↦ₘ memVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LD rd rd offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LD rd rd offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrd : s.getReg rd = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hmem_piece := holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR)
@@ -276,7 +276,7 @@ theorem sd_spec_same (rs : Reg) (v : Word) (memOld : Word) (offset : BitVec 12) 
       ((rs ↦ᵣ v) ** ((v + signExtend12 offset) ↦ₘ v)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SD rs rs offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SD rs rs offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs : s.getReg rs = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left (holdsFor_sepConj_elim_left hPR))
   have hvalid : isValidDwordAccess (v + signExtend12 offset) = true :=
@@ -315,7 +315,7 @@ theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
       (base + 4) (rs ↦ᵣ v) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BEQ rs rs offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BEQ rs rs offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs : s.getReg rs = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BEQ rs rs offset)) :=
@@ -343,7 +343,7 @@ theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
       (base + 4) (rs ↦ᵣ v) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.BNE rs rs offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.BNE rs rs offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs : s.getReg rs = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BNE rs rs offset)) :=
@@ -395,7 +395,7 @@ theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Word)
       (rd ↦ᵣ (base + 4)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.JALR rd rd offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.JALR rd rd offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrd : s.getReg rd = v :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.JALR rd rd offset)) :=

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2588,7 +2588,7 @@ theorem CodeReq.empty_satisfiedBy (s : MachineState) : CodeReq.empty.SatisfiedBy
   fun _ _ h => by simp [CodeReq.empty] at h
 
 /-- A singleton CodeReq is satisfied iff the state has the instruction at that address. -/
-theorem CodeReq.singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState) :
+theorem CodeReq.singleton_satisfiedBy {a : Word} {i : Instr} {s : MachineState} :
     (CodeReq.singleton a i).SatisfiedBy s ↔ s.code a = some i := by
   constructor
   · intro h; exact h a i (by simp [CodeReq.singleton])
@@ -2605,7 +2605,7 @@ theorem CodeReq.singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState) 
 /-- An instrAt fact gives CodeReq.singleton satisfaction. -/
 theorem instrAt_singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState)
     (h : (instrAt a i).holdsFor s) : (CodeReq.singleton a i).SatisfiedBy s :=
-  (CodeReq.singleton_satisfiedBy a i s).mpr ((holdsFor_instrAt a i s).mp h)
+  CodeReq.singleton_satisfiedBy.mpr ((holdsFor_instrAt a i s).mp h)
 
 /-- Step preserves code (single step). -/
 theorem step_code_preserved (s s' : MachineState) (h : step s = some s') :

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -58,7 +58,7 @@ theorem generic_lwu_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LWU rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LWU rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -102,7 +102,7 @@ theorem generic_lw_spec (rd rs1 : Reg) (v_addr vOld : Word)
        (dwordAddr ↦ₘ wordVal)) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.LW rd rs1 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.LW rd rs1 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
@@ -144,7 +144,7 @@ theorem generic_sw_spec (rs1 rs2 : Reg) (v_addr v_data : Word)
        (dwordAddr ↦ₘ replaceWord32 wordOld ((byteOffset (v_addr + signExtend12 offset)) / 4) (v_data.truncate 32))) := by
   intro R hR s hcr hPR hpc; subst hpc
   have hfetch : s.code s.pc = some (.SW rs1 rs2 offset) :=
-    (CodeReq.singleton_satisfiedBy s.pc (.SW rs1 rs2 offset) s).mp hcr
+    CodeReq.singleton_satisfiedBy.mp hcr
   have hrs1 : s.getReg rs1 = v_addr :=
     (holdsFor_regIs _ _ s).mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))


### PR DESCRIPTION
## Summary
- Flip `CodeReq.singleton_satisfiedBy (a : Word) (i : Instr) (s : MachineState)` to all-implicit.
- Every caller passed these as `_` placeholders or redundant concretes — implicit binders remove the noise.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)