### PR TITLE
refactor(DivMod/Compose/Base): flip 5 pcFree_* post-bundle theorems to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -374,8 +374,8 @@ theorem divScratchOwn_unfold_right (sp : Word) (Q : Assertion) :
     (divScratchOwn sp ** Q) := by
   rw [divScratchOwn_unfold]
 
-theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem : Word) :
+theorem pcFree_divScratchValues {sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem : Word} :
     (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       shiftMem nMem jMem).pcFree := by
   unfold divScratchValues; pcFree
@@ -383,8 +383,7 @@ theorem pcFree_divScratchValues (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
 instance (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word) :
     Assertion.PCFree (divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
         shiftMem nMem jMem) :=
-  ⟨pcFree_divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem⟩
+  ⟨pcFree_divScratchValues⟩
 
 /-- `divScratchOwn` is pc-free: all its 15 atoms are `memOwn`. Proof goes
     through the `_unfold` rewrite since the bundle is `@[irreducible]`. -/
@@ -501,14 +500,14 @@ theorem loopSetupPost_unfold (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   delta loopSetupPost; rfl
 
 /-- `loopSetupPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_loopSetupPost (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem pcFree_loopSetupPost {sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3).pcFree := by
   rw [loopSetupPost_unfold]; pcFree
 
 instance pcFreeInst_loopSetupPost
     (sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Assertion.PCFree (loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3) :=
-  ⟨pcFree_loopSetupPost sp nVal shift a0 a1 a2 a3 b0 b1 b2 b3⟩
+  ⟨pcFree_loopSetupPost⟩
 
 -- ============================================================================
 -- Postcondition bundles for denorm + epilogue paths
@@ -550,13 +549,13 @@ theorem denormDivPost_unfold (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
   delta denormDivPost; rfl
 
 /-- `denormDivPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
+theorem pcFree_denormDivPost {sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word} :
     (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3).pcFree := by
   rw [denormDivPost_unfold]; pcFree
 
 instance pcFreeInst_denormDivPost (sp shift u0 u1 u2 u3 q0 q1 q2 q3 : Word) :
     Assertion.PCFree (denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3) :=
-  ⟨pcFree_denormDivPost sp shift u0 u1 u2 u3 q0 q1 q2 q3⟩
+  ⟨pcFree_denormDivPost⟩
 
 /-- Postcondition for MOD denorm + epilogue (shift ≠ 0).
     Encapsulates antiShift and denormalized u'[0..3]. -/
@@ -590,13 +589,13 @@ theorem denormModPost_unfold (sp shift u0 u1 u2 u3 : Word) :
   delta denormModPost; rfl
 
 /-- `denormModPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_denormModPost (sp shift u0 u1 u2 u3 : Word) :
+theorem pcFree_denormModPost {sp shift u0 u1 u2 u3 : Word} :
     (denormModPost sp shift u0 u1 u2 u3).pcFree := by
   rw [denormModPost_unfold]; pcFree
 
 instance pcFreeInst_denormModPost (sp shift u0 u1 u2 u3 : Word) :
     Assertion.PCFree (denormModPost sp shift u0 u1 u2 u3) :=
-  ⟨pcFree_denormModPost sp shift u0 u1 u2 u3⟩
+  ⟨pcFree_denormModPost⟩
 
 -- ============================================================================
 -- Postcondition bundle for normB (PhaseAB + CLZ + PhaseC2 + NormB)
@@ -642,13 +641,13 @@ theorem normBPost_unfold (sp nVal shift b0 b1 b2 b3 : Word) :
   delta normBPost; rfl
 
 /-- `normBPost` is pc-free: all its atoms are `regIs` / `memIs`. -/
-theorem pcFree_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
+theorem pcFree_normBPost {sp nVal shift b0 b1 b2 b3 : Word} :
     (normBPost sp nVal shift b0 b1 b2 b3).pcFree := by
   rw [normBPost_unfold]; pcFree
 
 instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
     Assertion.PCFree (normBPost sp nVal shift b0 b1 b2 b3) :=
-  ⟨pcFree_normBPost sp nVal shift b0 b1 b2 b3⟩
+  ⟨pcFree_normBPost⟩
 
 -- ============================================================================
 -- `se12_32`/`se12_40`/`se12_48`/`se12_56` were deleted by issue #493 / #494:


### PR DESCRIPTION
## Summary
Flip the 5 `pcFree_*` post-bundle helpers in `DivMod/Compose/Base.lean` to implicit:
- `pcFree_divScratchValues` (19 word args)
- `pcFree_loopSetupPost` (11)
- `pcFree_denormDivPost` (10)
- `pcFree_denormModPost` (6)
- `pcFree_normBPost` (7)

Each has a single `PCFree` instance callsite that redundantly repeats the same bound variable names; flipping to implicit shrinks each instance body to `⟨pcFree_X⟩`. Aligns with the in-flight family flips in #815 / #852 / #854.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)