### PR TITLE
refactor(Evm64/Basic): flip toNat_eq_getLimb0_of_high_zero (v) to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -144,7 +144,7 @@ private theorem or3_eq_zero_right (a b c : BitVec 64) (h : a ||| b ||| c = 0) : 
   bv_decide
 
 /-- When the upper three limbs OR to zero, `v.toNat` equals `(v.getLimb 0).toNat`. -/
-theorem toNat_eq_getLimb0_of_high_zero (v : EvmWord)
+theorem toNat_eq_getLimb0_of_high_zero {v : EvmWord}
     (h : v.getLimb 1 ||| v.getLimb 2 ||| v.getLimb 3 = 0) :
     v.toNat = (v.getLimb 0).toNat := by
   have h1 := or3_eq_zero_left _ _ _ h

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -592,7 +592,7 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
   -- Due to the different x10 values per Phase C exit and the complex memory layouts,
   -- the composition is done inline in the merge callback.
   have hidx_toNat : idx.toNat = i0.toNat :=
-    EvmWord.toNat_eq_getLimb0_of_high_zero idx hhigh_zero
+    EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   have hresult_high1 : getLimb result 1 = 0 :=
     byte_getLimb_high idx value (1 : Fin 4) (by decide)
   have hresult_high2 : getLimb result 2 = 0 :=
@@ -911,7 +911,7 @@ theorem evm_byte_stack_spec (sp base : Word)
         simp only [BitVec.ult, signExtend12_32,
                    word_toNat_32]
         have hidx_toNat : idx.toNat = i0.toNat :=
-          EvmWord.toNat_eq_getLimb0_of_high_zero idx hhigh
+          EvmWord.toNat_eq_getLimb0_of_high_zero hhigh
         rw [decide_eq_true_eq]; omega
       exact evm_byte_body_evmWord_spec sp base idx val v5 v6 v10 hhigh hlt_i0 hlt
     · -- Case 2: idx.toNat >= 32, high limbs zero → zero result
@@ -922,7 +922,7 @@ theorem evm_byte_stack_spec (sp base : Word)
         simp only [BitVec.ult, signExtend12_32,
                    word_toNat_32]
         have hidx_toNat : idx.toNat = i0.toNat :=
-          EvmWord.toNat_eq_getLimb0_of_high_zero idx hhigh
+          EvmWord.toNat_eq_getLimb0_of_high_zero hhigh
         rw [decide_eq_false_iff_not]; omega
       have h_raw := evm_byte_zero_geq32_spec sp base i0 i1 i2 i3 v0 v1 v2 v3 v5 v10 hhigh hlarge
       have h_framed := cpsTriple_frameR

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -800,7 +800,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
     (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
-    EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+    EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   -- from Phase C postcondition into body postcondition conversion.
   -- Each hbodyL_ev has precondition (P ** ⌜dispatch_fact⌝) and postcondition (getLimb result).

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -956,7 +956,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
     (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
-    EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+    EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   let resultPost :=
     (.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -165,7 +165,7 @@ theorem evm_sar_stack_spec (sp base : Word)
         Classical.byContradiction (fun h => hhigh h)
       -- High limbs = 0 but shift ≥ 256 → s0 ≥ 256
       have hlarge : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = false := by
-        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh'
+        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh'
         rw [h_toNat] at hge
         have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
         simp only [BitVec.ult, h256]
@@ -182,7 +182,7 @@ theorem evm_sar_stack_spec (sp base : Word)
       EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
-      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
       rw [h_toNat] at hlt
       have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
       simp only [BitVec.ult, h256]

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -152,7 +152,7 @@ theorem evm_shr_stack_spec (sp base : Word)
       -- High limbs = 0 but shift ≥ 256 → s0 ≥ 256
       -- (shift.toNat = s0.toNat when high limbs are 0)
       have hlarge : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = false := by
-        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh'
+        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh'
         rw [h_toNat] at hge
         have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
         simp only [BitVec.ult, h256]
@@ -172,7 +172,7 @@ theorem evm_shr_stack_spec (sp base : Word)
       EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
-      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
       rw [h_toNat] at hlt
       have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
       simp only [BitVec.ult, h256]

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -774,7 +774,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
     (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
-    EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+    EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   let resultPost :=
     (.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -151,7 +151,7 @@ theorem evm_shl_stack_spec (sp base : Word)
         Classical.byContradiction (fun h => hhigh h)
       -- High limbs = 0 but shift ≥ 256 → s0 ≥ 256
       have hlarge : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = false := by
-        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh'
+        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh'
         rw [h_toNat] at hge
         have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
         simp only [BitVec.ult, h256]
@@ -168,7 +168,7 @@ theorem evm_shl_stack_spec (sp base : Word)
       EvmWord.high_limbs_zero_of_toNat_lt shift (by omega)
     -- s0 < 256
     have hlt_s0 : BitVec.ult (shift.getLimb 0) (signExtend12 (256 : BitVec 12)) = true := by
-      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero shift hhigh_zero
+      have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
       rw [h_toNat] at hlt
       have h256 : (signExtend12 (256 : BitVec 12)).toNat = 256 := by decide
       simp only [BitVec.ult, h256]

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -82,7 +82,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
     · have hhigh' : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
       have hlarge : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = false := by
-        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh'
+        have h_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh'
         simp only [EvmWord.getLimb_as_getLimbN_0] at h_toNat
         rw [h_toNat] at hge
         have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by decide
@@ -98,7 +98,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
     have hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
       EvmWord.high_limbs_zero_of_toNat_lt b (by omega)
     have hsmall : BitVec.ult (b.getLimbN 0) (signExtend12 (31 : BitVec 12)) = true := by
-      have hb_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero b hhigh
+      have hb_toNat := EvmWord.toNat_eq_getLimb0_of_high_zero hhigh
       simp only [EvmWord.getLimb_as_getLimbN_0] at hb_toNat
       have h31 : (signExtend12 (31 : BitVec 12)).toNat = 31 := by decide
       simp only [BitVec.ult, h31]


### PR DESCRIPTION
## Summary

Flip the \`(v : EvmWord)\` argument of \`EvmWord.toNat_eq_getLimb0_of_high_zero\` to implicit. All 13 callers across \`Shift/*\`, \`SignExtend/Spec\`, and \`Byte/Spec\` passed \`v\` positionally. It is recoverable from the following hypothesis \`h : v.getLimb 1 ||| v.getLimb 2 ||| v.getLimb 3 = 0\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)