### PR TITLE
refactor(SepLogic): flip CodeReq.SatisfiedBy_mono (s) to implicit

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -343,7 +343,7 @@ theorem cpsTriple_extend_code {entry exit_ : Word} {cr cr' : CodeReq} {P Q : Ass
     (h : cpsTriple entry exit_ cr P Q) :
     cpsTriple entry exit_ cr' P Q := by
   intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
+  exact h R hR s (CodeReq.SatisfiedBy_mono hmono hcr') hPR hpc
 
 /-- Monotonicity for cpsBranch: extend to a larger CodeReq. -/
 theorem cpsBranch_extend_code {entry : Word} {cr cr' : CodeReq}
@@ -352,7 +352,7 @@ theorem cpsBranch_extend_code {entry : Word} {cr cr' : CodeReq}
     (h : cpsBranch entry cr P exit_t Q_t exit_f Q_f) :
     cpsBranch entry cr' P exit_t Q_t exit_f Q_f := by
   intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
+  exact h R hR s (CodeReq.SatisfiedBy_mono hmono hcr') hPR hpc
 
 /-- Sequential composition: cpsTriple followed by cpsBranch, same CodeReq.
     Unlike `cpsTriple_seq_cpsBranch`, does not require disjointness.
@@ -537,7 +537,7 @@ theorem cpsNBranch_extend_code {entry : Word} {cr cr' : CodeReq}
     (h : cpsNBranch entry cr P exits) :
     cpsNBranch entry cr' P exits := by
   intro R hR s hcr' hPR hpc
-  exact h R hR s (CodeReq.SatisfiedBy_mono s hmono hcr') hPR hpc
+  exact h R hR s (CodeReq.SatisfiedBy_mono hmono hcr') hPR hpc
 
 /-- Frame a `cpsNBranch` on the left by a PC-free frame `F`: the pre-assertion
     becomes `P ** F` and each exit assertion in the list becomes `ex.2 ** F`.

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2624,7 +2624,7 @@ theorem CodeReq.SatisfiedBy_preserved (cr : CodeReq) (k : Nat) (s s' : MachineSt
   exact hcr a i hcri
 
 /-- Monotonicity: if cr2 subsumes cr1, any state satisfying cr2 also satisfies cr1. -/
-theorem CodeReq.SatisfiedBy_mono {cr1 cr2 : CodeReq} (s : MachineState)
+theorem CodeReq.SatisfiedBy_mono {cr1 cr2 : CodeReq} {s : MachineState}
     (hmono : ∀ a i, cr1 a = some i → cr2 a = some i)
     (h : cr2.SatisfiedBy s) : cr1.SatisfiedBy s :=
   fun a i hcr1 => h a i (hmono a i hcr1)


### PR DESCRIPTION
## Summary

Flip the \`(s : MachineState)\` argument of \`CodeReq.SatisfiedBy_mono\` to implicit. All 3 CPSSpec.lean callers passed \`s\` positionally, and s is recoverable from the following hypothesis \`h : cr2.SatisfiedBy s\`.

Shortens each call from \`SatisfiedBy_mono s hmono hcr\` to \`SatisfiedBy_mono hmono hcr\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)