### PR TITLE
refactor(DivN4Overestimate): flip n4_max_{skip,addback}_div_mod_limbs to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -565,7 +565,7 @@ theorem addbackN4_first_carry_ne_zero (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     `EvmWord.div` / `EvmWord.mod` result. Direct consumer-facing form of
     `n4_max_skip_correct` — replaces the `fromLimbs` wrapper with eight
     `getLimbN` equalities that slot directly into `evmWordIs_sp32_limbs_eq`. -/
-theorem n4_max_skip_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+theorem n4_max_skip_div_mod_limbs {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     (hb3nz : b3 ≠ 0)
     (hc3_zero : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 0) :
     let ms := mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3
@@ -596,7 +596,7 @@ theorem n4_max_skip_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
 /-- n=4 max+addback path: per-limb quotient/remainder equalities. Direct
     consumer-facing form of `n4_max_addback_correct` — the corrected quotient
     is `qHat' = 2 * signExtend12 4095 = 2^64 - 2` in the low limb, zeros above. -/
-theorem n4_max_addback_div_mod_limbs (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+theorem n4_max_addback_div_mod_limbs {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     (hb3nz : b3 ≠ 0)
     (hc3_one : (mulsubN4 (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3).2.2.2.2 = 1)
     (hcarry_one : addbackN4_carry
@@ -680,10 +680,7 @@ theorem n4_max_skip_div_mod_getLimbN (a b : EvmWord)
     (EvmWord.mod a b).getLimbN 2 = ms.2.2.1 ∧
     (EvmWord.mod a b).getLimbN 3 = ms.2.2.2.1 := by
   intro ms
-  have hraw := n4_max_skip_div_mod_limbs
-    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    hb3nz hc3_zero
+  have hraw := n4_max_skip_div_mod_limbs hb3nz hc3_zero
   rw [EvmWord.fromLimbs_match_getLimbN_id a, EvmWord.fromLimbs_match_getLimbN_id b] at hraw
   exact hraw
 
@@ -723,10 +720,7 @@ theorem n4_max_addback_div_mod_getLimbN (a b : EvmWord)
     (EvmWord.mod a b).getLimbN 2 = ab.2.2.1 ∧
     (EvmWord.mod a b).getLimbN 3 = ab.2.2.2.1 := by
   intro ms ab qHat'
-  have hraw := n4_max_addback_div_mod_limbs
-    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-    hb3nz hc3_one hcarry_one
+  have hraw := n4_max_addback_div_mod_limbs hb3nz hc3_one hcarry_one
   rw [EvmWord.fromLimbs_match_getLimbN_id a, EvmWord.fromLimbs_match_getLimbN_id b] at hraw
   exact hraw
 


### PR DESCRIPTION
## Summary

Mirror of #938 but for the consumer-facing \`_div_mod_limbs\` wrappers:
- \`n4_max_skip_div_mod_limbs\`
- \`n4_max_addback_div_mod_limbs\`

Each has a single in-file caller (the EvmWord-level \`_div_mod_getLimbN\` wrapper) passing \`a.getLimbN 0 .. a.getLimbN 3\`, \`b.getLimbN 0 .. b.getLimbN 3\` positionally. All 8 args are recoverable from \`hc3_zero\` / \`hc3_one\`.

Callers shortened from 8 positional args + hypotheses to hypotheses only.

All bound variables (no literals). Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)