### PR TITLE
refactor: inline single-use isLt renames (#694)

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -55,10 +55,9 @@ theorem getLimb_xor (x y : EvmWord) (i : Fin 4) :
 theorem getLimb_not (x : EvmWord) (i : Fin 4) :
     (~~~x).getLimb i = ~~~(x.getLimb i) := by
   simp only [getLimb]
-  have hi := i.isLt
   ext j
   simp only [BitVec.getElem_extractLsb', BitVec.getElem_not, BitVec.getLsbD_not]
-  have hbound : i.val * 64 + j < 256 := by omega
+  have hbound : i.val * 64 + j < 256 := by have := i.isLt; omega
   simp [hbound]
 
 /-- Round-trip: fromLimbs ∘ getLimb = id. -/
@@ -158,7 +157,7 @@ theorem toNat_eq_getLimb0_of_high_zero (v : EvmWord)
   have hn3 : (v.extractLsb' (3 * 64) 64).toNat = 0 := by rw [h3]; rfl
   simp [BitVec.extractLsb'_toNat] at hn1 hn2 hn3
   simp [BitVec.extractLsb'_toNat]
-  have hv := v.isLt
+  have := v.isLt
   omega
 
 /-- Extract the k-th 64-bit limb, returning 0 when k ≥ 4 (out of range). -/

--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -30,7 +30,7 @@ theorem bv_eq_of_nat_eq (a b q r : EvmWord)
     a = b * q + r := by
   apply BitVec.eq_of_toNat_eq
   rw [BitVec.toNat_add, BitVec.toNat_mul]
-  have ha := a.isLt
+  have := a.isLt
   rw [Nat.mod_eq_of_lt (show b.toNat * q.toNat < 2^256 by omega),
       Nat.mod_eq_of_lt (show b.toNat * q.toNat + r.toNat < 2^256 by omega)]
   exact h_nat

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -33,9 +33,8 @@ namespace EvmWord
     Max product: (2^64-1)² = 2^128 - 2·2^64 + 1, high half = 2^64 - 2. -/
 theorem mulhu_toNat_le (a b : Word) : (rv64_mulhu a b).toNat ≤ 2^64 - 2 := by
   rw [rv64_mulhu_toNat]
-  have ha := a.isLt; have hb := b.isLt
-  have h1 : a.toNat ≤ 2^64 - 1 := by omega
-  have h2 : b.toNat ≤ 2^64 - 1 := by omega
+  have h1 : a.toNat ≤ 2^64 - 1 := by have := a.isLt; omega
+  have h2 : b.toNat ≤ 2^64 - 1 := by have := b.isLt; omega
   have h3 : a.toNat * b.toNat ≤ (2^64 - 1) * (2^64 - 1) := Nat.mul_le_mul h1 h2
   suffices (2^64 - 1) * (2^64 - 1) / 2^64 = 2^64 - 2 by
     exact Nat.le_trans (Nat.div_le_div_right h3) (Nat.le_of_eq this)


### PR DESCRIPTION
## Summary
Anonymize or inline single-use `have hX := X.isLt` bare renames that only feed `omega` in the local context:
- `Basic.getLimb_not`: move `i.isLt` into the specific omega by-block that uses it.
- `Basic.toNat_getLimb_decompose`: drop the `hv` name since nothing else references it.
- `DivBridge.euclidean_uniq`: drop the `ha` name for the same reason.
- `DivMulSubLimb.mulhu_toNat_le`: inline `a.isLt` / `b.isLt` into the specific `have h1` / `have h2` omega blocks that consume them.

Per issue #694 scope (bare-rename RHS only); each site anonymizes or narrows the rename without splitting multi-line compositions.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)