### PR TITLE
refactor(LoopBodyN2): flip u_addr_eq_n2 / u_addr8_eq_n2 / vtop_eq_v1_n2 (sp j) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -30,19 +30,19 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 /-- For n=2: uAddr = uBase + signExtend12 4080 -/
-theorem u_addr_eq_n2 (sp j : Word) :
+theorem u_addr_eq_n2 {sp j : Word} :
     sp + signExtend12 4056 - (j + (2 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- For n=2: (uBase + signExtend12 4080) + 8 = uBase + signExtend12 4088 -/
-theorem u_addr8_eq_n2 (sp j : Word) :
+theorem u_addr8_eq_n2 {sp j : Word} :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- For n=2: vtopBase + signExtend12 32 = sp + signExtend12 40 -/
-theorem vtop_eq_v1_n2 (sp : Word) :
+theorem vtop_eq_v1_n2 {sp : Word} :
     (sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 40 := by
   divmod_addr
@@ -116,10 +116,10 @@ theorem divK_loop_body_n2_max_skip_spec
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
   -- Rewrite uAddr → uBase + signExtend12 4080, and (uAddr+8) → uBase + signExtend12 4088
-  rw [u_addr_eq_n2 sp j] at TF
-  rw [u_addr8_eq_n2 sp j] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 40
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtopBase u2 v1 v2Old base
@@ -215,9 +215,9 @@ theorem divK_loop_body_n2_max_addback_spec
   have TF := divK_trial_max_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp j] at TF
-  rw [u_addr8_eq_n2 sp j] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u1 vtopBase u2 v1 v2Old base
@@ -365,9 +365,9 @@ theorem divK_loop_body_n2_call_skip_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp j] at TF
-  rw [u_addr8_eq_n2 sp j] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -511,9 +511,9 @@ theorem divK_loop_body_n2_call_addback_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp j] at TF
-  rw [u_addr8_eq_n2 sp j] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -85,9 +85,9 @@ theorem divK_loop_body_n2_max_skip_j0_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (0 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtopBase u2 v1 v2Old base
@@ -194,9 +194,9 @@ theorem divK_loop_body_n2_call_skip_j0_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (0 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -313,9 +313,9 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (1 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtopBase u2 v1 v2Old base
 
@@ -412,9 +412,9 @@ theorem divK_loop_body_n2_call_skip_j1_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (1 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -526,9 +526,9 @@ theorem divK_loop_body_n2_max_skip_j2_spec
   have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (2 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtopBase u2 v1 v2Old base
 
@@ -625,9 +625,9 @@ theorem divK_loop_body_n2_call_skip_j2_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (2 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -738,9 +738,9 @@ theorem divK_loop_body_n2_max_addback_j0_beq_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (0 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u1 vtopBase u2 v1 v2Old base
 
@@ -855,9 +855,9 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (0 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -951,9 +951,9 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (1 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u1 vtopBase u2 v1 v2Old base
 
@@ -1065,9 +1065,9 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (1 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 
@@ -1155,9 +1155,9 @@ theorem divK_loop_body_n2_max_addback_j2_beq_spec
   have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (2 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (2 : Word) u1 vtopBase u2 v1 v2Old base
 
@@ -1269,9 +1269,9 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n2 sp (2 : Word)] at TF
-  rw [u_addr8_eq_n2 sp (2 : Word)] at TF
-  rw [vtop_eq_v1_n2 sp] at TF
+  rw [u_addr_eq_n2] at TF
+  rw [u_addr8_eq_n2] at TF
+  rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
 


### PR DESCRIPTION
## Summary

Companion to #964 for the n=2 variants. Flip \`(sp j : Word)\` / \`(sp : Word)\` of three sibling address-rewrite lemmas to implicit:
- \`u_addr_eq_n2\`
- \`u_addr8_eq_n2\`
- \`vtop_eq_v1_n2\`

All used in \`rw [...]\` tactic calls with positional args; \`rw\` pattern-matches the LHS against the goal, so the positional args are redundant.

~20 call sites across LoopBodyN2.lean and LoopIterN2.lean shortened.

Part of #331.

## Test plan
- [x] \`lake build\` succeeds (full repo, 3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)