### PR TITLE
refactor(Rv64/Basic): flip getReg_setReg_eq (s r v) to implicit

### DIFF
--- a/EvmAsm/Rv64/Basic.lean
+++ b/EvmAsm/Rv64/Basic.lean
@@ -534,7 +534,7 @@ theorem getReg_setReg_ne (s : MachineState) (r r' : Reg) (v : Word)
     (h : r ≠ r') : (s.setReg r v).getReg r' = s.getReg r' := by
   cases r <;> cases r' <;> first | exact absurd rfl h | rfl
 
-theorem getReg_setReg_eq (s : MachineState) (r : Reg) (v : Word)
+theorem getReg_setReg_eq {s : MachineState} {r : Reg} {v : Word}
     (h : r ≠ .x0) : (s.setReg r v).getReg r = v := by
   cases r <;> first | exact absurd rfl h | rfl
 

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -1464,7 +1464,7 @@ theorem holdsFor_sepConj_regIs_setReg {r : Reg} {v v' : Word} {R : Assertion}
             fun w hw => by simp [PartialState.singletonReg] at hw⟩
     simp only [PartialState.singletonReg] at hr'
     split at hr' <;> simp_all
-    exact MachineState.getReg_setReg_eq _ _ _ hr_ne
+    exact MachineState.getReg_setReg_eq hr_ne
   -- h2 compatible with s.setReg r v' (doesn't own r)
   have hc2' : h2.CompatibleWith (s.setReg r v') := PartialState.CompatibleWith_setReg hc2 hr2
   refine ⟨(PartialState.singletonReg r v').union h2, ?_, PartialState.singletonReg r v', h2, hdisj', rfl, rfl, hh2⟩


### PR DESCRIPTION
## Summary

Flip the \`(s : MachineState) (r : Reg) (v : Word)\` arguments of \`MachineState.getReg_setReg_eq\` to implicit. The sole caller (\`SepLogic.lean:1467\`) already passed them as \`_ _ _\`, and Lean infers all three from the goal type \`(s.setReg r v).getReg r = v\`.

Shortens the call from \`getReg_setReg_eq _ _ _ hr_ne\` to \`getReg_setReg_eq hr_ne\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)