### PR TITLE
refactor(DivN4Overestimate): flip mulsub_double_addback_val256_combined (v0..v3 u0..u3) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -177,7 +177,7 @@ theorem n4_max_double_addback_correct {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     rw [hq_hat_toNat]; decide
   -- Apply combined Euclidean lemma: val256(a) = (q-2)*val256(b) + val256(ab'_lem).
   have hcombined := mulsub_double_addback_val256_combined
-    (signExtend12 4095) b0 b1 b2 b3 a0 a1 a2 a3 hbnz hq_over hc3_one hcarry1_zero hq_ge_2
+    (signExtend12 4095) hbnz hq_over hc3_one hcarry1_zero hq_ge_2
   simp only [] at hcombined
   -- Bridge from lemma's ab' to algorithm's ab': both second addbacks compute
   -- from the same low-4 ab limbs (low 4 are uTop-independent), and second

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -423,7 +423,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
 
 /-- Combined Euclidean equation for the double-addback case:
     val256(u) = (q.toNat - 2) * val256(v) + val256(ab'_result). -/
-theorem mulsub_double_addback_val256_combined (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
+theorem mulsub_double_addback_val256_combined (q : Word) {v0 v1 v2 v3 u0 u1 u2 u3 : Word}
     (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
     (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
     (hc3_one : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)


### PR DESCRIPTION
## Summary

Companion to #942 for the double-addback variant. Flip \`(v0..v3 u0..u3 : Word)\` to implicit while keeping \`q\` explicit (sole caller passes literal \`signExtend12 4095\`).

The middle 8 Word args are pinned by \`hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0\` and \`hc3_one\` (contains all 9 including q).

Sole caller shortened from 9 positional args + 5 hypotheses to 1 positional + 5 hypotheses.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)