### PR TITLE
feat(ci): remove review bot from PR default

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -1,8 +1,6 @@
   name: PR Review
 
   on:
-    pull_request:
-      types: [opened]
     issue_comment:
       types: [created]
 


### PR DESCRIPTION
Still supposed to be available with /review command.