### PR TITLE
refactor(ByteOps,HalfwordOps): flip get/set{Byte,Halfword}_eq args to implicit

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -60,10 +60,10 @@ theorem extractByte_replaceByte_same (w : Word) (pos : Fin 8) (b : BitVec 8) :
 
 /-! ## getByte / setByte in terms of extractByte / replaceByte -/
 
-theorem getByte_eq (s : MachineState) (addr : Word) :
+theorem getByte_eq {s : MachineState} {addr : Word} :
     s.getByte addr = extractByte (s.getMem (alignToDword addr)) (byteOffset addr) := rfl
 
-theorem setByte_eq (s : MachineState) (addr : Word) (b : BitVec 8) :
+theorem setByte_eq {s : MachineState} {addr : Word} {b : BitVec 8} :
     s.setByte addr b = s.setMem (alignToDword addr)
       (replaceByte (s.getMem (alignToDword addr)) (byteOffset addr) b) := rfl
 

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -39,10 +39,10 @@ theorem extractHalfword_replaceHalfword_same (w : Word) (pos : Fin 4) (h : BitVe
 
 /-! ## getHalfword / setHalfword in terms of extractHalfword / replaceHalfword -/
 
-theorem getHalfword_eq (s : MachineState) (addr : Word) :
+theorem getHalfword_eq {s : MachineState} {addr : Word} :
     s.getHalfword addr = extractHalfword (s.getMem (alignToDword addr)) ((byteOffset addr) / 2) := rfl
 
-theorem setHalfword_eq (s : MachineState) (addr : Word) (h : BitVec 16) :
+theorem setHalfword_eq {s : MachineState} {addr : Word} {h : BitVec 16} :
     s.setHalfword addr h = s.setMem (alignToDword addr)
       (replaceHalfword (s.getMem (alignToDword addr)) ((byteOffset addr) / 2) h) := rfl
 


### PR DESCRIPTION
## Summary
Flip `getByte_eq`, `setByte_eq`, `getHalfword_eq`, `setHalfword_eq` positional args to implicit. Consumed only via `simp only [...]` in the generic `{lbu,lb,sb,lhu,lh,sh}_spec` proofs, so the flip is transparent. Aligns with the broader simp-lemma implicit-arg cleanup arc.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)