### PR TITLE
feat(divmod): modN4StackPreCall — MOD-side call-trial pre-bundle (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -2,6 +2,7 @@ import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LimbSpec
 import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Spec
+import EvmAsm.Evm64.DivMod.SpecCall
 import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -464,63 +464,8 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
   ⟨pcFree_modN4StackPre sp a b v5 v6 v7 v10 v11
     q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
 
-/-- Call-trial counterpart to `modN4StackPre`. Identical to `modN4StackPre`
-    except the scratch bundle: uses `divScratchValuesCall` (19 cells)
-    instead of `divScratchValues` (15 cells).
-
-    Used as the precondition of the forthcoming
-    `evm_mod_n4_full_call_{skip,addback}_stack_pre_spec` theorems.
-    Definitionally equal to `divN4StackPreCall`. -/
-@[irreducible]
-def modN4StackPreCall (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
-  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-  (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-  (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-  (.x11 ↦ᵣ v11) **
-  evmWordIs sp a ** evmWordIs (sp + 32) b **
-  divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem retMem dMem dloMem scratch_un0
-
-theorem pcFree_modN4StackPreCall (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
-    (modN4StackPreCall sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
-  delta modN4StackPreCall divScratchValuesCall; pcFree
-
-instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
-    Assertion.PCFree (modN4StackPreCall sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-      shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
-  ⟨pcFree_modN4StackPreCall sp a b v5 v6 v7 v10 v11
-    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    shiftMem nMem jMem retMem dMem dloMem scratch_un0⟩
-
-/-- Named unfold for `modN4StackPreCall`. Mirror of `divN4StackPreCall_unfold`. -/
-theorem modN4StackPreCall_unfold (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 : Word)
-    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
-    modN4StackPreCall sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     (.x11 ↦ᵣ v11) **
-     evmWordIs sp a ** evmWordIs (sp + 32) b **
-     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
-  delta modN4StackPreCall; rfl
+-- `modN4StackPreCall` (MOD-side call-trial pre-bundle) lives in
+-- `DivMod/SpecCall.lean` to stay under the Spec.lean file-size guardrail.
 
 /-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
 theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -464,6 +464,64 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
   ⟨pcFree_modN4StackPre sp a b v5 v6 v7 v10 v11
     q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem⟩
 
+/-- Call-trial counterpart to `modN4StackPre`. Identical to `modN4StackPre`
+    except the scratch bundle: uses `divScratchValuesCall` (19 cells)
+    instead of `divScratchValues` (15 cells).
+
+    Used as the precondition of the forthcoming
+    `evm_mod_n4_full_call_{skip,addback}_stack_pre_spec` theorems.
+    Definitionally equal to `divN4StackPreCall`. -/
+@[irreducible]
+def modN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x11 ↦ᵣ v11) **
+  evmWordIs sp a ** evmWordIs (sp + 32) b **
+  divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0
+
+theorem pcFree_modN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  delta modN4StackPreCall divScratchValuesCall; pcFree
+
+instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
+  ⟨pcFree_modN4StackPreCall sp a b v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0⟩
+
+/-- Named unfold for `modN4StackPreCall`. Mirror of `divN4StackPreCall_unfold`. -/
+theorem modN4StackPreCall_unfold (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    modN4StackPreCall sp a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x11 ↦ᵣ v11) **
+     evmWordIs sp a ** evmWordIs (sp + 32) b **
+     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  delta modN4StackPreCall; rfl
+
 /-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
 theorem modN4StackPre_unfold (sp : Word) (a b : EvmWord)
     (v5 v6 v7 v10 v11 : Word)

--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -1,0 +1,81 @@
+/-
+  EvmAsm.Evm64.DivMod.SpecCall
+
+  Call-trial precondition bundles for the 256-bit EVM DIV and MOD
+  programs. Extracted from `Spec.lean` to stay under the 1500-line
+  file-size guardrail.
+
+  The call-trial variants use `divScratchValuesCall` (19 cells — the
+  base `divScratchValues` 15 cells plus 4 extras for the `div128`
+  subroutine call path). Used as preconditions of the forthcoming
+  `evm_{div,mod}_n4_full_call_{skip,addback}_stack_pre_spec` theorems.
+
+  `divN4StackPreCall` sits next to `divN4StackPre` in `Spec.lean`; this
+  file adds the MOD-side counterpart `modN4StackPreCall`.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Call-trial counterpart to `modN4StackPre`. Identical to `modN4StackPre`
+    except the scratch bundle: uses `divScratchValuesCall` (19 cells)
+    instead of `divScratchValues` (15 cells).
+
+    Used as the precondition of the forthcoming
+    `evm_mod_n4_full_call_{skip,addback}_stack_pre_spec` theorems.
+    Definitionally equal to `divN4StackPreCall`. -/
+@[irreducible]
+def modN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) : Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+  (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+  (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+  (.x11 ↦ᵣ v11) **
+  evmWordIs sp a ** evmWordIs (sp + 32) b **
+  divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0
+
+theorem pcFree_modN4StackPreCall (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0).pcFree := by
+  delta modN4StackPreCall divScratchValuesCall; pcFree
+
+instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    Assertion.PCFree (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+      shiftMem nMem jMem retMem dMem dloMem scratch_un0) :=
+  ⟨pcFree_modN4StackPreCall sp a b v5 v6 v7 v10 v11
+    q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    shiftMem nMem jMem retMem dMem dloMem scratch_un0⟩
+
+/-- Named unfold for `modN4StackPreCall`. Mirror of `divN4StackPreCall_unfold`. -/
+theorem modN4StackPreCall_unfold (sp : Word) (a b : EvmWord)
+    (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     shiftMem nMem jMem retMem dMem dloMem scratch_un0 : Word) :
+    modN4StackPreCall sp a b v5 v6 v7 v10 v11
+        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 =
+    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+     (.x11 ↦ᵣ v11) **
+     evmWordIs sp a ** evmWordIs (sp + 32) b **
+     divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+       shiftMem nMem jMem retMem dMem dloMem scratch_un0) := by
+  delta modN4StackPreCall; rfl
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds the MOD-side counterpart to \`divN4StackPreCall\` (#857). Mirror of \`modN4StackPre\` but using the 19-cell \`divScratchValuesCall\` scratch bundle instead of the 15-cell \`divScratchValues\`.

Definitionally equal to \`divN4StackPreCall\` — kept distinct for symmetric naming with the forthcoming \`evm_mod_n4_full_call_{skip,addback}_stack_pre_spec\` theorems.

## Includes
- \`modN4StackPreCall\` definition (irreducible).
- \`pcFree_modN4StackPreCall\` proof + \`Assertion.PCFree\` instance.
- \`modN4StackPreCall_unfold\` for restored access.

## Status

Continues the call-trial bundle scaffolding work, independent of Knuth B / div128Quot correctness which is in progress on a separate chain. Both DIV and MOD pre-bundles are now in place.

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Spec\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)