### PR TITLE
refactor(Program,SepLogic): flip 5 small simp lemmas to implicit

### DIFF
--- a/EvmAsm/Rv64/Program.lean
+++ b/EvmAsm/Rv64/Program.lean
@@ -18,7 +18,7 @@ def Program := List Instr
 
 instance : Append Program := ⟨List.append⟩
 
-@[simp] theorem Program.length_append (p q : Program) : (p ++ q).length = p.length + q.length :=
+@[simp] theorem Program.length_append {p q : Program} : (p ++ q).length = p.length + q.length :=
   List.length_append (as := p) (bs := q)
 
 @[simp] theorem Program.getElem?_append (p q : Program) (i : Nat) :
@@ -43,10 +43,10 @@ def execProgram (s : MachineState) : Program → MachineState
   | []      => s
   | i :: is => execProgram (execInstr s i) is
 
-@[simp] theorem execProgram_nil (s : MachineState) :
+@[simp] theorem execProgram_nil {s : MachineState} :
     execProgram s [] = s := rfl
 
-@[simp] theorem execProgram_cons (s : MachineState) (i : Instr) (is : List Instr) :
+@[simp] theorem execProgram_cons {s : MachineState} {i : Instr} {is : List Instr} :
     execProgram s (i :: is) = execProgram (execInstr s i) is := rfl
 
 theorem execProgram_append (s : MachineState) (p1 p2 : Program) :

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2096,7 +2096,7 @@ def unionAll : List CodeReq → CodeReq
   | cr :: rest => cr.union (unionAll rest)
 
 @[simp] theorem unionAll_nil : unionAll [] = empty := rfl
-@[simp] theorem unionAll_cons (cr : CodeReq) (rest : List CodeReq) :
+@[simp] theorem unionAll_cons {cr : CodeReq} {rest : List CodeReq} :
     unionAll (cr :: rest) = cr.union (unionAll rest) := rfl
 
 end CodeReq
@@ -2688,7 +2688,7 @@ def seps : List Assertion → Assertion
   | x :: xs => x ** seps xs
 
 @[simp] theorem seps_nil : seps ([] : List Assertion) = empAssertion := rfl
-@[simp] theorem seps_cons (x : Assertion) (xs : List Assertion) :
+@[simp] theorem seps_cons {x : Assertion} {xs : List Assertion} :
     seps (x :: xs) = (x ** seps xs) := rfl
 
 /-- Pick the n-th element to the front of a seps chain.


### PR DESCRIPTION
## Summary
Align with the simp-lemma implicit-arg cleanup arc:
- `Rv64/Program.lean`: `Program.length_append`, `execProgram_nil`, `execProgram_cons`
- `Rv64/SepLogic.lean`: `CodeReq.unionAll_cons`, `seps_cons`

All 5 consumed via `simp only [...]` — flip is transparent. No external positional callers.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)