### PR TITLE
feat(divmod): call_addback (BEQ) j=0 loop body modCode + sp-relative norm (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -101,6 +101,59 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0] at raw'
   exact raw'
 
+/-- Loop body n=4, call+addback (BEQ double-addback), j=0 against modCode
+    with sp-relative addresses. Mirror of `divK_loop_body_n4_call_addback_j0_beq_norm`
+    with `divCode → modCode`. Internally bridges the bundled
+    `loopBodyN4CallSkipJ0Pre` / `loopBodyN4CallAddbackBeqJ0Post` to the
+    sp-relative surface layout via `cpsTriple_weaken`. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode (sp base : Word)
+    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
+    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let qHat := div128Quot uTop u3 v3
+    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
+     then (1 : Word) else 0) ≠ (0 : Word) →
+    cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
+       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
+       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
+       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
+       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
+       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
+       ((sp + signExtend12 4024) ↦ₘ uTop) **
+       ((sp + signExtend12 4088) ↦ₘ qOld) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+       (sp + signExtend12 3960 ↦ₘ v3) **
+       (sp + signExtend12 3952 ↦ₘ dLo) **
+       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+  intro qHat dLo div_un0 hborrow
+  have raw := divK_loop_body_n4_call_addback_j0_beq_modCode sp jOld v5Old v6Old v7Old
+    v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
+    retMem dMem dloMem scratch_un0 base halign hbltu hcarry2_nz hborrow
+  refine cpsTriple_weaken ?_ ?_ raw
+  · intro _ hp
+    rw [loopBodyN4CallSkipJ0Pre_unfold]
+    simp only [se12_32, se12_40, se12_48, se12_56,
+               u_base_off0_j0, u_base_off4088_j0, u_base_off4080_j0,
+               u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
+    exact hp
+  · intro _ hq
+    rw [loopBodyN4CallAddbackBeqJ0Post_unfold] at hq
+    exact hq
+
 -- ============================================================================
 -- Preloop + loop body n=4 max+addback BEQ: base → base+908
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -558,4 +558,75 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode (sp base : Word)
     rw [loopBodyN4CallSkipJ0Post_unfold] at hq
     exact hq
 
+-- ============================================================================
+-- Call-addback path (BEQ double-addback): Loop body j=0 extended to modCode
+-- ============================================================================
+
+/-- Bundled postcondition for the call_addback (BEQ) j=0 loop body extended to
+    modCode. Combines `loopBodyN4AddbackBeqPost` (the addback branch output
+    with qHat = `div128Quot uTop u3 v3`) and the 4 scratch cells written by
+    the call-trial `div128` subroutine. Parallels `loopBodyN4CallSkipJ0Post`
+    for the skip branch. The precondition is shared with the call_skip branch
+    (`loopBodyN4CallSkipJ0Pre`) since the input layouts are identical. -/
+@[irreducible]
+def loopBodyN4CallAddbackBeqJ0Post
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
+  let qHat := div128Quot uTop u3 v3
+  let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ v3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0)
+
+/-- Named unfold for `loopBodyN4CallAddbackBeqJ0Post`. -/
+theorem loopBodyN4CallAddbackBeqJ0Post_unfold
+    (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    (let qHat := div128Quot uTop u3 v3
+     let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+     loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ v3) **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0)) := by
+  delta loopBodyN4CallAddbackBeqJ0Post; rfl
+
+/-- Extend call_addback (BEQ double-addback) j=0 loop body from
+    sharedDivModCode to modCode. Mirror of
+    `divK_loop_body_n4_call_addback_j0_beq_divCode` with
+    `divCode → modCode` (uses `sharedDivModCode_sub_modCode` instead).
+
+    Pre is shared with the call_skip branch (`loopBodyN4CallSkipJ0Pre`);
+    post is bundled as `loopBodyN4CallAddbackBeqJ0Post` so the algorithm's
+    27-step div128 let-chain doesn't pollute the statement. -/
+theorem divK_loop_body_n4_call_addback_j0_beq_modCode
+    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (base : Word)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : BitVec.ult uTop v3)
+    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
+    (hborrow : (if BitVec.ult uTop
+                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
+                then (1 : Word) else 0) ≠ (0 : Word)) :
+    cpsTriple (base + loopBodyOff) (base + denormOff) (modCode base)
+      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
+      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
+    (divK_loop_body_n4_call_addback_j0_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
+      halign hbltu hcarry2_nz hborrow)
+  refine cpsTriple_weaken ?_ ?_ h
+  · intro _ hp
+    rw [loopBodyN4CallSkipJ0Pre_unfold] at hp
+    exact hp
+  · intro _ hq
+    rw [loopBodyN4CallAddbackBeqJ0Post_unfold]
+    exact hq
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- MOD-side `modCode` counterpart of the existing `_divCode` lift for the call-path double-addback (BEQ) branch at j=0.
- Parallels the call_skip chain that landed in #903. Unblocks the MOD-side full-path call-trial addback composer.
- Follows the bundling pattern from PR #890 feedback — the 27-step `div128` let-chain stays inside irreducible bundles, not in the theorem statements.

Adds:
- `loopBodyN4CallAddbackBeqJ0Post` (irreducible) + `_unfold` — post bundle wrapping `loopBodyN4AddbackBeqPost` with the 4 scratch cells.
- `divK_loop_body_n4_call_addback_j0_beq_modCode` — extends from `sharedDivModCode` via `sharedDivModCode_sub_modCode`.
- `divK_loop_body_n4_call_addback_j0_beq_norm_modCode` — sp-relative surface-layout variant.

Pre is reused from call_skip (`loopBodyN4CallSkipJ0Pre`) since the input sepConj is identical.

## Test plan
- [x] `lake build` passes (full project)
- [x] File sizes OK: `FullPathN4Loop.lean` 632, `FullPathN4Beq.lean` 867 (both < 1200-line Compose cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)