### PR TITLE
refactor(Basic): flip pc_set{Reg,Mem,Byte,Halfword,Word32} simp lemmas to implicit

### DIFF
--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -482,19 +482,19 @@ termination_by l => l.length
 -- Simp lemmas
 -- ============================================================================
 
-@[simp] theorem pc_setReg (s : MachineState) (r : Reg) (v : Word) :
+@[simp] theorem pc_setReg {s : MachineState} {r : Reg} {v : Word} :
     (s.setReg r v).pc = s.pc := by cases r <;> rfl
 
-@[simp] theorem pc_setMem (s : MachineState) (a : Word) (v : Word) :
+@[simp] theorem pc_setMem {s : MachineState} {a : Word} {v : Word} :
     (s.setMem a v).pc = s.pc := by simp [setMem]
 
-@[simp] theorem pc_setByte (s : MachineState) (addr : Word) (b : BitVec 8) :
+@[simp] theorem pc_setByte {s : MachineState} {addr : Word} {b : BitVec 8} :
     (s.setByte addr b).pc = s.pc := by simp [setByte]
 
-@[simp] theorem pc_setHalfword (s : MachineState) (addr : Word) (h : BitVec 16) :
+@[simp] theorem pc_setHalfword {s : MachineState} {addr : Word} {h : BitVec 16} :
     (s.setHalfword addr h).pc = s.pc := by simp [setHalfword]
 
-@[simp] theorem pc_setWord32 (s : MachineState) (addr : Word) (v : BitVec 32) :
+@[simp] theorem pc_setWord32 {s : MachineState} {addr : Word} {v : BitVec 32} :
     (s.setWord32 addr v).pc = s.pc := by simp [setWord32]
 
 @[simp] theorem code_setReg (s : MachineState) (r : Reg) (v : Word) :


### PR DESCRIPTION
## Summary
Flip 5 `@[simp]`-tagged `pc_set*` projection lemmas in `MachineState` (`pc_setReg`, `pc_setMem`, `pc_setByte`, `pc_setHalfword`, `pc_setWord32`) from positional to implicit args. All callers reference them purely by name (in `simp only [...]` lists or `rw [...]` without args), so the flip is transparent. Aligns with the simp-lemma implicit-arg convention.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)