### PR TITLE
refactor(DivMod/LoopBodyN4): flip address-rewrite lemmas (sp j) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -30,19 +30,19 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 /-- For n=4: uAddr = uBase + signExtend12 4064 -/
-theorem u_addr_eq_n4 (sp j : Word) :
+theorem u_addr_eq_n4 {sp j : Word} :
     sp + signExtend12 4056 - (j + (4 : Word)) <<< (3 : BitVec 6).toNat =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
 
 /-- For n=4: (uBase + signExtend12 4064) + 8 = uBase + signExtend12 4072 -/
-theorem u_addr8_eq_n4 (sp j : Word) :
+theorem u_addr8_eq_n4 {sp j : Word} :
     ((sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4064) + 8 =
     (sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- For n=4: vtopBase + signExtend12 32 = sp + signExtend12 56 -/
-theorem vtop_eq_v3_n4 (sp : Word) :
+theorem vtop_eq_v3_n4 {sp : Word} :
     (sp + ((4 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat) + signExtend12 32 =
     sp + signExtend12 56 := by
   divmod_addr
@@ -117,10 +117,10 @@ theorem divK_loop_body_n4_max_skip_spec
   -- Expand let-bindings in TF to expose raw address expressions
   dsimp only [] at TF
   -- Rewrite uAddr → uBase + signExtend12 4064, and (uAddr+8) → uBase + signExtend12 4072
-  rw [u_addr_eq_n4 sp j] at TF
-  rw [u_addr8_eq_n4 sp j] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
   -- Rewrite vtopBase + signExtend12 32 → sp + signExtend12 56
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u3 vtopBase uTop v3 v2Old base
@@ -219,9 +219,9 @@ theorem divK_loop_body_n4_max_addback_spec
   have TF := divK_trial_max_full_spec sp j (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     uTop u3 v3 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp j] at TF
-  rw [u_addr8_eq_n4 sp j] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     j u3 vtopBase uTop v3 v2Old base
@@ -371,9 +371,9 @@ theorem divK_loop_body_n4_call_skip_spec
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp j] at TF
-  rw [u_addr8_eq_n4 sp j] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -517,9 +517,9 @@ theorem divK_loop_body_n4_call_addback_spec
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp j] at TF
-  rw [u_addr8_eq_n4 sp j] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -79,9 +79,9 @@ theorem divK_loop_body_n4_max_skip_j0_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     uTop u3 v3 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u3 vtopBase uTop v3 v2Old base
@@ -216,9 +216,9 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
@@ -315,9 +315,9 @@ theorem divK_loop_body_n4_max_addback_j0_beq_spec
   have TF := divK_trial_max_full_spec sp (0 : Word) (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     uTop u3 v3 base hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     (0 : Word) u3 vtopBase uTop v3 v2Old base
@@ -452,9 +452,9 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
   dsimp only [] at TF
-  rw [u_addr_eq_n4 sp (0 : Word)] at TF
-  rw [u_addr8_eq_n4 sp (0 : Word)] at TF
-  rw [vtop_eq_v3_n4 sp] at TF
+  rw [u_addr_eq_n4] at TF
+  rw [u_addr8_eq_n4] at TF
+  rw [vtop_eq_v3_n4] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
     rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base


### PR DESCRIPTION
## Summary

- Flip three n=4 address-rewrite lemmas in `LoopBodyN4.lean` from positional to implicit:
  - `u_addr_eq_n4 (sp j : Word)` → `{sp j : Word}`
  - `u_addr8_eq_n4 (sp j : Word)` → `{sp j : Word}`
  - `vtop_eq_v3_n4 (sp : Word)` → `{sp : Word}`
- Drop redundant positional args at all `rw [...]` call sites in `LoopBodyN4.lean` and `LoopIterN4.lean`.

Completes the n-variant sweep: #964 (n=1), #965 (n=2), #967 (n=3), this (n=4).

## Why it's safe

All callers are `rw [lemma ...]` which pattern-matches the LHS against the goal — the args are fully determined by unification, so positional passing is pure noise.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)