### PR TITLE
refactor(DivMod/LimbSpec/PhaseBTail): flip args on divK_phaseB_tail_{pre,post}_unfold to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseBTail.lean
@@ -41,7 +41,7 @@ def divK_phaseB_tail_pre (sp n nMem leading_limb : Word) : Assertion :=
 
 /-- Unfold lemma for `divK_phaseB_tail_pre`. Callers rewrite with this
     before normalizing the concrete `n` into an sp-relative offset. -/
-theorem divK_phaseB_tail_pre_unfold (sp n nMem leading_limb : Word) :
+theorem divK_phaseB_tail_pre_unfold {sp n nMem leading_limb : Word} :
     divK_phaseB_tail_pre sp n nMem leading_limb =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ n) **
      ((sp + signExtend12 3984) ↦ₘ nMem) **
@@ -58,7 +58,7 @@ def divK_phaseB_tail_post (sp n leading_limb : Word) : Assertion :=
   ((sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat + signExtend12 32) ↦ₘ leading_limb)
 
 /-- Unfold lemma for `divK_phaseB_tail_post`. -/
-theorem divK_phaseB_tail_post_unfold (sp n leading_limb : Word) :
+theorem divK_phaseB_tail_post_unfold {sp n leading_limb : Word} :
     divK_phaseB_tail_post sp n leading_limb =
     ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ leading_limb) **
      ((sp + signExtend12 3984) ↦ₘ n) **


### PR DESCRIPTION
## Summary

Flip 2 `@[irreducible]` bundle-unfold lemmas in `LimbSpec/PhaseBTail.lean` from explicit to implicit:
- `divK_phaseB_tail_pre_unfold {sp, n, nMem, leading_limb}`
- `divK_phaseB_tail_post_unfold {sp, n, leading_limb}`

All 12+ callers across `Compose/PhaseAB.lean`, `Compose/ModPhaseB.lean`, `Compose/ModPhaseBn{3,21}.lean`, and internal use them bare via `simp only [...]`.

Companion to the unfold sweep: #973, #996, #997, #998, #1005, #1007, #1008.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)