### PR TITLE
feat(evm-word-arith): div128Quot_rhatc_lt_2dHi — Phase 1b overflow bound (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -58,6 +58,8 @@
     actual `q1c` and `rhatc` regardless of which branch is taken.
   - `div128Quot_q1c_lt_pow33` — `q1c < 2^33` after Phase 1a correction,
     regardless of branch (Phase 1b prerequisite).
+  - `div128Quot_rhatc_lt_2dHi` — `rhatc.toNat < 2 * dHi.toNat` after Phase 1a,
+    regardless of branch (Phase 1b overflow-bound prerequisite).
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -739,6 +741,56 @@ theorem div128Quot_q1c_lt_pow33 (uHi dHi : Word) (hdHi_ge : dHi.toNat ≥ 2^31) 
     rw [h_eq, Nat.add_mod_right]
     have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
     rw [Nat.mod_eq_of_lt hq1_lt_word]
+    omega
+
+/-- **Phase 1b overflow-bound prerequisite — `rhatc.toNat < 2 * dHi.toNat`.**
+
+    After Phase 1a's hi1-correction, the post-correction remainder `rhatc`
+    is bounded by `2 * dHi`, regardless of which branch was taken. This
+    bounds Phase 1b's analysis (where `rhat' = rhatc + dHi` could have
+    overflowed without it).
+
+    - No-correction case (`hi1 = 0`): `rhatc = rhat = uHi mod dHi < dHi`
+      (using the Euclidean equation + `Nat.mod_lt`).
+    - Correction case (`hi1 ≠ 0`): `rhatc = rhat + dHi < 2 * dHi` (since
+      `rhat < dHi`, and the Word addition doesn't overflow because
+      `dHi < 2^32` ⟹ `rhat + dHi < 2^33 < 2^64`). -/
+theorem div128Quot_rhatc_lt_2dHi (uHi dHi : Word)
+    (hdHi_ne : dHi ≠ 0) (hdHi_lt : dHi.toNat < 2^32) :
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    rhatc.toNat < 2 * dHi.toNat := by
+  intro q1 rhat hi1 rhatc
+  -- rhat.toNat < dHi.toNat (Phase 1a output: rhat = uHi mod dHi)
+  have hq1_eq : q1.toNat = uHi.toNat / dHi.toNat := rv64_divu_toNat uHi dHi hdHi_ne
+  have h_eucl : q1.toNat * dHi.toNat + rhat.toNat = uHi.toNat :=
+    div128Quot_first_round_euclidean uHi dHi hdHi_ne
+  have hdHi_pos : 0 < dHi.toNat := by
+    rcases Nat.eq_zero_or_pos dHi.toNat with h | h
+    · exfalso; apply hdHi_ne; exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have hrhat_lt_dHi : rhat.toNat < dHi.toNat := by
+    have h_dam : dHi.toNat * (uHi.toNat / dHi.toNat) + uHi.toNat % dHi.toNat = uHi.toNat :=
+      Nat.div_add_mod _ _
+    have h_eucl_div :
+        (uHi.toNat / dHi.toNat) * dHi.toNat + rhat.toNat = uHi.toNat := by
+      rw [← hq1_eq]; exact h_eucl
+    have h_comm :
+        dHi.toNat * (uHi.toNat / dHi.toNat) = (uHi.toNat / dHi.toNat) * dHi.toNat :=
+      Nat.mul_comm _ _
+    have h_mod_lt : uHi.toNat % dHi.toNat < dHi.toNat := Nat.mod_lt _ hdHi_pos
+    omega
+  by_cases h_hi1 : hi1 = 0
+  · -- rhatc = rhat < dHi < 2 * dHi
+    simp only [rhatc, h_hi1, ↓reduceIte]
+    omega
+  · -- rhatc = rhat + dHi (Word add). Word add doesn't overflow (rhat + dHi < 2^33).
+    simp only [rhatc, h_hi1, ↓reduceIte]
+    rw [BitVec.toNat_add]
+    have h_sum_lt : rhat.toNat + dHi.toNat < 2^64 := by omega
+    rw [Nat.mod_eq_of_lt h_sum_lt]
     omega
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -60,6 +60,8 @@
     regardless of branch (Phase 1b prerequisite).
   - `div128Quot_rhatc_lt_2dHi` — `rhatc.toNat < 2 * dHi.toNat` after Phase 1a,
     regardless of branch (Phase 1b overflow-bound prerequisite).
+  - `div128Quot_phase1b_check_implies_q1c_pos` — when Phase 1b's BitVec.ult
+    check fires, `q1c.toNat ≥ 1` (proof: q1c = 0 ⟹ qDlo = 0 ⟹ check fails).
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -792,5 +794,29 @@ theorem div128Quot_rhatc_lt_2dHi (uHi dHi : Word)
     have h_sum_lt : rhat.toNat + dHi.toNat < 2^64 := by omega
     rw [Nat.mod_eq_of_lt h_sum_lt]
     omega
+
+/-- **Phase 1b sub-step.** When Phase 1b's `BitVec.ult rhatUn1 qDlo` check
+    fires (the Knuth multiplication check), the post-Phase-1a quotient
+    `q1c` must be at least 1.
+
+    Proof by contradiction: if `q1c = 0`, then `qDlo = 0 * dLo = 0` and
+    `rhatUn1 < 0` is impossible at the Nat level. So `q1c ≥ 1`, which
+    means the upcoming `q1' = q1c + signExtend12 4095` (= `q1c - 1`)
+    decrement is safe (no underflow). -/
+theorem div128Quot_phase1b_check_implies_q1c_pos
+    (q1c dLo rhatUn1 : Word)
+    (h_check : BitVec.ult rhatUn1 (q1c * dLo)) :
+    q1c.toNat ≥ 1 := by
+  by_contra h
+  push Not at h
+  have hq1c_zero : q1c.toNat = 0 := by omega
+  have hq1c_eq : q1c = 0 := BitVec.eq_of_toNat_eq (by simp [hq1c_zero])
+  rw [hq1c_eq] at h_check
+  have h_lt : rhatUn1.toNat < ((0 : Word) * dLo).toNat :=
+    (EvmWord.ult_iff _ _).mp h_check
+  have hmul_zero : ((0 : Word) * dLo).toNat = 0 := by
+    rw [BitVec.toNat_mul]; simp
+  rw [hmul_zero] at h_lt
+  exact Nat.not_lt_zero _ h_lt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -62,6 +62,9 @@
     regardless of branch (Phase 1b overflow-bound prerequisite).
   - `div128Quot_phase1b_check_implies_q1c_pos` — when Phase 1b's BitVec.ult
     check fires, `q1c.toNat ≥ 1` (proof: q1c = 0 ⟹ qDlo = 0 ⟹ check fails).
+  - `div128Quot_phase1b_correction_eucl` — when Phase 1b's check fires and
+    correction triggers (q1' = q1c - 1, rhat' = rhatc + dHi), the
+    Euclidean equation `q1' * dHi + rhat' = uHi` is preserved.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
@@ -818,5 +821,49 @@ theorem div128Quot_phase1b_check_implies_q1c_pos
     rw [BitVec.toNat_mul]; simp
   rw [hmul_zero] at h_lt
   exact Nat.not_lt_zero _ h_lt
+
+/-- **Phase 1b correction case — Euclidean preservation (factored form).**
+
+    Takes the prerequisites as explicit hypotheses (rather than computing them
+    via the let-bound algorithm chain) for cleaner type-checking. Callers
+    discharge them via:
+    - `h_post` from `div128Quot_first_round_post` (#837).
+    - `h_q1c_pos` from `div128Quot_phase1b_check_implies_q1c_pos` (#849).
+    - `h_rhatc_lt` from `div128Quot_rhatc_lt_2dHi` (#845).
+
+    Conclusion: `q1' = q1c - 1` and `rhat' = rhatc + dHi` (Phase 1b correction)
+    preserve the Word-level Euclidean equation
+    `q1'.toNat * dHi.toNat + rhat'.toNat = uHi.toNat`.
+
+    Algebra: `(q1c - 1) * dHi + (rhatc + dHi) = q1c * dHi + rhatc = uHi`. -/
+theorem div128Quot_phase1b_correction_eucl
+    (uHi dHi q1c rhatc : Word)
+    (hdHi_lt : dHi.toNat < 2^32)
+    (h_post : q1c.toNat * dHi.toNat + rhatc.toNat = uHi.toNat)
+    (h_q1c_pos : q1c.toNat ≥ 1)
+    (h_rhatc_lt : rhatc.toNat < 2 * dHi.toNat) :
+    (q1c + signExtend12 4095).toNat * dHi.toNat +
+      (rhatc + dHi).toNat = uHi.toNat := by
+  -- q1' = q1c - 1
+  have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+  have hq1'_toNat : (q1c + signExtend12 4095).toNat = q1c.toNat - 1 := by
+    rw [BitVec.toNat_add, h_se_neg1]
+    have h_eq : q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 := by omega
+    rw [h_eq, Nat.add_mod_right]
+    have hq1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
+    rw [Nat.mod_eq_of_lt hq1c_lt_word]
+  -- rhat' = rhatc + dHi (no overflow: rhatc < 2*dHi, dHi < 2^32 → rhatc + dHi < 3*2^32 < 2^64)
+  have hrhat'_toNat : (rhatc + dHi).toNat = rhatc.toNat + dHi.toNat := by
+    rw [BitVec.toNat_add]
+    apply Nat.mod_eq_of_lt
+    omega
+  rw [hq1'_toNat, hrhat'_toNat]
+  -- (q1c - 1) * dHi + (rhatc + dHi) = q1c * dHi + rhatc = uHi (h_post)
+  have h_expand : (q1c.toNat - 1 + 1) * dHi.toNat =
+                  (q1c.toNat - 1) * dHi.toNat + dHi.toNat := by
+    rw [Nat.add_mul, Nat.one_mul]
+  have h_eq : q1c.toNat - 1 + 1 = q1c.toNat := by omega
+  rw [h_eq] at h_expand
+  omega
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Companion to \`div128Quot_q1c_lt_pow33\` (#841). After Phase 1a's hi1-correction, the post-correction remainder \`rhatc\` is bounded by \`2 * dHi\`, regardless of which branch was taken:

- No-correction case (\`hi1 = 0\`): \`rhatc = rhat = uHi mod dHi < dHi\` (using the Euclidean equation + \`Nat.mod_lt\`).
- Correction case (\`hi1 ≠ 0\`): \`rhatc = rhat + dHi < 2 * dHi\`. Word addition doesn't overflow because \`dHi < 2^32\` ⟹ \`rhat + dHi < 2^33\`.

This bound is the **overflow safety prerequisite** for Phase 1b's \`rhat' = rhatc + dHi\` step (which then needs \`rhat' < 3 * dHi < 2^34\`, still no Word overflow).

## Status

Together with #841, both Phase 1a output bounds (q1c on the quotient, rhatc on the remainder) are now proven, setting up Phase 1b.

**Stacked on #841.**

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)