### PR TITLE
refactor(Basic): flip isValid{Dword,Mem,MemAddr,Halfword,Byte}Access_eq simp lemmas to implicit

### DIFF
--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -264,13 +264,13 @@ def isValidDwordAccess (addr : Word) : Bool :=
 def isValidMemAccess (addr : Word) : Bool :=
   isValidMemAddr addr && isAligned4 addr
 
-@[simp] theorem isValidDwordAccess_eq (addr : Word) :
+@[simp] theorem isValidDwordAccess_eq {addr : Word} :
     isValidDwordAccess addr = (isValidMemAddr addr && isAligned8 addr) := rfl
 
-@[simp] theorem isValidMemAccess_eq (addr : Word) :
+@[simp] theorem isValidMemAccess_eq {addr : Word} :
     isValidMemAccess addr = (isValidMemAddr addr && isAligned4 addr) := rfl
 
-@[simp] theorem isValidMemAddr_eq (addr : Word) :
+@[simp] theorem isValidMemAddr_eq {addr : Word} :
     isValidMemAddr addr = (decide (MEM_START ≤ addr.toNat) && decide (addr.toNat ≤ MEM_END)) := rfl
 
 @[simp] theorem isAligned8_eq (addr : Word) :
@@ -293,10 +293,10 @@ def isValidByteAccess (addr : Word) : Bool :=
 @[simp] theorem isAligned2_eq (addr : Word) :
     isAligned2 addr = (addr.toNat % 2 == 0) := rfl
 
-@[simp] theorem isValidHalfwordAccess_eq (addr : Word) :
+@[simp] theorem isValidHalfwordAccess_eq {addr : Word} :
     isValidHalfwordAccess addr = (isValidMemAddr addr && isAligned2 addr) := rfl
 
-@[simp] theorem isValidByteAccess_eq (addr : Word) :
+@[simp] theorem isValidByteAccess_eq {addr : Word} :
     isValidByteAccess addr = isValidMemAddr addr := rfl
 
 /-- ValidMemRange addr n holds when n consecutive doubleword-aligned memory accesses


### PR DESCRIPTION
## Summary
Continues the Basic.lean simp-family implicit-arg cleanup (#864/866/867/868/870). Flip the 5 `isValid*_eq` simp lemmas' positional `(addr : Word)` arg to implicit. No external callers.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)