### PR TITLE
refactor(Execution): flip stepN_{zero,succ,one,add} args to implicit

### DIFF
--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -689,20 +689,20 @@ def stepN : Nat → MachineState → Option MachineState
 -- ============================================================================
 
 @[simp]
-theorem stepN_zero (s : MachineState) :
+theorem stepN_zero {s : MachineState} :
     stepN 0 s = some s := rfl
 
 @[simp]
-theorem stepN_succ (s : MachineState) (n : Nat) :
+theorem stepN_succ {s : MachineState} {n : Nat} :
     stepN (n + 1) s = (step s).bind (stepN n ·) := rfl
 
-theorem stepN_one (s : MachineState) :
+theorem stepN_one {s : MachineState} :
     stepN 1 s = step s := by
   simp [stepN, Option.bind]
   cases step s <;> simp
 
 /-- Composing step counts: n+m steps = n steps then m steps. -/
-theorem stepN_add (n m : Nat) (s : MachineState) :
+theorem stepN_add {n m : Nat} {s : MachineState} :
     stepN (n + m) s = (stepN n s).bind (stepN m ·) := by
   induction n generalizing s with
   | zero => simp [Option.bind]


### PR DESCRIPTION
## Summary
Align the 4 foundational `stepN_*` congruence/step lemmas with the implicit-arg convention used by the rest of the step-family (`stepN_add_eq` in #859, `step_non_ecall_non_mem` in #823, `step_l*`/`step_s*` in #824).

Flipped:
- `stepN_zero {s}`
- `stepN_succ {s n}`
- `stepN_one {s}`
- `stepN_add {n m s}`

No external callers — all consumed via `simp` or internal recursion where the flip is transparent.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)