### PR TITLE
refactor(IsZero, Eq): flip iszero_or_reduce_correct / eq_xor_or_reduce_correct args to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Eq.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Eq.lean
@@ -16,7 +16,7 @@ namespace EvmWord
 -- EQ correctness
 -- ============================================================================
 
-theorem eq_xor_or_reduce_correct (a b : EvmWord) :
+theorem eq_xor_or_reduce_correct {a b : EvmWord} :
     let acc0 := a.getLimb 0 ^^^ b.getLimb 0
     let acc1 := acc0 ||| (a.getLimb 1 ^^^ b.getLimb 1)
     let acc2 := acc1 ||| (a.getLimb 2 ^^^ b.getLimb 2)

--- a/EvmAsm/Evm64/EvmWordArith/IsZero.lean
+++ b/EvmAsm/Evm64/EvmWordArith/IsZero.lean
@@ -16,7 +16,7 @@ namespace EvmWord
 -- ISZERO correctness
 -- ============================================================================
 
-theorem iszero_or_reduce_correct (a : EvmWord) :
+theorem iszero_or_reduce_correct {a : EvmWord} :
     (if BitVec.ult (a.getLimb 0 ||| a.getLimb 1 ||| a.getLimb 2 ||| a.getLimb 3) 1
      then (1 : Word) else 0) =
     (if a = 0 then (1 : Word) else 0) := by


### PR DESCRIPTION
## Summary

Flip the EvmWord args of two reduce-correct theorems to implicit:
- \`iszero_or_reduce_correct (a : EvmWord)\` → \`{a : EvmWord}\`
- \`eq_xor_or_reduce_correct (a b : EvmWord)\` → \`{a b : EvmWord}\`

Both are used as \`rw [← ...]\` at callers (IsZero/Spec.lean, Eq/Spec.lean) without positional args — \`rw\` pattern-matches the RHS to determine the args. No changes at call sites needed; the flip just makes the signature match the no-args use pattern.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)