### PR TITLE
feat(divmod): div128Quot_q1_prime_dLo_no_wrap — Knuth B KB-3f (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -1229,4 +1229,41 @@ theorem div128Quot_q1_prime_le_pow32_plus_one (uHi dHi dLo rhatUn1 : Word)
   have h_q1'_le_q1c : q1'.toNat ≤ q1c.toNat := div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
   omega
 
+/-- **KB-3f: No-wraparound for `q1' * dLo`.** Under the call-trial
+    precondition, the Word-level product equals the Nat-level product:
+
+    ```
+    (q1' * dLo).toNat = q1'.toNat * dLo.toNat
+    ```
+
+    Proof: from KB-3e, `q1'.toNat ≤ 2^32 + 1`; `dLo.toNat < 2^32`.  Hence
+    `q1'.toNat * dLo.toNat ≤ (2^32 + 1) * (2^32 - 1) = 2^64 - 1 < 2^64`.
+    Word multiplication therefore doesn't wrap, and `BitVec.toNat_mul`
+    gives the stated equality.
+
+    This is the key no-wraparound fact for subsequent Phase 2 analysis
+    (bounding `un21`, relating it to abstract dividend quantities). -/
+theorem div128Quot_q1_prime_dLo_no_wrap (uHi dHi dLo rhatUn1 : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q1 := rv64_divu uHi dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    (q1' * dLo).toNat = q1'.toNat * dLo.toNat := by
+  intro q1 hi1 q1c q1'
+  have h_q1'_le : q1'.toNat ≤ 2^32 + 1 :=
+    div128Quot_q1_prime_le_pow32_plus_one uHi dHi dLo rhatUn1
+      hdHi_ge hdLo_lt huHi_lt_vTop
+  -- q1'.toNat * dLo.toNat ≤ (2^32 + 1) * (2^32 - 1) = 2^64 - 1.
+  have h_mul_lt : q1'.toNat * dLo.toNat < 2^64 := by
+    have : q1'.toNat * dLo.toNat ≤ (2^32 + 1) * (2^32 - 1) := by
+      have hdLo_le : dLo.toNat ≤ 2^32 - 1 := by omega
+      exact Nat.mul_le_mul h_q1'_le hdLo_le
+    have h_eq : (2^32 + 1) * (2^32 - 1) = 2^64 - 1 := by decide
+    omega
+  rw [BitVec.toNat_mul, Nat.mod_eq_of_lt h_mul_lt]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
Under the call-trial precondition, the product \`q1' * dLo\` at the Word level equals the Nat-level product — **no wraparound**:

  \`(q1' * dLo).toNat = q1'.toNat * dLo.toNat\`

### Proof sketch
- From KB-3e (#981, merged): \`q1'.toNat ≤ 2^32 + 1\`.
- \`dLo.toNat < 2^32\`, so \`dLo.toNat ≤ 2^32 - 1\`.
- Product: \`q1'.toNat * dLo.toNat ≤ (2^32 + 1) * (2^32 - 1) = 2^64 - 1 < 2^64\`.
- Hence \`BitVec.toNat_mul\` + \`Nat.mod_eq_of_lt\` gives the equality.

### Why this matters

With \`q1' * dLo\` captured cleanly at Nat level, subsequent Phase 2 lemmas can relate \`un21\` (the Phase 2 dividend) to abstract quantities without BitVec-wraparound noise on this particular subterm.  A crucial ingredient for KB-4..KB-6 (Phase 2a/2b bounds + final assembly).

## Test plan
- [x] \`lake build\` passes (full project)
- [x] File size OK: KnuthTheoremB.lean ~1230 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)