### PR TITLE
refactor(Evm64/Basic): flip high_limbs_zero_of_toNat_lt (v) to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -426,7 +426,7 @@ theorem getLimb_ushiftRight (v : EvmWord) (n : Nat) (i : Fin 4) :
   rw [h1, h2]
 
 /-- When `v.toNat < 2^64`, the upper three limbs are zero. -/
-theorem high_limbs_zero_of_toNat_lt (v : EvmWord) (h : v.toNat < 2^64) :
+theorem high_limbs_zero_of_toNat_lt {v : EvmWord} (h : v.toNat < 2^64) :
     v.getLimb 1 ||| v.getLimb 2 ||| v.getLimb 3 = 0 := by
   -- Each upper limb extracts bits [k*64, k*64+64) which are all zero when v < 2^64
   have hlimb : ∀ k : Fin 4, k.val ≥ 1 → v.getLimb k = 0 := by

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -179,7 +179,7 @@ theorem evm_sar_stack_spec (sp base : Word)
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge
     -- High limbs must be 0 when shift < 256
     have hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
-      EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
+      EvmWord.high_limbs_zero_of_toNat_lt (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
       have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -169,7 +169,7 @@ theorem evm_shr_stack_spec (sp base : Word)
     have hresult : result = value >>> shift.toNat := by simp [result, show ¬(shift.toNat ≥ 256) from hge]
     -- High limbs must be 0 when shift < 256
     have hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
-      EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
+      EvmWord.high_limbs_zero_of_toNat_lt (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
       have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -165,7 +165,7 @@ theorem evm_shl_stack_spec (sp base : Word)
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge
     -- High limbs must be 0 when shift < 256
     have hhigh_zero : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
-      EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
+      EvmWord.high_limbs_zero_of_toNat_lt (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
       have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -96,7 +96,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
   · -- b < 31: body path
     push Not at hge
     have hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
-      EvmWord.high_limbs_zero_of_toNat_lt b (by omega)
+      EvmWord.high_limbs_zero_of_toNat_lt (by omega)
     have hsmall : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = true := by
       have hb_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh
       simp only [EvmWord.getLimb_as_getLimbN_0] at hb_toNat


### PR DESCRIPTION
## Summary

Flip the \`(v : EvmWord)\` argument of \`EvmWord.high_limbs_zero_of_toNat_lt\` to implicit. All 4 callers (ShlSemantic, SarSemantic, Semantic, SignExtend/Spec) passed \`v\` positionally, and it is recoverable from both the input hypothesis \`h : v.toNat < 2^64\` and the result type \`v.getLimb 1 ||| v.getLimb 2 ||| v.getLimb 3 = 0\`.

Shortens callers from \`high_limbs_zero_of_toNat_lt shift (by omega)\` to \`high_limbs_zero_of_toNat_lt (by omega)\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)