### PR TITLE
refactor: flip private beq_zero_false and combined_carry_toNat args to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -39,7 +39,7 @@ private theorem ite_word_01 (c : Prop) [Decidable c] :
   split <;> simp
 
 -- Combined carry: (carry_a ||| carry_b).toNat = (a + b + cin) / 2^64
-private theorem combined_carry_toNat (x y cin : Word) (hcin : cin.toNat ≤ 1) :
+private theorem combined_carry_toNat {x y cin : Word} (hcin : cin.toNat ≤ 1) :
     let psum := x + y
     let ca := if BitVec.ult psum y then (1 : Word) else 0
     let res := psum + cin
@@ -84,11 +84,11 @@ theorem add_carry_chain_correct (a b : EvmWord) :
   have hc0_le : carry0.toNat ≤ 1 := by
     have := a0.isLt; have := b0.isLt; rw [hc0]; omega
   have hc1 : carry1.toNat = (a1.toNat + b1.toNat + carry0.toNat) / 2^64 :=
-    combined_carry_toNat a1 b1 carry0 hc0_le
+    combined_carry_toNat hc0_le
   have hc1_le : carry1.toNat ≤ 1 := by
     have := a1.isLt; have := b1.isLt; rw [hc1]; omega
   have hc2 : carry2.toNat = (a2.toNat + b2.toNat + carry1.toNat) / 2^64 :=
-    combined_carry_toNat a2 b2 carry1 hc1_le
+    combined_carry_toNat hc1_le
   have hc2_le : carry2.toNat ≤ 1 := by
     have := a2.isLt; have := b2.isLt; rw [hc2]; omega
   -- toNat decomposition using local def names (a0, a1, ... not a.getLimb i)

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -58,7 +58,7 @@ theorem halfword_decompose (x : Word) :
 -- rv64_divu Nat-level correctness
 -- ============================================================================
 
-private theorem beq_zero_false (b : Word) (hb : b ≠ 0) : (b == 0#64) = false := by
+private theorem beq_zero_false {b : Word} (hb : b ≠ 0) : (b == 0#64) = false := by
   cases h : b == 0#64
   · rfl
   · exfalso; apply hb; exact eq_of_beq h
@@ -66,7 +66,7 @@ private theorem beq_zero_false (b : Word) (hb : b ≠ 0) : (b == 0#64) = false :
 /-- rv64_divu computes Nat-level division when divisor is nonzero. -/
 theorem rv64_divu_toNat (a b : Word) (hb : b ≠ 0) :
     (rv64_divu a b).toNat = a.toNat / b.toNat := by
-  unfold rv64_divu; rw [beq_zero_false b hb]; exact BitVec.toNat_udiv
+  unfold rv64_divu; rw [beq_zero_false hb]; exact BitVec.toNat_udiv
 
 /-- rv64_divu quotient times divisor doesn't exceed dividend. -/
 theorem rv64_divu_mul_le (a b : Word) (hb : b ≠ 0) :


### PR DESCRIPTION
## Summary

Two private helpers flipped to implicit:

- **`beq_zero_false (b : Word)`** (MultiLimb.lean): sole caller's \`rw [beq_zero_false b hb]\` → \`rw [beq_zero_false hb]\`. \`b\` inferred from \`hb : b ≠ 0\`.
- **`combined_carry_toNat (x y cin : Word)`** (Arithmetic.lean): two callers use \`have ... : ... := combined_carry_toNat x y cin hc_le\` with a type annotation that pins x, y, cin. Shortened to \`combined_carry_toNat hc_le\`.

Both private helpers; all callers in the same file. All bound vars.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)