### PR TITLE
refactor(DivMod/LoopDefs): flip loopIterPost{Max,Call}_{addback,skip} word args to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -162,7 +162,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_addback hb]; exact hp)
       (J3 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -173,7 +173,7 @@ theorem divK_loop_body_n1_max_unified_j3_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_skip hb]; exact hp)
       (J3 hborrow)
 
 /-- Unified j=2 max-path  spec: uses _beq spec for addback, _skip for skip. -/
@@ -210,7 +210,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_addback hb]; exact hp)
       (J2 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -221,7 +221,7 @@ theorem divK_loop_body_n1_max_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_skip hb]; exact hp)
       (J2 hborrow)
 
 /-- Unified j=1 max-path  spec: uses _beq spec for addback, _skip for skip. -/
@@ -259,7 +259,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_addback hb]; exact hp)
       (J1 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -271,7 +271,7 @@ theorem divK_loop_body_n1_max_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_skip hb]; exact hp)
       (J1 hborrow)
 
 /-- Unified j=0 max-path  spec: uses _beq spec for addback, _skip for skip.
@@ -310,7 +310,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_addback hb]; exact hp)
       (J0 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -322,7 +322,7 @@ theorem divK_loop_body_n1_max_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Max_skip hb]; exact hp)
       (J0 hborrow)
 
 -- ============================================================================
@@ -371,7 +371,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_addback hb]; exact hp)
       J3
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -383,7 +383,7 @@ theorem divK_loop_body_n1_call_unified_j3_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_skip hb]; exact hp)
       J3
 
 /-- Unified j=2 call-path  spec: uses _beq spec for addback, _skip for skip. -/
@@ -428,7 +428,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_addback hb]; exact hp)
       J2
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -440,7 +440,7 @@ theorem divK_loop_body_n1_call_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_skip hb]; exact hp)
       J2
 
 /-- Unified j=1 call-path  spec: uses _beq spec for addback, _skip for skip. -/
@@ -485,7 +485,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_addback hb]; exact hp)
       J1
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -497,7 +497,7 @@ theorem divK_loop_body_n1_call_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_skip hb]; exact hp)
       J1
 
 /-- Unified j=0 call-path  spec: uses _beq spec for addback, _skip for skip.
@@ -543,7 +543,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_addback hb]; exact hp)
       J0
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -555,7 +555,7 @@ theorem divK_loop_body_n1_call_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN1Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN1Call_skip hb]; exact hp)
       J0
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -96,7 +96,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J2 hborrow)
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -107,7 +107,7 @@ theorem divK_loop_body_n2_max_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J2 hborrow)
 
 /-- Unified  j=1 max-path spec: handles both skip and addback internally.
@@ -145,7 +145,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J1 hborrow)
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -157,7 +157,7 @@ theorem divK_loop_body_n2_max_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J1 hborrow)
 
 /-- Unified  j=0 max-path spec: handles both skip and addback internally.
@@ -196,7 +196,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_addback hb]; exact hp)
       (J0 hborrow)
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -208,7 +208,7 @@ theorem divK_loop_body_n2_max_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Max_skip hb]; exact hp)
       (J0 hborrow)
 
 -- ============================================================================
@@ -258,7 +258,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_addback hb]; exact hp)
       J2
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -270,7 +270,7 @@ theorem divK_loop_body_n2_call_unified_j2_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_skip hb]; exact hp)
       J2
 
 /-- Unified  j=1 call-path spec: handles both skip and addback internally. -/
@@ -315,7 +315,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_addback hb]; exact hp)
       J1
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -327,7 +327,7 @@ theorem divK_loop_body_n2_call_unified_j1_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_skip hb]; exact hp)
       J1
 
 /-- Unified  j=0 call-path spec: handles both skip and addback internally.
@@ -372,7 +372,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_addback hb]; exact hp)
       J0
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -384,7 +384,7 @@ theorem divK_loop_body_n2_call_unified_j0_spec
     exact cpsTriple_weaken
       (fun h hp => hp)
       (fun h hp => by
-        rw [← loopIterPostN2Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN2Call_skip hb]; exact hp)
       J0
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -158,7 +158,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
     intro_lets at J1
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (J1 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -169,7 +169,7 @@ theorem divK_loop_body_n3_max_unified_j1_spec
     intro_lets at J1
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (J1 hborrow)
 
 -- ============================================================================
@@ -209,7 +209,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
     intro_lets at J0
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Max_addback _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Max_addback hb]; exact hp)
       (J0 hborrow)
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
@@ -220,7 +220,7 @@ theorem divK_loop_body_n3_max_unified_j0_spec
     intro_lets at J0
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Max_skip _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Max_skip hb]; exact hp)
       (J0 hborrow)
 
 -- ============================================================================
@@ -267,7 +267,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
     intro_lets at J1
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Call_addback hb]; exact hp)
       J1
   · -- skip path
     have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
@@ -278,7 +278,7 @@ theorem divK_loop_body_n3_call_unified_j1_spec
     intro_lets at J1
     exact cpsTriple_weaken
       (fun h hp => hp)
-      (fun h hp => by rw [← loopIterPostN3Call_skip _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+      (fun h hp => by rw [← loopIterPostN3Call_skip hb]; exact hp)
       J1
 
 -- ============================================================================
@@ -327,7 +327,7 @@ theorem divK_loop_body_n3_call_unified_j0_spec
       (fun h hp => hp)
       (fun h hp => by
         rw [loopBodyN3CallAddbackBeqPost_eq_J] at hp
-        rw [← loopIterPostN3Call_addback _ _ _ _ _ _ _ _ _ _ _ _ hb]; exact hp)
+        rw [← loopIterPostN3Call_addback hb]; exact hp)
       J0
   · -- skip path
     have hborrow : isSkipBorrowN3Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -350,7 +350,7 @@ def loopN3MaxSkipSkipPost (sp v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig : Word) : Asse
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN1 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
-theorem loopIterPostN1Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN1Max_addback {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN1AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -358,7 +358,7 @@ theorem loopIterPostN1Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
         loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN1Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN1SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN1Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -376,7 +376,7 @@ theorem loopIterPostN1Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   (sp + signExtend12 3952 ↦ₘ div128DLo v0) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u0)
 
-theorem loopIterPostN1Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN1Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -384,7 +384,7 @@ theorem loopIterPostN1Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Wor
         loopBodyN1CallAddbackBeqPostJ loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN1Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN1Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN1Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -402,7 +402,7 @@ def loopIterPostN1 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   let c3 := (mulsubN4 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
   loopExitPostN2 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
-theorem loopIterPostN2Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN2Max_addback {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN2AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -410,7 +410,7 @@ theorem loopIterPostN2Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
         loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN2Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN2SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN2Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -428,7 +428,7 @@ theorem loopIterPostN2Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   (sp + signExtend12 3952 ↦ₘ div128DLo v1) **
   (sp + signExtend12 3944 ↦ₘ div128Un0 u1)
 
-theorem loopIterPostN2Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN2Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -436,7 +436,7 @@ theorem loopIterPostN2Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Wor
         loopBodyN2CallAddbackBeqPostJ loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
-theorem loopIterPostN2Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN2Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u2 u1 v1) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN2Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -455,7 +455,7 @@ def loopIterPostN2 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   loopExitPostN3 sp j r.1 c3 r.2.1 r.2.2.1 r.2.2.2.1 r.2.2.2.2.1 r.2.2.2.2.2 v0 v1 v2 v3
 
 /-- Producer equation: addback beq postcondition equals loopIterPostN3Max when borrow holds. -/
-theorem loopIterPostN3Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN3Max_addback {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN3AddbackBeqPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -464,7 +464,7 @@ theorem loopIterPostN3Max_addback (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
 /-- Producer equation: skip postcondition equals loopIterPostN3Max when ¬borrow. -/
-theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN3Max_skip {sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN3SkipPost sp j (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -483,7 +483,7 @@ theorem loopIterPostN3Max_skip (sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
 /-- Producer equation: call addback beq postcondition equals loopIterPostN3Call when borrow holds. -/
-theorem loopIterPostN3Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN3Call_addback {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN3CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
@@ -492,7 +492,7 @@ theorem loopIterPostN3Call_addback (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Wor
   unfold mulsubN4_c3 at hb; simp only [if_pos hb]; split <;> rfl
 
 /-- Producer equation: call skip postcondition equals loopIterPostN3Call when ¬borrow. -/
-theorem loopIterPostN3Call_skip (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem loopIterPostN3Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4_c3 (div128Quot u3 u2 v2) v0 v1 v2 v3 u0 u1 u2 u3)) :
     loopBodyN3CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop := by


### PR DESCRIPTION
## Summary
- Flip 11-12 Word arguments on 12 `loopIterPostN{1,2,3}{Max,Call}_{addback,skip}` equality lemmas to implicit.
- Every one of 35 call sites passed those words as `_` placeholders; the `hb : BitVec.ult ...` hypothesis determines them by unification.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)