### PR TITLE
refactor(Normalization): flip norm/denorm_div/mod_eq (a b s) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Normalization.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Normalization.lean
@@ -20,19 +20,19 @@ namespace EvmWord
 -- ============================================================================
 
 /-- Normalization preserves the quotient: `(a * 2^s) / (b * 2^s) = a / b`. -/
-theorem norm_div_eq (a b s : Nat) :
+theorem norm_div_eq {a b s : Nat} :
     (a * 2^s) / (b * 2^s) = a / b := by
   rcases Nat.eq_zero_or_pos b with rfl | hb
   · simp
   · rw [Nat.mul_comm a, Nat.mul_comm b, Nat.mul_div_mul_left _ _ (by positivity)]
 
 /-- Normalization scales the remainder: `(a * 2^s) % (b * 2^s) = (a % b) * 2^s`. -/
-theorem norm_mod_eq (a b s : Nat) :
+theorem norm_mod_eq {a b s : Nat} :
     (a * 2^s) % (b * 2^s) = (a % b) * 2^s :=
   Nat.mul_mod_mul_right (2^s) a b
 
 /-- Denormalization: dividing the scaled remainder by 2^s gives the true remainder. -/
-theorem denorm_mod_eq (a b s : Nat) :
+theorem denorm_mod_eq {a b s : Nat} :
     (a * 2^s) % (b * 2^s) / 2^s = a % b := by
   rw [norm_mod_eq, Nat.mul_comm, Nat.mul_div_cancel_left _ (by positivity : 0 < 2^s)]
 


### PR DESCRIPTION
## Summary
3 Nat-level normalization scaling lemmas flipped to implicit:
- `norm_div_eq`
- `norm_mod_eq`
- `denorm_mod_eq`

No external callers. Style alignment with the broader implicit-arg cleanup.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)