### PR TITLE
refactor(DivMod/Compose/FullPathN4*): flip args on 8 @[irreducible] _unfold lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -203,7 +203,7 @@ theorem evm_div_n4_preloop_max_skip_spec (sp base : Word)
 -- ============================================================================
 
 /-- Unfold preloopMaxSkipPostN4 to expanded form with sp-relative addresses. -/
-theorem preloopMaxSkipPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem preloopMaxSkipPostN4_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     preloopMaxSkipPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
     let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -278,7 +278,7 @@ def fullDivN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
     underlying sepConj structure once the `@[irreducible]` attribute
     above makes `delta` the only way in. Parallel to the `_unfold`
     theorems for the other post bundles (`denormDivPost_unfold` etc.). -/
-theorem fullDivN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem fullDivN4MaxSkipPost_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     fullDivN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
     (let shift := (clzResult b3).1
      let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -365,7 +365,7 @@ def fullModN4MaxSkipPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
 
 /-- Named unfold for `fullModN4MaxSkipPost`. Mirror of
     `fullDivN4MaxSkipPost_unfold`. -/
-theorem fullModN4MaxSkipPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem fullModN4MaxSkipPost_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     fullModN4MaxSkipPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
     (let shift := (clzResult b3).1
      let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -612,7 +612,7 @@ def preloopCallSkipPostN4 (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
   ((sp + signExtend12 3992) ↦ₘ shift)
 
 /-- Unfold preloopCallSkipPostN4 to expanded sp-relative form. -/
-theorem preloopCallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem preloopCallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     preloopCallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
     let antiShift := signExtend12 (0 : BitVec 12) - shift

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -451,7 +451,7 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
 
 /-- Unfold preloopMaxAddbackBeqPostN4 to expanded form with sp-relative addresses.
     The `if carry = 0` branches in loopBodyAddbackBeqPost flow through unchanged. -/
-theorem preloopMaxAddbackBeqPostN4_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem preloopMaxAddbackBeqPostN4_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     preloopMaxAddbackBeqPostN4 sp a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
     let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -548,7 +548,7 @@ def fullDivN4MaxAddbackBeqPost (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :
 /-- Named unfold for `fullDivN4MaxAddbackBeqPost`. Parallel to
     `fullDivN4MaxSkipPost_unfold` — restores access to the atomic
     components once `@[irreducible]` has made `delta` the only path. -/
-theorem fullDivN4MaxAddbackBeqPost_unfold (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem fullDivN4MaxAddbackBeqPost_unfold {sp a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     fullDivN4MaxAddbackBeqPost sp a0 a1 a2 a3 b0 b1 b2 b3 =
     (let shift := (clzResult b3).1
      let antiShift := signExtend12 (0 : BitVec 12) - shift
@@ -677,7 +677,7 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
 -- ============================================================================
 
 /-- Unfold preloopCallAddbackBeqPostN4 to expanded sp-relative form. -/
-theorem preloopCallAddbackBeqPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem preloopCallAddbackBeqPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     preloopCallAddbackBeqPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let shift := (clzResult b3).1
     let antiShift := signExtend12 (0 : BitVec 12) - shift

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -152,7 +152,7 @@ theorem evm_div_n4_preloop_shift0_call_skip_spec (sp base : Word)
 -- ============================================================================
 
 /-- Unfold preloopShift0CallSkipPostN4 to expanded sp-relative form. -/
-theorem preloopShift0CallSkipPostN4_unfold (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+theorem preloopShift0CallSkipPostN4_unfold {sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word} :
     preloopShift0CallSkipPostN4 sp base a0 a1 a2 a3 b0 b1 b2 b3 =
     let qHat := div128Quot (0 : Word) a3 b3
     let dLo := (b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat


### PR DESCRIPTION
## Summary

Flip 8 `@[irreducible]` bundle-unfold lemmas across three FullPathN4 compose files:

- **FullPathN4.lean** (4): `preloopMaxSkipPostN4_unfold`, `fullDivN4MaxSkipPost_unfold`, `fullModN4MaxSkipPost_unfold`, `preloopCallSkipPostN4_unfold`
- **FullPathN4Shift0.lean** (1): `preloopShift0CallSkipPostN4_unfold`
- **FullPathN4Beq.lean** (3): `preloopMaxAddbackBeqPostN4_unfold`, `fullDivN4MaxAddbackBeqPost_unfold`, `preloopCallAddbackBeqPostN4_unfold`

All positional args (`sp`, optional `base`, `a0..a3`, `b0..b3`) flipped to implicit. All callers across DivMod/Spec, Compose/ModFullPathN4, and internal use `simp only [lemma]` bare.

Companion to #1007 (Compose/Base.lean unfolds).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)