### PR TITLE
refactor(Evm64/Basic): flip a b args on eq_iff_limbs to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -456,7 +456,7 @@ theorem high_limbs_zero_of_toNat_lt {v : EvmWord} (h : v.toNat < 2^64) :
     (if c then x else y).getLimb i = if c then x.getLimb i else y.getLimb i := by
   split <;> rfl
 
-theorem eq_iff_limbs (a b : EvmWord) :
+theorem eq_iff_limbs {a b : EvmWord} :
     a = b ↔ (∀ i, a.getLimb i = b.getLimb i) := by
   constructor
   · intro h; subst h; intro; rfl


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on `eq_iff_limbs` in `EvmAsm/Evm64/Basic.lean`. Lemma is currently unused (scaffolding for potential EvmWord reasoning).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)