### PR TITLE
refactor(DivMod/Compose/ModCLZ): flip base arg on mod_clz_addr0..6 to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
@@ -63,13 +63,13 @@ private theorem clz_init_sub_mod (base : Word) :
         base + clzOff + BitVec.ofNat 64 (4 * 0) from by bv_addr] at h))
 
 -- Address lemmas for CLZ stages (reused from CLZ.lean, but those are private so we redefine)
-private theorem mod_clz_addr0 (base : Word) : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
-private theorem mod_clz_addr1 (base : Word) : (base + 120 : Word) + 16 = base + 136 := by bv_addr
-private theorem mod_clz_addr2 (base : Word) : (base + 136 : Word) + 16 = base + 152 := by bv_addr
-private theorem mod_clz_addr3 (base : Word) : (base + 152 : Word) + 16 = base + 168 := by bv_addr
-private theorem mod_clz_addr4 (base : Word) : (base + 168 : Word) + 16 = base + 184 := by bv_addr
-private theorem mod_clz_addr5 (base : Word) : (base + 184 : Word) + 16 = base + 200 := by bv_addr
-private theorem mod_clz_addr6 (base : Word) : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
+private theorem mod_clz_addr0 {base : Word} : (base + clzOff : Word) + 4 = base + 120 := by bv_addr
+private theorem mod_clz_addr1 {base : Word} : (base + 120 : Word) + 16 = base + 136 := by bv_addr
+private theorem mod_clz_addr2 {base : Word} : (base + 136 : Word) + 16 = base + 152 := by bv_addr
+private theorem mod_clz_addr3 {base : Word} : (base + 152 : Word) + 16 = base + 168 := by bv_addr
+private theorem mod_clz_addr4 {base : Word} : (base + 168 : Word) + 16 = base + 184 := by bv_addr
+private theorem mod_clz_addr5 {base : Word} : (base + 184 : Word) + 16 = base + 200 := by bv_addr
+private theorem mod_clz_addr6 {base : Word} : (base + 200 : Word) + 12 = base + phaseC2Off := by bv_addr
 
 /-- Combined CLZ stage: handles both taken and ntaken with conditional postcondition.
     (Reused from CLZ.lean — the stage specs are code-generic, only subsumption differs.) -/


### PR DESCRIPTION
## Summary

Flip 7 private PC-step address lemmas in `Compose/ModCLZ.lean` from `(base : Word)` to `{base : Word}` — mirror of the DIV-side `clz_addr0..6` already flipped in #977.

All callers are bare `rw [mod_clz_addr*] at *e`. No call-site changes needed.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)