### PR TITLE
refactor(SailEquiv): flip stateRel_nextPC (sRv sSail) to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -32,7 +32,7 @@ private theorem sign_extend_13_eq (imm : BitVec 13) :
   unfold sign_extend signExtend13 Sail.BitVec.signExtend; rfl
 
 /-- Writing Register.nextPC preserves StateRel (nextPC is not in the tracked register set). -/
-theorem stateRel_nextPC (sRv : MachineState) (sSail : SailState)
+theorem stateRel_nextPC {sRv : MachineState} {sSail : SailState}
     (hrel : StateRel sRv sSail) (v : BitVec 64) :
     StateRel sRv { sSail with regs := sSail.regs.insert Register.nextPC v } :=
   ⟨fun r => by
@@ -94,7 +94,7 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
   · simp only [h, ite_false]
@@ -119,7 +119,7 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
   · simp only [h, ite_false]
@@ -144,7 +144,7 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
   · simp only [h, ite_false]
@@ -177,7 +177,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
 
@@ -198,7 +198,7 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
   · simp only [h, ite_false]
@@ -231,7 +231,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
-    exact ⟨_, rfl, stateRel_nextPC _ _
+    exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
 
@@ -268,23 +268,23 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
       runSail_wX_bits_x5, runSail_wX_bits_x6, runSail_wX_bits_x7,
       runSail_wX_bits_x10, runSail_wX_bits_x11, runSail_wX_bits_x12]
   all_goals first
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x0 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x0 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x1 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x1 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x2 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x2 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x5 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x5 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x6 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x6 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x7 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x7 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x10 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x10 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x11 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x11 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel _) .x12 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel _) .x12 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel.mem_agree a⟩⟩
 
 private theorem sign_extend_12_eq (imm : BitVec 12) :
@@ -339,23 +339,23 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
       runSail_wX_bits_x5, runSail_wX_bits_x6, runSail_wX_bits_x7,
       runSail_wX_bits_x10, runSail_wX_bits_x11, runSail_wX_bits_x12]
   all_goals first
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x0 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x0 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x1 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x1 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x2 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x2 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x5 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x5 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x6 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x6 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x7 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x7 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x10 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x10 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x11 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x11 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
-    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC _ _ hrel_mid _) .x12 _ r,
+    | exact ⟨_, rfl, ⟨fun r => by simpa [execInstrBr, MachineState.setPC] using reg_agree_after_insert _ _ (stateRel_nextPC hrel_mid _) .x12 _ r,
         fun a => by simpa [execInstrBr, MachineState.setPC] using hrel_mid.mem_agree a⟩⟩
 
 end EvmAsm.Rv64.SailEquiv


### PR DESCRIPTION
## Summary
- Flip `stateRel_nextPC (sRv : MachineState) (sSail : SailState)` to implicit.
- All 24 call sites in `BranchProofs.lean` pass `_ _`; the `hrel : StateRel sRv sSail` hypothesis determines both by unification.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)