### PR TITLE
feat(divmod): evm_mod_n4_full_shift0_call_skip_stack_pre_spec(_bundled) (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -16,6 +16,7 @@
 
 import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
+import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
 
 open EvmAsm.Rv64.Tactics
 
@@ -572,6 +573,77 @@ theorem evm_div_n4_full_shift0_call_skip_stack_pre_spec_bundled (sp base : Word)
     hbnz hb3nz hshift_z halign hborrow
   exact cpsTriple_weaken
     (fun _ hp => by rw [divN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
+/-- EvmWord-level wrapper over `evm_mod_n4_full_shift0_call_skip_spec`.
+    MOD counterpart of `evm_div_n4_full_shift0_call_skip_stack_pre_spec`
+    with `divCode → modCode` and `fullDivN4Shift0CallSkipPost →
+    fullModN4Shift0CallSkipPost`. -/
+theorem evm_mod_n4_full_shift0_call_skip_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isSkipBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4Shift0CallSkipPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hraw := evm_mod_n4_full_shift0_call_skip_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_z halign hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_mod_n4_full_shift0_call_skip_stack_pre_spec`:
+    takes the precondition as a single `modN4StackPreCall` atom. -/
+theorem evm_mod_n4_full_shift0_call_skip_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hborrow : isSkipBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4Shift0CallSkipPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_mod_n4_full_shift0_call_skip_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_z halign hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [modN4StackPreCall_unfold] at hp; exact hp)
     (fun _ hq => hq)
     h
 


### PR DESCRIPTION
## Summary
- MOD counterpart of #936 (DIV shift=0 call-skip EvmWord wrapper).
- Wraps the limb-level \`evm_mod_n4_full_shift0_call_skip_spec\` (landed in #932) with the same \`evmWordIs\`/\`divScratchValuesCall\` precondition shape as the DIV variant, against \`modCode\`.
- Reuses \`isSkipBorrowN4Shift0Evm\` (landed in #936) and \`fullModN4Shift0CallSkipPost\` (landed in #932).

With this, the shift=0 call-skip stack-pre chain is complete for **both** DIV and MOD. The semantic call-skip stack specs (\`evm_{div,mod}_n4_shift0_call_skip_stack_spec\`) still need the separate Knuth-B / div128Quot-correctness chain.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File sizes OK: SpecCall.lean 650 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)