### PR TITLE
refactor(DivMod/LoopDefs/Post): flip args on loopExitPost_unfold + loopBodyN3CallAddbackBeqPost_eq_J

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -48,8 +48,8 @@ def loopExitPost (n : Word) (sp j q_f c3 un0F un1F un2F un3F u4F
   ((uBase + signExtend12 4064) ↦ₘ u4F) **
   (qAddr ↦ₘ q_f)
 
-theorem loopExitPost_unfold (n: Word) (sp j q_f c3 un0F un1F un2F un3F u4F
-    v0 v1 v2 v3 : Word) :
+theorem loopExitPost_unfold {n: Word} {sp j q_f c3 un0F un1F un2F un3F u4F
+    v0 v1 v2 v3 : Word} :
     loopExitPost n sp j q_f c3 un0F un1F un2F un3F u4F v0 v1 v2 v3 =
     let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let j' := j + signExtend12 4095
@@ -244,7 +244,7 @@ def loopBodyN3CallAddbackBeqPostJ (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word
   (sp + signExtend12 3944 ↦ₘ div128Un0 u2)
 
 /-- Bridge: j=0 specific call addback beq = generic-j at j=0. -/
-theorem loopBodyN3CallAddbackBeqPost_eq_J (sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+theorem loopBodyN3CallAddbackBeqPost_eq_J {sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
     loopBodyN3CallAddbackBeqPost sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopBodyN3CallAddbackBeqPostJ sp base (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   delta loopBodyN3CallAddbackBeqPost loopBodyN3CallAddbackBeqPostJ; rfl


### PR DESCRIPTION
## Summary

Flip args on two lemmas in `LoopDefs/Post.lean` from explicit to implicit:
- `loopExitPost_unfold` — `{n, sp, j, q_f, c3, un0F..un3F, u4F, v0..v3}`
- `loopBodyN3CallAddbackBeqPost_eq_J` — `{sp, base, v0..v3, u0..u3, uTop}`

All callers (4 sites across FullPathN{1,2,4}Loop.lean and LoopComposeN3.lean) use them bare.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)