### PR TITLE
refactor(Stack): flip signExtend12_ofNat_small m to implicit

### DIFF
--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -58,22 +58,22 @@ theorem evm_dup_spec (nsp base : Word)
        ((nsp + BitVec.ofNat 64 (n*32+24)) ↦ₘ s3)) := by
   -- signExtend12 normalizations for source offsets
   have hse_s0 : signExtend12 (BitVec.ofNat 12 (n*32)) = BitVec.ofNat 64 (n*32) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s1 : signExtend12 (BitVec.ofNat 12 (n*32+8)) = BitVec.ofNat 64 (n*32+8) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s2 : signExtend12 (BitVec.ofNat 12 (n*32+16)) = BitVec.ofNat 64 (n*32+16) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s3 : signExtend12 (BitVec.ofNat 12 (n*32+24)) = BitVec.ofNat 64 (n*32+24) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   -- signExtend12 normalizations for destination offsets
   have hm0  : nsp + signExtend12 (BitVec.ofNat 12 0)  = nsp      := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm8  : nsp + signExtend12 (BitVec.ofNat 12 8)  = nsp + 8  := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm16 : nsp + signExtend12 (BitVec.ofNat 12 16) = nsp + 16 := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm24 : nsp + signExtend12 (BitVec.ofNat 12 24) = nsp + 24 := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   -- ADDI spec
   have sA := addi_spec_gen_same .x12 (nsp + 32) (-32) base (by nofun)
   simp only [signExtend12_neg32] at sA

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -458,7 +458,7 @@ theorem evmWordIs_one_right (addr : Word) (Q : Assertion) :
 
 /-- Sign-extend a small non-negative 12-bit value to 64 bits.
     The MSB is clear when m < 2^11 = 2048, so signExtend = zeroExtend = identity. -/
-theorem signExtend12_ofNat_small (m : Nat) (hm : m < 2048) :
+theorem signExtend12_ofNat_small {m : Nat} (hm : m < 2048) :
     signExtend12 (BitVec.ofNat 12 m) = BitVec.ofNat 64 m := by
   unfold signExtend12
   rw [BitVec.signExtend_eq_setWidth_of_msb_false]

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -61,22 +61,22 @@ theorem evm_swap_spec (sp base : Word)
        ((sp + BitVec.ofNat 64 (n*32+24)) ↦ₘ a3)) := by
   -- signExtend12 normalizations for n-dependent source offsets
   have hse_s0 : signExtend12 (BitVec.ofNat 12 (n*32)) = BitVec.ofNat 64 (n*32) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s1 : signExtend12 (BitVec.ofNat 12 (n*32+8)) = BitVec.ofNat 64 (n*32+8) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s2 : signExtend12 (BitVec.ofNat 12 (n*32+16)) = BitVec.ofNat 64 (n*32+16) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   have hse_s3 : signExtend12 (BitVec.ofNat 12 (n*32+24)) = BitVec.ofNat 64 (n*32+24) :=
-    signExtend12_ofNat_small _ (by omega)
+    signExtend12_ofNat_small (by omega)
   -- signExtend12 normalizations for destination offsets (0,8,16,24)
   have hm0  : sp + signExtend12 (BitVec.ofNat 12 0)  = sp      := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm8  : sp + signExtend12 (BitVec.ofNat 12 8)  = sp + 8  := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm16 : sp + signExtend12 (BitVec.ofNat 12 16) = sp + 16 := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   have hm24 : sp + signExtend12 (BitVec.ofNat 12 24) = sp + 24 := by
-    rw [signExtend12_ofNat_small _ (by omega)]; bv_omega
+    rw [signExtend12_ofNat_small (by omega)]; bv_omega
   -- Limb 0 swap
   have L0 := swap_limb_spec sp
     (BitVec.ofNat 12 0) (BitVec.ofNat 12 (n*32))


### PR DESCRIPTION
## Summary
- Flip `signExtend12_ofNat_small (m : Nat) (hm : m < 2048)` — the `m` arg — to implicit.
- All 16 call sites pass `_ (by omega)`; the goal shape `signExtend12 (BitVec.ofNat 12 m) = BitVec.ofNat 64 m` determines `m` by unification when the lemma is used via `rw` or `exact`.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)