### PR TITLE
refactor(Evm64/EvmWordArith/Div): flip div/mod_eq_of_euclidean (a b q r) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -166,13 +166,13 @@ theorem div_mod_unique (a b q r : EvmWord) (hbnz : b ≠ 0)
     - `fromLimbs r_limbs < fromLimbs b_limbs`
     - `(fromLimbs b_limbs).toNat * (fromLimbs q_limbs).toNat + (fromLimbs r_limbs).toNat < 2^256`
     Then this theorem gives `fromLimbs q_limbs = div a b`. -/
-theorem div_eq_of_euclidean (a b : EvmWord) (q r : EvmWord) (hbnz : b ≠ 0)
+theorem div_eq_of_euclidean {a b : EvmWord} {q r : EvmWord} (hbnz : b ≠ 0)
     (h_eq : a = b * q + r) (h_rem_lt : r < b)
     (h_no_overflow : b.toNat * q.toNat + r.toNat < 2 ^ 256) :
     q = div a b :=
   (div_mod_unique a b q r hbnz h_rem_lt h_no_overflow h_eq).1
 
-theorem mod_eq_of_euclidean (a b : EvmWord) (q r : EvmWord) (hbnz : b ≠ 0)
+theorem mod_eq_of_euclidean {a b : EvmWord} {q r : EvmWord} (hbnz : b ≠ 0)
     (h_eq : a = b * q + r) (h_rem_lt : r < b)
     (h_no_overflow : b.toNat * q.toNat + r.toNat < 2 ^ 256) :
     r = mod a b :=

--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -53,7 +53,7 @@ theorem div_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
     (h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_nat_lt : r.toNat < b.toNat) :
     q = EvmWord.div a b :=
-  div_eq_of_euclidean a b q r hbnz
+  div_eq_of_euclidean hbnz
     (bv_eq_of_nat_eq a b q r h_nat_eq)
     (bv_lt_of_nat_lt r b h_nat_lt)
     (by have := a.isLt; omega)
@@ -64,7 +64,7 @@ theorem mod_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
     (h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_nat_lt : r.toNat < b.toNat) :
     r = EvmWord.mod a b :=
-  mod_eq_of_euclidean a b q r hbnz
+  mod_eq_of_euclidean hbnz
     (bv_eq_of_nat_eq a b q r h_nat_eq)
     (bv_lt_of_nat_lt r b h_nat_lt)
     (by have := a.isLt; omega)


### PR DESCRIPTION
## Summary
Continues #885. Flip `div_eq_of_euclidean {a b q r}` and `mod_eq_of_euclidean {a b q r}` to implicit. Only caller (DivBridge.lean) passes `a b q r hbnz`; `h_eq : a = b * q + r` determines all 4 — the flip collapses each site to `div_eq_of_euclidean hbnz` / `mod_eq_of_euclidean hbnz`.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)