### PR TITLE
feat(divmod): evm_mod_n4_full_call_addback_beq_stack_pre_spec(_bundled) (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -401,4 +401,85 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
     (fun _ hq => hq)
     h
 
+/-- EvmWord-level wrapper over `evm_mod_n4_full_call_addback_beq_spec`. Same
+    shape as `evm_div_n4_full_call_addback_beq_stack_pre_spec` but for the
+    MOD path: `divCode → modCode`, `evm_div_n4_full_call_addback_beq_spec →
+    evm_mod_n4_full_call_addback_beq_spec`, and `fullDivN4CallAddbackBeqPost
+    → fullModN4CallAddbackBeqPost`.
+
+    The MOD version does NOT require the `hvalid : ValidMemRange sp 8`
+    hypothesis that the DIV variant carries — the MOD preloop+full-path
+    specs don't consume validity hypotheses. -/
+theorem evm_mod_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
+    (hborrow : isAddbackBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hraw := evm_mod_n4_full_call_addback_beq_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_mod_n4_full_call_addback_beq_stack_pre_spec`:
+    takes the precondition as a single `modN4StackPreCall` atom. Mirror
+    of `evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled`. -/
+theorem evm_mod_n4_full_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu : isCallTrialN4Evm a b)
+    (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
+    (hborrow : isAddbackBorrowN4CallEvm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_mod_n4_full_call_addback_beq_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [modN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- MOD-side EvmWord-level wrapper around \`evm_mod_n4_full_call_addback_beq_spec\` (#924, merged).
- Parallels the DIV-side wrapper landed in #912.
- Closes the MOD call-addback chain at the **stack-pre** level — next step would be the semantic stack spec \`evm_mod_n4_call_addback_beq_stack_spec\` (requires Knuth-B).

New declarations:
- \`evm_mod_n4_full_call_addback_beq_stack_pre_spec\`: pre in \`evmWordIs sp a ** evmWordIs (sp+32) b ** divScratchValuesCall ...\` form.
- \`_bundled\` variant: uses the single \`modN4StackPreCall\` pre-bundle.

The MOD version omits the \`hvalid : ValidMemRange sp 8\` hypothesis the DIV variant carries — the MOD preloop / full-path specs don't consume validity hypotheses.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: SpecCall.lean 485 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)