### PR TITLE
refactor(GenericSpecs): flip generic_nop_spec base/exit_ to implicit

### DIFF
--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -221,7 +221,7 @@ theorem execInstrBr_jal_x0 (s : MachineState) (off : BitVec 21) :
       (CodeReq.singleton addr (.JAL .x0 offset))
       empAssertion
       empAssertion :=
-  generic_nop_spec (.JAL .x0 offset) addr (addr + signExtend21 offset)
+  generic_nop_spec (.JAL .x0 offset)
     (by intro s hpc; simp [execInstrBr, MachineState.setReg, hpc])
     (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -183,7 +183,7 @@ theorem generic_3reg_spec (instr : Instr) (rs1 rs2 rd : Reg)
 
 /-- Generic spec for instructions that only advance PC without changing state.
     Pre/Post: empAssertion  [frame handles the rest] -/
-theorem generic_nop_spec (instr : Instr) (base exit_ : Word)
+theorem generic_nop_spec (instr : Instr) {base exit_ : Word}
     (hexec : ∀ s, s.pc = base → execInstrBr s instr = s.setPC exit_)
     (hstep : ∀ s, s.code s.pc = some instr → step s = some (execInstrBr s instr)) :
     cpsTriple base exit_ (CodeReq.singleton base instr)

--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -438,7 +438,7 @@ theorem nop_spec (base : Word) :
     cpsTriple base (base + 4) (CodeReq.singleton base .NOP)
       empAssertion
       empAssertion :=
-  generic_nop_spec .NOP base (base + 4)
+  generic_nop_spec .NOP
     (by intro s hpc; simp [execInstrBr, hpc])
     (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 
@@ -451,7 +451,7 @@ theorem fence_spec (base : Word) :
     cpsTriple base (base + 4) (CodeReq.singleton base .FENCE)
       empAssertion
       empAssertion :=
-  generic_nop_spec .FENCE base (base + 4)
+  generic_nop_spec .FENCE
     (by intro s hpc; simp [execInstrBr, hpc])
     (by intro s hfetch; exact step_non_ecall_non_mem hfetch (by nofun) (by nofun) (by rfl))
 


### PR DESCRIPTION
## Summary

Flip \`(base exit_ : Word)\` of \`generic_nop_spec\` to implicit. Keep \`instr\` explicit — all 3 callers pass constructor literals (\`.NOP\`, \`.FENCE\`, \`.JAL .x0 offset\`), which per the #922 literal rule warrants staying explicit.

All 3 callers use \`term : cpsTriple base (base+4) ... := generic_nop_spec ...\` form; the expected type pins both \`base\` and \`exit_\`.

Three callsites shortened from \`generic_nop_spec X base (base + k) ...\` to \`generic_nop_spec X ...\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)