### PR TITLE
refactor(Rv64/Program): flip execProgram_append/seq args to implicit

### DIFF
--- a/EvmAsm/Rv64/Program.lean
+++ b/EvmAsm/Rv64/Program.lean
@@ -49,17 +49,17 @@ def execProgram (s : MachineState) : Program → MachineState
 @[simp] theorem execProgram_cons {s : MachineState} {i : Instr} {is : List Instr} :
     execProgram s (i :: is) = execProgram (execInstr s i) is := rfl
 
-theorem execProgram_append (s : MachineState) (p1 p2 : Program) :
+theorem execProgram_append {s : MachineState} {p1 p2 : Program} :
     execProgram s (p1 ++ p2) = execProgram (execProgram s p1) p2 := by
   induction p1 generalizing s with
   | nil => rfl
   | cons i is ih =>
     simp only [execProgram]
-    exact ih (execInstr s i)
+    exact ih
 
-theorem execProgram_seq (s : MachineState) (p1 p2 : Program) :
+theorem execProgram_seq {s : MachineState} {p1 p2 : Program} :
     execProgram s (p1 ;; p2) = execProgram (execProgram s p1) p2 :=
-  execProgram_append s p1 p2
+  execProgram_append
 
 -- ============================================================================
 -- Convenience constructors (macro-assembler style)


### PR DESCRIPTION
## Summary

Flip \`(s : MachineState) (p1 p2 : Program)\` args of \`execProgram_append\` and \`execProgram_seq\` to implicit. Neither is called externally; the recursive call in \`execProgram_append\`'s cons case and the delegation in \`execProgram_seq\` simplify:
- \`exact ih (execInstr s i)\` → \`exact ih\` (s inferred from goal after simp)
- \`execProgram_append s p1 p2\` → \`execProgram_append\`

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)