### PR TITLE
refactor(AddrNorm): flip word_{zero_add,add_zero} x to implicit

### DIFF
--- a/EvmAsm/Rv64/AddrNorm.lean
+++ b/EvmAsm/Rv64/AddrNorm.lean
@@ -37,10 +37,10 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 @[rv64_addr, grind =]
-theorem word_zero_add (x : Word) : (0 : Word) + x = x := BitVec.zero_add x
+theorem word_zero_add {x : Word} : (0 : Word) + x = x := BitVec.zero_add x
 
 @[rv64_addr, grind =]
-theorem word_add_zero (x : Word) : x + (0 : Word) = x := BitVec.add_zero x
+theorem word_add_zero {x : Word} : x + (0 : Word) = x := BitVec.add_zero x
 
 -- ============================================================================
 -- Atomic `signExtend13` evaluations


### PR DESCRIPTION
## Summary
Flip `word_zero_add {x}` and `word_add_zero {x}` in `Rv64/AddrNorm.lean` to implicit. Both are `@[rv64_addr, grind =]`-tagged rewrite lemmas; all 10 callers consume them via `rw [...]` / `simp only [...]` where `x` is inferred from the rewrite target. Aligns with the simp-lemma convention.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)