### PR TITLE
refactor: flip {mulsub,addback}_register_4limb_val256 args to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopSemantic.lean
+++ b/EvmAsm/Evm64/DivMod/LoopSemantic.lean
@@ -31,7 +31,7 @@ theorem mulsubN4_val256_eq (q v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
     val256 u0 u1 u2 u3 + ms.2.2.2.2.toNat * 2^256 =
       val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 + q.toNat * val256 v0 v1 v2 v3 := by
   simp only [mulsubN4, se12_0]
-  exact mulsub_register_4limb_val256 q v0 v1 v2 v3 u0 u1 u2 u3
+  exact mulsub_register_4limb_val256
 
 -- ============================================================================
 -- Addback: addbackN4 satisfies the 4-limb val256 addition equation
@@ -50,7 +50,7 @@ theorem addbackN4_val256_eq (un0 un1 un2 un3 u4_new v0 v1 v2 v3 : Word) :
       val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 + carry.toNat * 2^256 := by
   simp only [addbackN4_carry, se12_0]
   simp only [addbackN4, se12_0]
-  exact addback_register_4limb_val256 v0 v1 v2 v3 un0 un1 un2 un3
+  exact addback_register_4limb_val256
 
 /-- The 5th component of addbackN4 is u4_new + carry. -/
 theorem addbackN4_top_eq (un0 un1 un2 un3 u4_new v0 v1 v2 v3 : Word) :

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
@@ -190,7 +190,7 @@ theorem addback_limb_nat_word_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat â
     OR carry) to the val256 addition needed by `addback_correction_euclidean`.
     The let-bindings match the addback path in the loop body. -/
 theorem addback_register_4limb_val256
-    (v0 v1 v2 v3 un0 un1 un2 un3 : Word) :
+    {v0 v1 v2 v3 un0 un1 un2 un3 : Word} :
     -- Limb 0 (carryIn = 0)
     let upc0 := un0 + (0 : Word)
     let aun0 := upc0 + v0

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -169,7 +169,7 @@ theorem mulsub_limb_nat_word_eq (q v_i u_i carryIn : Word) :
 
     The initial carry is 0 (first limb). Each subsequent limb uses the
     Word carry from the previous limb. -/
-theorem mulsub_register_4limb_val256 (q v0 v1 v2 v3 u0 u1 u2 u3 : Word) :
+theorem mulsub_register_4limb_val256 {q v0 v1 v2 v3 u0 u1 u2 u3 : Word} :
     -- Limb 0 (carryIn = 0)
     let fs0 := q * v0 + (0 : Word)
     let ba0 := if BitVec.ult fs0 (0 : Word) then (1 : Word) else 0


### PR DESCRIPTION
## Summary

Flip the Word args of the two 4-limb val256 composition theorems to implicit:
- \`mulsub_register_4limb_val256\` (9 args: q, v0..v3, u0..u3)
- \`addback_register_4limb_val256\` (8 args: v0..v3, un0..un3)

Both have a single caller in \`LoopSemantic.lean\` using \`exact ...\` where the expected conclusion type provides inference.

Each callsite shortened from 8–9 positional args to none.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)