### PR TITLE
refactor(Evm64/Basic): flip getLimbN_ite to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -235,7 +235,7 @@ theorem getLimbN_one_two : (1 : EvmWord).getLimbN 2 = 0 :=
 theorem getLimbN_one_three : (1 : EvmWord).getLimbN 3 = 0 :=
   getLimbN_one_of_ne_zero 3 (by decide)
 
-theorem getLimbN_ite (c : Prop) [Decidable c] (x y : EvmWord) (k : Nat) :
+theorem getLimbN_ite {c : Prop} [Decidable c] {x y : EvmWord} {k : Nat} :
     (if c then x else y).getLimbN k = if c then x.getLimbN k else y.getLimbN k := by
   split <;> rfl
 


### PR DESCRIPTION
## Summary
Simp-tagged helper used in 6 call sites, all via `simp only [...]` — flip is transparent. Continues the `Evm64/Basic.lean` implicit-arg cleanup (#874 / #878-881 / #882).

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)