### PR TITLE
feat(divmod): Phase 1a/1b monotonicity + tight q1' bound — KB-3d + KB-3e (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -1131,4 +1131,102 @@ theorem div128Quot_q1_le_pow32_plus_one (uHi dHi dLo : Word)
   have h_expand : (2^32 + 2) * dHi.toNat = dHi.toNat * 2^32 + 2 * dHi.toNat := by ring
   omega
 
+/-- **KB-3d1: Phase 1a monotonicity.** The post-correction quotient `q1c`
+    is never larger than the pre-correction `q1`:
+
+    ```
+    q1c.toNat ≤ q1.toNat
+    ```
+
+    - No-correction branch (`hi1 = 0`): `q1c = q1`, equality.
+    - Correction branch (`hi1 ≠ 0`): `q1c = q1 - 1 < q1` at Nat, using
+      `hi1 ≠ 0 → q1 ≥ 2^32 ≥ 1`. -/
+theorem div128Quot_q1c_le_q1 (uHi dHi : Word) :
+    let q1 := rv64_divu uHi dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    q1c.toNat ≤ q1.toNat := by
+  intro q1 hi1 q1c
+  by_cases h_hi1 : hi1 = 0
+  · show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
+    rw [if_pos h_hi1]
+  · have hq1_ge : q1.toNat ≥ 2^32 := by
+      by_contra h
+      push_neg at h
+      apply h_hi1
+      apply BitVec.eq_of_toNat_eq
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      show q1.toNat / 2^32 = (0 : Word).toNat
+      rw [Nat.div_eq_of_lt h]
+      rfl
+    show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
+    rw [if_neg h_hi1]
+    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se_neg1]
+    have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
+    rw [show q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 from by omega,
+        Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
+    omega
+
+/-- **KB-3d2: Phase 1b monotonicity.** The post-Phase-1b quotient `q1'`
+    is never larger than the pre-Phase-1b `q1c`:
+
+    ```
+    q1'.toNat ≤ q1c.toNat
+    ```
+
+    - Check doesn't fire: `q1' = q1c`.
+    - Check fires: `q1' = q1c - 1 < q1c` (using
+      `div128Quot_phase1b_check_implies_q1c_pos` for the no-underflow). -/
+theorem div128Quot_q1_prime_le_q1c (q1c dLo rhatUn1 : Word) :
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    q1'.toNat ≤ q1c.toNat := by
+  intro q1'
+  by_cases h_check : BitVec.ult rhatUn1 (q1c * dLo)
+  · have h_q1c_pos := div128Quot_phase1b_check_implies_q1c_pos q1c dLo rhatUn1 h_check
+    show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat ≤ _
+    rw [if_pos h_check]
+    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se_neg1]
+    have h_q1c_lt : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
+    rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
+        Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt]
+    omega
+  · show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat ≤ _
+    rw [if_neg h_check]
+
+/-- **KB-3e: Tight post-Phase-1b bound on q1' under hcall.** Composes
+    `div128Quot_q1_le_pow32_plus_one` (q1 ≤ 2^32 + 1 under hcall) with
+    the Phase 1a/1b monotonicity lemmas to give:
+
+    ```
+    q1'.toNat ≤ 2^32 + 1
+    ```
+
+    under `uHi.toNat < dHi.toNat * 2^32 + dLo.toNat` (the call-trial
+    precondition). Tightens `div128Quot_q1_prime_lt_pow33` (`< 2^33`)
+    by roughly a factor of 2.
+
+    Used in Phase 2 analysis: with q1' ≤ 2^32 + 1 and dLo < 2^32, the
+    product q1' * dLo ≤ (2^32 + 1) * 2^32 ≈ 2^64, so we're at the edge
+    of the 64-bit range but not overflowing by much. -/
+theorem div128Quot_q1_prime_le_pow32_plus_one (uHi dHi dLo rhatUn1 : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q1 := rv64_divu uHi dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    q1'.toNat ≤ 2^32 + 1 := by
+  intro q1 hi1 q1c q1'
+  have h_q1_le : q1.toNat ≤ 2^32 + 1 :=
+    div128Quot_q1_le_pow32_plus_one uHi dHi dLo hdHi_ge hdLo_lt huHi_lt_vTop
+  have h_q1c_le_q1 : q1c.toNat ≤ q1.toNat := div128Quot_q1c_le_q1 uHi dHi
+  have h_q1'_le_q1c : q1'.toNat ≤ q1c.toNat := div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
+  omega
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Combines monotonicity lemmas (originally in #976) with a follow-up tight bound into one coherent PR. **Supersedes #976** — please close that PR.

### KB-3d (monotonicity)
- \`div128Quot_q1c_le_q1\`: Phase 1a correction only decrements (when it decrements), so \`q1c.toNat ≤ q1.toNat\`.
- \`div128Quot_q1_prime_le_q1c\`: Phase 1b multiplication-check correction similarly, so \`q1'.toNat ≤ q1c.toNat\`.

### KB-3e (tight q1' bound under hcall)
- \`div128Quot_q1_prime_le_pow32_plus_one\`: under the call-trial precondition \`uHi.toNat < dHi.toNat * 2^32 + dLo.toNat\`, we get \`q1'.toNat ≤ 2^32 + 1\`. Direct composition of KB-3c (\`div128Quot_q1_le_pow32_plus_one\`, #974) with the two monotonicity lemmas.

Tightens \`div128Quot_q1_prime_lt_pow33\` (\`< 2^33\`) by roughly a factor of 2 under the call-trial hypothesis. Useful for Phase 2 analysis bounding \`q1' * dLo\`.

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: KnuthTheoremB.lean ~1195 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)