### PR TITLE
refactor(DivMod/LoopDefs/Iter): flip args on iterWithDoubleAddback_{borrow,no_borrow} to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -187,7 +187,7 @@ def iterWithDoubleAddback (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
 -- Equation lemmas for iterWithDoubleAddback in each branch.
 -- These avoid expanding the full definition inline; producers `rw` with them.
 
-theorem iterWithDoubleAddback_borrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem iterWithDoubleAddback_borrow {qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : BitVec.ult uTop (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
     let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -201,7 +201,7 @@ theorem iterWithDoubleAddback_borrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
       (qHat + signExtend12 4095, ab.1, ab.2.1, ab.2.2.1, ab.2.2.2.1, ab.2.2.2.2) := by
   simp only [iterWithDoubleAddback, if_pos hb]
 
-theorem iterWithDoubleAddback_no_borrow (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+theorem iterWithDoubleAddback_no_borrow {qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
     (hb : ¬BitVec.ult uTop (mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2) :
     let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
     iterWithDoubleAddback qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop =


### PR DESCRIPTION
## Summary

Flip args on two equation lemmas in `LoopDefs/Iter.lean` from explicit to implicit:
- `iterWithDoubleAddback_borrow {qHat, v0..v3, u0..u3, uTop}`
- `iterWithDoubleAddback_no_borrow {qHat, v0..v3, u0..u3, uTop}`

Both currently scaffolding (no external callers) — aligns with the `iterN{1,2,3}_{true,false}` flip landed via #1015.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)