### PR TITLE
refactor(DivMod/Compose/ModPhaseB): flip base arg on 9 PC-step address lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -94,10 +94,10 @@ theorem divK_phaseB_tail_code_sub_modCode (base : Word) :
 -- The former `mod_phB_off_28` (identical to PhaseAB's private `phB_off_28`)
 -- now lives in `Compose/Base.lean` as the shared `phB_off_28` and is used
 -- directly from both the DIV and MOD sides.
-theorem mod_phB_i2_8 (base : Word) : (base + 60 : Word) + 8 = base + 68 := by bv_addr
-theorem mod_phB_addi_4 (base : Word) : (base + 68 : Word) + 4 = base + 72 := by bv_addr
-theorem mod_phB_bne_4 (base : Word) : (base + 72 : Word) + 4 = base + 76 := by bv_addr
-theorem mod_phB_t_20 (base : Word) : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
+theorem mod_phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+theorem mod_phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + 72 := by bv_addr
+theorem mod_phB_bne_4 {base : Word} : (base + 72 : Word) + 4 = base + 76 := by bv_addr
+theorem mod_phB_t_20 {base : Word} : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
 -- `mod_signExtend13_24` → use `se13_24` from `Compose/Base.lean`.
 theorem mod_phB_sp24_32 (sp : Word) :
     sp + ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat +
@@ -262,11 +262,11 @@ theorem mod_divK_phaseB_n1_nm1_x8 :
   decide
 
 -- Cascade address normalization
-theorem mod_phB_step1_4 (base : Word) : (base + 76 : Word) + 4 = base + 80 := by bv_addr
-theorem mod_phB_step1_8 (base : Word) : (base + 80 : Word) + 4 = base + 84 := by bv_addr
-theorem mod_phB_step2_4 (base : Word) : (base + 84 : Word) + 4 = base + 88 := by bv_addr
-theorem mod_phB_step2_8 (base : Word) : (base + 88 : Word) + 4 = base + 92 := by bv_addr
-theorem mod_phB_fall_4 (base : Word) : (base + 92 : Word) + 4 = base + 96 := by bv_addr
+theorem mod_phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by bv_addr
+theorem mod_phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
+theorem mod_phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
+theorem mod_phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
+theorem mod_phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + 96 := by bv_addr
 
 -- Tail memory address normalization
 theorem mod_phB_sp16_32 (sp : Word) :


### PR DESCRIPTION
## Summary

Flip 9 PC-step address lemmas in `ModPhaseB.lean` from `(base : Word)` to `{base : Word}`:
- `mod_phB_i2_8`, `mod_phB_addi_4`, `mod_phB_bne_4`, `mod_phB_t_20`
- `mod_phB_step1_4`, `mod_phB_step1_8`, `mod_phB_step2_4`, `mod_phB_step2_8`, `mod_phB_fall_4`

No call sites need updating — every current caller in `ModPhaseB.lean`, `ModPhaseBn3.lean`, `ModPhaseBn21.lean` uses `simp only [lemma, ...]` / `simp only [..., lemma, ...]` without positional `base`.

Companion to #973 which flipped the `sp`-taking lemmas in the same file.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)