### PR TITLE
refactor(DivLimbBridge): flip ne_zero_iff_getLimbN_or (v) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -831,7 +831,7 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_div_n4_full_max_skip_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
@@ -931,7 +931,7 @@ theorem evm_div_n4_full_max_addback_beq_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_div_n4_full_max_addback_beq_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
@@ -1114,7 +1114,7 @@ theorem evm_mod_n4_full_max_skip_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_mod_n4_full_max_skip_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)

--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -190,7 +190,7 @@ theorem evm_div_n4_full_call_skip_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_div_n4_full_call_skip_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
@@ -265,7 +265,7 @@ theorem evm_mod_n4_full_call_skip_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_mod_n4_full_call_skip_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
@@ -351,7 +351,7 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
         (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
-    (EvmWord.ne_zero_iff_getLimbN_or b).mp hbnz
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
   have hraw := evm_div_n4_full_call_addback_beq_spec sp base
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)

--- a/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivLimbBridge.lean
@@ -103,7 +103,7 @@ private theorem or_eq_zero_imp_right {a b : Word} (h : a ||| b = 0) : b = 0 := b
 /-- An EvmWord is nonzero iff the OR of its four limbs is nonzero.
     Forward direction: needed to bridge `b ≠ 0` (EvmWord-level) to the
     limb-level `b0 ||| b1 ||| b2 ||| b3 ≠ 0` required by combined specs. -/
-theorem ne_zero_iff_getLimbN_or (v : EvmWord) :
+theorem ne_zero_iff_getLimbN_or {v : EvmWord} :
     v ≠ 0 ↔ v.getLimbN 0 ||| v.getLimbN 1 ||| v.getLimbN 2 ||| v.getLimbN 3 ≠ 0 := by
   constructor
   · -- → : v ≠ 0 implies OR of limbs ≠ 0 (contrapositive: OR = 0 → v = 0)


### PR DESCRIPTION
## Summary

Flip \`(v : EvmWord)\` arg of \`EvmWord.ne_zero_iff_getLimbN_or\` to implicit. All 6 callers (3 in DivMod/SpecCall.lean, 3 in DivMod/Spec.lean) use \`(ne_zero_iff_getLimbN_or b).mp hbnz\`; v is recoverable from \`hbnz : b ≠ 0\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)