### PR TITLE
refactor(Evm64/Stack): flip args on 3 evmWordIs_sp{,32,64}_unfold_right to implicit

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -274,7 +274,7 @@ theorem evmWordIs_sp64_fold {sp : Word} {v : EvmWord} :
     even when the atoms sit mid-chain. Simpler call than
     `evmWordIs_sp_limbs_eq_right` when the caller already has the atoms
     in `v.getLimbN k` form (no explicit `hk : v.getLimbN k = wk` threads). -/
-theorem evmWordIs_sp_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+theorem evmWordIs_sp_unfold_right {sp : Word} {v : EvmWord} {Q : Assertion} :
     ((sp ↦ₘ v.getLimbN 0) ** ((sp + 8) ↦ₘ v.getLimbN 1) **
      ((sp + 16) ↦ₘ v.getLimbN 2) ** ((sp + 24) ↦ₘ v.getLimbN 3) ** Q) =
     (evmWordIs sp v ** Q) := by
@@ -282,7 +282,7 @@ theorem evmWordIs_sp_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
   rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
 
 /-- Mid-tree variant of `evmWordIs_sp32_unfold`. -/
-theorem evmWordIs_sp32_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+theorem evmWordIs_sp32_unfold_right {sp : Word} {v : EvmWord} {Q : Assertion} :
     (((sp + 32) ↦ₘ v.getLimbN 0) ** ((sp + 40) ↦ₘ v.getLimbN 1) **
      ((sp + 48) ↦ₘ v.getLimbN 2) ** ((sp + 56) ↦ₘ v.getLimbN 3) ** Q) =
     (evmWordIs (sp + 32) v ** Q) := by
@@ -290,7 +290,7 @@ theorem evmWordIs_sp32_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
   rw [sepConj_assoc', sepConj_assoc', sepConj_assoc']
 
 /-- Mid-tree variant of `evmWordIs_sp64_unfold`. Third-slot companion. -/
-theorem evmWordIs_sp64_unfold_right (sp : Word) (v : EvmWord) (Q : Assertion) :
+theorem evmWordIs_sp64_unfold_right {sp : Word} {v : EvmWord} {Q : Assertion} :
     (((sp + 64) ↦ₘ v.getLimbN 0) ** ((sp + 72) ↦ₘ v.getLimbN 1) **
      ((sp + 80) ↦ₘ v.getLimbN 2) ** ((sp + 88) ↦ₘ v.getLimbN 3) ** Q) =
     (evmWordIs (sp + 64) v ** Q) := by


### PR DESCRIPTION
## Summary

Flip args on 3 mid-tree fold variants in `Stack.lean`:
- `evmWordIs_sp_unfold_right {sp, v, Q}`
- `evmWordIs_sp32_unfold_right {sp, v, Q}`
- `evmWordIs_sp64_unfold_right {sp, v, Q}`

All three currently scaffolding (no external callers). Aligns with the base `_unfold` / `_fold` family flipped in #999.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)