### PR TITLE
refactor(Shift/Byte/SignExtend): flip base arg on 47 private PC-step lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -153,17 +153,17 @@ private theorem byte_beq_sub (base : Word) :
 -- ============================================================================
 
 -- Phase A offsets
-private theorem byte_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
-private theorem byte_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
-private theorem byte_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-private theorem byte_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem byte_off_36_20 (base : Word) : (base + 36 : Word) + 20 = base + 56 := by bv_omega
-private theorem byte_off_160_20 (base : Word) : (base + 160 : Word) + 20 = base + 180 := by bv_omega
+private theorem byte_off_20 {base : Word} : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem byte_off_24 {base : Word} : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem byte_off_28 {base : Word} : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem byte_off_32 {base : Word} : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem byte_off_36_20 {base : Word} : (base + 36 : Word) + 20 = base + 56 := by bv_omega
+private theorem byte_off_160_20 {base : Word} : (base + 160 : Word) + 20 = base + 180 := by bv_omega
 
 -- BNE/BEQ branch targets
-private theorem byte_bne_target (base : Word) : (base + 20 : Word) + signExtend13 140 = base + 160 := by
+private theorem byte_bne_target {base : Word} : (base + 20 : Word) + signExtend13 140 = base + 160 := by
   rv64_addr
-private theorem byte_beq_target (base : Word) : (base + 32 : Word) + signExtend13 128 = base + 160 := by
+private theorem byte_beq_target {base : Word} : (base + 32 : Word) + signExtend13 128 = base + 160 := by
   rv64_addr
 
 -- Phase C exit addresses

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -194,17 +194,17 @@ private theorem beq_sub_shrCode (base : Word) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem shr_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
-private theorem shr_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-private theorem shr_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
-private theorem shr_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
-private theorem shr_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-private theorem shr_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem shr_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
-private theorem shr_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
-private theorem shr_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
+private theorem shr_off_4 {base : Word} : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem shr_off_12 {base : Word} : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem shr_off_20 {base : Word} : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem shr_off_24 {base : Word} : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem shr_off_28 {base : Word} : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem shr_off_32 {base : Word} : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem shr_off_36_28 {base : Word} : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem shr_off_340_20 {base : Word} : (base + 340 : Word) + 20 = base + 360 := by bv_omega
+private theorem shr_bne_target {base : Word} : (base + 20 : Word) + signExtend13 320 = base + 340 := by
   rv64_addr
-private theorem shr_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
+private theorem shr_beq_target {base : Word} : (base + 32 : Word) + signExtend13 308 = base + 340 := by
   rv64_addr
 -- Phase C exit addresses
 private theorem shr_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -236,17 +236,17 @@ private theorem sign_fill_sub_sarCode (base : Word) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem sar_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
-private theorem sar_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-private theorem sar_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
-private theorem sar_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
-private theorem sar_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-private theorem sar_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem sar_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
-private theorem sar_off_352_28 (base : Word) : (base + 352 : Word) + 28 = base + 380 := by bv_omega
-private theorem sar_bne_target (base : Word) : (base + 20 : Word) + signExtend13 332 = base + 352 := by
+private theorem sar_off_4 {base : Word} : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem sar_off_12 {base : Word} : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem sar_off_20 {base : Word} : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem sar_off_24 {base : Word} : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem sar_off_28 {base : Word} : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem sar_off_32 {base : Word} : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem sar_off_36_28 {base : Word} : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem sar_off_352_28 {base : Word} : (base + 352 : Word) + 28 = base + 380 := by bv_omega
+private theorem sar_bne_target {base : Word} : (base + 20 : Word) + signExtend13 332 = base + 352 := by
   rv64_addr
-private theorem sar_beq_target (base : Word) : (base + 32 : Word) + signExtend13 320 = base + 352 := by
+private theorem sar_beq_target {base : Word} : (base + 32 : Word) + signExtend13 320 = base + 352 := by
   rv64_addr
 -- Phase C exit addresses
 private theorem sar_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 188 = base + 252 := by

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -184,17 +184,17 @@ private theorem beq_sub_shlCode (base : Word) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem shl_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
-private theorem shl_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-private theorem shl_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
-private theorem shl_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
-private theorem shl_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-private theorem shl_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem shl_off_36_28 (base : Word) : (base + 36 : Word) + 28 = base + 64 := by bv_omega
-private theorem shl_off_340_20 (base : Word) : (base + 340 : Word) + 20 = base + 360 := by bv_omega
-private theorem shl_bne_target (base : Word) : (base + 20 : Word) + signExtend13 320 = base + 340 := by
+private theorem shl_off_4 {base : Word} : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem shl_off_12 {base : Word} : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem shl_off_20 {base : Word} : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem shl_off_24 {base : Word} : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem shl_off_28 {base : Word} : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem shl_off_32 {base : Word} : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem shl_off_36_28 {base : Word} : (base + 36 : Word) + 28 = base + 64 := by bv_omega
+private theorem shl_off_340_20 {base : Word} : (base + 340 : Word) + 20 = base + 360 := by bv_omega
+private theorem shl_bne_target {base : Word} : (base + 20 : Word) + signExtend13 320 = base + 340 := by
   rv64_addr
-private theorem shl_beq_target (base : Word) : (base + 32 : Word) + signExtend13 308 = base + 340 := by
+private theorem shl_beq_target {base : Word} : (base + 32 : Word) + signExtend13 308 = base + 340 := by
   rv64_addr
 -- Phase C exit addresses
 private theorem shl_c_e0 (base : Word) : (base + 64 : Word) + signExtend13 176 = base + 240 := by

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -157,15 +157,15 @@ private theorem beq_sub_signextCode (base : Word) :
 -- Section 3: Address normalization lemmas
 -- ============================================================================
 
-private theorem se_off_4 (base : Word) : (base + 4 : Word) + 8 = base + 12 := by bv_omega
-private theorem se_off_12 (base : Word) : (base + 12 : Word) + 8 = base + 20 := by bv_omega
-private theorem se_off_20 (base : Word) : (base + 20 : Word) + 4 = base + 24 := by bv_omega
-private theorem se_off_24 (base : Word) : (base + 24 : Word) + 4 = base + 28 := by bv_omega
-private theorem se_off_28 (base : Word) : (base + 28 : Word) + 4 = base + 32 := by bv_omega
-private theorem se_off_32 (base : Word) : (base + 32 : Word) + 4 = base + 36 := by bv_omega
-private theorem se_bne_target (base : Word) : (base + 20 : Word) + signExtend13 168 = base + 188 := by
+private theorem se_off_4 {base : Word} : (base + 4 : Word) + 8 = base + 12 := by bv_omega
+private theorem se_off_12 {base : Word} : (base + 12 : Word) + 8 = base + 20 := by bv_omega
+private theorem se_off_20 {base : Word} : (base + 20 : Word) + 4 = base + 24 := by bv_omega
+private theorem se_off_24 {base : Word} : (base + 24 : Word) + 4 = base + 28 := by bv_omega
+private theorem se_off_28 {base : Word} : (base + 28 : Word) + 4 = base + 32 := by bv_omega
+private theorem se_off_32 {base : Word} : (base + 32 : Word) + 4 = base + 36 := by bv_omega
+private theorem se_bne_target {base : Word} : (base + 20 : Word) + signExtend13 168 = base + 188 := by
   rv64_addr
-private theorem se_beq_target (base : Word) : (base + 32 : Word) + signExtend13 156 = base + 188 := by
+private theorem se_beq_target {base : Word} : (base + 32 : Word) + signExtend13 156 = base + 188 := by
   rv64_addr
 -- Phase C exit addresses
 private theorem se_c_e0 (base : Word) : (base + 56 : Word) + signExtend13 100 = base + 156 := by
@@ -182,7 +182,7 @@ private theorem se_body2_exit (base : Word) : ((base + 96 : Word) + 24) + signEx
   rv64_addr
 private theorem se_body1_exit (base : Word) : ((base + 124 : Word) + 28) + signExtend21 36 = base + 188 := by
   rv64_addr
-private theorem se_done_exit (base : Word) : (base + 188 : Word) + 4 = base + 192 := by bv_omega
+private theorem se_done_exit {base : Word} : (base + 188 : Word) + 4 = base + 192 := by bv_omega
 
 -- ============================================================================
 -- Section 4: No-change path 1 — high limbs nonzero


### PR DESCRIPTION
## Summary

Flip 47 private PC-step address lemmas across 5 opcode compose files from `(base : Word)` to `{base : Word}`:
- `shr_off_*`, `shr_bne_target`, `shr_beq_target` in `Shift/Compose.lean` (10)
- `shl_off_*`, `shl_bne_target`, `shl_beq_target` in `Shift/ShlCompose.lean` (10)
- `sar_off_*`, `sar_bne_target`, `sar_beq_target` in `Shift/SarCompose.lean` (10)
- `byte_off_*`, `byte_bne_target`, `byte_beq_target` in `Byte/Spec.lean` (8)
- `se_off_*`, `se_bne_target`, `se_beq_target`, `se_done_exit` in `SignExtend/Compose.lean` (9)

All use `(base + K) + L = base + M` shape and every caller invokes them bare via `rw [lemma]` or `simp only [...]`. The `*_c_e{0..3}` cascade-dispatch lemmas are intentionally left explicit — they're passed positionally to `*_phase_c_spec_pure`.

Companion to the DivMod implicit-base sweep (#975, #977, #980, #982, #983).

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)