### PR TITLE
refactor(MultiLimb): flip hi32_toNat_lt / lo32_toNat_lt / halfword_decompose (x) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -47,8 +47,8 @@ theorem halfword_combine (a b : Word) (ha : a.toNat < 2^32) (hb : b.toNat < 2^32
 /-- Corollary: combining hi32 and lo32 of a word reconstructs it at the Nat level. -/
 theorem halfword_combine_hi_lo (x : Word) :
     (hi32 x <<< 32 ||| lo32 x).toNat = x.toNat := by
-  rw [halfword_combine _ _ (hi32_toNat_lt x) (lo32_toNat_lt x)]
-  exact (halfword_decompose x).symm
+  rw [halfword_combine _ _ hi32_toNat_lt lo32_toNat_lt]
+  exact halfword_decompose.symm
 
 -- ============================================================================
 -- 128-bit Euclidean uniqueness (Nat level)

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -26,13 +26,13 @@ def hi32 (x : Word) : Word := x >>> 32
 def lo32 (x : Word) : Word := (x <<< 32) >>> 32
 
 /-- `hi32 x` is bounded by 2^32. -/
-theorem hi32_toNat_lt (x : Word) : (hi32 x).toNat < 2 ^ 32 := by
+theorem hi32_toNat_lt {x : Word} : (hi32 x).toNat < 2 ^ 32 := by
   unfold hi32
   rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
   exact Nat.div_lt_of_lt_mul (show x.toNat < 2 ^ 32 * 2 ^ 32 by have := x.isLt; omega)
 
 /-- `lo32 x` is bounded by 2^32. -/
-theorem lo32_toNat_lt (x : Word) : (lo32 x).toNat < 2 ^ 32 := by
+theorem lo32_toNat_lt {x : Word} : (lo32 x).toNat < 2 ^ 32 := by
   unfold lo32
   rw [BitVec.toNat_ushiftRight, BitVec.toNat_shiftLeft, Nat.shiftRight_eq_div_pow]
   simp only [Nat.shiftLeft_eq]
@@ -42,7 +42,7 @@ theorem lo32_toNat_lt (x : Word) : (lo32 x).toNat < 2 ^ 32 := by
     _ = 2 ^ 32 * 2 ^ 32 := by ring
 
 /-- Half-word decomposition: `x = hi32(x) * 2^32 + lo32(x)` at the Nat level. -/
-theorem halfword_decompose (x : Word) :
+theorem halfword_decompose {x : Word} :
     x.toNat = (hi32 x).toNat * 2 ^ 32 + (lo32 x).toNat := by
   unfold hi32 lo32
   rw [BitVec.toNat_ushiftRight, BitVec.toNat_ushiftRight, BitVec.toNat_shiftLeft,


### PR DESCRIPTION
## Summary

Flip the \`(x : Word)\` arg of three halfword lemmas in MultiLimb.lean to implicit. Sole caller (\`halfword_combine_hi_lo\` in Div128Lemmas.lean) passes x positionally three times in:

\`\`\`
rw [halfword_combine _ _ (hi32_toNat_lt x) (lo32_toNat_lt x)]
exact (halfword_decompose x).symm
\`\`\`

After flip, the \`rw\` / \`.symm\` contexts infer x from surrounding patterns:

\`\`\`
rw [halfword_combine _ _ hi32_toNat_lt lo32_toNat_lt]
exact halfword_decompose.symm
\`\`\`

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)