### PR TITLE
refactor(DivMod/LoopBodyN3): flip address-rewrite lemmas (sp j) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -30,19 +30,19 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 /-- For n=3: uAddr = uBase + signExtend12 4072 -/
-theorem u_addr_eq_n3 (sp j : Word) :
+theorem u_addr_eq_n3 {sp j : Word} :
     sp + signExtend12 4056 - (j + (3 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- For n=3: (uBase + signExtend12 4072) + 8 = uBase + signExtend12 4080 -/
-theorem u_addr8_eq_n3 (sp j : Word) :
+theorem u_addr8_eq_n3 {sp j : Word} :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- For n=3: vtopBase + signExtend12 32 = sp + signExtend12 48 -/
-theorem vtop_eq_v2_n3 (sp : Word) :
+theorem vtop_eq_v2_n3 {sp : Word} :
     (sp + ((3 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 48 := by
   divmod_addr
@@ -115,10 +115,10 @@ theorem divK_loop_body_n3_max_skip_spec
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
   -- Rewrite uAddr → uBase + signExtend12 4072, and (uAddr+8) → uBase + signExtend12 4080
-  rw [u_addr_eq_n3 sp j] at TF
-  rw [u_addr8_eq_n3 sp j] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 48
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtopBase u3 v2 v2Old base
@@ -217,9 +217,9 @@ theorem divK_loop_body_n3_max_addback_spec
   have TF := divK_trial_max_full_spec sp j (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u3 u2 v2 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp j] at TF
-  rw [u_addr8_eq_n3 sp j] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u2 vtopBase u3 v2 v2Old base
@@ -368,9 +368,9 @@ theorem divK_loop_body_n3_call_skip_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp j] at TF
-  rw [u_addr8_eq_n3 sp j] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -515,9 +515,9 @@ theorem divK_loop_body_n3_call_addback_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp j] at TF
-  rw [u_addr8_eq_n3 sp j] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -80,9 +80,9 @@ theorem divK_loop_body_n3_max_skip_j0_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u3 u2 v2 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (0 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtopBase u3 v2 v2Old base
@@ -189,9 +189,9 @@ theorem divK_loop_body_n3_call_skip_j0_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (0 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -316,9 +316,9 @@ theorem divK_loop_body_n3_max_skip_j1_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u3 u2 v2 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (1 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtopBase u3 v2 v2Old base
@@ -425,9 +425,9 @@ theorem divK_loop_body_n3_call_skip_j1_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (1 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -544,9 +544,9 @@ theorem divK_loop_body_n3_max_addback_beq_j0_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u3 u2 v2 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (0 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u2 vtopBase u3 v2 v2Old base
@@ -665,9 +665,9 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (0 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -766,9 +766,9 @@ theorem divK_loop_body_n3_max_addback_beq_j1_spec
   have TF := divK_trial_max_full_spec sp (1 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u3 u2 v2 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (1 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (1 : Word) u2 vtopBase u3 v2 v2Old base
@@ -887,9 +887,9 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n3 sp (1 : Word)] at TF
-  rw [u_addr8_eq_n3 sp (1 : Word)] at TF
-  rw [vtop_eq_v2_n3 sp] at TF
+  rw [u_addr_eq_n3] at TF
+  rw [u_addr8_eq_n3] at TF
+  rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base


### PR DESCRIPTION
## Summary

- Flip three n=3 address-rewrite lemmas in `LoopBodyN3.lean` from positional to implicit:
  - `u_addr_eq_n3 (sp j : Word)` → `{sp j : Word}`
  - `u_addr8_eq_n3 (sp j : Word)` → `{sp j : Word}`
  - `vtop_eq_v2_n3 (sp : Word)` → `{sp : Word}`
- Drop redundant positional args at all `rw [...]` call sites in `LoopBodyN3.lean` and `LoopIterN3.lean`.

Companion to #964 (n=1) and #965 (n=2) — final of the three n-variant mirrors.

## Why it's safe

All callers are `rw [lemma ...]` which pattern-matches the LHS against the goal — the args are fully determined by unification, so positional passing is pure noise.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)