### PR TITLE
feat(divmod): Phase 2b bounds via Phase 1b reuse — Knuth B KB-5 (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -798,4 +798,56 @@ theorem div128Quot_phase2a_q0c_lt_pow33 (un21 dHi : Word)
     q0c.toNat < 2^33 :=
   div128Quot_q1c_lt_pow33 un21 dHi hdHi_ge
 
+-- ============================================================================
+-- Piece B: Phase 2b bounds via Phase 1b reuse (KB-5)
+-- ============================================================================
+
+/-- **KB-5a: Phase 2b Euclidean.** Instantiation of
+    `div128Quot_phase1b_post` with `uHi := un21`, `q1c := q0c`,
+    `rhatc := rhat2c`: post-Phase-2b (Phase 2b's multiplication-check
+    correction), the corrected quotient `q0'` and remainder `rhat2'`
+    still satisfy the Euclidean equation against `un21`. -/
+theorem div128Quot_phase2b_post (un21 dHi : Word)
+    (hdHi_lt : dHi.toNat < 2^32) (q0c rhat2c dLo rhat2Un0 : Word)
+    (h_post : q0c.toNat * dHi.toNat + rhat2c.toNat = un21.toNat)
+    (h_rhat2c_lt : rhat2c.toNat < 2 * dHi.toNat) :
+    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
+               else q0c
+    let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
+    q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat :=
+  div128Quot_phase1b_post un21 dHi q0c rhat2c dLo rhat2Un0 hdHi_lt h_post h_rhat2c_lt
+
+/-- **KB-5b: Phase 2b check implies q0c ≥ 1.** Instantiation of
+    `div128Quot_phase1b_check_implies_q1c_pos`. -/
+theorem div128Quot_phase2b_check_implies_q0c_pos (q0c dLo rhat2Un0 : Word)
+    (h_check : BitVec.ult rhat2Un0 (q0c * dLo)) :
+    q0c.toNat ≥ 1 :=
+  div128Quot_phase1b_check_implies_q1c_pos q0c dLo rhat2Un0 h_check
+
+/-- **KB-5c: Phase 2b quotient bound.** Instantiation of
+    `div128Quot_phase1b_quotient_bound` with `uHi := un21`. -/
+theorem div128Quot_phase2b_quotient_bound (un21 dHi : Word)
+    (hdHi_ne : dHi ≠ 0) (hdHi_lt : dHi.toNat < 2^32)
+    (dLo rhat2Un0 : Word) :
+    let q0 := rv64_divu un21 dHi
+    let hi2 := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
+               else q0c
+    q0'.toNat + 2 ≥ un21.toNat / dHi.toNat ∧
+    q0'.toNat ≤ un21.toNat / dHi.toNat :=
+  div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo rhat2Un0
+
+/-- **KB-5d: Phase 2b output bound.** Instantiation of
+    `div128Quot_q1_prime_lt_pow33` with `uHi := un21`: `q0' < 2^33`. -/
+theorem div128Quot_phase2b_q0_prime_lt_pow33 (un21 dHi : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31) (dLo rhat2Un0 : Word) :
+    let q0 := rv64_divu un21 dHi
+    let hi2 := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
+               else q0c
+    q0'.toNat < 2^33 :=
+  div128Quot_q1_prime_lt_pow33 un21 dHi hdHi_ge dLo rhat2Un0
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- **Stacks on #1014 (KB-4 Phase 2a).**
- Four thin instantiation wrappers mirroring KB-4 for Phase 2b:

  - **KB-5a** \`div128Quot_phase2b_post\`: \`q0' * dHi + rhat2' = un21\`.
  - **KB-5b** \`div128Quot_phase2b_check_implies_q0c_pos\`: \`q0c ≥ 1\` when the Phase 2b check fires.
  - **KB-5c** \`div128Quot_phase2b_quotient_bound\`: \`q0' ∈ [un21/dHi - 2, un21/dHi]\`.
  - **KB-5d** \`div128Quot_phase2b_q0_prime_lt_pow33\`: \`q0' < 2^33\`.

Each proof is a single function call to the Phase 1b counterpart (\`div128Quot_phase1b_post\` / \`_phase1b_check_implies_q1c_pos\` / \`_phase1b_quotient_bound\` / \`_q1_prime_lt_pow33\`) with \`un21\` and \`q0c\` substituted for \`uHi\` and \`q1c\` respectively.

### Status check

With KB-4 (Phase 2a) and KB-5 (Phase 2b) both landing as thin wrappers, the **remaining Knuth-B work** is:
- The un21 identity chain (KB-3h..3m: #1004 → #1009 → #1011 — already stacked).
- KB-6 final assembly (\`q1' * 2^32 + q0' = true quotient\`).
- Closing the abstract identity (connecting KB-3m's additive form + KB-4c + KB-5d to produce the Knuth bound on \`div128Quot.toNat\`).

## Test plan
- [x] \`lake build\` passes (on top of #1014's branch, full project green)
- [x] File size OK: Div128QuotientBounds.lean ~855 lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)