### PR TITLE
refactor(Evm64/Basic): flip getLimb_ushiftRight (v n i) to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -400,7 +400,7 @@ theorem getLimb_ushiftRight_zero (v : EvmWord) (i : Fin 4) :
 
     The mask `if bs = 0 then 0 else allOnes 64` ensures the `bs = 0` case reduces to
     just the logical shift with no spurious high bits from the left-shift. -/
-theorem getLimb_ushiftRight (v : EvmWord) (n : Nat) (i : Fin 4) :
+theorem getLimb_ushiftRight {v : EvmWord} {n : Nat} {i : Fin 4} :
     getLimb (v >>> n) i =
     (getLimbN v (i.val + n / 64) >>> (n % 64)) |||
     ((getLimbN v (i.val + n / 64 + 1) <<< (64 - n % 64)) &&&

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -531,7 +531,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
   have hbs_lt : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-  rw [getLimb_ushiftRight value s0.toNat i, hL_div,
+  rw [getLimb_ushiftRight, hL_div,
       getLimbN_lt value (i.val + L) hiL,
       getLimbN_lt value (i.val + L + 1) hiL1]
   by_cases hmod0 : s0.toNat % 64 = 0
@@ -565,7 +565,7 @@ private theorem shr_bridge_last (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-  rw [getLimb_ushiftRight value s0.toNat i, hL_div, hiL,
+  rw [getLimb_ushiftRight, hL_div, hiL,
       getLimbN_lt value 3 (by omega), getLimbN_ge value 4 (by omega)]
   simp [show bs.toNat % 64 = s0.toNat % 64 from by omega]
 
@@ -580,7 +580,7 @@ private theorem shr_bridge_zero (value : EvmWord) (s0 : Word)
   rw [hresult]
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-  rw [getLimb_ushiftRight value s0.toNat i, hL_div,
+  rw [getLimb_ushiftRight, hL_div,
       getLimbN_ge value (i.val + L) (by omega),
       getLimbN_ge value (i.val + L + 1) (by omega)]
   simp

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -661,7 +661,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- sshiftRight agrees with ushiftRight for merge limbs
   rw [getLimb_sshiftRight_eq_ushiftRight value s0.toNat i (by omega)]
-  rw [getLimb_ushiftRight value s0.toNat i, hL_div,
+  rw [getLimb_ushiftRight, hL_div,
       getLimbN_lt value (i.val + L) (by omega),
       getLimbN_lt value (i.val + L + 1) hiL1]
   by_cases hmod0 : s0.toNat % 64 = 0


### PR DESCRIPTION
## Summary
All 4 call sites use `rw [getLimb_ushiftRight value s0.toNat i, ...]`; the rewrite target `getLimb (v >>> n) i = RHS` fully determines v, n, i by unification. Flipping to implicit shortens each rewrite to `rw [getLimb_ushiftRight, ...]`.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)