### PR TITLE
refactor(ControlFlow): flip pcIndep_* family args to implicit

### DIFF
--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -134,27 +134,27 @@ theorem pcIndep_and {P Q : MachineState → Prop} (hP : pcIndep P) (hQ : pcIndep
   intro s v ⟨hp, hq⟩
   exact ⟨hP s v hp, hQ s v hq⟩
 
-theorem pcIndep_holdsFor_regIs (r : Reg) (val : Word) :
+theorem pcIndep_holdsFor_regIs {r : Reg} {val : Word} :
     pcIndep (regIs r val).holdsFor := by
   intro s v h
   simp only [holdsFor_regIs, MachineState.getReg_setPC] at *; exact h
 
-theorem pcIndep_holdsFor_memIs (a : Word) (val : Word) :
+theorem pcIndep_holdsFor_memIs {a : Word} {val : Word} :
     pcIndep (memIs a val).holdsFor := by
   intro s v h
   simp only [holdsFor_memIs, MachineState.getMem, MachineState.setPC] at *; exact h
 
-theorem pcIndep_committedIs (vals : List (Word × Word)) :
+theorem pcIndep_committedIs {vals : List (Word × Word)} :
     pcIndep (MachineState.committedIs vals) := by
   intro s v h
   simp only [MachineState.committedIs, MachineState.committed_setPC] at *; exact h
 
-theorem pcIndep_publicValuesIs (vals : List (BitVec 8)) :
+theorem pcIndep_publicValuesIs {vals : List (BitVec 8)} :
     pcIndep (MachineState.publicValuesIs vals) := by
   intro s v h
   simp only [MachineState.publicValuesIs, MachineState.publicValues_setPC] at *; exact h
 
-theorem pcIndep_privateInputIs (vals : List (BitVec 8)) :
+theorem pcIndep_privateInputIs {vals : List (BitVec 8)} :
     pcIndep (MachineState.privateInputIs vals) := by
   intro s v h
   simp only [MachineState.privateInputIs, MachineState.privateInput_setPC] at *; exact h


### PR DESCRIPTION
## Summary
Align the 5 `pcIndep_*` state-fact lemmas (`pcIndep_holdsFor_regIs`, `pcIndep_holdsFor_memIs`, `pcIndep_committedIs`, `pcIndep_publicValuesIs`, `pcIndep_privateInputIs`) with the implicit-arg style used by the `pcFree_*` (#812) and `holdsFor_*` (#840) families.

No current callers — this is a pure style-alignment cleanup that prevents a future migration step if a `PCIndep` typeclass instance is added.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)