### PR TITLE
refactor(Evm64/Basic): flip getLimb_fromLimbs + getLimb_as_getLimbN family to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -95,7 +95,7 @@ private theorem getLimb_fromLimbs_3 (limbs : Fin 4 → Word) :
   bv_decide
 
 /-- Round-trip: getLimb ∘ fromLimbs = id. -/
-theorem getLimb_fromLimbs (limbs : Fin 4 → Word) (i : Fin 4) :
+theorem getLimb_fromLimbs {limbs : Fin 4 → Word} {i : Fin 4} :
     (EvmWord.fromLimbs limbs).getLimb i = limbs i := by
   rcases i with ⟨i, hi⟩
   have : i = 0 ∨ i = 1 ∨ i = 2 ∨ i = 3 := by omega
@@ -175,16 +175,16 @@ theorem getLimbN_ge (v : EvmWord) (k : Nat) (h : k ≥ 4) :
 
 /-- Convert getLimb (Fin 4) to getLimbN (Nat). Use this simp lemma to normalize
     all getLimb calls to getLimbN for consistent Expr.hash in xperm. -/
-theorem getLimb_eq_getLimbN (v : EvmWord) (i : Fin 4) :
+theorem getLimb_eq_getLimbN {v : EvmWord} {i : Fin 4} :
     v.getLimb i = v.getLimbN i.val := by
   simp [getLimbN, i.isLt]
 
 /-- Convert `getLimb (k : Fin 4)` to `getLimbN k` for concrete indices.
     Use `simp only [getLimb_as_getLimbN]` to batch-convert bridge lemma hypotheses. -/
-theorem getLimb_as_getLimbN_0 (v : EvmWord) : v.getLimb 0 = v.getLimbN 0 := by simp [getLimbN]
-theorem getLimb_as_getLimbN_1 (v : EvmWord) : v.getLimb 1 = v.getLimbN 1 := by simp [getLimbN]
-theorem getLimb_as_getLimbN_2 (v : EvmWord) : v.getLimb 2 = v.getLimbN 2 := by simp [getLimbN]
-theorem getLimb_as_getLimbN_3 (v : EvmWord) : v.getLimb 3 = v.getLimbN 3 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_0 {v : EvmWord} : v.getLimb 0 = v.getLimbN 0 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_1 {v : EvmWord} : v.getLimb 1 = v.getLimbN 1 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_2 {v : EvmWord} : v.getLimb 2 = v.getLimbN 2 := by simp [getLimbN]
+theorem getLimb_as_getLimbN_3 {v : EvmWord} : v.getLimb 3 = v.getLimbN 3 := by simp [getLimbN]
 
 -- getLimbN versions of operation lemmas (for xperm AC fast path consistency)
 theorem getLimbN_and (x y : EvmWord) (k : Nat) :

--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -148,7 +148,7 @@ theorem getLimbN_fromLimbs_match {w0 w1 w2 w3 : Word} :
                show (1 : Nat) < 4 from by omega,
                show (2 : Nat) < 4 from by omega,
                show (3 : Nat) < 4 from by omega, dite_true]
-    exact getLimb_fromLimbs _ _
+    exact getLimb_fromLimbs
 
 /-- Variant: the getLimbN of fromLimbs equals the corresponding input word.
     Useful for rewriting individual limb assertions. -/


### PR DESCRIPTION
## Summary
6 more helpers flipped in the ongoing Evm64/Basic.lean implicit-arg cleanup (#874 / #878 / #879 / #880):
- `getLimb_fromLimbs {limbs i}`
- `getLimb_eq_getLimbN {v i}`
- `getLimb_as_getLimbN_{0,1,2,3} {v}`

One `rw [getLimb_fromLimbs _ _]` site in `DivLimbBridge.lean` drops the placeholders.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)