### PR TITLE
refactor(SepLogic): flip CodeReq.Disjoint.singleton (i1 i2) to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/LimbSpec.lean
+++ b/EvmAsm/Evm64/Shift/LimbSpec.lean
@@ -359,7 +359,7 @@ theorem shr_cascade_step_spec (v5 v10 : Word)
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   -- Step 1: ADDI x10, x0, k at base (singleton CR)
   have s1 := addi_spec_gen .x10 .x0 v10 0 k base (by nofun)
   -- Frame ADDI with x5 and permute
@@ -409,7 +409,7 @@ theorem shr_cascade_step_spec_pure (v5 v10 : Word)
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   have s1 := addi_spec_gen .x10 .x0 v10 0 k base (by nofun)
   have s1' : cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI .x10 .x0 k))
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
@@ -470,20 +470,20 @@ theorem shr_phase_c_spec (v5 v10 : Word) (base : Word)
   -- Disjointness proofs between sub-CRs
   have hd_beq0_cs1 : cr_beq0.Disjoint cr_cs1 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_beq0_cs2 : cr_beq0.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_cs1_cs2 : cr_cs1.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Step 0: BEQ x5 x0 176 at base (singleton CR)
   have beq0_raw := beq_spec_gen .x5 .x0 176 v5 (0 : Word) base
   rw [he0] at beq0_raw
@@ -569,20 +569,20 @@ theorem shr_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   let cr_cs2 := shr_cascade_step_code 2 32 (base + 12)
   have hd_beq0_cs1 : cr_beq0.Disjoint cr_cs1 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_beq0_cs2 : cr_beq0.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_cs1_cs2 : cr_cs1.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Step 0: BEQ x5 x0 176 — keep ⌜v5 = 0⌝ / ⌜v5 ≠ 0⌝
   have beq0_raw := beq_spec_gen .x5 .x0 176 v5 (0 : Word) base
   rw [he0] at beq0_raw
@@ -750,8 +750,8 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Disjoint: crLd1 vs crLor2
   have hd_ld1_lor2 : crLd1.Disjoint crLor2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   -- Compose LD + LD/OR (need to frame + perm)
   have lw1f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ s0) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lw1
   have lor2f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lor2
@@ -766,15 +766,15 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   have hd_12_lor3 : (crLd1.union crLor2).Disjoint crLor3 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega)))
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))))
   have c13 := cpsTriple_seq_with_perm hd_12_lor3
     (fun h hp => by xperm_hyp hp) c12 lor3f
   -- CR so far: (crLd1 ∪ crLor2) ∪ crLor3
@@ -801,13 +801,13 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   have hd_lin_bne : crLinear.Disjoint crBne :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+        (CodeReq.Disjoint.singleton (by bv_omega))
         (CodeReq.Disjoint.union_left
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))))
       (CodeReq.Disjoint.union_left
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Compose linear chain + BNE branch
   have br1 := cpsTriple_seq_cpsBranch_with_perm hd_lin_bne
     (fun h hp => by xperm_hyp hp) c13 bne1f
@@ -825,7 +825,7 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   -- Disjoint: crLd5 vs crSltiu
   have hd_ld5_sltiu : crLd5.Disjoint crSltiu :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   -- Frame and compose LD + SLTIU
   have lw5f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ s3) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) lw5
   have sltiuf := cpsTriple_frameR ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3)) (by pcFree) sltiu_raw
@@ -852,8 +852,8 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
   -- Disjoint: (crLd5 ∪ crSltiu) vs crBeq
   have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
     CodeReq.Disjoint.union_left
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   -- Compose LD+SLTIU chain with BEQ branch
   have br2 := cpsTriple_seq_cpsBranch_with_perm hd_56_beq
     (fun h hp => by xperm_hyp hp) c56 beq1f
@@ -868,9 +868,9 @@ theorem shr_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.singleton a i).Disjoint crTail :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton h24 _ _)
-        (CodeReq.Disjoint.singleton h28 _ _))
-      (CodeReq.Disjoint.singleton h32 _ _)
+        (CodeReq.Disjoint.singleton h24)
+        (CodeReq.Disjoint.singleton h28))
+      (CodeReq.Disjoint.singleton h32)
   -- crLor2 = singleton (base+4) ∪ singleton (base+4+4), each vs crTail
   have hd_lor2_tail : crLor2.Disjoint crTail :=
     CodeReq.Disjoint.union_left

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -530,20 +530,20 @@ theorem sar_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   let cr_cs2 := shr_cascade_step_code 2 36 (base + 12)
   have hd_beq0_cs1 : cr_beq0.Disjoint cr_cs1 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_beq0_cs2 : cr_beq0.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_cs1_cs2 : cr_cs1.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Step 0: BEQ x5 x0 188
   have beq0_raw := beq_spec_gen .x5 .x0 188 v5 (0 : Word) base
   rw [he0] at beq0_raw

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -263,7 +263,7 @@ theorem signext_cascade_step_spec (v5 v10 : Word)
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   have s1 := addi_spec_gen .x10 .x0 v10 0 k base (by nofun)
   have s1' : cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI .x10 .x0 k))
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
@@ -360,8 +360,8 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   rw [ha48] at lor2
   have hd_ld1_lor2 : crLd1.Disjoint crLor2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have lw1f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) ** (sp ↦ₘ b0) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lw1
   have lor2f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lor2
   have c12 := cpsTriple_seq_with_perm hd_ld1_lor2
@@ -373,15 +373,15 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   have hd_12_lor3 : (crLd1.union crLor2).Disjoint crLor3 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_left
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega)))
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))))
   have c13 := cpsTriple_seq_with_perm hd_12_lor3
     (fun h hp => by xperm_hyp hp) c12 lor3f
   let crLinear := (crLd1.union crLor2).union crLor3
@@ -405,13 +405,13 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   have hd_lin_bne : crLinear.Disjoint crBne :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_left
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+        (CodeReq.Disjoint.singleton (by bv_omega))
         (CodeReq.Disjoint.union_left
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-          (CodeReq.Disjoint.singleton (by bv_omega) _ _)))
+          (CodeReq.Disjoint.singleton (by bv_omega))
+          (CodeReq.Disjoint.singleton (by bv_omega))))
       (CodeReq.Disjoint.union_left
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   have br1 := cpsTriple_seq_cpsBranch_with_perm hd_lin_bne
     (fun h hp => by xperm_hyp hp) c13 bne1f
   -- ── Part 3: Fall-through path (base+24..base+32): LD + SLTIU + BEQ ──
@@ -424,7 +424,7 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
   rw [ha28] at sltiu_raw
   let sltiuVal := (if BitVec.ult b0 (signExtend12 (31 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hd_ld5_sltiu : crLd5.Disjoint crSltiu :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   have lw5f := cpsTriple_frameR ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ b3) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) lw5
   have sltiuf := cpsTriple_frameR ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (sp ↦ₘ b0) ** ((sp + 8) ↦ₘ b1) ** ((sp + 16) ↦ₘ b2) ** ((sp + 24) ↦ₘ b3)) (by pcFree) sltiu_raw
   have c56 := cpsTriple_seq_with_perm hd_ld5_sltiu
@@ -447,8 +447,8 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
     (by pcFree) beq1
   have hd_56_beq : (crLd5.union crSltiu).Disjoint crBeq :=
     CodeReq.Disjoint.union_left
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have br2 := cpsTriple_seq_cpsBranch_with_perm hd_56_beq
     (fun h hp => by xperm_hyp hp) c56 beq1f
   let crTail := (crLd5.union crSltiu).union crBeq
@@ -458,9 +458,9 @@ theorem signext_phase_a_spec (sp r5 r10 : Word)
       (CodeReq.singleton a i).Disjoint crTail :=
     CodeReq.Disjoint.union_right
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton h24 _ _)
-        (CodeReq.Disjoint.singleton h28 _ _))
-      (CodeReq.Disjoint.singleton h32 _ _)
+        (CodeReq.Disjoint.singleton h24)
+        (CodeReq.Disjoint.singleton h28))
+      (CodeReq.Disjoint.singleton h32)
   have hd_lor2_tail : crLor2.Disjoint crTail :=
     CodeReq.Disjoint.union_left
       (sd_tail (base + 4) _ (by bv_omega) (by bv_omega) (by bv_omega))
@@ -587,20 +587,20 @@ theorem signext_phase_c_spec (v5 v10 : Word) (base : Word)
   -- Disjointness proofs
   have hd_beq0_cs1 : cr_beq0.Disjoint cr_cs1 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_beq0_cs2 : cr_beq0.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_cs1_cs2 : cr_cs1.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Step 0: BEQ x5 x0 100 at base
   have beq0_raw := beq_spec_gen .x5 .x0 100 v5 (0 : Word) base
   rw [he0] at beq0_raw
@@ -673,7 +673,7 @@ theorem signext_cascade_step_spec_pure (v5 v10 : Word)
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BEQ .x5 .x10 offset)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   have s1 := addi_spec_gen .x10 .x0 v10 0 k base (by nofun)
   have s1' : cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI .x10 .x0 k))
       ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
@@ -724,20 +724,20 @@ theorem signext_phase_c_spec_pure (v5 v10 : Word) (base : Word)
   let cr_cs2 := signext_cascade_step_code 2 24 (base + 12)
   have hd_beq0_cs1 : cr_beq0.Disjoint cr_cs1 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_beq0_cs2 : cr_beq0.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega))
   have hd_cs1_cs2 : cr_cs1.Disjoint cr_cs2 :=
     CodeReq.Disjoint.union_left
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-        (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
   -- Step 0: BEQ x5 x0 100
   have beq0_raw := beq_spec_gen .x5 .x0 100 v5 (0 : Word) base
   rw [he0] at beq0_raw

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -104,7 +104,7 @@ theorem rlp_phase1_step_spec (v5 v10 : Word)
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x10 .x0 k))
       (CodeReq.singleton (base + 4) (.BLTU .x5 .x10 offset)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   -- Step 1: ADDI x10, x0, k at base
   have s1 := addi_spec_gen .x10 .x0 v10 0 k base (by nofun)
   have s1' : cpsTriple base (base + 4) (CodeReq.singleton base (.ADDI .x10 .x0 k))
@@ -185,11 +185,11 @@ private theorem step_code_Disjoint_8 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
       (rlp_phase1_step_code k2 off2 (base + 8)) :=
   CodeReq.Disjoint.union_left
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
 
 /-- Cascade-step at `base` is disjoint from step at `base + 16`. -/
 private theorem step_code_Disjoint_16 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
@@ -198,11 +198,11 @@ private theorem step_code_Disjoint_16 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13
       (rlp_phase1_step_code k2 off2 (base + 16)) :=
   CodeReq.Disjoint.union_left
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
 
 /-- Cascade-step at `base` is disjoint from step at `base + 24`. -/
 private theorem step_code_Disjoint_24 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
@@ -211,11 +211,11 @@ private theorem step_code_Disjoint_24 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13
       (rlp_phase1_step_code k2 off2 (base + 24)) :=
   CodeReq.Disjoint.union_left
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
     (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _)
-      (CodeReq.Disjoint.singleton (by bv_omega) _ _))
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
 
 /-- Bundled exit postcondition for the Phase 1 classifier: the register-
     ownership triple with `x10` holding the threshold constant `k`.

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -90,7 +90,7 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.SLLI .x11 .x11 8))
       (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) :=
-    CodeReq.Disjoint.singleton (by bv_omega) _ _
+    CodeReq.Disjoint.singleton (by bv_omega)
   -- Step 1: SLLI x11, x11, 8 — use `slli_spec_gen_same` (rd = rs1),
   -- then frame with x12 to bring it into scope.
   have s1Base := slli_spec_gen_same .x11 len 8 base (by nofun)

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -235,7 +235,7 @@ theorem rlp_phase2_long_iter_spec
       ((CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1))).union
         CodeReq.empty) :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton h34 _ _)
+      (CodeReq.Disjoint.singleton h34)
       (CodeReq.Disjoint.empty_right _)
   have hd3 : CodeReq.Disjoint
       (CodeReq.singleton (base + 8) (.ADD .x11 .x11 .x12))
@@ -243,9 +243,9 @@ theorem rlp_phase2_long_iter_spec
         ((CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1))).union
           CodeReq.empty)) :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton h23 _ _)
+      (CodeReq.Disjoint.singleton h23)
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton h24 _ _)
+        (CodeReq.Disjoint.singleton h24)
         (CodeReq.Disjoint.empty_right _))
   have hd2 : CodeReq.Disjoint
       (CodeReq.singleton (base + 4) (.SLLI .x11 .x11 8))
@@ -254,11 +254,11 @@ theorem rlp_phase2_long_iter_spec
           ((CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1))).union
             CodeReq.empty))) :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton h12 _ _)
+      (CodeReq.Disjoint.singleton h12)
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton h13 _ _)
+        (CodeReq.Disjoint.singleton h13)
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton h14 _ _)
+          (CodeReq.Disjoint.singleton h14)
           (CodeReq.Disjoint.empty_right _)))
   have hd1 : CodeReq.Disjoint
       (CodeReq.singleton base (.LBU .x12 .x13 0))
@@ -268,13 +268,13 @@ theorem rlp_phase2_long_iter_spec
             ((CodeReq.singleton (base + 16) (.ADDI .x14 .x14 (-1))).union
               CodeReq.empty)))) :=
     CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton h01 _ _)
+      (CodeReq.Disjoint.singleton h01)
       (CodeReq.Disjoint.union_right
-        (CodeReq.Disjoint.singleton h02 _ _)
+        (CodeReq.Disjoint.singleton h02)
         (CodeReq.Disjoint.union_right
-          (CodeReq.Disjoint.singleton h03 _ _)
+          (CodeReq.Disjoint.singleton h03)
           (CodeReq.Disjoint.union_right
-            (CodeReq.Disjoint.singleton h04 _ _)
+            (CodeReq.Disjoint.singleton h04)
             (CodeReq.Disjoint.empty_right _))))
   -- Extend s5's CR with a trailing empty.
   have s5_ext : cpsTriple (base + 16) (base + 20)

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2111,7 +2111,7 @@ def CodeReq.Disjoint (cr1 cr2 : CodeReq) : Prop :=
 
 /-- Singleton CodeReqs at different addresses are disjoint. -/
 theorem CodeReq.Disjoint.singleton {a1 a2 : Word} (h : a1 ≠ a2)
-    (i1 i2 : Instr) : CodeReq.Disjoint (CodeReq.singleton a1 i1) (CodeReq.singleton a2 i2) := by
+    {i1 i2 : Instr} : CodeReq.Disjoint (CodeReq.singleton a1 i1) (CodeReq.singleton a2 i2) := by
   intro a
   simp only [CodeReq.singleton]
   cases hb1 : a == a1 with


### PR DESCRIPTION
## Summary
- Flip `CodeReq.Disjoint.singleton ... (i1 i2 : Instr)` to implicit.
- All 107 call sites pass `(by bv_omega) _ _` or `hXY _ _`; the two `Instr` placeholders are determined by the expected type `CodeReq.Disjoint (CodeReq.singleton a1 i1) (CodeReq.singleton a2 i2)`.
- Part of issue #331 (frequent `_` args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)