### PR TITLE
refactor(SailEquiv): flip runSail_jump_to (target s) to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -93,7 +93,7 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : sRv.getReg rs1 == sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -118,7 +118,7 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : sRv.getReg rs1 != sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -143,7 +143,7 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -176,7 +176,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
     simp only [show BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -197,7 +197,7 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -230,7 +230,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
     simp only [show BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
-    rw [runSail_jump_to _ _ misa_val h_align h_misa]
+    rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
@@ -260,7 +260,7 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
     runSail_get_next_pc sSail (sRv.pc + 4) h_nextpc,
     runSail_readReg_PC sSail sRv.pc h_pc,
     sign_extend_21_eq]
-  rw [runSail_jump_to _ _ misa_val h_align h_misa]
+  rw [runSail_jump_to misa_val h_align h_misa]
   simp only [RETIRE_SUCCESS, runSail_bind, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
@@ -331,7 +331,7 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
   -- Rewrite BitVec.update to &&& ~~~1 before applying jump_to
   simp only [show @Sail.BitVec.update (m := 64) (sRv.getReg rs1 + signExtend12 offset) 0 0#1 =
     (sRv.getReg rs1 + signExtend12 offset) &&& ~~~1#64 from jalr_mask_equiv _]
-  rw [runSail_jump_to _ _ misa_val h_align h_misa_mid]
+  rw [runSail_jump_to misa_val h_align h_misa_mid]
   simp only [RETIRE_SUCCESS, runSail_bind, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -350,7 +350,7 @@ private theorem align4_getLsbD1 (v : BitVec 64) (h : v &&& 3 = 0) :
 /-- jump_to succeeds for 4-byte aligned targets: writes nextPC, returns RETIRE_SUCCESS.
     Requires 4-byte alignment (bits 0,1 = 0) and that misa is readable in the
     SAIL state. Alignment makes the Ext_Zca result irrelevant (bit 1 = 0). -/
-theorem runSail_jump_to (target : BitVec 64) (s : SailState)
+theorem runSail_jump_to {target : BitVec 64} {s : SailState}
     (misa_val : BitVec 64)
     (h_align : target &&& 3 = 0)
     (h_misa : s.regs.get? Register.misa = some misa_val) :


### PR DESCRIPTION
## Summary
- Flip `runSail_jump_to (target : BitVec 64) (s : SailState)` to implicit.
- All 8 call sites pass `_ _` for both; the `rw [runSail (jump_to target) s = ...]` goal determines them by unification.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)