### PR TITLE
refactor(Rv64/SepLogic): flip args on ofProg_{nil,cons,append} to implicit

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2055,11 +2055,11 @@ theorem ofIndexed_cons (p : Word × Instr) (ps : List (Word × Instr)) :
   simp only [ofIndexed, List.foldl, union_empty_left]
   exact ofIndexed_foldl_acc (singleton p.1 p.2) ps
 
-theorem ofProg_cons (base : Word) (i : Instr) (rest : List Instr) :
+theorem ofProg_cons {base : Word} {i : Instr} {rest : List Instr} :
     ofProg base (i :: rest) = (singleton base i).union (ofProg (base + 4) rest) := by
   simp only [ofProg, progIndexed]; exact ofIndexed_cons (base, i) (progIndexed (base + 4) rest)
 
-theorem ofProg_nil (base : Word) : ofProg base [] = empty := rfl
+theorem ofProg_nil {base : Word} : ofProg base [] = empty := rfl
 
 /-- If an address doesn't match any instruction position in a program block,
     the ofProg CodeReq returns none at that address. -/
@@ -2084,7 +2084,7 @@ theorem ofIndexed_append (xs ys : List (Word × Instr)) :
   simp only [ofIndexed, List.foldl_append]
   exact ofIndexed_foldl_acc _ ys
 
-theorem ofProg_append (base : Word) (p1 p2 : List Instr) :
+theorem ofProg_append {base : Word} {p1 p2 : List Instr} :
     ofProg base (p1 ++ p2) =
       (ofProg base p1).union (ofProg (base + BitVec.ofNat 64 (4 * p1.length)) p2) := by
   simp only [ofProg, progIndexed_append]


### PR DESCRIPTION
## Summary

Flip 3 `CodeReq.ofProg_*` program-unfold lemmas in `EvmAsm/Rv64/SepLogic.lean` from explicit to implicit args:
- `ofProg_nil {base}`
- `ofProg_cons {base} {i} {rest}`
- `ofProg_append {base} {p1} {p2}`

All callers across RLP Phase2 specs, LimbSpec/CLZ, and inside SepLogic itself use them bare via `simp only [...]` or `rw [...]`. Positional args are resolved by LHS unification.

`ofProg_none_range` and `progIndexed_append` are intentionally left explicit — their induction proofs apply the IH term-mode via `ih (base + 4)`.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)