### PR TITLE
refactor(Normalization): flip norm_euclidean_bridge (a b q r s) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -185,7 +185,7 @@ theorem norm_euclidean_correct {aVal bVal qNat r_norm : Nat} (s : Nat)
     qNat = aVal / bVal ∧ r_norm / 2^s = aVal % bVal := by
   -- Convert to the form expected by norm_euclidean_bridge
   have heq' : aVal * 2^s = bVal * 2^s * qNat + r_norm := by linarith
-  exact norm_euclidean_bridge aVal bVal qNat r_norm s heq' hlt
+  exact norm_euclidean_bridge heq' hlt
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/Normalization.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Normalization.lean
@@ -43,7 +43,7 @@ theorem denorm_mod_eq (a b s : Nat) :
 /-- If we prove the Euclidean property for normalized values `a' = a * 2^s`,
     `b' = b * 2^s`, the quotient is the same as for the original values,
     and the remainder can be recovered by dividing by 2^s. -/
-theorem norm_euclidean_bridge (a b q r s : Nat)
+theorem norm_euclidean_bridge {a b q r s : Nat}
     (h_eq : a * 2^s = b * 2^s * q + r)
     (h_rem : r < b * 2^s) :
     q = a / b ∧ r / 2^s = a % b := by


### PR DESCRIPTION
## Summary
Flip `norm_euclidean_bridge (a b q r s : Nat)` to implicit. Sole caller in `DivRemainderBound.lean` passes `aVal bVal qNat r_norm s heq' hlt`; the hypothesis `h_eq : a * 2^s = b * 2^s * q + r` determines all 5 by unification.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)