### PR TITLE
refactor(Evm64/EvmWordArith/DivBridge): flip 3 bridge helpers (a b q r) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -25,7 +25,7 @@ namespace EvmWord
 
 /-- If the Nat-level equation `a = b * q + r` holds and `a < 2^256`,
     then the BitVec-level equation `a = b * q + r` holds (no overflow). -/
-theorem bv_eq_of_nat_eq (a b q r : EvmWord)
+theorem bv_eq_of_nat_eq {a b q r : EvmWord}
     (h_nat : a.toNat = b.toNat * q.toNat + r.toNat) :
     a = b * q + r := by
   apply BitVec.eq_of_toNat_eq
@@ -36,7 +36,7 @@ theorem bv_eq_of_nat_eq (a b q r : EvmWord)
   exact h_nat
 
 /-- Nat strict inequality implies BitVec strict inequality. -/
-theorem bv_lt_of_nat_lt (a b : EvmWord) (h : a.toNat < b.toNat) : a < b :=
+theorem bv_lt_of_nat_lt {a b : EvmWord} (h : a.toNat < b.toNat) : a < b :=
   BitVec.lt_def.mpr h
 
 -- ============================================================================
@@ -54,8 +54,8 @@ theorem div_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
     (h_nat_lt : r.toNat < b.toNat) :
     q = EvmWord.div a b :=
   div_eq_of_euclidean a b q r hbnz
-    (bv_eq_of_nat_eq a b q r h_nat_eq)
-    (bv_lt_of_nat_lt r b h_nat_lt)
+    (bv_eq_of_nat_eq h_nat_eq)
+    (bv_lt_of_nat_lt h_nat_lt)
     (by have := a.isLt; omega)
 
 /-- If the Nat-level Euclidean property holds (`a = b * q + r` with `r < b`),
@@ -65,8 +65,8 @@ theorem mod_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
     (h_nat_lt : r.toNat < b.toNat) :
     r = EvmWord.mod a b :=
   mod_eq_of_euclidean a b q r hbnz
-    (bv_eq_of_nat_eq a b q r h_nat_eq)
-    (bv_lt_of_nat_lt r b h_nat_lt)
+    (bv_eq_of_nat_eq h_nat_eq)
+    (bv_lt_of_nat_lt h_nat_lt)
     (by have := a.isLt; omega)
 
 -- ============================================================================
@@ -99,7 +99,7 @@ theorem val256_mul_single (q v0 v1 v2 v3 : Word) :
     (no underflow) and `val256 r < val256 b`, then `fromLimbs q_limbs = div a b`.
 
     This connects `mulsub_chain_no_underflow` to `div_of_nat_euclidean`. -/
-theorem div_from_mulsub (a b q r : EvmWord)
+theorem div_from_mulsub {a b q r : EvmWord}
     (hbnz : b ≠ 0)
     (h_chain : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_rem : r.toNat < b.toNat) :

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -245,7 +245,7 @@ theorem mulsub_4limb_euclidean_div (qNat : Nat)
     rw [ha, hb, hq, hr]; linarith
   have h_lt : r.toNat < b.toNat := by rw [hr, hb]; exact h_rem
   have h_bnz : b ≠ 0 := fromLimbs_ne_zero_of_or v0 v1 v2 v3 hbnz
-  exact div_from_mulsub a b q r h_bnz h_eq h_lt
+  exact div_from_mulsub h_bnz h_eq h_lt
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -163,7 +163,7 @@ theorem val256_euclidean_to_div_mod
   have h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat := by
     rw [ha, hb, hq, hr]; nlinarith [Nat.mul_comm (val256 q0 q1 q2 q3) (val256 b0 b1 b2 b3)]
   have h_nat_lt : r.toNat < b.toNat := by rw [hr, hb]; exact hlt
-  exact div_from_mulsub a b q r hbnz' h_nat_eq h_nat_lt
+  exact div_from_mulsub hbnz' h_nat_eq h_nat_lt
 
 -- ============================================================================
 -- Normalization round-trip: normalized Euclidean → original div/mod


### PR DESCRIPTION
## Summary
3 more Nat → BitVec bridge helpers flipped:
- `bv_eq_of_nat_eq {a b q r}` — `h_nat` determines all 4
- `bv_lt_of_nat_lt {a b}` — `h` determines both
- `div_from_mulsub {a b q r}` — `h_chain` determines all 4

Internal `div_of_nat_euclidean` / `mod_of_nat_euclidean` callers + two external sites in `DivMulSubLimb.lean` / `DivRemainderBound.lean` drop their positional args.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)