### PR TITLE
refactor(Evm64/Stack): flip sp/v args on 6 evmWordIs_sp{,32,64}_{unfold,fold} to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -1340,7 +1340,7 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
   rw [show evmWordIs sp a =
       ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3))
-      from evmWordIs_sp_unfold sp a]
+      from evmWordIs_sp_unfold]
   rw [show evmWordIs (sp + 32) (EvmWord.div a b) =
       (((sp + 32) ↦ₘ (signExtend12 4095 : Word)) **
        ((sp + 40) ↦ₘ (0 : Word)) **
@@ -1435,7 +1435,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   rw [show evmWordIs sp a =
       ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
        ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3))
-      from evmWordIs_sp_unfold sp a]
+      from evmWordIs_sp_unfold]
   -- Fold the four denorm output slots into `evmWordIs (sp+32) (EvmWord.mod a b)`.
   rw [show evmWordIs (sp + 32) (EvmWord.mod a b) = _ from h_slot.symm]
   rw [divScratchValues_unfold]

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -212,7 +212,7 @@ theorem evmWordIs_congr_both {a b : Word} {v w : EvmWord}
 /-- Unfold `evmWordIs sp v` into four limb-level memory atoms at
     `sp, sp+8, sp+16, sp+24`. Trivial rewrite of the definition; provided as a
     named lemma for readability at call sites in stack-level specs. -/
-theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp_unfold {sp : Word} {v : EvmWord} :
     evmWordIs sp v =
     ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
      ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) := rfl
@@ -224,18 +224,18 @@ theorem evmWordIs_sp_unfold (sp : Word) (v : EvmWord) :
     rewrite baked in, for use on post-conditions produced by the limb-level
     DIV/MOD specs (which naturally produce `sp + 0 ↦ₘ …` atoms). Sublemma
     "S3" from `project_div_n4_reshape_plan.md`. -/
-theorem evmWordIs_sp_fold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp_fold {sp : Word} {v : EvmWord} :
     (((sp + 0) ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
      ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3)) =
     evmWordIs sp v := by
   rw [show (sp + 0 : Word) = sp from by bv_omega]
-  exact (evmWordIs_sp_unfold sp v).symm
+  exact evmWordIs_sp_unfold.symm
 
 /-- Unfold `evmWordIs (sp+32) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+32, sp+40, sp+48, sp+56`. Bridges the
     separation-logic `evmWordIs` predicate and the raw limb atoms that the
     limb-level specs produce for the `b`-operand on the EVM stack. -/
-theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp32_unfold {sp : Word} {v : EvmWord} :
     evmWordIs (sp + 32) v =
     (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
      ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) := by
@@ -245,17 +245,17 @@ theorem evmWordIs_sp32_unfold (sp : Word) (v : EvmWord) :
 /-- Companion of `evmWordIs_sp_fold` for the `b`-operand slot at `sp + 32`.
     Folds four limb atoms at `sp + 32, +40, +48, +56` into
     `evmWordIs (sp + 32) v`. -/
-theorem evmWordIs_sp32_fold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp32_fold {sp : Word} {v : EvmWord} :
     (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
      ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3)) =
     evmWordIs (sp + 32) v :=
-  (evmWordIs_sp32_unfold sp v).symm
+  evmWordIs_sp32_unfold.symm
 
 /-- Unfold `evmWordIs (sp+64) v` into four limb-level memory atoms at the
     absolute stack addresses `sp+64, sp+72, sp+80, sp+88`. Third-slot
     counterpart to `evmWordIs_sp32_unfold` — useful for ternary-op stack
     specs (ADDMOD / MULMOD) whose third operand lives at `sp + 64`. -/
-theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp64_unfold {sp : Word} {v : EvmWord} :
     evmWordIs (sp + 64) v =
     (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) := by
@@ -263,11 +263,11 @@ theorem evmWordIs_sp64_unfold (sp : Word) (v : EvmWord) :
   rw [spAddr64_8, spAddr64_16, spAddr64_24]
 
 /-- Third-slot companion (ternary ops / ADDMOD / MULMOD). -/
-theorem evmWordIs_sp64_fold (sp : Word) (v : EvmWord) :
+theorem evmWordIs_sp64_fold {sp : Word} {v : EvmWord} :
     (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3)) =
     evmWordIs (sp + 64) v :=
-  (evmWordIs_sp64_unfold sp v).symm
+  evmWordIs_sp64_unfold.symm
 
 /-- Mid-tree variant of `evmWordIs_sp_unfold`: threads a remainder `Q` so
     `rw ←` can fold `(sp ↦ₘ v.getLimbN 0) ** …` back into `evmWordIs sp v`


### PR DESCRIPTION
## Summary

Flip 6 stack-word unfold/fold lemmas in `EvmAsm/Evm64/Stack.lean` from `(sp : Word) (v : EvmWord)` to `{sp : Word} {v : EvmWord}`:
- `evmWordIs_sp_unfold`, `evmWordIs_sp_fold`
- `evmWordIs_sp32_unfold`, `evmWordIs_sp32_fold`
- `evmWordIs_sp64_unfold`, `evmWordIs_sp64_fold`

All `rw [lemma]` / `simp only` sites keep working unchanged. 5 internal term-mode call sites (`.symm`, `from evmWordIs_sp_unfold sp a`) are updated to drop positional args — Lean infers them from expected type.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)