### PR TITLE
refactor(Evm64): flip 4 Evm64 simp lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -448,12 +448,12 @@ theorem high_limbs_zero_of_toNat_lt (v : EvmWord) (h : v.toNat < 2^64) :
   have h3 := hlimb 3 (by omega)
   simp [h1, h2, h3]
 
-@[simp] theorem getLimb_one (i : Fin 4) :
+@[simp] theorem getLimb_one {i : Fin 4} :
     (1 : EvmWord).getLimb i = if i = 0 then 1 else 0 := by
   have h : ∀ j : Fin 4, (1 : EvmWord).getLimb j = if j = 0 then 1 else 0 := by decide
   exact h i
 
-@[simp] theorem getLimb_ite (c : Prop) [Decidable c] (x y : EvmWord) (i : Fin 4) :
+@[simp] theorem getLimb_ite {c : Prop} [Decidable c] {x y : EvmWord} {i : Fin 4} :
     (if c then x else y).getLimb i = if c then x.getLimb i else y.getLimb i := by
   split <;> rfl
 

--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -107,7 +107,7 @@ def evmCodeIs (base : Word) (bytes : List (BitVec 8)) : Assertion :=
 -- Basic properties
 -- ============================================================================
 
-@[simp] theorem evmCodeIs_nil (base : Word) :
+@[simp] theorem evmCodeIs_nil {base : Word} :
     evmCodeIs base [] = empAssertion := rfl
 
 /-- evmCodeIs of a non-empty list decomposes into a chunk and the rest. -/

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -449,7 +449,7 @@ theorem evmWordIs_one_right (addr : Word) (Q : Assertion) :
 -- Shared infrastructure for stack operation specs
 -- ============================================================================
 
-@[simp] theorem EvmWord.getLimb_zero (i : Fin 4) : (0 : EvmWord).getLimb i = 0 := by
+@[simp] theorem EvmWord.getLimb_zero {i : Fin 4} : (0 : EvmWord).getLimb i = 0 := by
   have h : ∀ j : Fin 4, (0 : EvmWord).getLimb j = 0 := by decide
   exact h i
 


### PR DESCRIPTION
## Summary
Extend the simp-lemma implicit-arg cleanup to 4 Evm64 lemmas:
- `Evm64/CodeRegion.lean`: `evmCodeIs_nil {base}`
- `Evm64/Stack.lean`: `EvmWord.getLimb_zero {i}`
- `Evm64/Basic.lean`: `getLimb_one {i}`, `getLimb_ite {c} [Decidable c] {x y i}`

No external positional callers — all consumed via `simp only [...]`.

## Test plan
- [x] `lake build` green (3558 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)