### PR TITLE
feat(divmod): divN4StackPreCall — call-trial pre-bundle (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -374,6 +374,64 @@ theorem divN4StackPre_unfold_atoms (sp : Word) (a b : EvmWord)
   rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchValues_unfold]
 
+/-- Call-trial counterpart to `divN4StackPre`. Identical to `divN4StackPre`
+    except for the scratch bundle: uses `divScratchValuesCall` (19 cells —
+    15 from `divScratchValues` plus 4 extra for the `div128`-subroutine
+    call path) instead of `divScratchValues` (15 cells).
+
+    Used as the precondition of the forthcoming
+    `evm_div_n4_full_call_{skip,addback}_stack_pre_spec` theorems. -/
+@[irreducible]
+def divN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x11 ↦ᵣ v11) **
+  evmWordIs sp a ** evmWordIs (sp + 32) b **
+  divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0
+
+theorem pcFree_divN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  delta divN4StackPreCall divScratchValuesCall; pcFree
+
+instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
+  ⟨pcFree_divN4StackPreCall sp a b v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0⟩
+
+/-- Named unfold for `divN4StackPreCall`. -/
+theorem divN4StackPreCall_unfold (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    divN4StackPreCall sp a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x11 ↦ᵣ v11) **
+     evmWordIs sp a ** evmWordIs (sp + 32) b **
+     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  delta divN4StackPreCall; rfl
+
 /-- MOD-side parallel of `divN4StackPre`. Identical content — same registers,
     same operands, same scratch bundle. The name is kept distinct so the
     forthcoming MOD stack spec reads symmetrically with its DIV counterpart.


### PR DESCRIPTION
## Summary

Adds the call-trial counterpart to \`divN4StackPre\`. Identical structure except the scratch bundle: uses \`divScratchValuesCall\` (19 cells — 15 from \`divScratchValues\` plus 4 extra for the \`div128\`-subroutine call path) instead of \`divScratchValues\` (15 cells).

Used as the precondition of the forthcoming \`evm_div_n4_full_call_{skip,addback}_stack_pre_spec\` theorems.

## Includes
- \`divN4StackPreCall\` definition (irreducible).
- \`pcFree_divN4StackPreCall\` proof + \`Assertion.PCFree\` instance.
- \`divN4StackPreCall_unfold\` for restored access after the irreducible.

## Independence

Filed off main, **independent of the in-flight Knuth B PR chain** (#810-#853 — Piece A complete, Piece B in progress). This is the **call-trial bundle scaffolding** that downstream stack specs will need once Piece B's div128Quot correctness lands. Building it now in parallel saves a serial dependency.

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Spec\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)