### PR TITLE
refactor(Shift/ComposeBase): flip base arg on shr_phase_{a,c}_code_sub_ofProg to implicit

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -87,7 +87,7 @@ private theorem ofProg_phase_c_sub_shrCode (base : Word) :
 private theorem phase_c_sub_shrCode (base : Word) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shrCode base a = some i := by
   intro a i h
-  exact ofProg_phase_c_sub_shrCode base a i (shr_phase_c_code_sub_ofProg (base + 64) a i h)
+  exact ofProg_phase_c_sub_shrCode base a i (shr_phase_c_code_sub_ofProg a i h)
 
 /-- Body 3 code (ofProg, 7 instrs at +84) is subsumed by shrCode (block 3). -/
 private theorem body_3_sub_shrCode (base : Word) :

--- a/EvmAsm/Evm64/Shift/ComposeBase.lean
+++ b/EvmAsm/Evm64/Shift/ComposeBase.lean
@@ -64,7 +64,7 @@ theorem shr_zero_path_len : shr_zero_path.length = 5 := by decide
 -- ============================================================================
 
 /-- Bridge: `shr_phase_a_code` (union chain, 9 instrs) ⊆ `ofProg shr_phase_a`. -/
-theorem shr_phase_a_code_sub_ofProg (base : Word) :
+theorem shr_phase_a_code_sub_ofProg {base : Word} :
     ∀ a i, shr_phase_a_code base a = some i →
       (CodeReq.ofProg base shr_phase_a) a = some i := by
   unfold shr_phase_a_code shr_ld_or_acc_code
@@ -90,7 +90,7 @@ theorem shr_phase_a_code_sub_ofProg (base : Word) :
                 (by decide) (by decide) (by bv_omega) (by decide)
 
 /-- Bridge: `shr_phase_c_code` (union chain, 5 instrs) ⊆ `ofProg shr_phase_c`. -/
-theorem shr_phase_c_code_sub_ofProg (base : Word) :
+theorem shr_phase_c_code_sub_ofProg {base : Word} :
     ∀ a i, shr_phase_c_code base a = some i →
       (CodeReq.ofProg base shr_phase_c) a = some i := by
   unfold shr_phase_c_code shr_cascade_step_code

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -85,7 +85,7 @@ private theorem ofProg_phase_c_sub_shlCode (base : Word) :
 private theorem phase_c_sub_shlCode (base : Word) :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shlCode base a = some i := by
   intro a i h
-  exact ofProg_phase_c_sub_shlCode base a i (shr_phase_c_code_sub_ofProg (base + 64) a i h)
+  exact ofProg_phase_c_sub_shlCode base a i (shr_phase_c_code_sub_ofProg a i h)
 
 /-- SHL Body 3 code (7 instrs at +84) is subsumed by shlCode (block 3). -/
 private theorem shl_body_3_sub_shlCode (base : Word) :


### PR DESCRIPTION
## Summary

Flip `(base : Word)` to implicit on two shared bridge lemmas in `Shift/ComposeBase.lean`:
- `shr_phase_a_code_sub_ofProg`
- `shr_phase_c_code_sub_ofProg`

Callers pass `(base + 64)` term-mode — flipping lets them drop the arg; Lean infers `base + 64` from the expected type at the enclosing `ofProg_phase_c_sub_{shr,shl}Code` argument position.

Call-site updates: 2 sites (Compose.lean:90 and ShlCompose.lean:88).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)