### PR TITLE
refactor(DivLimbBridge): flip val256_pos_of_or_ne_zero (b0..b3) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -155,7 +155,7 @@ theorem div_correct_n4_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+  have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   -- val256(q0, 0, 0, 0) = q0.toNat
   have hq_val : val256 q0 0 0 0 = q0.toNat := val256_zero_upper_3 q0
@@ -185,7 +185,7 @@ theorem div_correct_n3_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+  have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 0 0 = q1.toNat * 2^64 + q0.toNat :=
     (accumulated_eq_val256_n3 q0 q1).symm
@@ -213,7 +213,7 @@ theorem div_correct_n2_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+  have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 q2 0 = q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
     (accumulated_eq_val256_n2 q0 q1 q2).symm
@@ -241,7 +241,7 @@ theorem div_correct_n1_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+  have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 q2 q3 =
       q3.toNat * 2^192 + q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=

--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -70,7 +70,7 @@ theorem val256_ge_pow192_of_limb3 (b0 b1 b2 b3 : Word) (h : b3 ≠ 0) :
 -- ============================================================================
 
 /-- OR-reduce nonzero implies val256 > 0. -/
-theorem val256_pos_of_or_ne_zero (b0 b1 b2 b3 : Word)
+theorem val256_pos_of_or_ne_zero {b0 b1 b2 b3 : Word}
     (h : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
     val256 b0 b1 b2 b3 > 0 := by
   rcases limbs_or_ne_zero_imp b0 b1 b2 b3 h with h0 | h1 | h2 | h3
@@ -88,7 +88,7 @@ theorem fromLimbs_ne_zero_of_or (b0 b1 b2 b3 : Word)
   have h0 : val256 b0 b1 b2 b3 = 0 := by
     rw [val256_eq_fromLimbs_toNat]
     have := congr_arg BitVec.toNat heq; simpa using this
-  linarith [val256_pos_of_or_ne_zero b0 b1 b2 b3 h]
+  linarith [val256_pos_of_or_ne_zero h]
 
 -- ============================================================================
 -- EvmWord nonzero ↔ getLimbN OR nonzero

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -74,7 +74,7 @@ theorem hq_over_from_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   simp only [] at hab'
   rw [hcarry2_one] at hab'
   -- Bounds
-  have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero v0 v1 v2 v3 hbnz
+  have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero hbnz
   have hab'_bound := val256_bound
     (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).1
     (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.1

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -192,7 +192,7 @@ theorem n4_max_addback_correct (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     -- hmulsub_raw: val256 u + 1 * 2^256 = val256 un + qHat * val256 v
     -- So qHat * val256 v ≥ val256 u + 1 (since 2^256 > val256 un)
     have hv_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
-    have hv_pos := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+    have hv_pos := val256_pos_of_or_ne_zero hbnz
     have hq_mul_gt : (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 >
         val256 a0 a1 a2 a3 := by nlinarith
     rw [hq_hat_toNat] at hq_mul_gt
@@ -226,7 +226,7 @@ theorem mulsubN4_c3_le_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hu_bound := val256_bound u0 u1 u2 u3
   have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have hv_bound := val256_bound v0 v1 v2 v3
-  have hv_pos := val256_pos_of_or_ne_zero v0 v1 v2 v3 hbnz
+  have hv_pos := val256_pos_of_or_ne_zero hbnz
   -- From hq_over: q * val256(v) ≤ (⌊u/v⌋ + 1) * val256(v)
   --            = ⌊u/v⌋ * val256(v) + val256(v) ≤ val256(u) + val256(v)
   have hdiv_mul_le : val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 *
@@ -361,7 +361,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hab' := addbackN4_val256_eq ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3
   simp only [] at hab'
   -- Bounds
-  have hv_pos := val256_pos_of_or_ne_zero v0 v1 v2 v3 hbnz
+  have hv_pos := val256_pos_of_or_ne_zero hbnz
   have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have hab1_bound := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
   have hab'_result_bound := val256_bound
@@ -503,7 +503,7 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hv_bound := val256_bound v0 v1 v2 v3
   have hu_bound := val256_bound u0 u1 u2 u3
   have hab_bound := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
-  have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero v0 v1 v2 v3 hbnz
+  have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero hbnz
   -- q * val256(v) > val256(u) (from c3 = 1, i.e., borrow)
   have hqv_gt_u : q.toNat * val256 v0 v1 v2 v3 > val256 u0 u1 u2 u3 := by nlinarith
   -- q ≥ 1

--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -49,7 +49,7 @@ theorem val256_ms_un_eq_val256_mod_max_skip
       val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 := by linarith
   -- Overestimate: val256(a)/val256(b) ≤ qHat.
   have hge := max_trial_overestimate_n4 a0 a1 a2 a3 b0 b1 b2 b3 hb3nz
-  have hv := val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz
+  have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨hq, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   -- Substitute `qHat = val256(a)/val256(b)` into the mulsub equation, then
   -- compare with `Nat.div_add_mod` to conclude.
@@ -71,7 +71,7 @@ theorem val256_ms_un_lt_val256_b_max_skip
     val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 < val256 b0 b1 b2 b3 := by
   intro ms
   rw [val256_ms_un_eq_val256_mod_max_skip a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_zero]
-  exact Nat.mod_lt _ (val256_pos_of_or_ne_zero b0 b1 b2 b3 hbnz)
+  exact Nat.mod_lt _ (val256_pos_of_or_ne_zero hbnz)
 
 end EvmWord
 


### PR DESCRIPTION
## Summary
The hypothesis `h : b0 ||| b1 ||| b2 ||| b3 ≠ 0` determines all 4 limbs. All 8 call sites (passing `b0..b3` or `v0..v3`) drop the positional args.

## Test plan
- [x] `lake build` green (3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)