### PR TITLE
refactor(Evm64/Basic): flip w arg on getLimbN_fromLimbs_const_0..3 to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -579,16 +579,16 @@ theorem getLimbN_fromLimbs_const {w : Word} {k : Nat} :
     Avoids the chained `getLimbN_fromLimbs_const` + `show (k : Nat) < 4 from by decide`
     + `ite_true` idiom at call sites that iterate over the four concrete limb
     indices (issue #263). -/
-theorem getLimbN_fromLimbs_const_0 (w : Word) :
+theorem getLimbN_fromLimbs_const_0 {w : Word} :
     (fromLimbs (fun _ => w)).getLimbN 0 = w := by
   rw [getLimbN_fromLimbs_const, if_pos (by decide)]
-theorem getLimbN_fromLimbs_const_1 (w : Word) :
+theorem getLimbN_fromLimbs_const_1 {w : Word} :
     (fromLimbs (fun _ => w)).getLimbN 1 = w := by
   rw [getLimbN_fromLimbs_const, if_pos (by decide)]
-theorem getLimbN_fromLimbs_const_2 (w : Word) :
+theorem getLimbN_fromLimbs_const_2 {w : Word} :
     (fromLimbs (fun _ => w)).getLimbN 2 = w := by
   rw [getLimbN_fromLimbs_const, if_pos (by decide)]
-theorem getLimbN_fromLimbs_const_3 (w : Word) :
+theorem getLimbN_fromLimbs_const_3 {w : Word} :
     (fromLimbs (fun _ => w)).getLimbN 3 = w := by
   rw [getLimbN_fromLimbs_const, if_pos (by decide)]
 


### PR DESCRIPTION
## Summary

Flip 4 `getLimbN_fromLimbs_const_{0,1,2,3}` limb-index lemmas in `EvmAsm/Evm64/Basic.lean` from `(w : Word)` to `{w : Word}`.

All callers (in `Stack.lean` for `evmWordIs_fromLimbs_const` and in `Shift/SarSemantic.lean`) use them bare via `rw [...]` / `simp only [...]`. Pure signature cleanup.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)