### PR TITLE
refactor(Rv64/RLP): flip v5/k args on 2 exit-post-unfold lemmas to implicit

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -229,7 +229,7 @@ def rlp_phase1_exit_post (v5 : Word) (k : BitVec 12) : Assertion :=
 
 /-- Unfold lemma for `rlp_phase1_exit_post`. Use when a consumer needs the
     explicit register-ownership form. -/
-theorem rlp_phase1_exit_post_unfold (v5 : Word) (k : BitVec 12) :
+theorem rlp_phase1_exit_post_unfold {v5 : Word} {k : BitVec 12} :
     rlp_phase1_exit_post v5 k =
     ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x10 ↦ᵣ ((0 : Word) + signExtend12 k))) := by

--- a/EvmAsm/Rv64/RLP/Phase2Short.lean
+++ b/EvmAsm/Rv64/RLP/Phase2Short.lean
@@ -69,7 +69,7 @@ def rlp_phase2_short_length_post
   let length := v5 + signExtend12 (-k)
   (.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ length)
 
-theorem rlp_phase2_short_length_post_unfold (v5 : Word) (k : BitVec 12) :
+theorem rlp_phase2_short_length_post_unfold {v5 : Word} {k : BitVec 12} :
     rlp_phase2_short_length_post v5 k =
     ((.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ (v5 + signExtend12 (-k)))) := by
   delta rlp_phase2_short_length_post; rfl


### PR DESCRIPTION
## Summary

Flip args on 2 bundle-unfold lemmas in `Rv64/RLP`:
- `rlp_phase2_short_length_post_unfold {v5, k}` in `Phase2Short.lean`
- `rlp_phase1_exit_post_unfold {v5, k}` in `Phase1.lean`

Both are used via `simp only [lemma]` bare at one call site each.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)