### PR TITLE
refactor(Rv64/Execution): flip step_non_ecall_non_mem (s) to implicit

### DIFF
--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -85,7 +85,7 @@ theorem beq_eq_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   have hrs2 : s.getReg rs2 = v :=
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
     simp [execInstrBr, hrs1, hrs2]
   refine ⟨1, s.setPC (s.pc + signExtend13 offset), ?_, by simp [MachineState.setPC], ?_⟩
@@ -110,7 +110,7 @@ theorem beq_ne_spec (rs1 rs2 : Reg) (offset : BitVec 13)
   have hrs2 : s.getReg rs2 = v2 :=
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + 4) := by
     simp [execInstrBr, hrs1, hrs2, hne]
   refine ⟨1, s.setPC (s.pc + 4), ?_, by simp [MachineState.setPC], ?_⟩

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -223,7 +223,7 @@ theorem execInstrBr_jal_x0 (s : MachineState) (off : BitVec 21) :
       empAssertion :=
   generic_nop_spec (.JAL .x0 offset) addr (addr + signExtend21 offset)
     (by intro s hpc; simp [execInstrBr, MachineState.setReg, hpc])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- JALR x0 executes as a pure PC update (x0 write is dropped). -/
 theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
@@ -245,7 +245,7 @@ theorem execInstrBr_jalr_x0 (s : MachineState) (rs1 : Reg) (off : BitVec 12) :
   have hexec : execInstrBr s (.JALR .x0 rs1 offset) = s.setPC ((v + signExtend12 offset) &&& ~~~1) := by
     rw [execInstrBr_jalr_x0, hrs1]
   have hstep : step s = some (execInstrBr s (.JALR .x0 rs1 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   refine ⟨1, s.setPC ((v + signExtend12 offset) &&& ~~~1), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
     rw [hstep, hexec]; rfl
@@ -303,7 +303,7 @@ theorem if_eq_branch_step (rs1 rs2 : Reg) (v1 v2 : Word)
     holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
   -- Execute the BNE instruction
   have hstep' : step s = some (execInstrBr s (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)))) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   -- The entire precondition (P ** R form from cpsBranch) is pcFree
   have hpcfree : (((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
       (P ⋒ (rs1 ↦ᵣ v1) ⋒ (rs2 ↦ᵣ v2))) ** R).pcFree :=
@@ -388,7 +388,7 @@ theorem if_eq_spec (rs1 rs2 : Reg) (v1 v2 : Word)
     holdsFor_regIs.mp (aAnd_holdsFor_elim (aAnd_holdsFor_elim haAnd).2).2
   -- Execute BNE
   have hstep' : step s = some (execInstrBr s (Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4)))) :=
-    step_non_ecall_non_mem s hfetch_bne (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch_bne (by nofun) (by nofun) (by rfl)
   -- pcFree for the full precondition with frame
   have hpcfree_all : (((s.pc ↦ᵢ Instr.BNE rs1 rs2 (BitVec.ofNat 13 (4 * (then_body.length + 1) + 4))) **
       ((s.pc + 4 + BitVec.ofNat 64 (4 * then_body.length)) ↦ᵢ Instr.JAL Reg.x0 (BitVec.ofNat 21 (4 * else_body.length + 4))) **

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -422,7 +422,7 @@ def step (s : MachineState) : Option MachineState :=
   | some i => some (execInstrBr s i)
 
 /-- step for non-ECALL, non-EBREAK, non-memory instructions. -/
-@[simp] theorem step_non_ecall_non_mem (s : MachineState) {i : Instr}
+@[simp] theorem step_non_ecall_non_mem {s : MachineState} {i : Instr}
     (hfetch : s.code s.pc = some i) (hne : i ≠ .ECALL) (hnb : i ≠ .EBREAK)
     (hnm : i.isMemAccess = false) :
     step s = some (execInstrBr s i) := by

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -229,7 +229,7 @@ theorem generic_bne_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BNE rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   -- Case split on v1 = v2
   by_cases heq : v1 = v2
   · -- Not taken: v1 = v2
@@ -280,7 +280,7 @@ theorem generic_beq_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BEQ rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   by_cases heq : v1 = v2
   · -- Taken: v1 = v2
     have hexec' : execInstrBr s (.BEQ rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
@@ -335,7 +335,7 @@ theorem generic_bltu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BLTU rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   by_cases hlt : BitVec.ult v1 v2
   · -- Taken: v1 <u v2
     have hexec' : execInstrBr s (.BLTU rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
@@ -390,7 +390,7 @@ theorem generic_bge_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BGE rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   by_cases hlt : BitVec.slt v1 v2
   · -- Not taken: slt v1 v2 → ¬(¬slt), so BGE falls through
     have hexec' : execInstrBr s (.BGE rs1 rs2 offset) = s.setPC (s.pc + 4) := by
@@ -445,7 +445,7 @@ theorem generic_blt_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (ba
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BLT rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   by_cases hlt : BitVec.slt v1 v2
   · -- Taken: slt v1 v2
     have hexec' : execInstrBr s (.BLT rs1 rs2 offset) = s.setPC (s.pc + signExtend13 offset) := by
@@ -500,7 +500,7 @@ theorem generic_bgeu_spec (rs1 rs2 : Reg) (offset : BitVec 13) (v1 v2 : Word) (b
     holdsFor_regIs.mp (holdsFor_sepConj_elim_right
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.BGEU rs1 rs2 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   by_cases hlt : BitVec.ult v1 v2
   · -- Not taken: ult v1 v2 → ¬(¬ult), so BGEU falls through
     have hexec' : execInstrBr s (.BGEU rs1 rs2 offset) = s.setPC (s.pc + 4) := by
@@ -547,7 +547,7 @@ theorem generic_jal_spec (rd : Reg) (vOld : Word) (offset : BitVec 21) (base : W
   have hfetch : s.code s.pc = some (.JAL rd offset) :=
     CodeReq.singleton_satisfiedBy.mp hcr
   have hstep' : step s = some (execInstrBr s (.JAL rd offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   -- execInstrBr s (.JAL rd offset) = (s.setReg rd (s.pc + 4)).setPC (s.pc + signExtend21 offset)
   refine ⟨1, (s.setReg rd (s.pc + 4)).setPC (s.pc + signExtend21 offset), ?_, rfl, ?_⟩
   · show (step s).bind (stepN 0) = some _
@@ -570,7 +570,7 @@ theorem generic_jalr_spec (rd rs1 : Reg) (v1 vOld : Word) (offset : BitVec 12) (
     holdsFor_regIs.mp (holdsFor_sepConj_elim_left
       (holdsFor_sepConj_elim_left hPR))
   have hstep' : step s = some (execInstrBr s (.JALR rd rs1 offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.JALR rd rs1 offset) =
       (s.setReg rd (s.pc + 4)).setPC ((v1 + signExtend12 offset) &&& ~~~1) := by
     simp only [execInstrBr, hrs1]; rfl

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -35,7 +35,7 @@ theorem add_spec (rd rs1 rs2 : Reg) (v1 v2 vOld : Word) (base : Word)
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 + v2))) :=
   generic_3reg_spec (.ADD rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ base hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rd, rs2: rd := rd + rs2 (rd = rs1, rs2 distinct) -/
 theorem add_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
@@ -45,7 +45,7 @@ theorem add_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
       ((rd ↦ᵣ (v1 + v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.ADD rd rd rs2) rd rs2 v1 v2 _ base hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rs1, rd: rd := rs1 + rd (rd = rs2, rs1 distinct) -/
 theorem add_spec_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word) (base : Word)
@@ -55,7 +55,7 @@ theorem add_spec_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word) (base : Word)
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + v2))) :=
   generic_2reg_spec (.ADD rd rs1 rd) rs1 rd v1 v2 (v1 + v2) base hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADD rd, rd, rd: rd := rd + rd = 2 * rd (all same) -/
 theorem add_spec_all_same (rd : Reg) (v : Word) (base : Word)
@@ -65,7 +65,7 @@ theorem add_spec_all_same (rd : Reg) (v : Word) (base : Word)
       (rd ↦ᵣ (v + v)) :=
   generic_1reg_spec (.ADD rd rd rd) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rs1, rs2: rd := rs1 - rs2 (all registers distinct) -/
 theorem sub_spec (rd rs1 rs2 : Reg) (v1 v2 vOld : Word) (base : Word)
@@ -75,7 +75,7 @@ theorem sub_spec (rd rs1 rs2 : Reg) (v1 v2 vOld : Word) (base : Word)
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 - v2))) :=
   generic_3reg_spec (.SUB rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ base hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rd, rs2: rd := rd - rs2 -/
 theorem sub_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
@@ -85,7 +85,7 @@ theorem sub_spec_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word) (base : Word)
       ((rd ↦ᵣ (v1 - v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SUB rd rd rs2) rd rs2 v1 v2 _ base hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SUB rd, rd, rd: rd := rd - rd = 0 -/
 theorem sub_spec_all_same (rd : Reg) (v : Word) (base : Word)
@@ -95,7 +95,7 @@ theorem sub_spec_all_same (rd : Reg) (v : Word) (base : Word)
       (rd ↦ᵣ (v - v)) :=
   generic_1reg_spec (.SUB rd rd rd) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- ALU Instructions (Immediate)
@@ -109,7 +109,7 @@ theorem addi_spec (rd rs1 : Reg) (v1 vOld : Word) (imm : BitVec 12) (base : Word
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + signExtend12 imm))) :=
   generic_2reg_spec (.ADDI rd rs1 imm) rs1 rd v1 vOld (v1 + signExtend12 imm) base hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADDI rd, rd, imm: rd := rd + sext(imm) (same register) -/
 theorem addi_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
@@ -119,7 +119,7 @@ theorem addi_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
       (rd ↦ᵣ (v + signExtend12 imm)) :=
   generic_1reg_spec (.ADDI rd rd imm) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- ALU Instructions (Immediate): ORI
@@ -133,7 +133,7 @@ theorem ori_spec (rd rs1 : Reg) (v1 vOld : Word) (imm : BitVec 12) (base : Word)
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 ||| signExtend12 imm))) :=
   generic_2reg_spec (.ORI rd rs1 imm) rs1 rd v1 vOld (v1 ||| signExtend12 imm) base hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ORI rd, rd, imm: rd := rd | sext(imm) (same register) -/
 theorem ori_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
@@ -143,7 +143,7 @@ theorem ori_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
       (rd ↦ᵣ (v ||| signExtend12 imm)) :=
   generic_1reg_spec (.ORI rd rd imm) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- ALU Instructions (Immediate): SLTI
@@ -157,7 +157,7 @@ theorem slti_spec (rd rs1 : Reg) (v1 vOld : Word) (imm : BitVec 12) (base : Word
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.slt v1 (signExtend12 imm) then 1 else 0))) :=
   generic_2reg_spec (.SLTI rd rs1 imm) rs1 rd v1 vOld _ base hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SLTI rd, rd, imm: rd := (rd <s sext(imm)) ? 1 : 0 (same register) -/
 theorem slti_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
@@ -167,7 +167,7 @@ theorem slti_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
       (rd ↦ᵣ (if BitVec.slt v (signExtend12 imm) then 1 else 0)) :=
   generic_1reg_spec (.SLTI rd rd imm) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- RV64I Word Instructions: ADDIW
@@ -181,7 +181,7 @@ theorem addiw_spec (rd rs1 : Reg) (v1 vOld : Word) (imm : BitVec 12) (base : Wor
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ ((v1.truncate 32 + (signExtend12 imm).truncate 32 : BitVec 32).signExtend 64))) :=
   generic_2reg_spec (.ADDIW rd rs1 imm) rs1 rd v1 vOld _ base hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- ADDIW rd, rd, imm: rd := signExtend64(truncate32(rd) + truncate32(sext(imm))) (same register) -/
 theorem addiw_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
@@ -191,7 +191,7 @@ theorem addiw_spec_same (rd : Reg) (v : Word) (imm : BitVec 12) (base : Word)
       (rd ↦ᵣ ((v.truncate 32 + (signExtend12 imm).truncate 32 : BitVec 32).signExtend 64)) :=
   generic_1reg_spec (.ADDIW rd rd imm) rd v _ base hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Upper Immediate Instructions
@@ -206,7 +206,7 @@ theorem lui_spec (rd : Reg) (vOld : Word) (imm : BitVec 20) (base : Word)
       (rd ↦ᵣ ((imm.zeroExtend 32 : BitVec 32) <<< 12).signExtend 64) :=
   generic_1reg_spec (.LUI rd imm) rd vOld _ base hrd_ne_x0
     (by intro s _ _; simp [execInstrBr])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- AUIPC rd, imm: rd := PC + signExtend64(imm << 12)
     In RV64, AUIPC sign-extends the 32-bit shifted value before adding to PC. -/
@@ -217,7 +217,7 @@ theorem auipc_spec (rd : Reg) (vOld : Word) (imm : BitVec 20) (base : Word)
       (rd ↦ᵣ (base + ((imm.zeroExtend 32 : BitVec 32) <<< 12).signExtend 64)) :=
   generic_1reg_spec (.AUIPC rd imm) rd vOld _ base hrd_ne_x0
     (by intro s hpc _; simp [execInstrBr, hpc])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Memory Instructions (LD/SD for 64-bit doubleword access)
@@ -319,7 +319,7 @@ theorem beq_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   have hrs : s.getReg rs = v :=
     holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BEQ rs rs offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BEQ rs rs offset) = s.setPC (s.pc + signExtend13 offset) := by
     simp only [execInstrBr, hrs, beq_self_eq_true, ite_true]
   refine ⟨1, s.setPC (s.pc + signExtend13 offset), ?_, Or.inl ⟨rfl, ?_⟩⟩
@@ -347,7 +347,7 @@ theorem bne_spec_same (rs : Reg) (offset : BitVec 13) (v : Word) (base : Word) :
   have hrs : s.getReg rs = v :=
     holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.BNE rs rs offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.BNE rs rs offset) = s.setPC (s.pc + 4) := by
     simp only [execInstrBr, hrs, bne_iff_ne, ne_eq, not_true_eq_false, ite_false]
   refine ⟨1, s.setPC (s.pc + 4), ?_, Or.inr ⟨rfl, ?_⟩⟩
@@ -399,7 +399,7 @@ theorem jalr_spec_same (rd : Reg) (v : Word) (offset : BitVec 12) (base : Word)
   have hrd : s.getReg rd = v :=
     holdsFor_regIs.mp (holdsFor_sepConj_elim_left hPR)
   have hstep' : step s = some (execInstrBr s (.JALR rd rd offset)) :=
-    step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl)
+    step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl)
   have hexec' : execInstrBr s (.JALR rd rd offset) =
       (s.setReg rd (s.pc + 4)).setPC ((v + signExtend12 offset) &&& ~~~1) := by
     simp only [execInstrBr, hrd]; rfl
@@ -421,7 +421,7 @@ theorem mv_spec (rd rs : Reg) (v vOld : Word) (base : Word)
       ((rs ↦ᵣ v) ** (rd ↦ᵣ v)) :=
   generic_2reg_spec (.MV rd rs) rs rd v vOld v base hrd_ne_x0
     (by intro s _ hrs _; simp [execInstrBr, hrs])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- LI rd, imm: rd := imm (pseudo for loading immediate) -/
 theorem li_spec (rd : Reg) (vOld imm : Word) (base : Word)
@@ -431,7 +431,7 @@ theorem li_spec (rd : Reg) (vOld imm : Word) (base : Word)
       (rd ↦ᵣ imm) :=
   generic_1reg_spec (.LI rd imm) rd vOld _ base hrd_ne_x0
     (by intro s _ _; simp [execInstrBr])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- NOP: no operation (pseudo for ADDI x0, x0, 0) -/
 theorem nop_spec (base : Word) :
@@ -440,7 +440,7 @@ theorem nop_spec (base : Word) :
       empAssertion :=
   generic_nop_spec .NOP base (base + 4)
     (by intro s hpc; simp [execInstrBr, hpc])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- System Instructions
@@ -453,7 +453,7 @@ theorem fence_spec (base : Word) :
       empAssertion :=
   generic_nop_spec .FENCE base (base + 4)
     (by intro s hpc; simp [execInstrBr, hpc])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Summary

--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -68,7 +68,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 + v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.ADD rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -77,7 +77,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 - v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SUB rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem and_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -86,7 +86,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 &&& v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.AND rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem or_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -95,7 +95,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 ||| v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.OR rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem xor_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -104,7 +104,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 ^^^ v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.XOR rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -113,7 +113,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SLTU rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srl_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -122,7 +122,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 >>> (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SRL rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sll_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -131,7 +131,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 <<< (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SLL rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sra_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -140,7 +140,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (BitVec.sshiftRight v1 (v2.toNat % 64))) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.SRA rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Immediate specs
@@ -153,7 +153,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (v + signExtend12 imm)) :=
   generic_1reg_spec (.ADDI rd rd imm) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem addi_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -162,7 +162,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + signExtend12 imm))) :=
   generic_2reg_spec (.ADDI rd rs1 imm) rs1 rd v1 vOld (v1 + signExtend12 imm) addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem xori_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -171,7 +171,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (v ^^^ signExtend12 imm)) :=
   generic_1reg_spec (.XORI rd rd imm) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem andi_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -180,7 +180,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 &&& signExtend12 imm))) :=
   generic_2reg_spec (.ANDI rd rs1 imm) rs1 rd v1 vOld (v1 &&& signExtend12 imm) addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem andi_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -189,7 +189,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (v &&& signExtend12 imm)) :=
   generic_1reg_spec (.ANDI rd rd imm) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltiu_spec_gen_same (rd : Reg) (v : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -198,7 +198,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (if BitVec.ult v (signExtend12 imm) then (1 : Word) else (0 : Word))) :=
   generic_1reg_spec (.SLTIU rd rd imm) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem slli_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -207,7 +207,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (v <<< shamt.toNat)) :=
   generic_1reg_spec (.SLLI rd rd shamt) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem slli_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -216,7 +216,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 <<< shamt.toNat))) :=
   generic_2reg_spec (.SLLI rd rs1 shamt) rs1 rd v1 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srli_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -225,7 +225,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (v >>> shamt.toNat)) :=
   generic_1reg_spec (.SRLI rd rd shamt) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srli_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -234,7 +234,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 >>> shamt.toNat))) :=
   generic_2reg_spec (.SRLI rd rs1 shamt) rs1 rd v1 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srai_spec_gen_same (rd : Reg) (v : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -243,7 +243,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ (BitVec.sshiftRight v shamt.toNat)) :=
   generic_1reg_spec (.SRAI rd rd shamt) rd v _ addr hrd_ne_x0
     (by intro s _ hrd; simp [execInstrBr, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem srai_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (shamt : BitVec 6)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -252,7 +252,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (BitVec.sshiftRight v1 shamt.toNat))) :=
   generic_2reg_spec (.SRAI rd rs1 shamt) rs1 rd v1 vOld (BitVec.sshiftRight v1 shamt.toNat) addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Pseudo instructions
@@ -265,7 +265,7 @@ namespace EvmAsm.Rv64
       (rd ↦ᵣ imm) :=
   generic_1reg_spec (.LI rd imm) rd vOld _ addr hrd_ne_x0
     (by intro s _ _; simp [execInstrBr])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem li_spec_gen_own (rd : Reg) (imm : Word) (addr : Word)
     (hrd_ne_x0 : rd ≠ .x0) :
@@ -286,7 +286,7 @@ namespace EvmAsm.Rv64
       ((rs ↦ᵣ v) ** (rd ↦ᵣ v)) :=
   generic_2reg_spec (.MV rd rs) rs rd v vOld v addr hrd_ne_x0
     (by intro s _ hrs _; simp [execInstrBr, hrs])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Branch/Jump specs
@@ -370,7 +370,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (if BitVec.slt v1 v2 then (1 : Word) else 0))) :=
   generic_3reg_spec (.SLT rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -379,7 +379,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0))) :=
   generic_3reg_spec (.SLTU rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltu_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -388,7 +388,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.ult v1 v2 then (1 : Word) else 0))) :=
   generic_2reg_spec (.SLTU rd rs1 rd) rs1 rd v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem or_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -397,7 +397,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 ||| v2))) :=
   generic_3reg_spec (.OR rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- M extension: multiply specs
@@ -410,7 +410,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 * v2))) :=
   generic_3reg_spec (.MUL rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mul_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -419,7 +419,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ (v1 * v2)) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.MUL rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -428,7 +428,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulhu v1 v2)) :=
   generic_3reg_spec (.MULHU rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -437,7 +437,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_mulhu v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.MULHU rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhu_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -446,7 +446,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ rv64_mulhu v1 v2)) :=
   generic_2reg_spec (.MULHU rd rs1 rd) rs1 rd v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mul_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -455,7 +455,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 * v2))) :=
   generic_2reg_spec (.MUL rd rs1 rd) rs1 rd v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- M extension: division specs
@@ -468,7 +468,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_divu v1 v2)) :=
   generic_3reg_spec (.DIVU rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem divu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -477,7 +477,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_divu v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.DIVU rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem remu_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -486,7 +486,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_remu v1 v2)) :=
   generic_3reg_spec (.REMU rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem remu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -495,7 +495,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_remu v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.REMU rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -504,7 +504,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 - v2))) :=
   generic_2reg_spec (.SUB rd rs1 rd) rs1 rd v1 v2 (v1 - v2) addr hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sub_spec_gen (rd rs1 rs2 : Reg) (v1 v2 vOld : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -513,7 +513,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 - v2))) :=
   generic_3reg_spec (.SUB rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sltiu_spec_gen (rd rs1 : Reg) (vOld v1 : Word) (imm : BitVec 12)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -522,7 +522,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (if BitVec.ult v1 (signExtend12 imm) then (1 : Word) else (0 : Word)))) :=
   generic_2reg_spec (.SLTIU rd rs1 imm) rs1 rd v1 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 _; simp [execInstrBr, hrs1])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 /-- SD rs1 x0 offset: mem[rs1 + sext(offset)] := 0.
     Specialized version of sd_spec_gen for x0 (always reads as 0).
@@ -545,7 +545,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 >>> (v2.toNat % 64)))) :=
   generic_3reg_spec (.SRL rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem sll_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -554,7 +554,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 <<< (v2.toNat % 64)))) :=
   generic_3reg_spec (.SLL rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem add_spec_gen_rd_eq_rs2 (rd rs1 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -563,7 +563,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rd ↦ᵣ (v1 + v2))) :=
   generic_2reg_spec (.ADD rd rs1 rd) rs1 rd v1 v2 (v1 + v2) addr hrd_ne_x0
     (by intro s _ hrs1 hrd; simp [execInstrBr, hrs1, hrd])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem add_spec_gen (rd rs1 rs2 : Reg) (v1 v2 vOld : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -572,7 +572,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ (v1 + v2))) :=
   generic_3reg_spec (.ADD rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- ADDI rd x0 imm: load immediate (clean postcondition using signExtend12 imm)
@@ -741,7 +741,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulh v1 v2)) :=
   generic_3reg_spec (.MULH rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulh_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -750,7 +750,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_mulh v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.MULH rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhsu_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -759,7 +759,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_mulhsu v1 v2)) :=
   generic_3reg_spec (.MULHSU rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem mulhsu_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -768,7 +768,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_mulhsu v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.MULHSU rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem div_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -777,7 +777,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_div v1 v2)) :=
   generic_3reg_spec (.DIV rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem div_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -786,7 +786,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_div v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.DIV rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem rem_spec_gen (rd rs1 rs2 : Reg) (vOld v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -795,7 +795,7 @@ namespace EvmAsm.Rv64
       ((rs1 ↦ᵣ v1) ** (rs2 ↦ᵣ v2) ** (rd ↦ᵣ rv64_rem v1 v2)) :=
   generic_3reg_spec (.REM rd rs1 rs2) rs1 rs2 rd v1 v2 vOld _ addr hrd_ne_x0
     (by intro s _ hrs1 hrs2; simp [execInstrBr, hrs1, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 @[spec_gen_rv64] theorem rem_spec_gen_rd_eq_rs1 (rd rs2 : Reg) (v1 v2 : Word)
     (addr : Word) (hrd_ne_x0 : rd ≠ .x0) :
@@ -804,7 +804,7 @@ namespace EvmAsm.Rv64
       ((rd ↦ᵣ rv64_rem v1 v2) ** (rs2 ↦ᵣ v2)) :=
   generic_2reg_rd_eq_rs1_spec (.REM rd rd rs2) rd rs2 v1 v2 _ addr hrd_ne_x0
     (by intro s _ hrd hrs2; simp [execInstrBr, hrd, hrs2])
-    (by intro s hfetch; exact step_non_ecall_non_mem s hfetch (by nofun) (by nofun) (by rfl))
+    (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
 -- ============================================================================
 -- Phase 5: Halfword memory specs (LH, LHU, SH)


### PR DESCRIPTION
## Summary

Flip \`(s : MachineState)\` arg of \`step_non_ecall_non_mem\` to implicit. 100+ call sites across GenericSpecs, InstructionSpecs, SyscallSpecs, ControlFlow, SailEquiv, and Compare/LimbSpec all passed \`s\` positionally. \`s\` is recoverable from the following \`hfetch : s.code s.pc = some i\` hypothesis.

6 files touched; every call site shortens from \`step_non_ecall_non_mem s hfetch ...\` to \`step_non_ecall_non_mem hfetch ...\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)