### PR TITLE
refactor(EvmWordArith): flip arg on 4 CLZ/halfword bridge lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -150,14 +150,14 @@ private theorem clzInit_no_overflow (val : Word) :
 -- Connection: clzResult = pipeline + stage 5
 -- ============================================================================
 
-theorem clzResult_fst_eq (val : Word) :
+theorem clzResult_fst_eq {val : Word} :
     (clzResult val).1 =
       if (clzPipeline val).2 >>> 63 ≠ 0
       then (clzPipeline val).1
       else (clzPipeline val).1 + signExtend12 1 := by
   unfold clzResult clzPipeline clzStep; rfl
 
-theorem clzResult_snd_eq (val : Word) :
+theorem clzResult_snd_eq {val : Word} :
     (clzResult val).2 = (clzPipeline val).2 := by
   unfold clzResult clzPipeline clzStep; rfl
 
@@ -328,7 +328,7 @@ theorem msb_imp_clz_zero {val : Word} (hmsb : val >>> (63 : Nat) ≠ 0) :
 -- ============================================================================
 
 /-- CLZ shift=0 iff the MSB is set: `(clzResult val).1 = 0 ↔ val >>> 63 ≠ 0`. -/
-theorem clzResult_fst_eq_zero_iff (val : Word) :
+theorem clzResult_fst_eq_zero_iff {val : Word} :
     (clzResult val).1 = 0 ↔ val >>> (63 : Nat) ≠ 0 := by
   constructor
   · intro h

--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -45,7 +45,7 @@ theorem halfword_combine (a b : Word) (ha : a.toNat < 2^32) (hb : b.toNat < 2^32
   rw [Nat.mod_eq_of_lt (show a.toNat * 2 ^ 32 < 2 ^ 64 by nlinarith)]
 
 /-- Corollary: combining hi32 and lo32 of a word reconstructs it at the Nat level. -/
-theorem halfword_combine_hi_lo (x : Word) :
+theorem halfword_combine_hi_lo {x : Word} :
     (hi32 x <<< 32 ||| lo32 x).toNat = x.toNat := by
   rw [halfword_combine _ _ hi32_toNat_lt lo32_toNat_lt]
   exact halfword_decompose.symm


### PR DESCRIPTION
## Summary

Flip args on 4 equation/bridge lemmas:
- `clzResult_fst_eq {val}` — used via `rw` at 6 sites (CLZLemmas.lean, MaxTrialVacuity.lean)
- `clzResult_snd_eq {val}` — used via `rw` at 1 site
- `clzResult_fst_eq_zero_iff {val}` — scaffolding
- `halfword_combine_hi_lo {x}` — scaffolding

Sibling lemmas `clzResult_fst_{toNat_le,top_bound}` and `clzPipeline_{fst_le,invariant}` are intentionally left explicit because they're called term-mode (`have h := lemma b3`).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)