### PR TITLE
refactor(DivMulSubLimb): flip mulsub_carry_word_eq args to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -131,8 +131,7 @@ theorem mulsub_limb_word_carry_eq {q v_i u_i carryIn : Word} :
     ((borrowAdd + prodHi) + borrowSub).toNat =
       borrowAdd.toNat + prodHi.toNat + borrowSub.toNat := by
   intro prodLo prodHi fullSub borrowAdd borrowSub
-  exact mulsub_carry_word_eq borrowAdd prodHi borrowSub
-    mulsub_limb_carry_strict_lt
+  exact mulsub_carry_word_eq mulsub_limb_carry_strict_lt
 
 -- ============================================================================
 -- Per-limb equation using Word carry directly

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -176,7 +176,7 @@ theorem mulsub_limb_carry_lt_of_sum_le_one (q v_i : Word)
 /-- When the carry is < 2^64, the Word-level carry equals the Nat-level carry.
     This ensures the register-level carryOut correctly tracks the Nat-level
     carry for use as the next limb's carryIn. -/
-theorem mulsub_carry_word_eq (borrowAdd prodHi borrowSub : Word)
+theorem mulsub_carry_word_eq {borrowAdd prodHi borrowSub : Word}
     (h : borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64) :
     ((borrowAdd + prodHi) + borrowSub).toNat =
     borrowAdd.toNat + prodHi.toNat + borrowSub.toNat := by


### PR DESCRIPTION
## Summary

Flip \`(borrowAdd prodHi borrowSub : Word)\` args of \`mulsub_carry_word_eq\` to implicit. Sole caller used \`exact ...\` with all 3 passed positionally; expected conclusion type pins the args, and the hypothesis \`h : borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64\` also pins them.

Caller shortened to \`exact mulsub_carry_word_eq mulsub_limb_carry_strict_lt\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)