### PR TITLE
refactor(Rv64): flip addr arg on byteOffset_lt_8 / halfwordOffset_lt_4 to implicit

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -14,7 +14,7 @@ namespace EvmAsm.Rv64
 
 /-! ## byteOffset bound -/
 
-theorem byteOffset_lt_8 (addr : Word) : byteOffset addr < 8 := by
+theorem byteOffset_lt_8 {addr : Word} : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
 

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -52,7 +52,7 @@ private theorem byteOffset_lt_8' (addr : Word) : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
 
-theorem halfwordOffset_lt_4 (addr : Word) : (byteOffset addr) / 2 < 4 := by
+theorem halfwordOffset_lt_4 {addr : Word} : (byteOffset addr) / 2 < 4 := by
   have := byteOffset_lt_8' addr; omega
 
 /-! ## LHU generic spec


### PR DESCRIPTION
## Summary

Flip `(addr : Word)` to implicit on two bound lemmas:
- `byteOffset_lt_8` in `Rv64/ByteOps.lean`
- `halfwordOffset_lt_4` in `Rv64/HalfwordOps.lean`

Both have no external callers (scaffolding). The private sibling `byteOffset_lt_8'` in `HalfwordOps.lean` is intentionally left explicit because its single caller uses it term-mode.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)