### PR TITLE
feat(divmod): shift=0 call-addback EvmWord wrappers (DIV + MOD) (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -647,4 +647,168 @@ theorem evm_mod_n4_full_shift0_call_skip_stack_pre_spec_bundled (sp base : Word)
     (fun _ hq => hq)
     h
 
+-- ============================================================================
+-- Shift = 0 call-trial addback (BEQ): EvmWord-level wrappers (DIV + MOD)
+-- ============================================================================
+
+/-- Addback-needed condition at n=4 shift=0 path in EvmWord form. Borrow
+    fires (mulsub underflowed), so the algorithm decrements the
+    `div128Quot`-computed trial quotient and adds back. -/
+def isAddbackBorrowN4Shift0Evm (a b : EvmWord) : Prop :=
+  isAddbackBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem isAddbackBorrowN4Shift0Evm_def (a b : EvmWord) :
+    isAddbackBorrowN4Shift0Evm a b =
+    isAddbackBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
+
+/-- Double-addback carry2≠0 condition at n=4 shift=0 path in EvmWord form. -/
+def isAddbackCarry2NzN4Shift0Evm (a b : EvmWord) : Prop :=
+  isAddbackCarry2NzN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+
+theorem isAddbackCarry2NzN4Shift0Evm_def (a b : EvmWord) :
+    isAddbackCarry2NzN4Shift0Evm a b =
+    isAddbackCarry2NzN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+                              (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
+
+/-- EvmWord-level wrapper over `evm_div_n4_full_shift0_call_addback_beq_spec`. -/
+theorem evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hcarry2_nz : isAddbackCarry2NzN4Shift0Evm a b)
+    (hborrow : isAddbackBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullDivN4Shift0CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hraw := evm_div_n4_full_shift0_call_addback_beq_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_z halign hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec`. -/
+theorem evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hcarry2_nz : isAddbackCarry2NzN4Shift0Evm a b)
+    (hborrow : isAddbackBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (divCode base)
+      (divN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullDivN4Shift0CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_z halign hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [divN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
+/-- EvmWord-level wrapper over `evm_mod_n4_full_shift0_call_addback_beq_spec`. -/
+theorem evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hcarry2_nz : isAddbackCarry2NzN4Shift0Evm a b)
+    (hborrow : isAddbackBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
+       (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       evmWordIs sp a ** evmWordIs (sp + 32) b **
+       divScratchValuesCall sp q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old
+         u5 u6 u7 shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4Shift0CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0 :=
+    (EvmWord.ne_zero_iff_getLimbN_or).mp hbnz
+  have hraw := evm_mod_n4_full_shift0_call_addback_beq_spec sp base
+    (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+    (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+    v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz' hb3nz hshift_z halign hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun h hp => by
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ rfl rfl rfl rfl,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun _ hq => hq)
+    hraw
+
+/-- Bundled version of `evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec`. -/
+theorem evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
+    (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
+    (q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b ≠ 0)
+    (hb3nz : b.getLimbN 3 ≠ 0)
+    (hshift_z : (clzResult (b.getLimbN 3)).1 = 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hcarry2_nz : isAddbackCarry2NzN4Shift0Evm a b)
+    (hborrow : isAddbackBorrowN4Shift0Evm a b) :
+    cpsTriple base (base + nopOff) (modCode base)
+      (modN4StackPreCall sp a b v5 v6 v7 v10 v11
+         q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+         shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (fullModN4Shift0CallAddbackBeqPost sp base
+        (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
+  have h := evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec sp base a b
+    v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3nz hshift_z halign hcarry2_nz hborrow
+  exact cpsTriple_weaken
+    (fun _ hp => by rw [modN4StackPreCall_unfold] at hp; exact hp)
+    (fun _ hq => hq)
+    h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Closes the shift=0 call+addback BEQ scaffolding at the EvmWord stack-pre level for **both** DIV and MOD.
- Parallel to: shift>0 call-addback EvmWord wrappers (#912 DIV, #927 MOD), and shift=0 call-skip EvmWord wrappers (#936 DIV, #940 MOD).

New declarations (all in \`SpecCall.lean\`):
- \`isAddbackBorrowN4Shift0Evm\` + \`_def\`
- \`isAddbackCarry2NzN4Shift0Evm\` + \`_def\`
- \`evm_div_n4_full_shift0_call_addback_beq_stack_pre_spec(_bundled)\`
- \`evm_mod_n4_full_shift0_call_addback_beq_stack_pre_spec(_bundled)\`

### Status after this PR

The DIV/MOD n=4 **call-trial stack-pre** chain is now complete at the EvmWord level across the full 2×2 grid: \`{shift>0, shift=0}\` × \`{skip, addback+BEQ}\`. What remains for issue #61 is the semantic stack specs \`evm_{div,mod}_n4_*_call_{skip,addback_beq}_stack_spec\` that lift \`fullDivN4*CallPost\` to the semantic \`evmWordIs (sp+32) (EvmWord.div a b)\` post — those still require the Knuth-B / \`div128Quot\`-correctness chain.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: SpecCall.lean 814 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)