### PR TITLE
refactor(SepLogic): flip CodeReq.union_empty_left/right (cr) to implicit

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2033,21 +2033,21 @@ theorem union_assoc (cr1 cr2 cr3 : CodeReq) :
     (cr1.union cr2).union cr3 = cr1.union (cr2.union cr3) := by
   funext a; simp only [union]; cases cr1 a <;> rfl
 
-theorem union_empty_left (cr : CodeReq) : empty.union cr = cr := by
+theorem union_empty_left {cr : CodeReq} : empty.union cr = cr := by
   funext a; simp [union, empty]
 
-theorem union_empty_right (cr : CodeReq) : cr.union empty = cr := by
+theorem union_empty_right {cr : CodeReq} : cr.union empty = cr := by
   funext a; simp only [union, empty]; cases cr a <;> rfl
 
 private theorem ofIndexed_foldl_acc (acc : CodeReq) (ps : List (Word × Instr)) :
     ps.foldl (fun cr (ai : Word × Instr) => cr.union (singleton ai.1 ai.2)) acc =
     acc.union (ps.foldl (fun cr (ai : Word × Instr) => cr.union (singleton ai.1 ai.2)) empty) := by
   induction ps generalizing acc with
-  | nil => exact (union_empty_right acc).symm
+  | nil => exact union_empty_right.symm
   | cons p ps ih =>
     simp only [List.foldl]
     rw [ih, union_assoc]; congr 1
-    rw [show empty.union (singleton p.1 p.2) = singleton p.1 p.2 from union_empty_left _]
+    rw [show empty.union (singleton p.1 p.2) = singleton p.1 p.2 from union_empty_left]
     exact (ih (singleton p.1 p.2)).symm
 
 theorem ofIndexed_cons (p : Word × Instr) (ps : List (Word × Instr)) :


### PR DESCRIPTION
## Summary

Flip the \`(cr : CodeReq)\` arg of \`CodeReq.union_empty_left\` and \`CodeReq.union_empty_right\` to implicit. Both are called only from within SepLogic.lean:

- line 2046: \`(union_empty_right acc).symm\` → \`union_empty_right.symm\` (cr inferred from \`.symm\`'s expected type)
- line 2050: \`union_empty_left _\` → \`union_empty_left\` (cr inferred via the surrounding \`show ... from ...\`)
- line 2055: used as simp lemma — unchanged

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)