### PR TITLE
feat(divmod): div128Quot_phase1b_no_underflow — Knuth B KB-3a (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -1026,4 +1026,32 @@ theorem div128Quot_phase1b_quotient_bound (uHi dHi : Word)
       rw [if_neg h_check]
     exact ⟨by omega, by omega⟩
 
+/-- **KB-3a: Post-Phase-1b no-underflow bound.** The post-corrected
+    quotient `q1'` times `dHi` doesn't exceed `uHi` at the Nat level:
+
+    ```
+    q1'.toNat * dHi.toNat ≤ uHi.toNat
+    ```
+
+    Direct consequence of the Phase 1b Euclidean equation
+    `q1'.toNat * dHi.toNat + rhat'.toNat = uHi.toNat` (from
+    `div128Quot_phase1b_post`) and `rhat'.toNat ≥ 0`.
+
+    Useful corollary for Phase 2 analysis: it justifies that
+    `uHi - q1' * dHi` doesn't underflow at the Nat level (the subtraction
+    is well-defined as a Nat subtraction). -/
+theorem div128Quot_phase1b_no_underflow (uHi dHi : Word)
+    (hdHi_lt : dHi.toNat < 2^32) (q1c rhatc dLo rhatUn1 : Word)
+    (h_post : q1c.toNat * dHi.toNat + rhatc.toNat = uHi.toNat)
+    (h_rhatc_lt : rhatc.toNat < 2 * dHi.toNat) :
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    let rhat' := if BitVec.ult rhatUn1 (q1c * dLo) then rhatc + dHi else rhatc
+    q1'.toNat * dHi.toNat ≤ uHi.toNat := by
+  intro q1' rhat'
+  -- Extract Phase 1b Euclidean at the right types (matching our local lets).
+  have h_eucl : q1'.toNat * dHi.toNat + rhat'.toNat = uHi.toNat :=
+    div128Quot_phase1b_post uHi dHi q1c rhatc dLo rhatUn1 hdHi_lt h_post h_rhatc_lt
+  omega
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- **Stacks on #963 (KB-2), which stacks on #960 (KB-1).** Please merge in order: #960 → #963 → this PR.
- Small utility lemma: \`q1'.toNat * dHi.toNat ≤ uHi.toNat\`.
- Direct consequence of \`div128Quot_phase1b_post\` (Euclidean: \`q1' * dHi + rhat' = uHi\`) with \`rhat' ≥ 0\`.

### Motivation

For Phase 2 analysis (KB-3b onward), we need to treat \`uHi - q1' * dHi\` as a well-defined Nat subtraction (so we can relate \`un21\` to abstract dividend quantities without BitVec wraparound noise on this particular subterm). This lemma records the no-underflow witness.

## Test plan
- [x] \`lake build\` passes (on top of KB-2's branch, full project green)
- [x] File size OK: KnuthTheoremB.lean ~1060 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)