### PR TITLE
refactor(DivAccumulate): flip val256_zero_upper_{1,2,3} to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -31,17 +31,17 @@ namespace EvmWord
 -- ============================================================================
 
 /-- val256 with upper 3 limbs zero: reduces to single limb. -/
-theorem val256_zero_upper_3 (q0 : Word) :
+theorem val256_zero_upper_3 {q0 : Word} :
     val256 q0 0 0 0 = q0.toNat := by
   unfold val256; simp
 
 /-- val256 with upper 2 limbs zero: reduces to 2-limb value. -/
-theorem val256_zero_upper_2 (q0 q1 : Word) :
+theorem val256_zero_upper_2 {q0 q1 : Word} :
     val256 q0 q1 0 0 = q0.toNat + q1.toNat * 2^64 := by
   unfold val256; simp
 
 /-- val256 with upper 1 limb zero: reduces to 3-limb value. -/
-theorem val256_zero_upper_1 (q0 q1 q2 : Word) :
+theorem val256_zero_upper_1 {q0 q1 q2 : Word} :
     val256 q0 q1 q2 0 = q0.toNat + q1.toNat * 2^64 + q2.toNat * 2^128 := by
   unfold val256; simp
 
@@ -158,7 +158,7 @@ theorem div_correct_n4_no_shift
   have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   -- val256(q0, 0, 0, 0) = q0.toNat
-  have hq_val : val256 q0 0 0 0 = q0.toNat := val256_zero_upper_3 q0
+  have hq_val : val256 q0 0 0 0 = q0.toNat := val256_zero_upper_3
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 0 0 0 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -260,7 +260,7 @@ theorem n4_max_double_addback_correct {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
   -- Rewrite the Euclidean equation in val256_euclidean_to_div_mod's expected form.
   have hq_hat''_toNat : qHat''.toNat = (signExtend12 (4095 : BitVec 12) : Word).toNat - 2 := by
     simp only [qHat'']; decide
-  have hq_val : val256 qHat'' 0 0 0 = qHat''.toNat := val256_zero_upper_3 qHat''
+  have hq_val : val256 qHat'' 0 0 0 = qHat''.toNat := val256_zero_upper_3
   have heuclid : val256 a0 a1 a2 a3 =
       val256 qHat'' 0 0 0 * val256 b0 b1 b2 b3 +
       val256 ab'.1 ab'.2.1 ab'.2.2.1 ab'.2.2.2.1 := by


### PR DESCRIPTION
## Summary

Flip the \`(q0 q1 q2 : Word)\` args of \`val256_zero_upper_1\`, \`val256_zero_upper_2\`, \`val256_zero_upper_3\` to implicit. Callers fall into two forms:
- \`rw [val256_zero_upper_N]\` with no positional args — unchanged
- \`have ... : val256 q 0 0 0 = q.toNat := val256_zero_upper_3 q\` — the type annotation already pins q0; positional q redundant.

Two \`have\` sites in DivAccumulate.lean and DivN4DoubleAddback.lean shortened.

All bound variables (no literals). Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)