### PR TITLE
refactor(DivBridge): flip div/mod_of_nat_euclidean (a b q r) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -49,7 +49,7 @@ theorem bv_lt_of_nat_lt {a b : EvmWord} (h : a.toNat < b.toNat) : a < b :=
     This is the master bridge theorem: to prove the algorithm computes
     the correct quotient, it suffices to show the Euclidean property at
     the Nat level. The no-overflow condition is automatic since `a < 2^256`. -/
-theorem div_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
+theorem div_of_nat_euclidean {a b q r : EvmWord} (hbnz : b ≠ 0)
     (h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_nat_lt : r.toNat < b.toNat) :
     q = EvmWord.div a b :=
@@ -60,7 +60,7 @@ theorem div_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
 
 /-- If the Nat-level Euclidean property holds (`a = b * q + r` with `r < b`),
     then `r = EvmWord.mod a b`. -/
-theorem mod_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
+theorem mod_of_nat_euclidean {a b q r : EvmWord} (hbnz : b ≠ 0)
     (h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_nat_lt : r.toNat < b.toNat) :
     r = EvmWord.mod a b :=
@@ -104,8 +104,8 @@ theorem div_from_mulsub {a b q r : EvmWord}
     (h_chain : a.toNat = b.toNat * q.toNat + r.toNat)
     (h_rem : r.toNat < b.toNat) :
     q = EvmWord.div a b ∧ r = EvmWord.mod a b :=
-  ⟨div_of_nat_euclidean a b q r hbnz h_chain h_rem,
-   mod_of_nat_euclidean a b q r hbnz h_chain h_rem⟩
+  ⟨div_of_nat_euclidean hbnz h_chain h_rem,
+   mod_of_nat_euclidean hbnz h_chain h_rem⟩
 
 end EvmWord
 

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
@@ -51,12 +51,12 @@ private theorem bnz_of_lt (a b : EvmWord) (h : a.toNat < b.toNat) : b ≠ 0 := b
 /-- When a < b, the quotient is 0. -/
 theorem div_zero_of_lt (a b : EvmWord) (h_lt : a.toNat < b.toNat) :
     EvmWord.div a b = 0 :=
-  (div_of_nat_euclidean a b 0 a (bnz_of_lt a b h_lt) (by simp) h_lt).symm
+  (div_of_nat_euclidean (q := 0) (r := a) (bnz_of_lt a b h_lt) (by simp) h_lt).symm
 
 /-- When a < b, the remainder is a itself. -/
 theorem mod_self_of_lt (a b : EvmWord) (h_lt : a.toNat < b.toNat) :
     EvmWord.mod a b = a :=
-  (mod_of_nat_euclidean a b 0 a (bnz_of_lt a b h_lt) (by simp) h_lt).symm
+  (mod_of_nat_euclidean (q := 0) (r := a) (bnz_of_lt a b h_lt) (by simp) h_lt).symm
 
 -- ============================================================================
 -- n=4 shift=0 correctness: q=1 case (b ≤ a < 2*b)
@@ -70,7 +70,7 @@ theorem div_one_of_ge_lt (a b : EvmWord)
     (h_ge : b.toNat ≤ a.toNat) (h_lt2 : a.toNat < 2 * b.toNat) :
     EvmWord.div a b = 1 := by
   have h1 : (1 : EvmWord).toNat = 1 := by decide
-  exact (div_of_nat_euclidean a b 1 (a - b) (bnz_of_lt2 a b h_lt2)
+  exact (div_of_nat_euclidean (q := 1) (r := a - b) (bnz_of_lt2 a b h_lt2)
     (by rw [h1, BitVec.toNat_sub_of_le (BitVec.le_def.mpr h_ge)]; omega)
     (by rw [BitVec.toNat_sub_of_le (BitVec.le_def.mpr h_ge)]; omega)).symm
 
@@ -79,7 +79,7 @@ theorem mod_sub_of_ge_lt (a b : EvmWord)
     (h_ge : b.toNat ≤ a.toNat) (h_lt2 : a.toNat < 2 * b.toNat) :
     EvmWord.mod a b = a - b := by
   have h1 : (1 : EvmWord).toNat = 1 := by decide
-  exact (mod_of_nat_euclidean a b 1 (a - b) (bnz_of_lt2 a b h_lt2)
+  exact (mod_of_nat_euclidean (q := 1) (r := a - b) (bnz_of_lt2 a b h_lt2)
     (by rw [h1, BitVec.toNat_sub_of_le (BitVec.le_def.mpr h_ge)]; omega)
     (by rw [BitVec.toNat_sub_of_le (BitVec.le_def.mpr h_ge)]; omega)).symm
 


### PR DESCRIPTION
## Summary

Flip \`(a b q r : EvmWord)\` args of \`div_of_nat_euclidean\` and \`mod_of_nat_euclidean\` to implicit. All four are recoverable from \`h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat\`.

- \`DivBridge.lean:107-108\` (div_from_mulsub): drop all 4 positional args.
- \`DivN4Lemmas.lean:54,59,73,82\` (div_zero_of_lt, mod_self_of_lt, div_one_of_ge_lt, mod_sub_of_ge_lt): use named \`(q := ...)\` / \`(r := ...)\` since the literals (\`0\`, \`a\`, \`1\`, \`a - b\`) aren't in the result type \`q = EvmWord.div a b\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)