### PR TITLE
refactor(Execution): flip execInstrBr_eq_execInstr (s i) to implicit

### DIFF
--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -195,7 +195,7 @@ def execInstrBr (s : MachineState) (i : Instr) : MachineState :=
 
 /-- For non-branch instructions, execInstrBr agrees with execInstr
     (both advance PC by 4 and compute the same state update). -/
-theorem execInstrBr_eq_execInstr (s : MachineState) (i : Instr)
+theorem execInstrBr_eq_execInstr {s : MachineState} {i : Instr}
     (h : i.isBranch = false) : execInstrBr s i = execInstr s i := by
   cases i <;> simp_all [execInstrBr, execInstr, Instr.isBranch,
     MachineState.pc_setReg, MachineState.pc_setMem,


### PR DESCRIPTION
## Summary
No external callers — the hypothesis `h : i.isBranch = false` + goal `execInstrBr s i = execInstr s i` determine s, i by unification in any future use. Style alignment with the rest of the `step_*` / `execInstrBr` implicit family.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)