### PR TITLE
refactor(SepLogic): flip sepConj_pure_right (P Q) to implicit

### DIFF
--- a/EvmAsm/Evm64/Byte/LimbSpec.lean
+++ b/EvmAsm/Evm64/Byte/LimbSpec.lean
@@ -351,14 +351,14 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
       -- taken: strip ⌜v5 ≠ 0⌝ frame
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       -- ntaken: combine ⌜v5 ≠ 0⌝ ∧ ⌜v5 ≠ 1⌝
       (fun h hp => by
-        have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, hne0⟩ := (sepConj_pure_right h).1 hp
         have hne1 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1_framed
   -- Step 3: ADDI x10 x0 2 at base+12 (extend to cr, frame with x5)
   have addi2_raw := addi_spec_gen .x10 .x0 ((0 : Word) + signExtend12 1) (0 : Word) 2 (base + 12) (by nofun)
@@ -399,14 +399,14 @@ theorem byte_phase_c_spec (v5 v10 : Word) (base : Word)
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
       -- taken: strip ⌜conj⌝ frame
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       -- ntaken: combine ⌜v5≠0 ∧ v5≠1⌝ ∧ ⌜v5≠2⌝
       (fun h hp => by
-        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right h).1 hp
         have hne2 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2_framed
   -- Build cpsNBranch from inside out
   -- Fallthrough at base+20: trivial single-exit (0 steps)

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -256,7 +256,7 @@ theorem evm_byte_zero_high_spec (sp base : Word)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hhigh)
   -- Frame BNE with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ i3) **
@@ -331,7 +331,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
+      exact ((sepConj_pure_right _).mp h_rest).2 hlow)
   -- Frame BNE(ntaken) with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ i3) **
@@ -376,7 +376,7 @@ theorem evm_byte_zero_geq32_spec (sp base : Word)
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
+      exact ((sepConj_pure_right _).mp h_rest).2 hsltiu_eq)
   -- Frame BEQ(taken) with remaining state
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ i0) **
@@ -492,7 +492,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
+      exact ((sepConj_pure_right _).mp h_rest).2 hhigh_zero)
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ i3) ** (.x6 ↦ᵣ r6) **
      (sp ↦ₘ i0) ** ((sp + 8) ↦ₘ i1) ** ((sp + 16) ↦ₘ i2) ** ((sp + 24) ↦ₘ i3) **
@@ -529,7 +529,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      have heq := ((sepConj_pure_right _ _ _).mp h_rest).2
+      have heq := ((sepConj_pure_right _).mp h_rest).2
       simp [hsltiu_eq] at heq)
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ i0) ** (.x6 ↦ᵣ r6) **

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -63,7 +63,7 @@ theorem divK_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word
   have hbeq_clean := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbeq_exit
   -- 4. Frame LD with x0, x5, x7, x2, x10
   have hldf := cpsTriple_frameR
@@ -321,7 +321,7 @@ theorem evm_mod_bzero_spec (sp base : Word)
   have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hbz ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hbz ((sepConj_pure_right _).mp h_rest).2)
   have hbeq := cpsTriple_extend_code (beq_singleton_sub_modCode base) hbeq_clean
   -- Step 3: Frame BEQ with regs + mem
   have hbeq_framed := cpsTriple_frameR
@@ -375,7 +375,7 @@ theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
   have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hbnz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hbnz)
   have hbeq := cpsTriple_extend_code (beq_singleton_sub_modCode base) hbeq_clean
   -- Step 3: Frame BEQ with regs + mem
   have hbeq_framed := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -593,7 +593,7 @@ theorem mod_denorm_preamble_spec (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
   have hbeq_clean := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbeq_exit
   -- 4. Frame LD with x0, x5, x7, x2, x10
   have hldf := cpsTriple_frameR
@@ -718,7 +718,7 @@ theorem evm_div_shift0_epilogue_spec (sp base : Word)
   have hbeq_exit := cpsBranch_takenStripPure2 hbeqe
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
   -- 4. Frame LD with x0, x5, x7, x2, x10
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
@@ -803,7 +803,7 @@ theorem evm_mod_shift0_epilogue_spec (sp base : Word)
   have hbeq_exit := cpsBranch_takenStripPure2 hbeqe
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
   -- 4. Frame LD with x0, x5, x7, x2, x10
   have hldf := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -69,7 +69,7 @@ theorem mod_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
   have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
   have hbeq := cpsTriple_extend_code (beq_shift_sub_modCode base) hbeq_clean
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
@@ -98,7 +98,7 @@ theorem mod_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
   have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
   have hbeq := cpsTriple_extend_code (beq_shift_sub_modCode base) hbeq_clean
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -255,7 +255,7 @@ theorem mod_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   have hblt_clean := cpsBranch_ntakenStripPure2 hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hm_ge)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
   have hblte := cpsTriple_extend_code (blt_loopSetup_sub_modCode base) hblt_clean
   have hbltef := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
@@ -287,7 +287,7 @@ theorem mod_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   have hblt_clean := cpsBranch_takenStripPure2 hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hm_lt ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hm_lt ((sepConj_pure_right _).mp h_rest).2)
   have hblte := cpsTriple_extend_code (blt_loopSetup_sub_modCode base) hblt_clean
   have hbltef := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -159,7 +159,7 @@ theorem evm_mod_phaseB_n4_spec (sp base : Word)
   have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb3nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb3nz)
   have hbne := cpsTriple_extend_code (bne_x10_singleton_sub_modCode base) hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -86,7 +86,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_modCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -121,7 +121,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_modCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
@@ -156,7 +156,7 @@ theorem evm_mod_phaseB_n2_spec (sp base : Word)
   have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb1nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb1nz)
   have hbne2 := cpsTriple_extend_code (bne_x6_8_sub_modCode base) hbne2_clean
   have hbne2f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
@@ -267,7 +267,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_modCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -302,7 +302,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_modCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
@@ -337,7 +337,7 @@ theorem evm_mod_phaseB_n1_spec (sp base : Word)
   have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb1z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb1z ((sepConj_pure_right _).mp h_rest).2)
   have hbne2 := cpsTriple_extend_code (bne_x6_8_sub_modCode base) hbne2_clean
   have hbne2f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -85,7 +85,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_modCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -120,7 +120,7 @@ theorem evm_mod_phaseB_n3_spec (sp base : Word)
   have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb2nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb2nz)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_modCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -63,7 +63,7 @@ theorem divK_phaseC2_ntaken_spec (sp shift v2 shiftMem : Word) (base : Word)
   have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 (show shift ≠ (0 : Word) from hshift_nz))
   have hbeq := cpsTriple_extend_code (beq_shift_sub_divCode base) hbeq_clean
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
@@ -92,7 +92,7 @@ theorem divK_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
   have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hshift_z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hshift_z ((sepConj_pure_right _).mp h_rest).2)
   have hbeq := cpsTriple_extend_code (beq_shift_sub_divCode base) hbeq_clean
   have hbeqf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -256,7 +256,7 @@ theorem divK_loopSetup_ntaken_spec (sp n v1 v5 : Word) (base : Word)
   have hblt_clean := cpsBranch_ntakenStripPure2 hblt_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hm_ge)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hm_ge)
   have hblte := cpsTriple_extend_code (blt_loopSetup_sub_divCode base) hblt_clean
   have hbltef := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))
@@ -287,7 +287,7 @@ theorem divK_loopSetup_taken_spec (sp n v1 v5 : Word) (base : Word)
   have hblt_clean := cpsBranch_takenStripPure2 hblt_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hm_lt ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hm_lt ((sepConj_pure_right _).mp h_rest).2)
   have hblte := cpsTriple_extend_code (blt_loopSetup_sub_divCode base) hblt_clean
   have hbltef := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) ** ((sp + signExtend12 3984) ↦ₘ n))

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -178,7 +178,7 @@ theorem evm_div_bzero_spec (sp base : Word)
   have hbeq_clean := cpsBranch_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd hbz ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hbz ((sepConj_pure_right _).mp h_rest).2)
   -- Extend BEQ to divCode CodeReq
   have hbeq := cpsTriple_extend_code (beq_singleton_sub_divCode base) hbeq_clean
   -- Step 3: Frame BEQ with regs + mem (no code atoms needed in frame)
@@ -235,7 +235,7 @@ theorem evm_div_phaseA_ntaken_spec (sp base : Word)
   have hbeq_clean := cpsBranch_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hbnz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hbnz)
   -- Extend BEQ to divCode CodeReq
   have hbeq := cpsTriple_extend_code (beq_singleton_sub_divCode base) hbeq_clean
   -- Step 3: Frame BEQ with regs + mem
@@ -308,7 +308,7 @@ theorem evm_div_phaseB_n4_spec (sp base : Word)
   have hbne_clean := cpsBranch_takenStripPure2 hbne_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb3nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb3nz)
   have hbne := cpsTriple_extend_code (bne_x10_singleton_sub_divCode base) hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]
@@ -549,7 +549,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_divCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -584,7 +584,7 @@ theorem evm_div_phaseB_n3_spec (sp base : Word)
   have hbne1_clean := cpsBranch_takenStripPure2 hbne1_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb2nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb2nz)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_divCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
@@ -693,7 +693,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_divCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -728,7 +728,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_divCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
@@ -763,7 +763,7 @@ theorem evm_div_phaseB_n2_spec (sp base : Word)
   have hbne2_clean := cpsBranch_takenStripPure2 hbne2_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hb1nz)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hb1nz)
   have hbne2 := cpsTriple_extend_code (bne_x6_8_sub_divCode base) hbne2_clean
   have hbne2f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **
@@ -873,7 +873,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne0_clean := cpsBranch_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb3z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb3z ((sepConj_pure_right _).mp h_rest).2)
   have hbne0 := cpsTriple_extend_code (bne_x10_singleton_sub_divCode base) hbne0_clean
   have hbne0f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (4 : Word)) ** (.x6 ↦ᵣ b1) ** (.x7 ↦ᵣ b2) **
@@ -908,7 +908,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne1_clean := cpsBranch_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb2z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb2z ((sepConj_pure_right _).mp h_rest).2)
   have hbne1 := cpsTriple_extend_code (bne_x7_16_sub_divCode base) hbne1_clean
   have hbne1f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (3 : Word)) ** (.x10 ↦ᵣ b3) ** (.x6 ↦ᵣ b1) **
@@ -943,7 +943,7 @@ theorem evm_div_phaseB_n1_spec (sp base : Word)
   have hbne2_clean := cpsBranch_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact absurd hb1z ((sepConj_pure_right _ _ _).mp h_rest).2)
+      exact absurd hb1z ((sepConj_pure_right _).mp h_rest).2)
   have hbne2 := cpsTriple_extend_code (bne_x6_8_sub_divCode base) hbne2_clean
   have hbne2f := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (2 : Word)) ** (.x10 ↦ᵣ b3) ** (.x7 ↦ᵣ b2) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/AddBackFinalLoopControl.lean
@@ -81,9 +81,9 @@ theorem divK_loop_control_spec (j : Word) (loop_back_off : BitVec 13)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       hbge_raw
   have hbge_ext : cpsBranch (base + 4) cr
       ((.x1 ↦ᵣ j') ** (.x0 ↦ᵣ 0))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -96,14 +96,14 @@ theorem divK_clz_stage_taken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val coun
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have taken := cpsBranch_takenPath composed (fun hp hQf => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-    exact hne ((sepConj_pure_right _ _ _).1 h_x0p).2)
+    exact hne ((sepConj_pure_right _).1 h_x0p).2)
   intro R hR s hcr hPR hpc
   obtain ⟨k, s', hstep, hpc', hQR⟩ := taken R hR s hcr hPR hpc
   exact ⟨k, s', hstep, hpc', by
     obtain ⟨hp, hcompat, hpq⟩ := hQR
     exact ⟨hp, hcompat, sepConj_mono_left (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
       xperm_hyp hp') hp hpq⟩⟩
 
 /-- CLZ stage, not-taken branch: val >>> K = 0, execute SLLI+ADDI.
@@ -149,7 +149,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-    exact ((sepConj_pure_right _ _ _).1 h_x0p).2 (by rw [heq]))
+    exact ((sepConj_pure_right _).1 h_x0p).2 (by rw [heq]))
   have I1 := slli_spec_gen_same .x5 val M_s (base + 8) (by nofun)
   have I2 := addi_spec_gen_same .x6 count M_a (base + 12) (by nofun)
   have hslli_addi : cpsTriple (base + 8) (base + 16) cr
@@ -162,7 +162,7 @@ theorem divK_clz_stage_ntaken_spec (K M_s : BitVec 6) (M_a : BitVec 12) (val cou
   have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
       xperm_hyp hp')
     ntaken hframed
   exact cpsTriple_weaken
@@ -219,14 +219,14 @@ theorem divK_clz_last_taken_spec (val count v7 : Word) (base : Word)
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have taken := cpsBranch_takenPath composed (fun hp hQf => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-    exact hne ((sepConj_pure_right _ _ _).1 h_x0p).2)
+    exact hne ((sepConj_pure_right _).1 h_x0p).2)
   intro R hR s hcr hPR hpc
   obtain ⟨k, s', hstep, hpc', hQR⟩ := taken R hR s hcr hPR hpc
   exact ⟨k, s', hstep, hpc', by
     obtain ⟨hp, hcompat, hpq⟩ := hQR
     exact ⟨hp, hcompat, sepConj_mono_left (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
       xperm_hyp hp') hp hpq⟩⟩
 
 /-- CLZ last stage, ntaken: val >>> 63 = 0, execute ADDI.
@@ -272,7 +272,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
     (fun h hp => by xperm_hyp hp) hbody hbne_ext
   have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
     obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-    exact ((sepConj_pure_right _ _ _).1 h_x0p).2 (by rw [heq]))
+    exact ((sepConj_pure_right _).1 h_x0p).2 (by rw [heq]))
   have I2 := addi_spec_gen_same .x6 count 1 (base + 8) (by nofun)
   have haddi : cpsTriple (base + 8) (base + 12) cr
       (.x6 ↦ᵣ count)
@@ -284,7 +284,7 @@ theorem divK_clz_last_ntaken_spec (val count v7 : Word) (base : Word)
   have full := cpsTriple_seq_perm_same_cr
     (fun h hp => by
       have hp' := sepConj_mono_left (sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
       xperm_hyp hp')
     ntaken hframed
   exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Clamp.lean
@@ -82,19 +82,19 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat dHi v5Old : Word) (base : Word
     rw [hq, hr]
     have taken := cpsBranch_takenPath composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact ((sepConj_pure_right _).1 h_x0p).2 hcond)
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp') taken
   · have hq : q1' = q1 + signExtend12 4095 := if_neg hcond
     have hr : rhat' = rhat + dHi := if_neg hcond
     rw [hq, hr]
     have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
+      exact hcond ((sepConj_pure_right _).1 h_x0p).2)
     have I1 := addi_spec_gen_same .x10 q1 4095 (base + 8) (by nofun)
     have I2 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat dHi (base + 12) (by nofun)
     have hcorr : cpsTriple (base + 8) (base + 16) cr
@@ -107,7 +107,7 @@ theorem divK_div128_clamp_q1_merged_spec (q1 rhat dHi v5Old : Word) (base : Word
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp') ntaken hcorr_framed
     exact cpsTriple_weaken
       (fun h hp => hp)
@@ -167,19 +167,19 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 dHi v1Old : Word) (base : Wor
     rw [hq, hr]
     have taken := cpsBranch_takenPath composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact ((sepConj_pure_right _).1 h_x0p).2 hcond)
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp') taken
   · have hq : q0' = q0 + signExtend12 4095 := if_neg hcond
     have hr : rhat2' = rhat2 + dHi := if_neg hcond
     rw [hq, hr]
     have ntaken := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact hcond ((sepConj_pure_right _ _ _).1 h_x0p).2)
+      exact hcond ((sepConj_pure_right _).1 h_x0p).2)
     have I1 := addi_spec_gen_same .x5 q0 4095 (base + 8) (by nofun)
     have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2 dHi (base + 12) (by nofun)
     have hcorr : cpsTriple (base + 8) (base + 16) cr
@@ -192,7 +192,7 @@ theorem divK_div128_clamp_q0_merged_spec (q0 rhat2 dHi v1Old : Word) (base : Wor
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp') ntaken hcorr_framed
     exact cpsTriple_weaken
       (fun h hp => hp)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1.lean
@@ -103,7 +103,7 @@ theorem divK_div128_prodcheck1_merged_spec
     rw [hq, hr]
     have taken_br := cpsBranch_takenPath composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact ((sepConj_pure_right _).1 h_x0p).2 hcond)
     have I4 := addi_spec_gen_same .x10 q1 4095 (base + 24) (by nofun)
     have I5 := add_spec_gen_rd_eq_rs1 .x7 .x6 rhat dHi (base + 28) (by nofun)
     have hcorr : cpsTriple (base + 24) (base + 32) cr
@@ -117,7 +117,7 @@ theorem divK_div128_prodcheck1_merged_spec
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp')
       taken_br hcorr_framed
     exact cpsTriple_weaken
@@ -128,7 +128,7 @@ theorem divK_div128_prodcheck1_merged_spec
     rw [hq, hr]
     have ntaken_br := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact absurd ((sepConj_pure_right _).1 h_x0p).2 hcond)
     have I_jal := jal_x0_spec_gen 12 (base + 20)
     rw [se21_12] at I_jal
     have ha_jal : (base + 20 : Word) + 12 = base + 32 := by bv_addr
@@ -161,7 +161,7 @@ theorem divK_div128_prodcheck1_merged_spec
             ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1) ** (.x7 ↦ᵣ rhat) ** (.x11 ↦ᵣ un1) **
              (.x6 ↦ᵣ dHi) ** (sp + signExtend12 3952 ↦ₘ dlo))) h :=
             sepConj_mono_left (sepConj_mono_right
-              (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+              (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
           xperm_hyp hp')
         ntaken_br
     exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -104,7 +104,7 @@ theorem divK_div128_prodcheck2_merged_spec
     rw [hq]
     have taken_br := cpsBranch_takenPath composed (fun hp hQf => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact ((sepConj_pure_right _).1 h_x0p).2 hcond)
     have I5 := addi_spec_gen_same .x5 q0 4095 (base + 28) (by nofun)
     have hcorr : cpsTriple (base + 28) (base + 32) cr
         (.x5 ↦ᵣ q0)
@@ -117,7 +117,7 @@ theorem divK_div128_prodcheck2_merged_spec
     have full := cpsTriple_seq_perm_same_cr
       (fun h hp => by
         have hp' := sepConj_mono_left (sepConj_mono_right
-          (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+          (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
         xperm_hyp hp')
       taken_br hcorr_framed
     exact cpsTriple_weaken
@@ -127,7 +127,7 @@ theorem divK_div128_prodcheck2_merged_spec
     rw [hq]
     have ntaken_br := cpsBranch_ntakenPath composed (fun hp hQt => by
       obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_x0p⟩, _⟩ := hQt
-      exact absurd ((sepConj_pure_right _ _ _).1 h_x0p).2 hcond)
+      exact absurd ((sepConj_pure_right _).1 h_x0p).2 hcond)
     have I_jal := jal_x0_spec_gen 8 (base + 24)
     rw [se21_8] at I_jal
     have ha_jal : (base + 24 : Word) + 8 = base + 32 := by bv_addr
@@ -160,7 +160,7 @@ theorem divK_div128_prodcheck2_merged_spec
             ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ q0) ** (.x11 ↦ᵣ un0) **
              (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))) h :=
             sepConj_mono_left (sepConj_mono_right
-              (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+              (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
           xperm_hyp hp')
         ntaken_br
     exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -81,9 +81,9 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       hblt_raw
   have hblt_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseA.lean
@@ -84,9 +84,9 @@ theorem divK_phaseA_spec (sp : Word) (base : Word)
   have hbeq := cpsBranch_weaken
     (fun _ hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbeq_raw
   -- 3. Frame BEQ with remaining registers and memory
   have hbeq_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBCascade.lean
@@ -67,9 +67,9 @@ theorem divK_phaseB_cascade_step_spec (nVal : BitVec 12) (rx : Reg) (check v5 : 
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       hbne_raw
   -- 3. Frame BNE with x5
   have hbne_framed := cpsBranch_frameR

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -84,9 +84,9 @@ theorem divK_phaseC2_spec (sp shift v2 shiftMem : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       hbeq_raw
   have hbeq_framed := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -47,9 +47,9 @@ theorem divK_correction_branch_spec (borrow : Word) (skip_off : BitVec 13) (base
   exact cpsBranch_weaken
     (fun _ hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbeq
 
 /-- Load uHi = u[j+n] and uLo = u[j+n-1] for trial quotient estimation.

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -554,7 +554,7 @@ theorem divK_correction_skip_spec
     cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       skip
   -- Frame with all other state and permute
   have skip_framed := cpsTriple_frameR
@@ -638,7 +638,7 @@ theorem divK_correction_addback_spec
     cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       ntaken
   -- Frame ntaken with all addback state
   have ntaken_framed := cpsTriple_frameR
@@ -912,7 +912,7 @@ theorem divK_beq_passthrough (carry : Word) (base : Word) (hne : carry ≠ 0) :
   exact cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     ntaken
 
 -- Address normalization for BEQ taken (double-addback backward branch)
@@ -982,7 +982,7 @@ theorem divK_double_addback_beq_spec
   have beq_taken' := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     beq_taken
   -- 2. Second addback (base+732 → base+880)
   have AB2 := divK_addback_full_spec sp uBase qHat' v0 v1 v2 v3 aun0 aun1 aun2 aun3 aun4
@@ -1181,7 +1181,7 @@ theorem divK_store_loop_j0_spec
   have hbge_exit := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
@@ -1265,7 +1265,7 @@ theorem divK_store_loop_jgt0_spec
   have hbge_exit := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
   have SQx0 : cpsTriple (base + 884) (base + 900) (sharedDivModCode base)
@@ -1706,7 +1706,7 @@ theorem divK_trial_max_full_spec
   have ntaken_clean := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp) ntaken
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) ntaken
   -- 3. Trial max (base+504 → base+516)
   have TM := divK_trial_max_extended v11Old base
   -- 4. Frame save_trial_load with x11 + x0, compose with BLTU ntaken
@@ -1808,7 +1808,7 @@ theorem divK_trial_call_full_spec
   have taken_clean := cpsTriple_weaken
     (fun h hp => hp)
     (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp) taken
+      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp) taken
   -- 3. Trial call path (base+512 → base+516)
   have TCP := divK_trial_call_path_spec sp j uLo uHi vTop vtopBase base
     v2Old v11Old retMem dMem dloMem un0Mem

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -282,7 +282,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hhigh)
   -- Frame BNE with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -381,7 +381,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
+      exact ((sepConj_pure_right _).mp h_rest).2 hlow)
   -- Frame BNE(ntaken) with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -425,7 +425,7 @@ theorem evm_shr_zero_large_spec (sp base : Word)
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
+      exact ((sepConj_pure_right _).mp h_rest).2 hsltiu_eq)
   -- Frame BEQ(taken) with remaining state
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) **
@@ -675,7 +675,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
+      exact ((sepConj_pure_right _).mp h_rest).2 hhigh_zero)
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -712,7 +712,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      have heq := ((sepConj_pure_right _ _ _).mp h_rest).2
+      have heq := ((sepConj_pure_right _).mp h_rest).2
       simp [hsltiu_eq] at heq)
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **

--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -386,9 +386,9 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
         (cpsBranch_weaken
           (fun _ hp => hp)
           (fun h hp => sepConj_mono_right
-            (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
           (fun h hp => sepConj_mono_right
-            (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
           s2_raw))
   -- Compose with disjoint CRs
   exact cpsTriple_seq_cpsBranch_with_perm hd
@@ -495,9 +495,9 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word)) h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word)) h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       beq0_raw
   -- Frame BEQ with x10
   have beq0f := cpsBranch_frameR
@@ -608,17 +608,17 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
       -- taken: strip ⌜v5 ≠ 0⌝ frame
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       -- ntaken: (regs ** ⌜v5 ≠ 1⌝) ** ⌜v5 ≠ 0⌝ → regs ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
       (fun h hp => by
         -- hp : ((x5 ** x0 ** x10 ** ⌜v5 ≠ 1⌝) ** ⌜v5 ≠ 0⌝) h
-        have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, hne0⟩ := (sepConj_pure_right h).1 hp
         -- hinner : (x5 ** x0 ** x10 ** ⌜v5 ≠ 1⌝) h
         have hne1 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         -- Reconstruct: regs ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1f
   -- Step 2: cascade step at base+12, framed with ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 32 (base + 12) e2 hc2
@@ -638,15 +638,15 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       -- pre: right-assoc ↔ left-nested
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
       -- taken: (regs ** ⌜v5=2⌝) ** ⌜conj⌝ → regs ** ⌜v5=2⌝
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       -- ntaken: (regs ** ⌜v5≠2⌝) ** ⌜v5≠0 ∧ v5≠1⌝ → regs ** ⌜v5≠0 ∧ v5≠1 ∧ v5≠2⌝
       (fun h hp => by
         -- hp : ((x5 ** x0 ** x10 ** ⌜v5 ≠ 2⌝) ** ⌜v5 ≠ 0 ∧ v5 ≠ 1⌝) h
-        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right h).1 hp
         have hne2 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f
   -- Fallthrough at base+20: trivial cpsNBranch
   have ft := cpsNBranch_refl (base + 20)
@@ -790,9 +790,9 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       bne_raw
   -- Frame BNE with remaining state
   have bne1f := cpsBranch_frameR
@@ -842,9 +842,9 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       beq_raw
   -- Frame BEQ with remaining state
   have beq1f := cpsBranch_frameR

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -327,7 +327,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hhigh)
   -- Frame BNE with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -418,7 +418,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
+      exact ((sepConj_pure_right _).mp h_rest).2 hlow)
   -- Frame BNE(ntaken) with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -462,7 +462,7 @@ theorem evm_sar_sign_fill_large_spec (sp base : Word)
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
+      exact ((sepConj_pure_right _).mp h_rest).2 hsltiu_eq)
   -- Frame BEQ(taken) with remaining state
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) **
@@ -566,13 +566,13 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (base + 12) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) :=
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       (fun h hp => by
-        have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, hne0⟩ := (sepConj_pure_right h).1 hp
         have hne1 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := shr_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 36 (base + 12) e2 hc2
@@ -585,13 +585,13 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (base + 20) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝) :=
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       (fun h hp => by
-        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right h).1 hp
         have hne2 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f
   -- Fallthrough at base+20
   have ft := cpsNBranch_refl (base + 20)
@@ -832,7 +832,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
+      exact ((sepConj_pure_right _).mp h_rest).2 hhigh_zero)
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -869,7 +869,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      have heq := ((sepConj_pure_right _ _ _).mp h_rest).2
+      have heq := ((sepConj_pure_right _).mp h_rest).2
       simp [hsltiu_eq] at heq)
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -271,7 +271,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hhigh)
   -- Frame BNE with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -369,7 +369,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
+      exact ((sepConj_pure_right _).mp h_rest).2 hlow)
   -- Frame BNE(ntaken) with remaining state
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) **
@@ -413,7 +413,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
+      exact ((sepConj_pure_right _).mp h_rest).2 hsltiu_eq)
   -- Frame BEQ(taken) with remaining state
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) **
@@ -650,7 +650,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh_zero)
+      exact ((sepConj_pure_right _).mp h_rest).2 hhigh_zero)
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ s3) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -687,7 +687,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      have heq := ((sepConj_pure_right _ _ _).mp h_rest).2
+      have heq := ((sepConj_pure_right _).mp h_rest).2
       simp [hsltiu_eq] at heq)
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ s0) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -241,7 +241,7 @@ theorem signext_nochange_high_spec (sp base : Word)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact absurd ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+      exact absurd ((sepConj_pure_right _).mp h_rest).2 hhigh)
   -- Frame BNE
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
@@ -329,7 +329,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hlow)
+      exact ((sepConj_pure_right _).mp h_rest).2 hlow)
   have hbne_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) **
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -367,7 +367,7 @@ theorem signext_nochange_geq31_spec (sp base : Word)
   have hbeq_taken := cpsBranch_takenStripPure2 hbeq
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
-      exact ((sepConj_pure_right _ _ _).mp h_rest).2 hsltiu_eq)
+      exact ((sepConj_pure_right _).mp h_rest).2 hsltiu_eq)
   have hbeq_framed := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) **
      (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
@@ -465,7 +465,7 @@ theorem signext_body_spec (sp base : Word)
   rw [se_bne_target, se_off_20] at hbne_raw
   have hbne := cpsBranch_extend_code (bne_sub_signextCode base) hbne_raw
   have hbne_nt := cpsBranch_ntakenStripPure2 hbne
-    (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; exact ((sepConj_pure_right _ _ _).mp h_rest).2 hhigh)
+    (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; exact ((sepConj_pure_right _).mp h_rest).2 hhigh)
   have hbne_f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbne_nt
@@ -493,7 +493,7 @@ theorem signext_body_spec (sp base : Word)
   rw [se_beq_target, se_off_32] at hbeq_raw
   have hbeq := cpsBranch_extend_code (beq_sub_signextCode base) hbeq_raw
   have hbeq_nt := cpsBranch_ntakenStripPure2 hbeq
-    (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; have := ((sepConj_pure_right _ _ _).mp h_rest).2; simp [hsltiu_eq] at this)
+    (fun hp hQt => by obtain ⟨_, _, _, _, _, h_rest⟩ := hQt; have := ((sepConj_pure_right _).mp h_rest).2; simp [hsltiu_eq] at this)
   have hbeq_f := cpsTriple_frameR
     ((.x6 ↦ᵣ r6) ** (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3) **
      ((sp + 32) ↦ₘ v0) ** ((sp + 40) ↦ₘ v1) ** ((sp + 48) ↦ₘ v2) ** ((sp + 56) ↦ₘ v3)) (by pcFree) hbeq_nt

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -286,9 +286,9 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
         (cpsBranch_weaken
           (fun _ hp => hp)
           (fun h hp => sepConj_mono_right
-            (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
           (fun h hp => sepConj_mono_right
-            (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word) + signExtend12 k) h').1 hp').1) h hp)
+            (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
           s2_raw))
   exact cpsTriple_seq_cpsBranch_with_perm hd
     (fun _ hp => hp) s1' s2'
@@ -395,9 +395,9 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       bne_raw
   have bne1f := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ b3) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
@@ -438,9 +438,9 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       beq_raw
   have beq1f := cpsBranch_frameR
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ b0) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3))
@@ -611,9 +611,9 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
     cpsBranch_weaken
       (fun _ hp => hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ (v5 = (0 : Word)) h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       (fun h hp => sepConj_mono_right
-        (fun h' hp' => ((sepConj_pure_right _ (v5 ≠ (0 : Word)) h').1 hp').1) h hp)
+        (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
       beq0_raw
   have beq0f := cpsBranch_frameR
     (.x10 ↦ᵣ v10) (by pcFree) beq0
@@ -760,13 +760,13 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (base + 12) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 1)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1⌝) :=
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       (fun h hp => by
-        have ⟨hinner, hne0⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, hne0⟩ := (sepConj_pure_right h).1 hp
         have hne1 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 hne1))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 hne1))))
       cs1f
   -- Step 2: cascade step at base+12
   have cs2_raw := signext_cascade_step_spec_pure v5 ((0 : Word) + signExtend12 1) 2 24 (base + 12) e2 hc2
@@ -779,13 +779,13 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
       (base + 20) ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ ((0 : Word) + signExtend12 2)) ** ⌜v5 ≠ 0 ∧ v5 ≠ (0 : Word) + signExtend12 1 ∧ v5 ≠ (0 : Word) + signExtend12 2⌝) :=
     cpsBranch_weaken
       (fun h hp => (congrFun (show _ = _ from by xperm) h).mp hp)
-      (fun h hp => (sepConj_pure_right _ _ h).1 hp |>.1)
+      (fun h hp => (sepConj_pure_right h).1 hp |>.1)
       (fun h hp => by
-        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right _ _ h).1 hp
+        have ⟨hinner, ⟨hne0, hne1⟩⟩ := (sepConj_pure_right h).1 hp
         have hne2 := sepConj_extract_pure_end3 h hinner
         have hregs := sepConj_strip_pure_end3 h hinner
         exact (congrFun (show _ = _ from by xperm) h).mp
-          ((sepConj_pure_right _ _ h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
+          ((sepConj_pure_right h).2 (And.intro hregs (And.intro hne0 (And.intro hne1 hne2)))))
       cs2f
   -- Fallthrough at base+20
   have ft := cpsNBranch_refl (base + 20)

--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -118,12 +118,12 @@ theorem cpsTriple_strip_pure_and_convert
   have hfact : fact := by
     obtain ⟨hp, _, hpq⟩ := hPFR
     obtain ⟨h1, _, _, _, hPF, _⟩ := hpq
-    exact ((sepConj_pure_right P fact h1).1 hPF).2
+    exact ((sepConj_pure_right h1).1 hPF).2
   have hPR : (P ** R).holdsFor s := by
     obtain ⟨hp, hcompat, hpq⟩ := hPFR
     exact ⟨hp, hcompat, by
       obtain ⟨h1, h2, hd, hunion, hPF, hR_⟩ := hpq
-      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right P fact h1).1 hPF).1, hR_⟩⟩
+      exact ⟨h1, h2, hd, hunion, ((sepConj_pure_right h1).1 hPF).1, hR_⟩⟩
   obtain ⟨k, s', hstep, hpc', hQR⟩ := hbody R hR s hcr hPR hpc
   exact ⟨k, s', hstep, hpc', by
     obtain ⟨hp', hcompat', hpq'⟩ := hQR

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -246,7 +246,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
   · -- Taken: v1 ≠ v2
     have hexec' : execInstrBr s (.BNE rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
       simp only [execInstrBr, hrs1, hrs2, bne_iff_ne, ne_eq, heq, not_false_eq_true, ite_true]
@@ -260,7 +260,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
 
 /-- Generic spec for BEQ: branch if equal. -/
 theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (base : Word) :
@@ -295,7 +295,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
   · -- Not taken: v1 ≠ v2
     have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + 4) := by
       simp only [execInstrBr, hrs1, hrs2, beq_iff_eq, heq, ite_false]
@@ -309,7 +309,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, heq⟩⟩, hR2⟩
 
 -- ============================================================================
 -- Group 9b: Branch (BLTU) — cpsBranch (unsigned less than)
@@ -350,7 +350,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
   · -- Not taken: ¬(v1 <u v2)
     have hexec' : execInstrBr s (.BLTU rs1 rs2 offset) = s.setPC (s.pc + 4) := by
       simp [execInstrBr, hrs1, hrs2, hlt]
@@ -364,7 +364,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
 
 -- ============================================================================
 -- Group 9c: Branch (BGE) — cpsBranch (signed greater or equal)
@@ -405,7 +405,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
   · -- Taken: ¬slt v1 v2 → BGE branches
     have hexec' : execInstrBr s (.BGE rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
       simp [execInstrBr, hrs1, hrs2, hlt]
@@ -419,7 +419,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
 
 -- ============================================================================
 -- Group 9d: Branch (BLT) — cpsBranch (signed less than)
@@ -460,7 +460,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
   · -- Not taken: ¬slt v1 v2
     have hexec' : execInstrBr s (.BLT rs1 rs2 offset) = s.setPC (s.pc + 4) := by
       simp [execInstrBr, hrs1, hrs2, hlt]
@@ -474,7 +474,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
 
 -- ============================================================================
 -- Group 9e: Branch (BGEU) — cpsBranch (unsigned greater or equal)
@@ -515,7 +515,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
   · -- Taken: ¬ult v1 v2 → BGEU branches
     have hexec' : execInstrBr s (.BGEU rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
       simp [execInstrBr, hrs1, hrs2, hlt]
@@ -529,7 +529,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
       obtain ⟨h1a, h1b, hd1, hu1, hRs1, hRs2⟩ := hP1
       exact ⟨hp, hcompat, h1, h2, hd, hu,
         ⟨h1a, h1b, hd1, hu1, hRs1,
-         (sepConj_pure_right _ _ h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
+         (sepConj_pure_right h1b).mpr ⟨hRs2, hlt⟩⟩, hR2⟩
 
 -- ============================================================================
 -- Group 10: JAL (jump and link)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -113,7 +113,7 @@ theorem rlp_phase2_long_loop_five_byte_spec
         refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
           (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
         intro h' hp'
-        exact ((sepConj_pure_right _ _ _).1 hp').1)
+        exact ((sepConj_pure_right _).1 hp').1)
       tri1
   -- Iters 2-5: four-byte closure at base with (ptr+1, cnt=4).
   have four_byte := rlp_phase2_long_loop_four_byte_spec ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -110,7 +110,7 @@ theorem rlp_phase2_long_loop_four_byte_spec
         refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
           (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
         intro h' hp'
-        exact ((sepConj_pure_right _ _ _).1 hp').1)
+        exact ((sepConj_pure_right _).1 hp').1)
       tri1
   -- Iters 2-4: three-byte closure at base with (ptr+1, cnt=3).
   have three_byte := rlp_phase2_long_loop_three_byte_spec ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -107,7 +107,7 @@ theorem rlp_phase2_long_loop_one_byte_spec
       refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
         (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
       intro h' hp'
-      exact ((sepConj_pure_right _ _ _).1 hp').1)
+      exact ((sepConj_pure_right _).1 hp').1)
     tri
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -117,7 +117,7 @@ theorem rlp_phase2_long_loop_three_byte_spec
         refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
           (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
         intro h' hp'
-        exact ((sepConj_pure_right _ _ _).1 hp').1)
+        exact ((sepConj_pure_right _).1 hp').1)
       tri1
   -- Iter 2+3: two-byte closure starting at base with ptr+1, cnt = 2.
   have two_byte := rlp_phase2_long_loop_two_byte_spec ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -121,7 +121,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
         refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
           (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
         intro h' hp'
-        exact ((sepConj_pure_right _ _ _).1 hp').1)
+        exact ((sepConj_pure_right _).1 hp').1)
       tri1
   -- Iter 2: one-byte spec at base, using state from tri1's post.
   -- Permute post to match one-byte spec's pre shape (put x13, x14 first).

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -966,7 +966,7 @@ theorem sepConj_pure_left (P : Prop) (Q : Assertion) :
     exact ⟨PartialState.empty, h, PartialState.Disjoint_empty_left h,
            PartialState.union_empty_left h, ⟨rfl, hp⟩, hq⟩
 
-theorem sepConj_pure_right (P : Assertion) (Q : Prop) :
+theorem sepConj_pure_right {P : Assertion} {Q : Prop} :
     ∀ h, (P ** ⌜Q⌝) h ↔ P h ∧ Q := by
   intro h
   rw [sepConj_comm]
@@ -1284,13 +1284,13 @@ theorem sepConj_mono {P P' Q Q' : Assertion} (hp : ∀ h, P h → P' h) (hq : �
 theorem sepConj_strip_pure_end2 {A B : Assertion} {P : Prop} :
     ∀ h, (A ** B ** ⌜P⌝) h → (A ** B) h :=
   fun h hp => sepConj_mono_right
-    (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1) h hp
+    (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp
 
 /-- Strip a pure fact at depth 3: A ** B ** C ** ⌜P⌝ → A ** B ** C -/
 theorem sepConj_strip_pure_end3 {A B C : Assertion} {P : Prop} :
     ∀ h, (A ** B ** C ** ⌜P⌝) h → (A ** B ** C) h :=
   fun h hp => sepConj_mono_right (sepConj_mono_right
-    (fun h' hp' => ((sepConj_pure_right _ _ h').1 hp').1)) h hp
+    (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
 
 /-- Strip a pure fact at depth 3 (middle position): A ** B ** C ** ⌜P⌝ ** D → A ** B ** C ** D -/
 theorem sepConj_strip_pure_depth3 {A B C D : Assertion} {P : Prop} :
@@ -1304,7 +1304,7 @@ theorem sepConj_extract_pure_end3 {A B C : Assertion} {P : Prop} :
   fun h hp => by
     obtain ⟨_, _, _, _, _, h2⟩ := hp
     obtain ⟨_, _, _, _, _, h3⟩ := h2
-    exact ((sepConj_pure_right _ _ _).1 h3).2
+    exact ((sepConj_pure_right _).1 h3).2
 
 /-- Push the outer atom of a 4-chain left-associated `(3-chain) ** D`
     into the right-associated 4-chain — the inverse of the tree shape


### PR DESCRIPTION
## Summary
- Flip `sepConj_pure_right (P : Assertion) (Q : Prop)` to implicit. The ∀ h binder stays explicit — it's the identifier that pins down P and Q by unification.
- 155 call sites passed `_ _ h`; those now just pass `h`. Two sites in `CPSSpec.lean` that named `P fact h1` drop the positional args too.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)