### PR TITLE
refactor(Evm64/SpAddr): flip sp arg on 6 spAddr{32,64}_{8,16,24} lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/SpAddr.lean
+++ b/EvmAsm/Evm64/SpAddr.lean
@@ -26,17 +26,17 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 open EvmAsm.Rv64.Tactics
 
-theorem spAddr32_8  (sp : Word) : sp + 32 + 8  = sp + 40 := by bv_addr
-theorem spAddr32_16 (sp : Word) : sp + 32 + 16 = sp + 48 := by bv_addr
-theorem spAddr32_24 (sp : Word) : sp + 32 + 24 = sp + 56 := by bv_addr
+theorem spAddr32_8 {sp : Word} : sp + 32 + 8  = sp + 40 := by bv_addr
+theorem spAddr32_16 {sp : Word} : sp + 32 + 16 = sp + 48 := by bv_addr
+theorem spAddr32_24 {sp : Word} : sp + 32 + 24 = sp + 56 := by bv_addr
 
 /-- Third-slot siblings of `spAddr32_*`: flatten `(sp + 64) + {8,16,24}` →
     `sp + {72,80,88}`. Parallel to the `(sp + 32) + …` family above but for
     the third operand of ternary 256-bit opcodes (ADDMOD / MULMOD),
     which lives at stack offset `sp + 64`. Also covers the internal
     address bumps `evmWordIs_sp64_unfold` needs. -/
-theorem spAddr64_8  (sp : Word) : sp + 64 + 8  = sp + 72 := by bv_addr
-theorem spAddr64_16 (sp : Word) : sp + 64 + 16 = sp + 80 := by bv_addr
-theorem spAddr64_24 (sp : Word) : sp + 64 + 24 = sp + 88 := by bv_addr
+theorem spAddr64_8 {sp : Word} : sp + 64 + 8  = sp + 72 := by bv_addr
+theorem spAddr64_16 {sp : Word} : sp + 64 + 16 = sp + 80 := by bv_addr
+theorem spAddr64_24 {sp : Word} : sp + 64 + 24 = sp + 88 := by bv_addr
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Flip 6 shared stack-address-flattening lemmas in `EvmAsm/Evm64/SpAddr.lean` from `(sp : Word)` to `{sp : Word}`:
- `spAddr32_8`, `spAddr32_16`, `spAddr32_24`
- `spAddr64_8`, `spAddr64_16`, `spAddr64_24`

All callers (Byte, Lt, Or, Gt, Sgt, Eq, etc.) use them bare as `simp only [spAddr32_8, ...]` / `rw [spAddr32_8, ...]`. Pure signature cleanup — no call-site changes.

## Test plan

- [x] `lake build` succeeds locally (3560 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)