### PR TITLE
refactor(DivLimbBridge): flip limbs_or_ne_zero_imp + fromLimbs_ne_zero_of_or to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -295,7 +295,7 @@ theorem div_of_val256_eq_div
   have ha : a.toNat = val256 a0 a1 a2 a3 := (val256_eq_fromLimbs_toNat a0 a1 a2 a3).symm
   have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
   have hq_val : q.toNat = val256 q0 q1 q2 q3 := (val256_eq_fromLimbs_toNat q0 q1 q2 q3).symm
-  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or b0 b1 b2 b3 hbnz
+  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   -- q.toNat = a.toNat / b.toNat
   have hq_nat : q.toNat = a.toNat / b.toNat := by rw [hq_val, ha, hb]; exact hq
   -- (EvmWord.div a b).toNat = a.toNat / b.toNat
@@ -321,7 +321,7 @@ theorem mod_of_val256_eq_mod
   have ha : a.toNat = val256 a0 a1 a2 a3 := (val256_eq_fromLimbs_toNat a0 a1 a2 a3).symm
   have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
   have hr_val : r.toNat = val256 r0 r1 r2 r3 := (val256_eq_fromLimbs_toNat r0 r1 r2 r3).symm
-  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or b0 b1 b2 b3 hbnz
+  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   have hr_nat : r.toNat = a.toNat % b.toNat := by rw [hr_val, ha, hb]; exact hr
   have hmod : (EvmWord.mod a b).toNat = a.toNat % b.toNat := by
     unfold EvmWord.mod; rw [if_neg hbnz']; exact BitVec.toNat_umod

--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -24,7 +24,7 @@ namespace EvmWord
 -- ============================================================================
 
 /-- If the 4-way OR of limbs is nonzero, at least one limb is nonzero. -/
-theorem limbs_or_ne_zero_imp (b0 b1 b2 b3 : Word)
+theorem limbs_or_ne_zero_imp {b0 b1 b2 b3 : Word}
     (h : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
     b0 ≠ 0 ∨ b1 ≠ 0 ∨ b2 ≠ 0 ∨ b3 ≠ 0 := by
   by_contra hall
@@ -73,14 +73,14 @@ theorem val256_ge_pow192_of_limb3 (b0 b1 b2 b3 : Word) (h : b3 ≠ 0) :
 theorem val256_pos_of_or_ne_zero (b0 b1 b2 b3 : Word)
     (h : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
     val256 b0 b1 b2 b3 > 0 := by
-  rcases limbs_or_ne_zero_imp b0 b1 b2 b3 h with h0 | h1 | h2 | h3
+  rcases limbs_or_ne_zero_imp h with h0 | h1 | h2 | h3
   · linarith [val256_pos_of_limb0 b0 b1 b2 b3 h0]
   · linarith [val256_ge_pow64_of_limb1 b0 b1 b2 b3 h1]
   · linarith [val256_ge_pow128_of_limb2 b0 b1 b2 b3 h2]
   · linarith [val256_ge_pow192_of_limb3 b0 b1 b2 b3 h3]
 
 /-- OR-reduce nonzero implies the fromLimbs word is nonzero. -/
-theorem fromLimbs_ne_zero_of_or (b0 b1 b2 b3 : Word)
+theorem fromLimbs_ne_zero_of_or {b0 b1 b2 b3 : Word}
     (h : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
     (fromLimbs fun i : Fin 4 =>
       match i with | 0 => b0 | 1 => b1 | 2 => b2 | 3 => b3) ≠ 0 := by

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -243,7 +243,7 @@ theorem mulsub_4limb_euclidean_div (qNat : Nat)
   have h_eq : a.toNat = b.toNat * q.toNat + r.toNat := by
     rw [ha, hb, hq, hr]; linarith
   have h_lt : r.toNat < b.toNat := by rw [hr, hb]; exact h_rem
-  have h_bnz : b ≠ 0 := fromLimbs_ne_zero_of_or v0 v1 v2 v3 hbnz
+  have h_bnz : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   exact div_from_mulsub a b q r h_bnz h_eq h_lt
 
 end EvmWord

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -159,7 +159,7 @@ theorem val256_euclidean_to_div_mod
   have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
   have hq : q.toNat = val256 q0 q1 q2 q3 := (val256_eq_fromLimbs_toNat q0 q1 q2 q3).symm
   have hr : r.toNat = val256 r0 r1 r2 r3 := (val256_eq_fromLimbs_toNat r0 r1 r2 r3).symm
-  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or b0 b1 b2 b3 hbnz
+  have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   have h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat := by
     rw [ha, hb, hq, hr]; nlinarith [Nat.mul_comm (val256 q0 q1 q2 q3) (val256 b0 b1 b2 b3)]
   have h_nat_lt : r.toNat < b.toNat := by rw [hr, hb]; exact hlt


### PR DESCRIPTION
## Summary
Both lemmas' hypothesis `h : b0 ||| b1 ||| b2 ||| b3 ≠ 0` determines all four limbs. 4 `fromLimbs_ne_zero_of_or` call sites + 1 `limbs_or_ne_zero_imp` site drop positional args.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)