### PR TITLE
refactor(DivMod/LoopCompose): flip sp arg on address-overlap lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -33,25 +33,25 @@ open EvmAsm.Rv64
 -- ============================================================================
 
 /-- j=3 un0 at uBase(3)+0 = j=2 u1 at uBase(2)-8 -/
-theorem u_n1_j3_0_eq_j2_4088 (sp : Word) :
+theorem u_n1_j3_0_eq_j2_4088 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- j=3 un1 at uBase(3)-8 = j=2 u2 at uBase(2)-16 -/
-theorem u_n1_j3_4088_eq_j2_4080 (sp : Word) :
+theorem u_n1_j3_4088_eq_j2_4080 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- j=3 un2 at uBase(3)-16 = j=2 u3 at uBase(2)-24 -/
-theorem u_n1_j3_4080_eq_j2_4072 (sp : Word) :
+theorem u_n1_j3_4080_eq_j2_4072 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- j=3 un3 at uBase(3)+4072 = j=2 uTop at uBase(2)+4064 -/
-theorem u_n1_j3_4072_eq_j2_4064 (sp : Word) :
+theorem u_n1_j3_4072_eq_j2_4064 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
@@ -64,25 +64,25 @@ theorem u_n1_j3_4072_eq_j2_4064 (sp : Word) :
 -- ============================================================================
 
 /-- j=2 un0 at uBase(2)+0 = j=1 u1 at uBase(1)-8 -/
-theorem u_n1_j2_0_eq_j1_4088 (sp : Word) :
+theorem u_n1_j2_0_eq_j1_4088 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- j=2 un1 at uBase(2)-8 = j=1 u2 at uBase(1)-16 -/
-theorem u_n1_j2_4088_eq_j1_4080 (sp : Word) :
+theorem u_n1_j2_4088_eq_j1_4080 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- j=2 un2 at uBase(2)-16 = j=1 u3 at uBase(1)-24 -/
-theorem u_n1_j2_4080_eq_j1_4072 (sp : Word) :
+theorem u_n1_j2_4080_eq_j1_4072 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- j=2 un3 at uBase(2)+4072 = j=1 uTop at uBase(1)+4064 -/
-theorem u_n1_j2_4072_eq_j1_4064 (sp : Word) :
+theorem u_n1_j2_4072_eq_j1_4064 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
@@ -95,25 +95,25 @@ theorem u_n1_j2_4072_eq_j1_4064 (sp : Word) :
 -- ============================================================================
 
 /-- j=1 un0 at uBase(1)+0 = j=0 u1 at uBase(0)-8 -/
-theorem u_n1_j1_0_eq_j0_4088 (sp : Word) :
+theorem u_n1_j1_0_eq_j0_4088 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- j=1 un1 at uBase(1)-8 = j=0 u2 at uBase(0)-16 -/
-theorem u_n1_j1_4088_eq_j0_4080 (sp : Word) :
+theorem u_n1_j1_4088_eq_j0_4080 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- j=1 un2 at uBase(1)-16 = j=0 u3 at uBase(0)-24 -/
-theorem u_n1_j1_4080_eq_j0_4072 (sp : Word) :
+theorem u_n1_j1_4080_eq_j0_4072 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- j=1 un3 at uBase(1)+4072 = j=0 uTop at uBase(0)+4064 -/
-theorem u_n1_j1_4072_eq_j0_4064 (sp : Word) :
+theorem u_n1_j1_4072_eq_j0_4064 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -33,25 +33,25 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 -- ============================================================================
 
 /-- j=2 un0 at uBase(2)+0 = j=1 u1 at uBase(1)-8 -/
-theorem u_j2_0_eq_j1_4088 (sp : Word) :
+theorem u_j2_0_eq_j1_4088 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- j=2 un1 at uBase(2)-8 = j=1 u2 at uBase(1)-16 -/
-theorem u_j2_4088_eq_j1_4080 (sp : Word) :
+theorem u_j2_4088_eq_j1_4080 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- j=2 un2 at uBase(2)-16 = j=1 u3 at uBase(1)-24 -/
-theorem u_j2_4080_eq_j1_4072 (sp : Word) :
+theorem u_j2_4080_eq_j1_4072 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- j=2 un3 at uBase(2)-24 = j=1 uTop at uBase(1)-32 -/
-theorem u_j2_4072_eq_j1_4064 (sp : Word) :
+theorem u_j2_4072_eq_j1_4064 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
@@ -450,8 +450,8 @@ theorem divK_loop_n2_max_max_spec
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -531,8 +531,8 @@ theorem divK_loop_n2_call_call_spec
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -619,8 +619,8 @@ theorem divK_loop_n2_max_call_spec
       delta loopIterPostN2Max loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -705,8 +705,8 @@ theorem divK_loop_n2_call_max_spec
       delta loopIterPostN2Call loopExitPostN2 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -27,25 +27,25 @@ open EvmAsm.Evm64.DivMod.AddrNorm (jpred_1)
 -- ============================================================================
 
 /-- j=1 un0 at uBase(1)+0 = j=0 u1 at uBase(0)-8 -/
-theorem u_j1_0_eq_j0_4088 (sp : Word) :
+theorem u_j1_0_eq_j0_4088 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 0 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 := by
   divmod_addr
 
 /-- j=1 un1 at uBase(1)-8 = j=0 u2 at uBase(0)-16 -/
-theorem u_j1_4088_eq_j0_4080 (sp : Word) :
+theorem u_j1_4088_eq_j0_4080 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 := by
   divmod_addr
 
 /-- j=1 un2 at uBase(1)-16 = j=0 u3 at uBase(0)-24 -/
-theorem u_j1_4080_eq_j0_4072 (sp : Word) :
+theorem u_j1_4080_eq_j0_4072 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 := by
   divmod_addr
 
 /-- j=1 un3 at uBase(1)-24 = j=0 uTop at uBase(0)-32 -/
-theorem u_j1_4072_eq_j0_4064 (sp : Word) :
+theorem u_j1_4072_eq_j0_4064 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 := by
   divmod_addr
@@ -108,8 +108,8 @@ theorem divK_loop_n3_max_skip_skip_spec
       delta loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -412,8 +412,8 @@ theorem divK_loop_n3_max_max_spec
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -498,8 +498,8 @@ theorem divK_loop_n3_call_call_spec
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -586,8 +586,8 @@ theorem divK_loop_n3_max_call_spec
       delta loopIterPostN3Max loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f
@@ -671,8 +671,8 @@ theorem divK_loop_n3_call_max_spec
       delta loopIterPostN3Call loopExitPostN3 loopExitPost at hp
       simp only [] at hp ⊢
       have hj' := jpred_1
-      rw [hj', u_j1_0_eq_j0_4088 sp, u_j1_4088_eq_j0_4080 sp,
-          u_j1_4080_eq_j0_4072 sp, u_j1_4072_eq_j0_4064 sp] at hp
+      rw [hj', u_j1_0_eq_j0_4088, u_j1_4088_eq_j0_4080,
+          u_j1_4080_eq_j0_4072, u_j1_4072_eq_j0_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J1f J0f

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN1.lean
@@ -113,8 +113,8 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
         have hj' := jpred_1
-        rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
-            u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
+        rw [hj', u_n1_j1_0_eq_j0_4088, u_n1_j1_4088_eq_j0_4080,
+            u_n1_j1_4080_eq_j0_4072, u_n1_j1_4072_eq_j0_4064] at hp
         rw [sepConj_assoc'] at hp
         xperm_hyp hp)
       J1f J0f
@@ -180,8 +180,8 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
         delta loopIterPostN1Max loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
         have hj' := jpred_1
-        rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
-            u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
+        rw [hj', u_n1_j1_0_eq_j0_4088, u_n1_j1_4088_eq_j0_4080,
+            u_n1_j1_4080_eq_j0_4072, u_n1_j1_4072_eq_j0_4064] at hp
         rw [sepConj_assoc'] at hp
         xperm_hyp hp)
       J1f J0f
@@ -248,8 +248,8 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
         have hj' := jpred_1
-        rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
-            u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
+        rw [hj', u_n1_j1_0_eq_j0_4088, u_n1_j1_4088_eq_j0_4080,
+            u_n1_j1_4080_eq_j0_4072, u_n1_j1_4072_eq_j0_4064] at hp
         rw [sepConj_assoc'] at hp
         xperm_hyp hp)
       J1f J0f
@@ -314,8 +314,8 @@ theorem divK_loop_n1_iter10_unified_spec (bltu_1 bltu_0 : Bool)
         delta loopIterPostN1Call loopExitPostN1 loopExitPost at hp
         simp only [] at hp ⊢
         have hj' := jpred_1
-        rw [hj', u_n1_j1_0_eq_j0_4088 sp, u_n1_j1_4088_eq_j0_4080 sp,
-            u_n1_j1_4080_eq_j0_4072 sp, u_n1_j1_4072_eq_j0_4064 sp] at hp
+        rw [hj', u_n1_j1_0_eq_j0_4088, u_n1_j1_4088_eq_j0_4080,
+            u_n1_j1_4080_eq_j0_4072, u_n1_j1_4072_eq_j0_4064] at hp
         rw [sepConj_assoc'] at hp
         xperm_hyp hp)
       J1f J0f
@@ -401,8 +401,8 @@ theorem divK_loop_n1_max_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_2
-      rw [hj', u_n1_j2_0_eq_j1_4088 sp, u_n1_j2_4088_eq_j1_4080 sp,
-          u_n1_j2_4080_eq_j1_4072 sp, u_n1_j2_4072_eq_j1_4064 sp] at hp
+      rw [hj', u_n1_j2_0_eq_j1_4088, u_n1_j2_4088_eq_j1_4080,
+          u_n1_j2_4080_eq_j1_4072, u_n1_j2_4072_eq_j1_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J2f H10f
@@ -481,8 +481,8 @@ theorem divK_loop_n1_call_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopN1Iter10PreWithScratch loopN1Iter10Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_2
-      rw [hj', u_n1_j2_0_eq_j1_4088 sp, u_n1_j2_4088_eq_j1_4080 sp,
-          u_n1_j2_4080_eq_j1_4072 sp, u_n1_j2_4072_eq_j1_4064 sp] at hp
+      rw [hj', u_n1_j2_0_eq_j1_4088, u_n1_j2_4088_eq_j1_4080,
+          u_n1_j2_4080_eq_j1_4072, u_n1_j2_4072_eq_j1_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J2f H10f
@@ -642,8 +642,8 @@ theorem divK_loop_n1_max_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_3
-      rw [hj', u_n1_j3_0_eq_j2_4088 sp, u_n1_j3_4088_eq_j2_4080 sp,
-          u_n1_j3_4080_eq_j2_4072 sp, u_n1_j3_4072_eq_j2_4064 sp] at hp
+      rw [hj', u_n1_j3_0_eq_j2_4088, u_n1_j3_4088_eq_j2_4080,
+          u_n1_j3_4080_eq_j2_4072, u_n1_j3_4072_eq_j2_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J3f H210f
@@ -749,8 +749,8 @@ theorem divK_loop_n1_call_iter210_spec (bltu_2 bltu_1 bltu_0 : Bool)
       delta loopN1Iter210PreWithScratch loopN1Iter210Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_3
-      rw [hj', u_n1_j3_0_eq_j2_4088 sp, u_n1_j3_4088_eq_j2_4080 sp,
-          u_n1_j3_4080_eq_j2_4072 sp, u_n1_j3_4072_eq_j2_4064 sp] at hp
+      rw [hj', u_n1_j3_0_eq_j2_4088, u_n1_j3_4088_eq_j2_4080,
+          u_n1_j3_4080_eq_j2_4072, u_n1_j3_4072_eq_j2_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J3f H210f

--- a/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopUnifiedN2.lean
@@ -180,8 +180,8 @@ theorem divK_loop_n2_max_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_2
-      rw [hj', u_j2_0_eq_j1_4088 sp, u_j2_4088_eq_j1_4080 sp,
-          u_j2_4080_eq_j1_4072 sp, u_j2_4072_eq_j1_4064 sp] at hp
+      rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+          u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J2f H10f
@@ -255,8 +255,8 @@ theorem divK_loop_n2_call_iter10_spec (bltu_1 bltu_0 : Bool)
       delta loopN2Iter10PreWithScratch loopN2Iter10Pre at ⊢
       simp only [] at hp ⊢
       have hj' := jpred_2
-      rw [hj', u_j2_0_eq_j1_4088 sp, u_j2_4088_eq_j1_4080 sp,
-          u_j2_4080_eq_j1_4072 sp, u_j2_4072_eq_j1_4064 sp] at hp
+      rw [hj', u_j2_0_eq_j1_4088, u_j2_4088_eq_j1_4080,
+          u_j2_4080_eq_j1_4072, u_j2_4072_eq_j1_4064] at hp
       rw [sepConj_assoc'] at hp
       xperm_hyp hp)
     J2f H10f


### PR DESCRIPTION
## Summary

- Flip 20 `u_*_eq_*` address-overlap lemmas in `LoopComposeN{1,2,3}.lean` from `(sp : Word)` to `{sp : Word}`:
  - `LoopComposeN1.lean`: 12 lemmas (`u_n1_j{1,2,3}_*_eq_j{0,1,2}_*`)
  - `LoopComposeN2.lean`: 4 lemmas (`u_j2_*_eq_j1_*`)
  - `LoopComposeN3.lean`: 4 lemmas (`u_j1_*_eq_j0_*`)
- Drop the trailing `sp` positional arg at all `rw [...]` call sites in `LoopUnifiedN{1,2}.lean` and `LoopComposeN{2,3}.lean`.

Continues the n=1..4 implicit-flip sweep from #964/#965/#967/#968 into the LoopCompose tier.

## Why it's safe

All callers are `rw [lemma sp]` which pattern-matches the LHS of the equation against the goal — `sp` is uniquely determined by unification, so positional passing is pure noise.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)