### PR TITLE
refactor(LoopBodyN1): flip u_addr_eq_n1 / u_addr8_eq_n1 / vtop_eq_v0_n1 (sp j) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -30,19 +30,19 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 /-- For n=1: uAddr = uBase + signExtend12 4088 -/
-theorem u_addr_eq_n1 (sp j : Word) :
+theorem u_addr_eq_n1 {sp j : Word} :
     sp + signExtend12 4056 - (j + (1 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- For n=1: (uBase + signExtend12 4088) + 8 = uBase + signExtend12 0 -/
-theorem u_addr8_eq_n1 (sp j : Word) :
+theorem u_addr8_eq_n1 {sp j : Word} :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 0 := by
   divmod_addr
 
 /-- For n=1: vtopBase + signExtend12 32 = sp + signExtend12 32 -/
-theorem vtop_eq_v0_n1 (sp : Word) :
+theorem vtop_eq_v0_n1 {sp : Word} :
     (sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 32 := by
   divmod_addr
@@ -77,9 +77,9 @@ theorem divK_trial_max_full_spec_n1
   have TF := divK_trial_max_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp j] at TF
-  rw [u_addr8_eq_n1 sp j] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   exact TF
 
 /-- Trial call full spec specialized for n=1, with addresses rewritten. -/
@@ -145,9 +145,9 @@ theorem divK_trial_call_full_spec_n1
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp j] at TF
-  rw [u_addr8_eq_n1 sp j] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   exact TF
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -78,9 +78,9 @@ theorem divK_loop_body_n1_call_skip_j0_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (0 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -201,9 +201,9 @@ theorem divK_loop_body_n1_call_skip_j1_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (1 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -324,9 +324,9 @@ theorem divK_loop_body_n1_call_skip_j2_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (2 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -447,9 +447,9 @@ theorem divK_loop_body_n1_call_skip_j3_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (3 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (3 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -79,9 +79,9 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (0 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -197,9 +197,9 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (1 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -315,9 +315,9 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (2 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -433,9 +433,9 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (3 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (3 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -75,9 +75,9 @@ theorem divK_loop_body_n1_max_skip_j0_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (0 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u0 vtopBase u1 v0 v2Old base
@@ -170,9 +170,9 @@ theorem divK_loop_body_n1_max_skip_j3_spec
   have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (3 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (3 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (3 : Word) u0 vtopBase u1 v0 v2Old base
 
@@ -258,9 +258,9 @@ theorem divK_loop_body_n1_max_skip_j1_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (1 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u0 vtopBase u1 v0 v2Old base
 
@@ -346,9 +346,9 @@ theorem divK_loop_body_n1_max_skip_j2_spec
   have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (2 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u0 vtopBase u1 v0 v2Old base
 

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -64,9 +64,9 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (0 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u0 vtopBase u1 v0 v2Old base
 
@@ -146,9 +146,9 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (3 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (3 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (3 : Word) u0 vtopBase u1 v0 v2Old base
 
@@ -228,9 +228,9 @@ theorem divK_loop_body_n1_max_addback_j1_beq_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (1 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u0 vtopBase u1 v0 v2Old base
 
@@ -310,9 +310,9 @@ theorem divK_loop_body_n1_max_addback_j2_beq_spec
   have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n1 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n1 sp (2 : Word)] at TF
-  rw [vtop_eq_v0_n1 sp] at TF
+  rw [u_addr_eq_n1] at TF
+  rw [u_addr8_eq_n1] at TF
+  rw [vtop_eq_v0_n1] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u0 vtopBase u1 v0 v2Old base
 


### PR DESCRIPTION
## Summary

Flip \`(sp j : Word)\` / \`(sp : Word)\` of three sibling address-rewrite lemmas for n=1 to implicit:
- \`u_addr_eq_n1\`
- \`u_addr8_eq_n1\`
- \`vtop_eq_v0_n1\`

All used in \`rw [...]\` tactic calls with positional args. Since \`rw\` pattern-matches the LHS against the goal anyway, the positional args are redundant — unification works without them.

~20 call sites across \`LoopBodyN1.lean\`, \`LoopIterN1/{Call,Max,MaxBeq,CallBeq}.lean\` shortened from \`rw [u_addr_eq_n1 sp j]\` to \`rw [u_addr_eq_n1]\`.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)