### PR TITLE
refactor(DivMod/Spec): flip addr/a on evmWordIs_{div,mod}_zero_right(_atoms) to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -61,26 +61,26 @@ open EvmAsm.Rv64.AddrNorm (word_add_zero word_toNat_0)
     `EvmWord.div_zero_right` into a single named lemma. Saves the inline
     `rw [evmWordIs_congr addr (EvmWord.div_zero_right a)]` idiom at each
     bzero spec's postcondition site. -/
-theorem evmWordIs_div_zero_right (addr : Word) (a : EvmWord) :
+theorem evmWordIs_div_zero_right {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.div a 0) = evmWordIs addr (0 : EvmWord) :=
   evmWordIs_congr addr EvmWord.div_zero_right
 
 /-- MOD counterpart of `evmWordIs_div_zero_right`. -/
-theorem evmWordIs_mod_zero_right (addr : Word) (a : EvmWord) :
+theorem evmWordIs_mod_zero_right {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
   evmWordIs_congr addr EvmWord.mod_zero_right
 
 /-- Full unfold of `evmWordIs addr (EvmWord.div a 0)` straight to four zero
     memIs atoms, bundling `evmWordIs_div_zero_right` + `evmWordIs_zero`
     into a single rewrite. -/
-theorem evmWordIs_div_zero_right_atoms (addr : Word) (a : EvmWord) :
+theorem evmWordIs_div_zero_right_atoms {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.div a 0) =
     ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
      ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
   rw [evmWordIs_div_zero_right, evmWordIs_zero]
 
 /-- MOD counterpart of `evmWordIs_div_zero_right_atoms`. -/
-theorem evmWordIs_mod_zero_right_atoms (addr : Word) (a : EvmWord) :
+theorem evmWordIs_mod_zero_right_atoms {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.mod a 0) =
     ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
      ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by


### PR DESCRIPTION
## Summary

Flip 4 zero-divisor post-rewrite lemmas in `DivMod/Spec.lean` from `(addr : Word) (a : EvmWord)` to `{addr : Word} {a : EvmWord}`:
- `evmWordIs_div_zero_right`, `evmWordIs_mod_zero_right`
- `evmWordIs_div_zero_right_atoms`, `evmWordIs_mod_zero_right_atoms`

All uses are bare `rw [lemma]` inside the file. Pure signature cleanup.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)