### PR TITLE
refactor(DivMod/Compose): flip sp arg on ModPhaseB tail-addr + divScratchOwn unfold lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -344,7 +344,7 @@ def divScratchOwn (sp : Word) : Assertion :=
 /-- Named unfold for `divScratchOwn`. Restores access to the underlying
     definition once the `@[irreducible]` attribute has made `delta` the only
     way in at call sites. Parallel to `divScratchValues_unfold`. -/
-theorem divScratchOwn_unfold (sp : Word) :
+theorem divScratchOwn_unfold {sp : Word} :
     divScratchOwn sp =
     (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
      memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
@@ -406,7 +406,7 @@ def divScratchOwnCall (sp : Word) : Assertion :=
 
 /-- Named unfold for `divScratchOwnCall`. Parallel to `divScratchOwn_unfold`
     and `divScratchValuesCall_unfold`. -/
-theorem divScratchOwnCall_unfold (sp : Word) :
+theorem divScratchOwnCall_unfold {sp : Word} :
     divScratchOwnCall sp =
     (divScratchOwn sp **
      memOwn (sp + signExtend12 3968) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -99,7 +99,7 @@ theorem mod_phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by 
 theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
 theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
 -- `mod_signExtend13_24` → use `se13_24` from `Compose/Base.lean`.
-theorem mod_phB_sp24_32 (sp : Word) :
+theorem mod_phB_sp24_32 {sp : Word} :
     sp + ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat +
       signExtend12 (32 : BitVec 12) = sp + 56 := by
   simp only [se12_4095, se12_32]
@@ -269,11 +269,11 @@ theorem mod_phB_step2_8 (base : Word) : (base + 88 : Word) + 4 = base + 92 := by
 theorem mod_phB_fall_4 (base : Word) : (base + 92 : Word) + 4 = base + 96 := by bv_addr
 
 -- Tail memory address normalization
-theorem mod_phB_sp16_32 (sp : Word) :
+theorem mod_phB_sp16_32 {sp : Word} :
     (sp + (16 : Word) + (32 : Word)) = sp + 48 := by bv_addr
-theorem mod_phB_sp8_32 (sp : Word) :
+theorem mod_phB_sp8_32 {sp : Word} :
     (sp + (8 : Word) + (32 : Word)) = sp + 40 := by bv_addr
-theorem mod_phB_sp0_32 (sp : Word) :
+theorem mod_phB_sp0_32 {sp : Word} :
     (sp + (0 : Word) + (32 : Word)) = sp + 32 := by bv_addr
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Flip 6 lemmas from `(sp : Word)` to `{sp : Word}`:
- `mod_phB_sp{24,16,8,0}_32` in `ModPhaseB.lean` — tail memory address normalization
- `divScratchOwn_unfold`, `divScratchOwnCall_unfold` in `Compose/Base.lean` — named unfolds

No call sites need updating — every current caller uses `rw [lemma]` or `simp only [lemma, ...]` without positional `sp`. Pure signature cleanup.

Continues the implicit-sp sweep from #970, #971, #972.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)