### PR TITLE
refactor(Val256ModBridge): flip val256_ms_un_eq/lt_val256_mod_max_skip to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeAssemble.lean
@@ -125,10 +125,10 @@ theorem val256_denorm_eq_val256_mod_max_skip
     linarith [h_scaled, h_un_scaled, (show (Vms_un + Q * Vb) * 2 ^ s = Vms_un * 2^s + Q * Vb * 2^s from by ring)]
   -- Apply Lemma A's result to get val256(u') = val256(ms_un) * 2^s / 2^s = val256(ms_un).
   have h_ms_un_lt_b :=
-    val256_ms_un_lt_val256_b_max_skip a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_un_zero
+    val256_ms_un_lt_val256_b_max_skip hbnz hb3nz hc3_un_zero
   simp only [] at h_ms_un_lt_b
   have h_ms_un_eq_mod :=
-    val256_ms_un_eq_val256_mod_max_skip a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_un_zero
+    val256_ms_un_eq_val256_mod_max_skip hbnz hb3nz hc3_un_zero
   simp only [] at h_ms_un_eq_mod
   -- Chain: val256(u') = val256(msN)/2^s = val256(ms_un)*2^s/2^s = val256(ms_un) = val256(a)%val256(b).
   rw [h_denorm, h_ms_n_scaled, Nat.mul_div_cancel _ (by positivity : 0 < 2^s)]

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -207,7 +207,7 @@ theorem u_top_eq_c3_n_max_skip
   have h_norm_u := val256_normalize_general hs0 hs a0 a1 a2 a3
   have h_norm_b := val256_normalize hs0 hs b0 b1 b2 b3 hb3_bound
   have h_ms_un_lt_b :=
-    val256_ms_un_lt_val256_b_max_skip a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_un_zero
+    val256_ms_un_lt_val256_b_max_skip hbnz hb3nz hc3_un_zero
   simp only [] at h_ms_un_lt_b
   have h_b_lt_pow := val256_lt_of_b3_bound b0 b1 b2 b3 s (by omega) hb3_bound
   have hs_pos : 0 < 2 ^ s := by positivity

--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -28,7 +28,7 @@ namespace EvmWord
     uniqueness argument (`remainder_lt_of_ge_floor`) rather than going through
     the `EvmWord.mod` / `fromLimbs` encoding of `n4_max_skip_correct`. -/
 theorem val256_ms_un_eq_val256_mod_max_skip
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hc3_zero : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 0) :
@@ -63,14 +63,14 @@ theorem val256_ms_un_eq_val256_mod_max_skip
     with `c3 = 0`). Follows from `val256_ms_un_eq_val256_mod_max_skip` +
     `Nat.mod_lt`. -/
 theorem val256_ms_un_lt_val256_b_max_skip
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hc3_zero : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 0) :
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
     val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 < val256 b0 b1 b2 b3 := by
   intro ms
-  rw [val256_ms_un_eq_val256_mod_max_skip a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_zero]
+  rw [val256_ms_un_eq_val256_mod_max_skip hbnz hb3nz hc3_zero]
   exact Nat.mod_lt _ (val256_pos_of_or_ne_zero hbnz)
 
 end EvmWord


### PR DESCRIPTION
## Summary

Flip \`(a0 a1 a2 a3 b0 b1 b2 b3 : Word)\` args of \`val256_ms_un_eq_val256_mod_max_skip\` and \`val256_ms_un_lt_val256_b_max_skip\` to implicit. Both theorems had 8 explicit Word args that every caller (3 sites across Val256ModBridge.lean, ModBridgeAssemble.lean, ModBridgeUtop.lean) passed positionally. All 8 are recoverable from the \`hc3_zero : (mulsubN4 ... b0..b3 a0..a3).2.2.2.2 = 0\` hypothesis.

Each call shortens from \`... a0 a1 a2 a3 b0 b1 b2 b3 hbnz hb3nz hc3_zero\` to \`... hbnz hb3nz hc3_zero\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)