### PR TITLE
feat(divmod): evm_mod_n4_preloop_call_addback_beq_spec (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -8,6 +8,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 
 open EvmAsm.Rv64.Tactics
@@ -364,6 +365,95 @@ theorem evm_mod_n4_full_call_skip_spec (sp base : Word)
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by delta fullModN4CallSkipPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
+-- ============================================================================
+-- MOD n=4 pre-loop + call+addback BEQ loop body: base → base+denormOff
+-- ============================================================================
+
+/-- n=4 MOD pre-loop + call+addback BEQ loop body: base → base+denormOff
+    (shift ≠ 0). Mirror of `evm_div_n4_preloop_call_addback_beq_spec`
+    (FullPathN4Beq.lean) with `divCode → modCode` and the corresponding
+    loopSetup/loop-body theorems swapped. The post `preloopCallAddbackBeqPostN4`
+    is shared with the DIV side (algorithm-level limb output is identical;
+    only the surrounding code differs). -/
+theorem evm_mod_n4_preloop_call_addback_beq_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
+    (hborrow : isAddbackBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + denormOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  unfold isCallTrialN4 at hbltu
+  unfold isAddbackBorrowN4Call at hborrow
+  unfold isAddbackCarry2NzN4CallAb at hcarry2_nz
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
+  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  have hPre := evm_mod_n4_to_loopSetup_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_nz
+  have hPreF := cpsTriple_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) hPre
+  have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm_modCode sp base
+    jMem (4 : Word) shift u0 (a0 >>> (antiShift.toNat % 64)) v11Old antiShift
+    b0' b1' b2' b3' u0 u1 u2 u3 u4 (0 : Word)
+    retMem dMem dloMem scratch_un0
+    halign hbltu hcarry2_nz
+  intro_lets at hLoop
+  have hLoop' := hLoop hborrow
+  have hLoopF := cpsTriple_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) ** ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ shift))
+    (by pcFree) hLoop'
+  have hFull := cpsTriple_seq_perm_same_cr
+    (fun h hp => by
+      delta loopSetupPost at hp
+      rw [x1_val_n4] at hp
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta preloopCallAddbackBeqPostN4; xperm_hyp hq)
     hFull
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- MOD-side preloop+loop-body composer for the call+addback BEQ branch at n=4.
- Mirrors \`evm_div_n4_preloop_call_addback_beq_spec\` (FullPathN4Beq.lean) with \`divCode → modCode\`, using the \`_norm_modCode\` j=0 loop-body lift landed in #908.
- Next increment in the MOD call-addback chain toward \`evm_mod_n4_full_call_addback_beq_spec\`.

Also adds \`FullPathN4Beq\` to ModFullPathN4.lean's imports so the shared \`preloopCallAddbackBeqPostN4\` post bundle and \`isAddbackCarry2NzN4CallAb\` indicator resolve.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File sizes OK: ModFullPathN4.lean 459 lines (< 1200-line Compose cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)