### PR TITLE
refactor(DivMod/Compose/FullPath*Loop): flip sp arg on uBase/qAddr lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -38,23 +38,23 @@ theorem x1_val_n1 : signExtend12 (4 : BitVec 12) - (1 : Word) = (3 : Word) := by
 -- uBase(3)-24    = sp+se(4008)  [u3]
 -- uBase(3)-32    = sp+se(4000)  [uTop]
 
-theorem n1_ub3_off0 (sp : Word) :
+theorem n1_ub3_off0 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4032 := by
   divmod_addr
-theorem n1_ub3_off4088 (sp : Word) :
+theorem n1_ub3_off4088 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4024 := by
   divmod_addr
-theorem n1_ub3_off4080 (sp : Word) :
+theorem n1_ub3_off4080 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4016 := by
   divmod_addr
-theorem n1_ub3_off4072 (sp : Word) :
+theorem n1_ub3_off4072 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4008 := by
   divmod_addr
-theorem n1_ub3_off4064 (sp : Word) :
+theorem n1_ub3_off4064 {sp : Word} :
     (sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4000 := by
   divmod_addr
@@ -64,7 +64,7 @@ theorem n1_ub3_off4064 (sp : Word) :
 -- uBase(0)+0 = sp+se(4056), already covered by n3_ub0_off0
 
 -- qAddr(j) = sp + se(4088) - j<<<3
-theorem n1_qa3 (sp : Word) :
+theorem n1_qa3 {sp : Word} :
     sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4064 := by
   divmod_addr
 -- n1_qa2 = n2_qa2 (same: sp + se(4088) - 16 = sp + se(4072))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -271,12 +271,12 @@ theorem evm_div_n1_preloop_loop_unified_spec
       simp only [x1_val_n1] at hp
       delta loopN1PreWithScratch loopN1Pre
       simp only []
-      simp only [n1_ub3_off0 sp, n1_ub3_off4088 sp, n1_ub3_off4080 sp,
-                  n1_ub3_off4072 sp, n1_ub3_off4064 sp,
-                  n2_ub2_off0 sp,
-                  n3_ub1_off0 sp,
-                  n3_ub0_off0 sp,
-                  n1_qa3 sp, n2_qa2 sp, n3_qa1 sp, n3_qa0 sp,
+      simp only [n1_ub3_off0, n1_ub3_off4088, n1_ub3_off4080,
+                  n1_ub3_off4072, n1_ub3_off4064,
+                  n2_ub2_off0,
+                  n3_ub1_off0,
+                  n3_ub0_off0,
+                  n1_qa3, n2_qa2, n3_qa1, n3_qa0,
                   se12_32, se12_40, se12_48, se12_56]
       xperm_hyp hp) hPreF hLoopF
   exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -38,23 +38,23 @@ theorem x1_val_n2 : signExtend12 (4 : BitVec 12) - (2 : Word) = (2 : Word) := by
 -- uBase(2)-24    = sp+se(4016)  [u3]
 -- uBase(2)-32    = sp+se(4008)  [uTop]
 
-theorem n2_ub2_off0 (sp : Word) :
+theorem n2_ub2_off0 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4040 := by
   divmod_addr
-theorem n2_ub2_off4088 (sp : Word) :
+theorem n2_ub2_off4088 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4032 := by
   divmod_addr
-theorem n2_ub2_off4080 (sp : Word) :
+theorem n2_ub2_off4080 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4024 := by
   divmod_addr
-theorem n2_ub2_off4072 (sp : Word) :
+theorem n2_ub2_off4072 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4016 := by
   divmod_addr
-theorem n2_ub2_off4064 (sp : Word) :
+theorem n2_ub2_off4064 {sp : Word} :
     (sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4008 := by
   divmod_addr
@@ -63,7 +63,7 @@ theorem n2_ub2_off4064 (sp : Word) :
 -- uBase(0)+0 = sp+se(4056), already covered by n3_ub0_off0
 
 -- qAddr(j) = sp + se(4088) - j<<<3
-theorem n2_qa2 (sp : Word) :
+theorem n2_qa2 {sp : Word} :
     sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4072 := by
   divmod_addr
 -- n2_qa1 = n3_qa1 (same: sp + se(4088) - 8 = sp + se(4080))

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2LoopUnified.lean
@@ -236,11 +236,11 @@ theorem evm_div_n2_preloop_loop_unified_spec
       simp only [x1_val_n2] at hp
       delta loopN2PreWithScratch loopN2Pre
       simp only []
-      simp only [n2_ub2_off0 sp, n2_ub2_off4088 sp, n2_ub2_off4080 sp,
-                  n2_ub2_off4072 sp, n2_ub2_off4064 sp,
-                  n3_ub1_off0 sp,
-                  n3_ub0_off0 sp,
-                  n2_qa2 sp, n3_qa1 sp, n3_qa0 sp,
+      simp only [n2_ub2_off0, n2_ub2_off4088, n2_ub2_off4080,
+                  n2_ub2_off4072, n2_ub2_off4064,
+                  n3_ub1_off0,
+                  n3_ub0_off0,
+                  n2_qa2, n3_qa1, n3_qa0,
                   se12_32, se12_40, se12_48, se12_56]
       xperm_hyp hp) hPreF hLoopF
   exact cpsTriple_weaken

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -30,34 +30,34 @@ theorem x1_val_n3 : signExtend12 (4 : BitVec 12) - (3 : Word) = (1 : Word) := by
 -- Address normalization: signExtend12/<<</>> → concrete values via simp, then bv_omega.
 -- bv_addr only handles (a+k1)+k2=a+k3; these involve subtraction and shifts.
 -- Pattern matches LoopComposeN3.lean.
-theorem n3_ub1_off0 (sp : Word) :
+theorem n3_ub1_off0 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4048 := by
   divmod_addr
-theorem n3_ub1_off4088 (sp : Word) :
+theorem n3_ub1_off4088 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4088 =
     sp + signExtend12 4040 := by
   divmod_addr
-theorem n3_ub1_off4080 (sp : Word) :
+theorem n3_ub1_off4080 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4080 =
     sp + signExtend12 4032 := by
   divmod_addr
-theorem n3_ub1_off4072 (sp : Word) :
+theorem n3_ub1_off4072 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4072 =
     sp + signExtend12 4024 := by
   divmod_addr
-theorem n3_ub1_off4064 (sp : Word) :
+theorem n3_ub1_off4064 {sp : Word} :
     (sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 4064 =
     sp + signExtend12 4016 := by
   divmod_addr
-theorem n3_ub0_off0 (sp : Word) :
+theorem n3_ub0_off0 {sp : Word} :
     (sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat) + signExtend12 (0 : BitVec 12) =
     sp + signExtend12 4056 := by
   divmod_addr
-theorem n3_qa1 (sp : Word) :
+theorem n3_qa1 {sp : Word} :
     sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4080 := by
   divmod_addr
-theorem n3_qa0 (sp : Word) :
+theorem n3_qa0 {sp : Word} :
     sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat = sp + signExtend12 4088 := by
   divmod_addr
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -201,9 +201,9 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
       simp only [x1_val_n3] at hp
       delta loopN3PreWithScratch loopN3Pre
       simp only []
-      simp only [n3_ub1_off0 sp, n3_ub1_off4088 sp, n3_ub1_off4080 sp,
-                  n3_ub1_off4072 sp, n3_ub1_off4064 sp, n3_ub0_off0 sp,
-                  n3_qa1 sp, n3_qa0 sp, se12_32, se12_40, se12_48, se12_56]
+      simp only [n3_ub1_off0, n3_ub1_off4088, n3_ub1_off4080,
+                  n3_ub1_off4072, n3_ub1_off4064, n3_ub0_off0,
+                  n3_qa1, n3_qa0, se12_32, se12_40, se12_48, se12_56]
       xperm_hyp hp) hPreF hLoopF
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
## Summary

- Flip 20 `n{1,2,3}_ub*_off*` / `n{1,2,3}_qa*` address lemmas in `FullPathN{1,2,3}Loop.lean` from `(sp : Word)` to `{sp : Word}`.
- Drop the trailing `sp` at all `simp only [lemma sp, ...]` call sites in `FullPathN{1,2,3}LoopUnified.lean`.

Continues the implicit-flip sweep from #970 (LoopCompose tier) into the FullPath compose tier.

## Why it's safe

All callers are `simp only [lemma sp, ...]` — simp unifies each lemma's LHS against the goal, so `sp` is fully determined by pattern-matching. Positional arg is redundant.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)