### PR TITLE
refactor(MultiLimb): flip val128_bound (hi lo) to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -321,7 +321,7 @@ theorem trial_quotient_ge_256 (u0 u1 u2 u3 v0 v1 v2 : Word) (hv2 : v2 ≠ 0) :
   exact trial_quotient_ge_general (val128 u3 u2) (val128 u1 u0)
     v2.toNat (val128 v1 v0) (2 ^ 128)
     (Nat.pos_of_ne_zero (by intro h; apply hv2; exact BitVec.eq_of_toNat_eq h))
-    (val128_bound u1 u0)
+    val128_bound
 
 -- ============================================================================
 -- val256 bound with zero top limb

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -127,7 +127,7 @@ theorem partial_product_decompose (q vi : Word) :
 /-- A 128-bit value represented as hi * 2^64 + lo. -/
 def val128 (hi lo : Word) : Nat := hi.toNat * 2 ^ 64 + lo.toNat
 
-theorem val128_bound (hi lo : Word) : val128 hi lo < 2 ^ 128 := by
+theorem val128_bound {hi lo : Word} : val128 hi lo < 2 ^ 128 := by
   unfold val128; have hhi := hi.isLt; have hlo := lo.isLt; nlinarith
 
 /-- If the high half is less than d, the 128-bit value is less than d * 2^64. -/


### PR DESCRIPTION
## Summary

Flip \`(hi lo : Word)\` args of \`val128_bound\` to implicit. Sole caller (Div128Lemmas.lean inside \`exact trial_quotient_ge_general ...\`) passed \`u1 u0\` positionally; the expected argument's type (\`val128 hi lo < 2^128\`) pins both args.

Shortened from \`(val128_bound u1 u0)\` to \`val128_bound\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)