### PR TITLE
feat(divmod): evm_div_n4_preloop_shift0_call_addback_beq_spec (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4
+import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 
 open EvmAsm.Rv64.Tactics
 
@@ -298,5 +299,140 @@ theorem evm_div_n4_full_shift0_call_skip_spec (sp base : Word)
     (fun h hq => by delta fullDivN4Shift0CallSkipPost; rw [sepConj_assoc'] at hq; xperm_hyp hq)
     hFull
 
+-- ============================================================================
+-- Condition definitions for shift=0 call+addback (BEQ) path
+-- ============================================================================
+
+/-- Addback condition at n=4 with shift=0 call path: borrow ≠ 0. Mulsub
+    with trial quotient `div128Quot 0 a3 b3` underflows, so the algorithm
+    decrements the trial quotient and adds back `b` to the partial remainder. -/
+def isAddbackBorrowN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let qHat := div128Quot (0 : Word) a3 b3
+  (if BitVec.ult (0 : Word) (mulsubN4_c3 qHat b0 b1 b2 b3 a0 a1 a2 a3)
+   then (1 : Word) else 0) ≠ (0 : Word)
+
+/-- Double-addback carry2 ≠ 0 condition at n=4 shift=0 call path (expressed
+    over raw a/b). Shift=0 specialization of `isAddbackCarry2NzN4CallAb`:
+    v=b, u=a, uTop=0 (no normalization). -/
+def isAddbackCarry2NzN4Shift0 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  isAddbackCarry2NzN4Call b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word)
+
+-- ============================================================================
+-- Postcondition for preloop + call+addback BEQ loop body (shift=0)
+-- ============================================================================
+
+/-- Postcondition for pre-loop + call+addback BEQ loop body at n=4, shift=0.
+    Uses unnormalized b[] and a[] directly (no shift) with uTop=0. Mirror
+    of `preloopShift0CallSkipPostN4` but with `loopBodyN4AddbackBeqPost`
+    replacing `loopBodyN4SkipPost`. -/
+@[irreducible]
+def preloopShift0CallAddbackBeqPostN4
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let qHat := div128Quot (0 : Word) a3 b3
+  let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un0 := (a3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  loopBodyN4AddbackBeqPost sp (0 : Word) qHat b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ b3) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ div_un0) **
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  ((sp + signExtend12 3992) ↦ₘ (0 : Word))
+
+-- ============================================================================
+-- Pre-loop + loop body (shift=0, call+addback BEQ): base → base+denormOff
+-- ============================================================================
+
+/-- n=4 pre-loop + call+addback BEQ loop body: base → base+denormOff (shift = 0).
+    Mirror of `evm_div_n4_preloop_shift0_call_skip_spec` with the call+skip
+    loop body replaced by call+addback (BEQ double-addback) variant.
+
+    At runtime the shift=0 path sets uTop=0 and passes raw b, a to the loop
+    body — see the call to `divK_loop_body_n4_call_addback_j0_beq_norm` below. -/
+theorem evm_div_n4_preloop_shift0_call_addback_beq_spec (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
+    (hshift_z : (clzResult b3).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hcarry2_nz : isAddbackCarry2NzN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hborrow : isAddbackBorrowN4Shift0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    cpsTriple base (base + denormOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b3).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+      (preloopShift0CallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3) := by
+  unfold isAddbackBorrowN4Shift0 at hborrow
+  unfold isAddbackCarry2NzN4Shift0 at hcarry2_nz
+  -- Pre-loop: base → base+loopBodyOff (shift=0)
+  have hPre := evm_div_n4_shift0_to_loopSetup_spec sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
+    hbnz hb3nz hshift_z
+  -- Frame preloop with x11, jMem, retMem, dMem, dloMem, scratch_un0
+  have hPreF := cpsTriple_frameR
+    ((.x11 ↦ᵣ v11Old) ** ((sp + signExtend12 3976) ↦ₘ jMem) **
+     (sp + signExtend12 3968 ↦ₘ retMem) ** (sp + signExtend12 3960 ↦ₘ dMem) **
+     (sp + signExtend12 3952 ↦ₘ dloMem) ** (sp + signExtend12 3944 ↦ₘ scratch_un0))
+    (by pcFree) hPre
+  -- Loop body: base+loopBodyOff → base+denormOff, call+addback BEQ with v=b, u=a, uTop=0
+  have hbltu : BitVec.ult (0 : Word) b3 := ult_zero_of_ne hb3nz
+  have hLoop := divK_loop_body_n4_call_addback_j0_beq_norm sp base
+    jMem (4 : Word) ((clzResult b3).1) ((clzResult b3).2 >>> (63 : Nat)) b3
+    v11Old (signExtend12 (0 : BitVec 12) - (clzResult b3).1)
+    b0 b1 b2 b3 a0 a1 a2 a3 (0 : Word) (0 : Word)
+    retMem dMem dloMem scratch_un0 halign
+    hbltu hcarry2_nz
+  intro_lets at hLoop
+  have hLoop' := hLoop hborrow
+  -- Frame loop body with a[], q[1-3]=0, padding, shift=0
+  have hLoopF := cpsTriple_frameR
+    (((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+     ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+     ((sp + signExtend12 4080) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4072) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4016) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4008) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 3992) ↦ₘ (clzResult b3).1))
+    (by pcFree) hLoop'
+  -- Compose preloop → loop body
+  have hFull := cpsTriple_seq_perm_same_cr
+    (fun h hp => by
+      simp only [x1_val_n4] at hp
+      xperm_hyp hp) hPreF hLoopF
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by
+      delta preloopShift0CallAddbackBeqPostN4
+      simp only [hshift_z] at hq
+      xperm_hyp hq)
+    hFull
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Opens the shift=0 call+addback BEQ chain on the DIV side (until now DIV shift=0 only had call-skip coverage).
- Mirror of \`evm_div_n4_preloop_shift0_call_skip_spec\` but using the call+addback BEQ j=0 loop body.

New declarations in \`FullPathN4Shift0.lean\`:
- \`isAddbackBorrowN4Shift0\` — runtime borrow-fires indicator for shift=0.
- \`isAddbackCarry2NzN4Shift0\` — double-addback branch indicator (shift=0 specialization of \`isAddbackCarry2NzN4CallAb\` with uTop=0, raw a/b).
- \`preloopShift0CallAddbackBeqPostN4\` — irreducible post bundle wrapping \`loopBodyN4AddbackBeqPost\` with frame atoms.
- \`evm_div_n4_preloop_shift0_call_addback_beq_spec\` — composes the shift=0 preloop with \`divK_loop_body_n4_call_addback_j0_beq_norm\` (passed v=b, u=a, uTop=0).

Also extends the file's imports with \`FullPathN4Beq\` so the shared addback-BEQ loop-body theorems and indicators resolve.

Next increment is the full-path composer \`evm_div_n4_full_shift0_call_addback_beq_spec\` glueing this preloop to the shift=0 DIV epilogue.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: FullPathN4Shift0.lean 438 lines (< 1200-line Compose cap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)