### PR TITLE
feat(divmod): evm_mod_n4_full_call_skip_stack_pre_spec(_bundled) (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -237,4 +237,79 @@ theorem evm_div_n4_full_call_skip_stack_pre_spec_bundled (sp base : Word)
     (fun _ hq => hq)
     h
 
+/-- EvmWord-level wrapper over `evm_mod_n4_full_call_skip_spec`. Same shape
+    as `evm_div_n4_full_call_skip_stack_pre_spec` but for the MOD path:
+    `divCode → modCode`, `evm_div_n4_full_call_skip_spec →
+    evm_mod_n4_full_call_skip_spec`, and `fullDivN4CallSkipPost →
+    fullModN4CallSkipPost`. -/
+theorem evm_mod_n4_full_call_skip_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hborrow : isSkipBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4CallSkipPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+  have hraw := evm_mod_n4_full_call_skip_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_nz halign hbltu hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_mod_n4_full_call_skip_stack_pre_spec`: takes
+    the precondition as a single `modN4StackPreCall` atom. Mirror of
+    `evm_div_n4_full_call_skip_stack_pre_spec_bundled`. -/
+theorem evm_mod_n4_full_call_skip_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hborrow : isSkipBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4CallSkipPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_mod_n4_full_call_skip_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_nz halign hbltu hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [modN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Adds the EvmWord-level wrappers for the MOD call-skip path. Mirror of the existing DIV-side \`evm_div_n4_full_call_skip_stack_pre_spec(_bundled)\` (SpecCall.lean:170/214) with \`divCode → modCode\`, the underlying full spec swapped from DIV to MOD (#899), and \`fullDivN4CallSkipPost → fullModN4CallSkipPost\` (#895).

## Provides
- \`evm_mod_n4_full_call_skip_stack_pre_spec\`: unbundled wrapper using inline register/memory atoms.
- \`evm_mod_n4_full_call_skip_stack_pre_spec_bundled\`: takes precondition as a single \`modN4StackPreCall\` atom.

## Status — completes the MOD-side call-skip scaffolding chain

| PR | What |
|----|------|
| #883 | \`divK_loop_body_n4_call_skip_j0_modCode\` (loop body, modCode) |
| #886 | \`_norm_modCode\` (sp-relative wrapper) |
| #890 | \`evm_mod_n4_preloop_call_skip_spec\` (preloop) |
| #895 | \`fullModN4CallSkipPost\` (post bundle) |
| #899 | \`evm_mod_n4_full_call_skip_spec\` (limb-level full path) |
| **This PR** | **EvmWord-level stack pre-spec wrappers** |

The stack pre-spec returns the concrete \`fullModN4CallSkipPost\` — turning that into \`modN4CallSkipStackPost\` requires the semantic bridge based on Knuth B / div128Quot correctness (separate chain).

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.SpecCall\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)