### PR TITLE
refactor(DivMod/LoopDefs/Post): flip args on loopBodyUnifiedPost_{true,false} simp lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -142,15 +142,15 @@ def loopBodyUnifiedPost (borrow_zero : Bool) (n : Word)
   else loopBodyAddbackBeqPost n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 @[simp]
-theorem loopBodyUnifiedPost_true (n : Word)
-    (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+theorem loopBodyUnifiedPost_true {n : Word}
+    {sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
     loopBodyUnifiedPost true n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopBodySkipPost n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [loopBodyUnifiedPost]
 
 @[simp]
-theorem loopBodyUnifiedPost_false (n : Word)
-    (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+theorem loopBodyUnifiedPost_false {n : Word}
+    {sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
     loopBodyUnifiedPost false n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop =
     loopBodyAddbackBeqPost n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
   simp [loopBodyUnifiedPost]


### PR DESCRIPTION
## Summary

Flip args on two `@[simp]` lemmas in `LoopDefs/Post.lean` from explicit to implicit:
- `loopBodyUnifiedPost_true {n, sp, j, qHat, v0..v3, u0..u3, uTop}`
- `loopBodyUnifiedPost_false {n, sp, j, qHat, v0..v3, u0..u3, uTop}`

All 22+ call sites across `LoopBodyN{1,2,3,4}.lean` and `LoopIterN4.lean` use them bare via `simp only [loopBodyUnifiedPost_{true,false}]`. `@[simp]` behavior is unaffected (simp rewrites LHS regardless of arg-mode).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)