### PR TITLE
refactor(DivAccumulate): flip accumulated_eq_val256_n{1,2,3,4} to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -113,22 +113,22 @@ theorem iter_accumulate_4
 -- ============================================================================
 
 /-- For n=4 (1 digit): the quotient is just q0, matching val256(q0, 0, 0, 0). -/
-theorem accumulated_eq_val256_n4 (q0 : Word) :
+theorem accumulated_eq_val256_n4 {q0 : Word} :
     q0.toNat = val256 q0 0 0 0 := by
   rw [val256_zero_upper_3]
 
 /-- For n=3 (2 digits): the accumulated quotient matches val256(q0, q1, 0, 0). -/
-theorem accumulated_eq_val256_n3 (q0 q1 : Word) :
+theorem accumulated_eq_val256_n3 {q0 q1 : Word} :
     q1.toNat * 2^64 + q0.toNat = val256 q0 q1 0 0 := by
   rw [val256_zero_upper_2]; ring
 
 /-- For n=2 (3 digits): the accumulated quotient matches val256(q0, q1, q2, 0). -/
-theorem accumulated_eq_val256_n2 (q0 q1 q2 : Word) :
+theorem accumulated_eq_val256_n2 {q0 q1 q2 : Word} :
     q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat = val256 q0 q1 q2 0 := by
   rw [val256_zero_upper_1]; ring
 
 /-- For n=1 (4 digits): the accumulated quotient matches val256(q0, q1, q2, q3). -/
-theorem accumulated_eq_val256_n1 (q0 q1 q2 q3 : Word) :
+theorem accumulated_eq_val256_n1 {q0 q1 q2 q3 : Word} :
     q3.toNat * 2^192 + q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat =
     val256 q0 q1 q2 q3 := by
   unfold val256; ring
@@ -188,7 +188,7 @@ theorem div_correct_n3_no_shift
   have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 0 0 = q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n3 q0 q1).symm
+    (accumulated_eq_val256_n3).symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 0 0 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub
@@ -216,7 +216,7 @@ theorem div_correct_n2_no_shift
   have hv := val256_pos_of_or_ne_zero hbnz
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 q2 0 = q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n2 q0 q1 q2).symm
+    (accumulated_eq_val256_n2).symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 q2 0 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub
@@ -245,7 +245,7 @@ theorem div_correct_n1_no_shift
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
   have hq_val : val256 q0 q1 q2 q3 =
       q3.toNat * 2^192 + q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n1 q0 q1 q2 q3).symm
+    (accumulated_eq_val256_n1).symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 q2 q3 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub


### PR DESCRIPTION
## Summary

Flip the \`(q0..q3 : Word)\` args of all four \`accumulated_eq_val256_nK\` sibling theorems to implicit. The three consumer sites (\`div_correct_n{1,2,3}_no_shift\`) already used \`have ... : ... := (accumulated_eq_val256_nK q0 ..).symm\` with type annotations that pin the args. \`n4\` has no callers.

Three call sites shortened by dropping the positional args.

All bound variables (no literals). Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)