### PR TITLE
refactor(SkipBorrowExtract): flip c3_le_u_top_of_skip_borrow (a0..a3 b0..b3) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1401,9 +1401,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   have hmod_eq : (clzResult (b.getLimbN 3)).1.toNat % 64 =
       (clzResult (b.getLimbN 3)).1.toNat := by omega
   -- c3_n ≤ uTop from runtime skip borrow, specialized to our shift form.
-  have hc3_le := EvmWord.c3_le_u_top_of_skip_borrow
-    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) hborrow
+  have hc3_le := EvmWord.c3_le_u_top_of_skip_borrow hborrow
   simp only [] at hc3_le
   -- Normalize `% 64` and `signExtend12 0 - shift` to the `(64 - s)` form
   -- the Lemma G adapter uses.

--- a/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SkipBorrowExtract.lean
@@ -18,7 +18,7 @@ namespace EvmWord
 
 /-- From the Word-level skip-borrow predicate (`1` if `uTop < c3_n` else `0`,
     equal to `0`), extract the Nat-level inequality `c3_n.toNat ≤ uTop.toNat`. -/
-theorem c3_le_u_top_of_skip_borrow (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+theorem c3_le_u_top_of_skip_borrow {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     (h : isSkipBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
     let shift := (clzResult b3).1
     let antiShift := signExtend12 (0 : BitVec 12) - shift


### PR DESCRIPTION
## Summary

Flip \`(a0 a1 a2 a3 b0 b1 b2 b3 : Word)\` args of \`c3_le_u_top_of_skip_borrow\` to implicit. Sole caller (\`DivMod/Spec.lean:1404\`) passed 8 positional Word args that are all recoverable from \`h : isSkipBorrowN4Max a0..a3 b0..b3\`. All bound variables (not literals) — flip is safe.

Shortens the call from 8 \`.getLimbN N\` positional args + \`hborrow\` to just \`EvmWord.c3_le_u_top_of_skip_borrow hborrow\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3559 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)