### PR TITLE
refactor(Evm64/Basic): flip 7 getLimb shift helpers (v n i) to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -300,7 +300,7 @@ theorem shiftLeft_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) :
     `getLimb (v <<< n) i = (getLimbN v (i - ls) <<< bs) ||| ((getLimbN v (i - ls - 1) >>> (64 - bs)) &&& mask)`
 
     The condition `i * 64 ≥ n` ensures all 64 extracted bits come from `v`. -/
-theorem getLimb_shiftLeft (v : EvmWord) (n : Nat) (i : Fin 4) (hge : i.val * 64 ≥ n) :
+theorem getLimb_shiftLeft {v : EvmWord} {n : Nat} {i : Fin 4} (hge : i.val * 64 ≥ n) :
     getLimb (v <<< n) i =
     (getLimbN v (i.val - n / 64) <<< (n % 64)) |||
     ((getLimbN v (i.val - n / 64 - 1) >>> (64 - n % 64)) &&&
@@ -356,7 +356,7 @@ theorem getLimb_shiftLeft (v : EvmWord) (n : Nat) (i : Fin 4) (hge : i.val * 64 
 
 /-- **SHL bridge lemma (first limb).** When `i = n / 64`, the i-th limb of `v <<< n` equals
     the lowest limb of `v` shifted left by `n % 64`. -/
-theorem getLimb_shiftLeft_eq_div (v : EvmWord) (n : Nat) (i : Fin 4) (heq : i.val = n / 64) :
+theorem getLimb_shiftLeft_eq_div {v : EvmWord} {n : Nat} {i : Fin 4} (heq : i.val = n / 64) :
     getLimb (v <<< n) i = getLimbN v 0 <<< (n % 64) := by
   simp only [getLimb]
   rw [getLimbN_eq_extractLsb']
@@ -375,7 +375,7 @@ theorem getLimb_shiftLeft_eq_div (v : EvmWord) (n : Nat) (i : Fin 4) (heq : i.va
 
 /-- **SHL bridge lemma (zero limb).** When `(i + 1) * 64 ≤ n`, the i-th limb of `v <<< n`
     is zero (all extracted bits are below the shift amount). -/
-theorem getLimb_shiftLeft_low (v : EvmWord) (n : Nat) (i : Fin 4) (hlo : (i.val + 1) * 64 ≤ n) :
+theorem getLimb_shiftLeft_low {v : EvmWord} {n : Nat} {i : Fin 4} (hlo : (i.val + 1) * 64 ≤ n) :
     getLimb (v <<< n) i = 0 := by
   simp only [getLimb]
   ext j
@@ -385,7 +385,7 @@ theorem getLimb_shiftLeft_low (v : EvmWord) (n : Nat) (i : Fin 4) (hlo : (i.val 
   simp [hlt]
 
 /-- Shifting a 256-bit word right by 0 is the identity on each limb. -/
-theorem getLimb_ushiftRight_zero (v : EvmWord) (i : Fin 4) :
+theorem getLimb_ushiftRight_zero {v : EvmWord} {i : Fin 4} :
     getLimb (v >>> 0) i = v.getLimb i := by
   simp [getLimb]
 
@@ -485,7 +485,7 @@ theorem eq_zero_iff_limbs (a : EvmWord) :
 /-- For merge limbs (all 64 extracted bits within v), sshiftRight agrees with ushiftRight.
     When `(i+1)*64 + n ≤ 256`, all bit positions `i*64 + j` (j < 64) satisfy
     `n + (i*64 + j) < 256`, so no sign extension occurs. -/
-theorem getLimb_sshiftRight_eq_ushiftRight (v : EvmWord) (n : Nat) (i : Fin 4)
+theorem getLimb_sshiftRight_eq_ushiftRight {v : EvmWord} {n : Nat} {i : Fin 4}
     (h : (i.val + 1) * 64 + n ≤ 256) :
     getLimb (BitVec.sshiftRight v n) i = getLimb (v >>> n) i := by
   simp only [getLimb]
@@ -500,7 +500,7 @@ theorem getLimb_sshiftRight_eq_ushiftRight (v : EvmWord) (n : Nat) (i : Fin 4)
 /-- **SAR bridge lemma (last limb).** When `i + n/64 = 3`, the i-th limb of
     `sshiftRight v n` equals `sshiftRight (v.getLimb 3) (n % 64)`.
     This is the limb that gets arithmetic (sign-preserving) shift. -/
-theorem getLimb_sshiftRight_last (v : EvmWord) (n : Nat) (i : Fin 4)
+theorem getLimb_sshiftRight_last {v : EvmWord} {n : Nat} {i : Fin 4}
     (hiL : i.val + n / 64 = 3) :
     getLimb (BitVec.sshiftRight v n) i =
     BitVec.sshiftRight (v.getLimb ⟨3, by omega⟩) (n % 64) := by
@@ -526,7 +526,7 @@ theorem getLimb_sshiftRight_last (v : EvmWord) (n : Nat) (i : Fin 4)
 
 /-- **SAR bridge lemma (sign limb via getLimb 3).** When `i + n/64 ≥ 4`, the i-th limb of
     `sshiftRight v n` equals `sshiftRight (v.getLimb 3) 63`. -/
-theorem getLimb_sshiftRight_sign' (v : EvmWord) (n : Nat) (i : Fin 4)
+theorem getLimb_sshiftRight_sign' {v : EvmWord} {n : Nat} {i : Fin 4}
     (hiL : i.val + n / 64 ≥ 4) :
     getLimb (BitVec.sshiftRight v n) i =
     BitVec.sshiftRight (v.getLimb ⟨3, by omega⟩) 63 := by
@@ -557,7 +557,7 @@ theorem getLimb_sshiftRight_sign' (v : EvmWord) (n : Nat) (i : Fin 4)
 theorem getLimb_sshiftRight_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) (i : Fin 4) :
     getLimb (BitVec.sshiftRight v n) i =
     BitVec.sshiftRight (v.getLimb ⟨3, by omega⟩) 63 :=
-  getLimb_sshiftRight_sign' v n i (by omega)
+  getLimb_sshiftRight_sign' (by omega)
 
 /-- `getLimb` of `fromLimbs` with a constant function. -/
 theorem getLimb_fromLimbs_const (w : Word) (i : Fin 4) :

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -660,7 +660,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- sshiftRight agrees with ushiftRight for merge limbs
-  rw [getLimb_sshiftRight_eq_ushiftRight value s0.toNat i (by omega)]
+  rw [getLimb_sshiftRight_eq_ushiftRight (by omega)]
   rw [getLimb_ushiftRight value s0.toNat i, hL_div,
       getLimbN_lt value (i.val + L) (by omega),
       getLimbN_lt value (i.val + L + 1) hiL1]
@@ -695,7 +695,7 @@ private theorem sar_bridge_last (value : EvmWord) (s0 : Word)
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-  rw [getLimb_sshiftRight_last value s0.toNat i (by omega)]
+  rw [getLimb_sshiftRight_last (by omega)]
   congr 1; omega
 
 -- Sign limb bridge: for limbs beyond the shift (i+L >= 4, sign extension).
@@ -712,7 +712,7 @@ private theorem sar_bridge_sign (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- getLimb (sshiftRight value n) i = sshiftRight (getLimb value 3) 63 for sign limbs
-  rw [getLimb_sshiftRight_sign' value s0.toNat i (by omega)]
+  rw [getLimb_sshiftRight_sign' (by omega)]
   -- sshiftRight (sshiftRight x bs) 63 = sshiftRight x 63 when bs < 64
   -- Both give sign extension (all bits = MSB of x)
   have hbs_val : bs.toNat = s0.toNat % 64 := by

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -498,7 +498,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft: i*64 >= s0.toNat since i >= L+1 and s0.toNat = L*64 + bs < (L+1)*64
-  rw [getLimb_shiftLeft value s0.toNat i (by omega), hL_div,
+  rw [getLimb_shiftLeft (by omega), hL_div,
       getLimbN_lt value (i.val - L) hiLsub,
       getLimbN_lt value (i.val - L - 1) hiLsub1]
   -- Now match the masks and shift amounts
@@ -536,7 +536,7 @@ private theorem shl_bridge_first (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_eq_div: i.val = n / 64
-  rw [getLimb_shiftLeft_eq_div value s0.toNat i (by omega)]
+  rw [getLimb_shiftLeft_eq_div (by omega)]
   -- getLimbN v 0 = getLimb v ⟨0, _⟩
   rw [getLimbN_lt value 0 (by omega)]
   -- Shift amounts match: bs.toNat % 64 = s0.toNat % 64
@@ -554,7 +554,7 @@ private theorem shl_bridge_zero (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft_low: (i+1)*64 <= s0.toNat since i < L and s0.toNat >= L*64
-  exact getLimb_shiftLeft_low value s0.toNat i (by omega)
+  exact getLimb_shiftLeft_low (by omega)
 
 -- ============================================================================
 -- Section 6: Body path composition with evmWordIs postcondition


### PR DESCRIPTION
## Summary
Continues the family cleanup started by #878. Flip `(v : EvmWord) (n : Nat) (i : Fin 4)` to implicit on 7 helpers:
- `getLimb_shiftLeft`, `getLimb_shiftLeft_eq_div`, `getLimb_shiftLeft_low`
- `getLimb_ushiftRight_zero`
- `getLimb_sshiftRight_eq_ushiftRight`, `getLimb_sshiftRight_last`, `getLimb_sshiftRight_sign'`

Every call site uses `rw [lemma value s0.toNat i (by omega)]`; the rewrite target (`getLimb (v <<< n) i` etc.) fully determines the three values by unification. Each site collapses to `rw [lemma (by omega)]`.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)