### PR TITLE
refactor(Evm64/Basic): flip eq_zero_iff_limbs (a) to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -465,7 +465,7 @@ theorem eq_iff_limbs (a b : EvmWord) :
       _ = fromLimbs b.getLimb := by congr 1; funext i; exact h i
       _ = b := fromLimbs_getLimb b
 
-theorem eq_zero_iff_limbs (a : EvmWord) :
+theorem eq_zero_iff_limbs {a : EvmWord} :
     a = 0 ↔ a.getLimb 0 = 0 ∧ a.getLimb 1 = 0 ∧ a.getLimb 2 = 0 ∧ a.getLimb 3 = 0 := by
   constructor
   · intro h; subst h

--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -96,7 +96,7 @@ theorem eq_zero_iff_limbs_or (b : EvmWord) :
     set b2 := b.getLimb 2 with hb2_def
     set b3 := b.getLimb 3 with hb3_def
     have ⟨h0, h1, h2, h3⟩ := limbs_or_eq_zero_imp b0 b1 b2 b3 h
-    exact (eq_zero_iff_limbs b).mpr ⟨hb0_def ▸ h0, hb1_def ▸ h1, hb2_def ▸ h2, hb3_def ▸ h3⟩
+    exact eq_zero_iff_limbs.mpr ⟨hb0_def ▸ h0, hb1_def ▸ h1, hb2_def ▸ h2, hb3_def ▸ h3⟩
 
 -- ============================================================================
 -- Division algebra: Euclidean property and uniqueness

--- a/EvmAsm/Evm64/EvmWordArith/IsZero.lean
+++ b/EvmAsm/Evm64/EvmWordArith/IsZero.lean
@@ -27,7 +27,7 @@ theorem iszero_or_reduce_correct (a : EvmWord) :
     have hor := ult_one_eq_zero.mp h
     have h12 := bv_or_eq_zero (show (a.getLimb 0 ||| a.getLimb 1) ||| (a.getLimb 2 ||| a.getLimb 3) = 0 by
       rw [BitVec.or_assoc] at hor; exact hor)
-    exact (eq_zero_iff_limbs a).mpr
+    exact eq_zero_iff_limbs.mpr
       ⟨(bv_or_eq_zero h12.1).1, (bv_or_eq_zero h12.1).2,
        (bv_or_eq_zero h12.2).1, (bv_or_eq_zero h12.2).2⟩
   · intro h; subst h; exact ult_one_eq_zero.mpr rfl


### PR DESCRIPTION
## Summary

Flip the \`(a : EvmWord)\` arg of \`eq_zero_iff_limbs\` to implicit. Both callers (EvmWordArith/IsZero.lean and EvmWordArith/Div.lean) use \`(eq_zero_iff_limbs a).mpr\` where \`a\` is inferable from the \`.mpr\` argument.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)