### PR TITLE
refactor(SailEquiv): flip runSail_rX_bits_of_stateRel (sRv sSail) to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -162,7 +162,7 @@ theorem add_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ADD rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,
@@ -196,7 +196,7 @@ theorem sub_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SUB rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,
@@ -229,7 +229,7 @@ theorem and_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.AND rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,
@@ -262,7 +262,7 @@ theorem or_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.OR rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,
@@ -295,7 +295,7 @@ theorem xor_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.XOR rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,
@@ -350,7 +350,7 @@ theorem slt_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLT rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     slt_value_equiv]
   cases rd <;>
     simp only [regToRegidx,
@@ -384,7 +384,7 @@ theorem sltu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLTU rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sltu_value_equiv]
   cases rd <;>
     simp only [regToRegidx,
@@ -427,7 +427,7 @@ theorem sll_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLL rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_left, Sail.BitVec.extractLsb]
   cases rd <;>
     simp only [regToRegidx,
@@ -461,7 +461,7 @@ theorem srl_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SRL rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_right, Sail.BitVec.extractLsb]
   cases rd <;>
     simp only [regToRegidx,
@@ -495,7 +495,7 @@ theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SRA rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     shift_bits_right_arith, Sail.BitVec.extractLsb, BitVec.toNatInt, Int.toNat_emod]
   cases rd <;>
     simp only [regToRegidx,
@@ -589,7 +589,7 @@ theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ADDIW rd rs1 imm)) sSail' := by
   unfold execute_ADDIW
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     addiw_equiv]
   cases rd <;>
     simp only [regToRegidx,
@@ -690,7 +690,7 @@ theorem mul_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.MUL rd rs1 rs2)) sSail' := by
   unfold execute_MUL
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     mul_low_equiv, LeanRV64D.Functions.xlen]
   cases rd <;>
     simp only [regToRegidx,

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -89,7 +89,7 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BEQ rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 == sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
@@ -114,7 +114,7 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BNE rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 != sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
@@ -139,7 +139,7 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BLT rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure, slt_equiv]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, slt_equiv]
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
@@ -164,7 +164,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BGE rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sge_equiv, slt_equiv]
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · -- slt = true, so !slt = false → not taken
@@ -193,7 +193,7 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BLTU rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure, ult_equiv]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, ult_equiv]
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
       runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
@@ -218,7 +218,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.BGEU rs1 rs2 offset)) sSail' := by
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_BTYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     uge_equiv, ult_equiv]
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · -- ult = true, so !ult = false → not taken
@@ -326,7 +326,7 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
   rw [runSail_ok_bind _ sSail s_mid _ h_elp_ok]
   simp only [runSail_bind, runSail_pure,
     runSail_get_next_pc s_mid (sRv.pc + 4) h_nextpc_mid,
-    runSail_rX_bits_of_stateRel sRv s_mid hrel_mid,
+    runSail_rX_bits_of_stateRel hrel_mid,
     sign_extend_12_eq]
   -- Rewrite BitVec.update to &&& ~~~1 before applying jump_to
   simp only [show @Sail.BitVec.update (m := 64) (sRv.getReg rs1 + signExtend12 offset) 0 0#1 =

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -33,7 +33,7 @@ theorem addi_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ADDI rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
   cases rd <;>
     simp only [regToRegidx,
@@ -67,7 +67,7 @@ theorem andi_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ANDI rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
   cases rd <;>
     simp only [regToRegidx,
@@ -101,7 +101,7 @@ theorem ori_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ORI rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
   cases rd <;>
     simp only [regToRegidx,
@@ -135,7 +135,7 @@ theorem xori_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.XORI rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
   cases rd <;>
     simp only [regToRegidx,
@@ -173,7 +173,7 @@ theorem slti_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLTI rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, slt_value_equiv]
   cases rd <;>
     simp only [regToRegidx,
@@ -207,7 +207,7 @@ theorem sltiu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLTIU rd rs1 imm)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend, sltu_value_equiv]
   cases rd <;>
     simp only [regToRegidx,
@@ -245,7 +245,7 @@ theorem mv_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.MV rd rs)) sSail' := by
   unfold execute_ITYPE
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sign_extend, Sail.BitVec.signExtend]
   cases rd <;>
     simp only [regToRegidx,

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -253,7 +253,7 @@ theorem mulh_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.MULH rd rs1 rs2)) sSail' := by
   unfold execute_MUL
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
       Signedness.Signed Signedness.Signed x y VectorHalf.High = rv64_mulh x y
     from mulh_high_equiv]
@@ -282,7 +282,7 @@ theorem mulhsu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.MULHSU rd rs1 rs2)) sSail' := by
   unfold execute_MUL
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
       Signedness.Signed Signedness.Unsigned x y VectorHalf.High = rv64_mulhsu x y
     from mulhsu_high_equiv]
@@ -322,7 +322,7 @@ theorem mulhu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.MULHU rd rs1 rs2)) sSail' := by
   unfold execute_MUL
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     show ∀ x y : Word, mult_to_bits_half (l := LeanRV64D.Functions.xlen)
       Signedness.Unsigned Signedness.Unsigned x y VectorHalf.High = rv64_mulhu x y
     from mulhu_high_equiv]
@@ -358,7 +358,7 @@ theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.DIV rd rs1 rs2)) sSail' := by
   unfold execute_DIV
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     LeanRV64D.Functions.not,
     Bool.not_false, Bool.true_and, ite_true, ite_false, Bool.false_eq_true]
   conv in to_bits_truncate _ => rw [div_full_equiv_applied]
@@ -394,7 +394,7 @@ theorem divu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.DIVU rd rs1 rs2)) sSail' := by
   unfold execute_DIV
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     LeanRV64D.Functions.xlen, LeanRV64D.Functions.not,
     Bool.not_true, Bool.false_and, ite_true, ite_false, Bool.false_eq_true]
   conv in to_bits_truncate _ => rw [divu_full_equiv]
@@ -430,7 +430,7 @@ theorem rem_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.REM rd rs1 rs2)) sSail' := by
   unfold execute_REM
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     Bool.false_eq_true, ite_false]
   conv in to_bits_truncate _ => rw [rem_full_equiv]
   cases rd <;>
@@ -465,7 +465,7 @@ theorem remu_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.REMU rd rs1 rs2)) sSail' := by
   unfold execute_REM
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure, ite_true]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, ite_true]
   conv in to_bits_truncate _ => rw [remu_full_equiv]
   cases rd <;>
     simp only [regToRegidx,

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -123,7 +123,7 @@ theorem runSail_rX_bits_x12 (s : SailState) (v : BitVec 64)
 
 /-- If StateRel holds, reading any Rv64 register from the SAIL state via rX_bits
     returns the same value as getReg, without modifying state. -/
-theorem runSail_rX_bits_of_stateRel (sRv : MachineState) (sSail : SailState)
+theorem runSail_rX_bits_of_stateRel {sRv : MachineState} {sSail : SailState}
     (hrel : StateRel sRv sSail) (r : Reg) :
     runSail (rX_bits (regToRegidx r)) sSail = some (sRv.getReg r, sSail) := by
   have ha := hrel.reg_agree r

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -60,7 +60,7 @@ theorem slli_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SLLI rd rs1 shamt)) sSail' := by
   unfold execute_SHIFTIOP
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sll_extractLsb_bv6]
   cases rd <;>
     simp only [regToRegidx,
@@ -94,7 +94,7 @@ theorem srli_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SRLI rd rs1 shamt)) sSail' := by
   unfold execute_SHIFTIOP
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     srl_extractLsb_bv6]
   cases rd <;>
     simp only [regToRegidx,
@@ -128,7 +128,7 @@ theorem srai_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.SRAI rd rs1 shamt)) sSail' := by
   unfold execute_SHIFTIOP
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure,
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     sra_extractLsb_bv6]
   cases rd <;>
     simp only [regToRegidx,


### PR DESCRIPTION
## Summary
- Flip `runSail_rX_bits_of_stateRel (sRv : MachineState) (sSail : SailState)` to implicit.
- All 33 call sites pass `sRv sSail hrel`; the `hrel : StateRel sRv sSail` hypothesis determines both state args by unification.
- Part of issue #331 (frequent `_` / redundant explicit args to implicit).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)