### PR TITLE
refactor(SailEquiv): flip runSail_{get_arch_pc,readReg_PC,get_next_pc} (s v) to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -633,7 +633,7 @@ theorem auipc_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.AUIPC rd imm)) sSail' := by
   unfold execute_UTYPE
-  simp only [runSail_bind, runSail_pure, runSail_get_arch_pc sSail sRv.pc h_pc, lui_equiv]
+  simp only [runSail_bind, runSail_pure, runSail_get_arch_pc h_pc, lui_equiv]
   cases rd <;>
     simp only [regToRegidx,
       runSail_wX_bits_x0, runSail_wX_bits_x1, runSail_wX_bits_x2,

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -92,7 +92,7 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 == sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -117,7 +117,7 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 != sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -142,7 +142,7 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure, slt_equiv]
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -175,7 +175,7 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
   · -- slt = false, so !slt = true → taken
     simp only [show BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -196,7 +196,7 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel sRv sSail hrel, runSail_pure, ult_equiv]
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -229,7 +229,7 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
   · -- ult = false, so !ult = true → taken
     simp only [show BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
-      runSail_readReg_PC sSail sRv.pc h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
     rw [runSail_jump_to _ _ misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC _ _
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -257,8 +257,8 @@ theorem jal_sail_equiv (sRv : MachineState) (sSail : SailState)
   obtain ⟨misa_val, h_misa⟩ := h_misa
   unfold execute_JAL
   simp only [runSail_bind,
-    runSail_get_next_pc sSail (sRv.pc + 4) h_nextpc,
-    runSail_readReg_PC sSail sRv.pc h_pc,
+    runSail_get_next_pc h_nextpc,
+    runSail_readReg_PC h_pc,
     sign_extend_21_eq]
   rw [runSail_jump_to _ _ misa_val h_align h_misa]
   simp only [RETIRE_SUCCESS, runSail_bind, runSail_pure]
@@ -325,7 +325,7 @@ theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
   unfold execute_JALR
   rw [runSail_ok_bind _ sSail s_mid _ h_elp_ok]
   simp only [runSail_bind, runSail_pure,
-    runSail_get_next_pc s_mid (sRv.pc + 4) h_nextpc_mid,
+    runSail_get_next_pc h_nextpc_mid,
     runSail_rX_bits_of_stateRel sRv s_mid hrel_mid,
     sign_extend_12_eq]
   -- Rewrite BitVec.update to &&& ~~~1 before applying jump_to

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -262,7 +262,7 @@ theorem runSail_xreg_write_callback (reg : regidx) (v : BitVec 64) (s : SailStat
 -- ============================================================================
 
 /-- get_arch_pc reads the PC register without modifying state. -/
-theorem runSail_get_arch_pc (s : SailState) (pc : BitVec 64)
+theorem runSail_get_arch_pc {s : SailState} {pc : BitVec 64}
     (h : s.regs.get? Register.PC = some pc) :
     runSail (get_arch_pc ()) s = some (pc, s) := by
   simp [runSail, get_arch_pc, PreSail.readReg, h,
@@ -274,7 +274,7 @@ theorem runSail_get_arch_pc (s : SailState) (pc : BitVec 64)
 -- ============================================================================
 
 /-- readReg PC returns the PC value without modifying state. -/
-theorem runSail_readReg_PC (s : SailState) (pc : BitVec 64)
+theorem runSail_readReg_PC {s : SailState} {pc : BitVec 64}
     (h : s.regs.get? Register.PC = some pc) :
     runSail (readReg Register.PC : SailM (BitVec 64)) s = some (pc, s) := by
   simp [runSail, PreSail.readReg, h,
@@ -293,7 +293,7 @@ theorem runSail_set_next_pc (target : BitVec 64) (s : SailState) :
     LeanRV64D.Functions.xlen]
 
 /-- get_next_pc reads the nextPC register. -/
-theorem runSail_get_next_pc (s : SailState) (v : BitVec 64)
+theorem runSail_get_next_pc {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.nextPC = some v) :
     runSail (get_next_pc ()) s = some (v, s) := by
   simp [runSail, get_next_pc, PreSail.readReg, h,


### PR DESCRIPTION
## Summary
- Flip three SailM readReg helpers that share the pattern `(s : SailState) (v : BitVec 64) (h : s.regs.get? ... = some v)`:
  - `runSail_get_arch_pc {s pc}`
  - `runSail_readReg_PC {s pc}`
  - `runSail_get_next_pc {s v}`
- Every call site passes `s` and `v` explicitly as redundant arguments the `h` hypothesis already determines by unification. Flipping simplifies the 9 affected call sites.
- Part of issue #331 (frequent explicit → implicit args).

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)