### PR TITLE
refactor(DivMod/AddrNorm): flip word_zero_add x to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNorm.lean
@@ -112,7 +112,7 @@ export EvmAsm.Rv64.AddrNorm
 -- to a concrete literal, leaving `0 + literal` behind).
 -- ============================================================================
 
-@[divmod_addr, grind =] theorem word_zero_add (x : Word) : (0 : Word) + x = x := BitVec.zero_add x
+@[divmod_addr, grind =] theorem word_zero_add {x : Word} : (0 : Word) + x = x := BitVec.zero_add x
 
 -- ============================================================================
 -- Loop-counter positivity: after `ADDI j j -1` (ie. `j + signExtend12 4095`),


### PR DESCRIPTION
## Summary
Mirror of #863 (which flipped the Rv64-level `word_zero_add` / `word_add_zero`). This file has only one explicit-arg tagged lemma; the rest (`se12_N` / `word_shl3_N` concrete literals) have no binders.

No explicit callers — consumed via `divmod_addr` / `grind` tactics.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)