### PR TITLE
feat(divmod): evm_mod_n4_full_call_addback_beq_spec (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -456,4 +456,109 @@ theorem evm_mod_n4_preloop_call_addback_beq_spec (sp base : Word)
     (fun h hq => by delta preloopCallAddbackBeqPostN4; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Full n=4 MOD path (call+addback BEQ, shift≠0): base → base+1068
+-- ============================================================================
+
+/-- Full n=4 MOD path: base → base+1068 (shift ≠ 0, call+addback BEQ).
+    Composes pre-loop + call+addback loop body + denorm preamble + MOD denorm
+    + MOD epilogue. Mirror of `evm_div_n4_full_call_addback_beq_spec`
+    (FullPathN4Beq.lean) using `modCode` and the MOD-specific post-loop
+    composer `evm_mod_preamble_denorm_epilogue_spec`. -/
+theorem evm_mod_n4_full_call_addback_beq_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4 a3 b2 b3)
+    (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
+    (hborrow : isAddbackBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) ** (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) ** ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) ** ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (fullModN4CallAddbackBeqPost sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := (clzResult b3).1
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
+  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
+  let b0' := b0 <<< (shift.toNat % 64)
+  let u4 := a3 >>> (antiShift.toNat % 64)
+  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
+  let u0 := a0 <<< (shift.toNat % 64)
+  let qHat := div128Quot u4 u3 b3'
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let ms := mulsubN4 qHat b0' b1' b2' b3' u0
+    ((a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)))
+    ((a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)))
+    u3
+  let c3 := ms.2.2.2.2
+  let u4_new := u4 - c3
+  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 u4_new b0' b1' b2' b3'
+  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3'
+  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+               else qHat + signExtend12 4095
+  let un0Out := if carry = 0 then ab'.1 else ab.1
+  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
+  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
+  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
+  let u4_out  := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
+  -- 1. Pre-loop + call+addback BEQ loop body: base → base+denormOff
+  have hA := evm_mod_n4_preloop_call_addback_beq_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
+  -- 2. Post-loop: base+denormOff → base+nopOff (modCode)
+  have hB := evm_mod_preamble_denorm_epilogue_spec sp base
+    un0Out un1Out un2Out un3Out shift
+    un3Out (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3
+    b0' b1' b2' b3'
+    hshift_nz
+  -- Frame post-loop with call+addback-specific atoms
+  have hBF := cpsTriple_frameR
+    (((sp + signExtend12 4088) ↦ₘ q_out) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4024) ↦ₘ u4_out) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+     (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ q_out) **
+     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+     (sp + signExtend12 3960 ↦ₘ b3') **
+     (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ div_un0))
+    (by pcFree) hB
+  -- 3. Compose A + B
+  have hFull := cpsTriple_seq_perm_same_cr
+    (fun h hp => by simp only [preloopCallAddbackBeqPostN4_unfold] at hp; xperm_hyp hp) hA hBF
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by delta fullModN4CallAddbackBeqPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
+    hFull
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Composes the full MOD n=4 path for the call+addback BEQ branch under \`shift ≠ 0\`: pre-loop → call+addback j=0 loop body → denorm preamble → MOD denorm + MOD epilogue.
- Built on #915 (preloop stage) + #919 (\`fullModN4CallAddbackBeqPost\` post bundle), both merged.
- Mirror of \`evm_div_n4_full_call_addback_beq_spec\` (FullPathN4Beq.lean) using \`modCode\` and the MOD-specific post-loop composer \`evm_mod_preamble_denorm_epilogue_spec\`.

This closes the **limb-level** MOD call-addback chain. Next step is the EvmWord-level wrapper \`evm_mod_n4_full_call_addback_beq_stack_pre_spec\` parallel to the DIV wrapper landed in #912.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: ModFullPathN4.lean 564 lines (< 1200-line Compose cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)