### PR TITLE
refactor(DivMod/Compose): flip base arg on clz_addr0..6 + phB_off_28 to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -669,7 +669,7 @@ instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
 -- in PhaseAB.lean and `mod_phB_off_28` in ModPhaseB.lean.
 -- ============================================================================
 
-theorem phB_off_28 (base : Word) : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
+theorem phB_off_28 {base : Word} : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
 
 -- n=4 special: x1 = signExtend12 4 - 4 = 0, used by the shift-0 fast path
 -- and the main `FullPathN4` path. Shared here so the two consumer files

--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -96,13 +96,13 @@ noncomputable def clzResult (val : Word) : Word × Word :=
   (c5, v4)
 
 -- Address lemmas for CLZ stages
-private theorem clz_addr0 (base : Word) : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
-private theorem clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_addr
-private theorem clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_addr
-private theorem clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_addr
-private theorem clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_addr
-private theorem clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_addr
-private theorem clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
+private theorem clz_addr0 {base : Word} : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
+private theorem clz_addr1 {base : Word} : (base + 120 : Word) + 16 = base + 136 := by bv_addr
+private theorem clz_addr2 {base : Word} : (base + 136 : Word) + 16 = base + 152 := by bv_addr
+private theorem clz_addr3 {base : Word} : (base + 152 : Word) + 16 = base + 168 := by bv_addr
+private theorem clz_addr4 {base : Word} : (base + 168 : Word) + 16 = base + 184 := by bv_addr
+private theorem clz_addr5 {base : Word} : (base + 184 : Word) + 16 = base + 200 := by bv_addr
+private theorem clz_addr6 {base : Word} : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     After stage: val' = if (val>>>K≠0) then val else val<<<M_s,


### PR DESCRIPTION
## Summary

Flip 8 PC-step address lemmas from `(base : Word)` to `{base : Word}`:
- `clz_addr0`..`clz_addr6` in `Compose/CLZ.lean` (7 private lemmas used as `rw [clz_addr*]`)
- `phB_off_28` in `Compose/Base.lean` (used in 7 `simp only [phB_off_28]` sites across PhaseAB, ModPhaseB, ModPhaseBn{3,21})

No call sites need updating — every caller uses the lemma bare; `rw` / `simp` unification resolves `base` from the goal.

Continues the implicit-base sweep from #975.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)