### PR TITLE
refactor(EvmWordArith): flip EvmWord.ult_iff (x y) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -23,9 +23,9 @@ theorem carry_toNat (x y : Word) :
   have hx := x.isLt; have hy := y.isLt
   have hsum : (x + y).toNat = (x.toNat + y.toNat) % 2^64 := BitVec.toNat_add x y
   split
-  · rename_i h; have := (ult_iff _ _).mp h; rw [hsum] at this
+  · rename_i h; have := (ult_iff).mp h; rw [hsum] at this
     simp [BitVec.toNat_ofNat]; omega
-  · rename_i h; have := mt (ult_iff _ _).mpr h; rw [hsum] at this; push Not at this
+  · rename_i h; have := mt (ult_iff).mpr h; rw [hsum] at this; push Not at this
     simp [BitVec.toNat_ofNat]; omega
 
 -- OR of two {0,1}-valued Words
@@ -267,8 +267,8 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
   -- Borrow flag toNat values
   have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
     simp only [borrow0]; split
-    · rename_i h; rw [if_pos ((ult_iff _ _).mp h)]; rfl
-    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff _ _).mpr hlt))]; rfl
+    · rename_i h; rw [if_pos ((ult_iff).mp h)]; rfl
+    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff).mpr hlt))]; rfl
   -- borrow0 is 0 or 1
   have hb0_01 : borrow0.toNat = 0 ∨ borrow0.toNat = 1 := by
     rw [hb0_nat]; split <;> simp
@@ -279,8 +279,8 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
     simp only [temp1, BitVec.toNat_sub]; congr 1; omega
   have hb1_cond : (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0) ↔
       (a0.toNat + a1.toNat * 2^64 < b0.toNat + b1.toNat * 2^64) := by
-    rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff _ _,
-        show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff _ _,
+    rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff,
+        show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff,
         htemp1_nat, hb0_nat]
     exact borrow_step_iff (2^64) a1.isLt b1.isLt a0.isLt b0.isLt
   have hb1_nat : borrow1.toNat = if (a0.toNat + a1.toNat * 2^64 <
@@ -298,8 +298,8 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
   have hb2_cond : (BitVec.ult a2 b2 ∨ BitVec.ult temp2 borrow1) ↔
       (a0.toNat + a1.toNat * 2^64 + a2.toNat * 2^128 <
        b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128) := by
-    rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff _ _,
-        show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff _ _,
+    rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff,
+        show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff,
         htemp2_nat, hb1_nat]
     have ha_bound : a0.toNat + a1.toNat * 2^64 < 2^128 := by
       have := a0.isLt; have := a1.isLt; nlinarith

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -55,7 +55,7 @@ theorem toNat_eq_limb_sum (v : EvmWord) :
   omega
 
 -- BitVec.ult ↔ toNat comparison
-theorem ult_iff {n : Nat} (x y : BitVec n) : BitVec.ult x y ↔ x.toNat < y.toNat :=
+theorem ult_iff {n : Nat} {x y : BitVec n} : BitVec.ult x y ↔ x.toNat < y.toNat :=
   ⟨fun h => BitVec.lt_def.mp (of_decide_eq_true h),
    fun h => decide_eq_true (BitVec.lt_def.mpr h)⟩
 

--- a/EvmAsm/Evm64/EvmWordArith/Comparison.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Comparison.lean
@@ -39,8 +39,8 @@ theorem lt_borrow_chain_correct (a b : EvmWord) :
   -- Step 1: borrow0 tracks 1-limb comparison
   have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
     simp only [borrow0]; split
-    · rename_i h; rw [if_pos ((ult_iff _ _).mp h)]; rfl
-    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff _ _).mpr hlt))]; rfl
+    · rename_i h; rw [if_pos ((ult_iff).mp h)]; rfl
+    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff).mpr hlt))]; rfl
   -- Step 2: borrow1 tracks 2-limb comparison
   have hb1_or : borrow1 = if (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0)
       then (1 : Word) else 0 := borrow_or_iff _ _
@@ -48,8 +48,8 @@ theorem lt_borrow_chain_correct (a b : EvmWord) :
     simp only [temp1, BitVec.toNat_sub]; congr 1; omega
   have hb1_cond : (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0) ↔
       (a0.toNat + a1.toNat * 2^64 < b0.toNat + b1.toNat * 2^64) := by
-    rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff _ _,
-        show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff _ _,
+    rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff,
+        show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff,
         htemp1_nat, hb0_nat]
     exact borrow_step_iff (2^64) a1.isLt b1.isLt a0.isLt b0.isLt
   have hb1_nat : borrow1.toNat = if (a0.toNat + a1.toNat * 2^64 <
@@ -65,8 +65,8 @@ theorem lt_borrow_chain_correct (a b : EvmWord) :
   have hb2_cond : (BitVec.ult a2 b2 ∨ BitVec.ult temp2 borrow1) ↔
       (a0.toNat + a1.toNat * 2^64 + a2.toNat * 2^128 <
        b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128) := by
-    rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff _ _,
-        show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff _ _,
+    rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff,
+        show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff,
         htemp2_nat, hb1_nat]
     have ha_bound : a0.toNat + a1.toNat * 2^64 < 2^128 := by
       have := a0.isLt; have := a1.isLt; nlinarith
@@ -86,8 +86,8 @@ theorem lt_borrow_chain_correct (a b : EvmWord) :
   have hb3_cond : (BitVec.ult a3 b3 ∨ BitVec.ult temp3 borrow2) ↔
       (a0.toNat + a1.toNat * 2^64 + a2.toNat * 2^128 + a3.toNat * 2^192 <
        b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128 + b3.toNat * 2^192) := by
-    rw [show BitVec.ult a3 b3 ↔ a3.toNat < b3.toNat from ult_iff _ _,
-        show BitVec.ult temp3 borrow2 ↔ temp3.toNat < borrow2.toNat from ult_iff _ _,
+    rw [show BitVec.ult a3 b3 ↔ a3.toNat < b3.toNat from ult_iff,
+        show BitVec.ult temp3 borrow2 ↔ temp3.toNat < borrow2.toNat from ult_iff,
         htemp3_nat, hb2_nat]
     have ha_bound : a0.toNat + a1.toNat * 2^64 + a2.toNat * 2^128 < 2^192 := by
       have := a0.isLt; have := a1.isLt; have := a2.isLt; nlinarith
@@ -144,12 +144,12 @@ theorem slt_result_correct (a b : EvmWord) :
     -- Same structure as lt_borrow_chain_correct steps 1-3
     have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
       simp only [borrow0]; split
-      · rename_i hh; rw [if_pos ((ult_iff _ _).mp hh)]; rfl
-      · rename_i hh; rw [if_neg (fun hlt => hh ((ult_iff _ _).mpr hlt))]; rfl
+      · rename_i hh; rw [if_pos ((ult_iff).mp hh)]; rfl
+      · rename_i hh; rw [if_neg (fun hlt => hh ((ult_iff).mpr hlt))]; rfl
     have hb1_cond : (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0) ↔
         (a0.toNat + a1.toNat * 2^64 < b0.toNat + b1.toNat * 2^64) := by
-      rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff _ _,
-          show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff _ _]
+      rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff,
+          show BitVec.ult temp1 borrow0 ↔ temp1.toNat < borrow0.toNat from ult_iff]
       simp only [temp1, BitVec.toNat_sub]; rw [hb0_nat]
       convert borrow_step_iff (2^64) a1.isLt b1.isLt a0.isLt b0.isLt using 2; omega
     have hb1_nat : borrow1.toNat = if (a0.toNat + a1.toNat * 2^64 <
@@ -160,8 +160,8 @@ theorem slt_result_correct (a b : EvmWord) :
     have hb2_cond : (BitVec.ult a2 b2 ∨ BitVec.ult temp2 borrow1) ↔
         (a0.toNat + a1.toNat * 2^64 + a2.toNat * 2^128 <
          b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128) := by
-      rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff _ _,
-          show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff _ _]
+      rw [show BitVec.ult a2 b2 ↔ a2.toNat < b2.toNat from ult_iff,
+          show BitVec.ult temp2 borrow1 ↔ temp2.toNat < borrow1.toNat from ult_iff]
       simp only [temp2, BitVec.toNat_sub]; rw [hb1_nat]
       have ha_bound : a0.toNat + a1.toNat * 2^64 < 2^128 := by
         have := a0.isLt; have := a1.isLt; nlinarith

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -820,7 +820,7 @@ theorem div128Quot_phase1b_check_implies_q1c_pos
   have hq1c_eq : q1c = 0 := BitVec.eq_of_toNat_eq (by simp [hq1c_zero])
   rw [hq1c_eq] at h_check
   have h_lt : rhatUn1.toNat < ((0 : Word) * dLo).toNat :=
-    (EvmWord.ult_iff _ _).mp h_check
+    (EvmWord.ult_iff).mp h_check
   have hmul_zero : ((0 : Word) * dLo).toNat = 0 := by
     rw [BitVec.toNat_mul]; simp
   rw [hmul_zero] at h_lt

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -304,7 +304,7 @@ theorem isCallTrialN4_toNat_lt (a3 b2 b3 : Word)
       ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
         (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat := by
   unfold isCallTrialN4 at h
-  exact (EvmWord.ult_iff _ _).mp h
+  exact (EvmWord.ult_iff).mp h
 
 /-- Antishift arithmetic: under `1 ≤ shift.toNat ≤ 63`, the algorithm's
     `antiShift = signExtend12 0 - shift` satisfies `antiShift.toNat % 64 =

--- a/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
@@ -188,6 +188,6 @@ theorem isMaxTrialN4_false_of_shift_nz (a3 b2 b3 : Word)
               (b3 <<< ((clzResult b3).1.toNat % 64) |||
                 b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat :=
     Nat.lt_of_lt_of_le h_u4 (le_trans h_b3_shifted h_or_ge)
-  exact (EvmWord.ult_iff _ _).mpr h_lt
+  exact (EvmWord.ult_iff).mpr h_lt
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Flip `EvmWord.ult_iff {n} (x y : BitVec n)` — the two BitVec args — to implicit.
- All 22 call sites pass `_ _`; the surrounding `.mp`/`.mpr` application, `show ... from`, or `rw` context determines them by unification.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)