### PR TITLE
feat(divmod): evm_div_n4_full_call_addback_beq_stack_pre_spec(_bundled) (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -152,6 +152,18 @@ theorem isAddbackBorrowN4CallEvm_def (a b : EvmWord) :
     isAddbackBorrowN4Call (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
+/-- Carry-2-non-zero condition at n=4 call path in EvmWord form: the
+    double-addback branch indicator used by the BEQ variant. Wraps the
+    raw-limb form `isAddbackCarry2NzN4CallAb`. -/
+def isAddbackCarry2NzN4CallEvm (a b : EvmWord) : Prop :=
+  isAddbackCarry2NzN4CallAb (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem isAddbackCarry2NzN4CallEvm_def (a b : EvmWord) :
+    isAddbackCarry2NzN4CallEvm a b =
+    isAddbackCarry2NzN4CallAb (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
+
 /-- Addback-needed condition at n=4 max path in EvmWord form: the runtime
     borrow check fires (mulsub underflowed), so the algorithm decrements
     the max trial quotient and adds back `b'` to the partial remainder

--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -312,4 +312,93 @@ theorem evm_mod_n4_full_call_skip_stack_pre_spec_bundled (sp base : Word)
     (fun _ hq => hq)
     h
 
+-- ============================================================================
+-- Call-trial addback (BEQ double-addback): EvmWord-level wrappers
+-- ============================================================================
+
+/-- EvmWord-level wrapper over `evm_div_n4_full_call_addback_beq_spec`. The
+    same shape as `evm_div_n4_full_call_skip_stack_pre_spec` but for the
+    addback branch: `hborrow` has the borrow-fires direction
+    (`isAddbackBorrowN4CallEvm`) and the BEQ variant also requires the
+    `hcarry2_nz` indicator.
+
+    The postcondition is still the concrete `fullDivN4CallAddbackBeqPost`
+    — turning that into `divN4CallAddbackBeqStackPost` requires the
+    semantic-correctness bridge which depends on Knuth B / `div128Quot`
+    correctness (separate chain). -/
+theorem evm_div_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
+    (hborrow : isAddbackBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullDivN4CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+  have hraw := evm_div_n4_full_call_addback_beq_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_nz hvalid halign hbltu hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_div_n4_full_call_addback_beq_stack_pre_spec`:
+    takes the precondition as a single `divN4StackPreCall` atom. Mirror
+    of `evm_div_n4_full_call_skip_stack_pre_spec_bundled` for the addback
+    branch. -/
+theorem evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (hvalid : ValidMemRange sp 8)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
+    (hborrow : isAddbackBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullDivN4CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_div_n4_full_call_addback_beq_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_nz hvalid halign hbltu hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [divN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Adds the DIV-side EvmWord-level wrapper around the existing limb-level `evm_div_n4_full_call_addback_beq_spec`, parallel to `evm_div_n4_full_call_skip_stack_pre_spec(_bundled)` landed earlier.
- Independent of the MOD-side call-addback chain in #908 and of the Knuth-B math chain — pure wrapping around existing infrastructure on main.

New declarations:
- `isAddbackCarry2NzN4CallEvm` + `_def` (Spec.lean): EvmWord wrapper for the raw-limb double-addback indicator `isAddbackCarry2NzN4CallAb`.
- `evm_div_n4_full_call_addback_beq_stack_pre_spec` (SpecCall.lean): precondition presented in `evmWordIs sp a ** evmWordIs (sp+32) b ** divScratchValuesCall …` form.
- `evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled`: uses the single `divN4StackPreCall` pre-bundle.

The post remains the concrete `fullDivN4CallAddbackBeqPost` — lifting that to a semantic `divN4CallAddbackBeqStackPost` requires the separate Knuth-B / `div128Quot`-correctness chain.

## Test plan
- [x] `lake build` passes (full project)
- [x] File sizes OK: Spec.lean 1497 (< 1500 cap), SpecCall.lean 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)