### PR TITLE
refactor(EvmWordArith/Div): flip div_zero_right / mod_zero_right (a) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -63,12 +63,12 @@ open EvmAsm.Rv64.AddrNorm (word_add_zero word_toNat_0)
     bzero spec's postcondition site. -/
 theorem evmWordIs_div_zero_right (addr : Word) (a : EvmWord) :
     evmWordIs addr (EvmWord.div a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr addr (EvmWord.div_zero_right a)
+  evmWordIs_congr addr EvmWord.div_zero_right
 
 /-- MOD counterpart of `evmWordIs_div_zero_right`. -/
 theorem evmWordIs_mod_zero_right (addr : Word) (a : EvmWord) :
     evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr addr (EvmWord.mod_zero_right a)
+  evmWordIs_congr addr EvmWord.mod_zero_right
 
 /-- Full unfold of `evmWordIs addr (EvmWord.div a 0)` straight to four zero
     memIs atoms, bundling `evmWordIs_div_zero_right` + `evmWordIs_zero`

--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -29,10 +29,10 @@ def mod (a b : EvmWord) : EvmWord :=
 -- Zero divisor lemmas
 -- ============================================================================
 
-theorem div_zero_right (a : EvmWord) : div a 0 = 0 := by
+theorem div_zero_right {a : EvmWord} : div a 0 = 0 := by
   simp [div]
 
-theorem mod_zero_right (a : EvmWord) : mod a 0 = 0 := by
+theorem mod_zero_right {a : EvmWord} : mod a 0 = 0 := by
   simp [mod]
 
 private theorem getLimb_zero (i : Fin 4) : (0 : EvmWord).getLimb i = 0 := by


### PR DESCRIPTION
## Summary

Flip \`(a : EvmWord)\` arg of sibling theorems \`div_zero_right\` and \`mod_zero_right\` to implicit. Callers:
- \`rw [div_zero_right]\` / \`rw [mod_zero_right]\` in Div.lean (no args)
- \`evmWordIs_congr addr (EvmWord.div_zero_right a)\` + mod counterpart in DivMod/Spec.lean — the 2nd arg's expected type \`h : x = y\` (with \`x = div a 0\`) pins \`a\`.

Two DivMod/Spec.lean sites shortened.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)