### PR TITLE
feat(divmod): tighter q1c/q1' bound ≤ 2^32 — Knuth B KB-3e' (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -322,6 +322,94 @@ theorem div128Quot_q1_prime_le_pow32_plus_one (uHi dHi dLo rhatUn1 : Word)
   have h_q1'_le_q1c : q1'.toNat ≤ q1c.toNat := div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
   omega
 
+/-- **KB-3e': Tighter post-Phase-1a bound on q1c under hcall.** Phase 1a's
+    `hi1` correction absorbs one overshoot beyond `2^32`:
+
+    ```
+    q1c.toNat ≤ 2^32
+    ```
+
+    - hi1 = 0 branch: `q1 < 2^32` (by definition of hi1), so q1c = q1 < 2^32.
+    - hi1 ≠ 0 branch: `q1 ≥ 2^32`, combined with KB-3c `q1 ≤ 2^32 + 1`,
+      gives `q1 ∈ {2^32, 2^32 + 1}`, so `q1c = q1 - 1 ∈ {2^32 - 1, 2^32}`.
+
+    Tightens KB-3c (`q1 ≤ 2^32 + 1`) by one after Phase 1a. The
+    post-Phase-1b analogue `div128Quot_q1_prime_le_pow32` follows by
+    Phase 1b monotonicity (KB-3d2). -/
+theorem div128Quot_q1c_le_pow32 (uHi dHi dLo : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q1 := rv64_divu uHi dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    q1c.toNat ≤ 2^32 := by
+  intro q1 hi1 q1c
+  have h_q1_le : q1.toNat ≤ 2^32 + 1 :=
+    div128Quot_q1_le_pow32_plus_one uHi dHi dLo hdHi_ge hdLo_lt huHi_lt_vTop
+  by_cases h_hi1 : hi1 = 0
+  · -- hi1 = 0 ⟹ q1 < 2^32 ⟹ q1c = q1 < 2^32.
+    have h32 : (32 : BitVec 6).toNat = 32 := by decide
+    have h_hi1_toNat : hi1.toNat = 0 := by rw [h_hi1]; rfl
+    have h_q1_div : q1.toNat / 2^32 = 0 := by
+      have : hi1.toNat = q1.toNat / 2^32 := by
+        rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      omega
+    have hq1_lt : q1.toNat < 2^32 := by
+      have h_pos : (0 : Nat) < 2^32 := by decide
+      exact Nat.lt_of_div_eq_zero h_pos h_q1_div
+    show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
+    rw [if_pos h_hi1]
+    omega
+  · -- hi1 ≠ 0 ⟹ q1 ≥ 2^32. KB-3c gives q1 ≤ 2^32 + 1, so q1c = q1 - 1 ≤ 2^32.
+    have hq1_ge : q1.toNat ≥ 2^32 := by
+      by_contra h
+      push_neg at h
+      apply h_hi1
+      apply BitVec.eq_of_toNat_eq
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      show q1.toNat / 2^32 = (0 : Word).toNat
+      rw [Nat.div_eq_of_lt h]
+      rfl
+    show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
+    rw [if_neg h_hi1]
+    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se_neg1]
+    have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
+    rw [show q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 from by omega,
+        Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
+    omega
+
+/-- **KB-3e'': Tighter post-Phase-1b bound on q1' under hcall.** Composes
+    KB-3e' (`div128Quot_q1c_le_pow32`) with Phase 1b monotonicity
+    (KB-3d2) to give:
+
+    ```
+    q1'.toNat ≤ 2^32
+    ```
+
+    Strict tightening of KB-3e (`q1' ≤ 2^32 + 1`) by one. Brings us one
+    step closer to Knuth's `q1' < 2^32` invariant (needed for clean
+    `halfword_combine` on the final output, avoiding the `% 2^32` wrap
+    in KB-6a). -/
+theorem div128Quot_q1_prime_le_pow32 (uHi dHi dLo rhatUn1 : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q1 := rv64_divu uHi dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    q1'.toNat ≤ 2^32 := by
+  intro q1 hi1 q1c q1'
+  have h_q1c_le : q1c.toNat ≤ 2^32 :=
+    div128Quot_q1c_le_pow32 uHi dHi dLo hdHi_ge hdLo_lt huHi_lt_vTop
+  have h_q1'_le_q1c : q1'.toNat ≤ q1c.toNat :=
+    div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
+  omega
+
 /-- **KB-3f: No-wraparound for `q1' * dLo`.** Under the call-trial
     precondition, the Word-level product equals the Nat-level product:
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -512,6 +512,110 @@ theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
       div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
     omega
 
+/-- **KB-6b: Phase 2b strict q0' bound `< 2^32` under `un21 < vTop`.** The
+    Phase 2 mirror of KB-3e''' (`div128Quot_q1_prime_lt_pow32`):
+
+    ```
+    q0'.toNat < 2^32
+    ```
+
+    under `un21.toNat < dHi.toNat * 2^32 + dLo.toNat` (the Phase 2
+    analogue of hcall) + `dHi ≥ 2^31` + `dHi < 2^32` + `dLo < 2^32`.
+
+    Case analysis on q0c (via `div128Quot_q1c_le_pow32` with `uHi := un21`):
+
+    - **q0c < 2^32**: Phase 2b monotonicity (via `div128Quot_q1_prime_le_q1c`
+      with `q1c := q0c`) gives `q0' ≤ q0c < 2^32`.
+    - **q0c = 2^32**: The Phase 2a Euclidean `q0c * dHi + rhat2c = un21`
+      combined with `un21 < dHi * 2^32 + dLo` forces `rhat2c < dLo < 2^32`.
+      Then `rhat2Un0.toNat = rhat2c.toNat * 2^32 + div_un0.toNat`
+      (halfword_combine) and `(q0c * dLo).toNat = 2^32 * dLo.toNat` (no
+      wrap). The Phase 2b check fires, making `q0' = q0c - 1 = 2^32 - 1`.
+
+    **Blocked in practice on `un21 < vTop`**: the Phase 2 precondition
+    requires threading Phase 1's post-state through a Knuth invariant
+    argument (q1' ≥ q_true ⇒ un21 = uHi·2^32 + div_un1 − q1'·vTop ≤ vTop).
+    This is the remaining Phase-2 gap; once closed, KB-6b + KB-6a combine
+    to give `div128Quot.toNat = q1'.toNat * 2^32 + q0'.toNat` without the
+    `% 2^32` wrap. -/
+theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdHi_lt : dHi.toNat < 2^32)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (hun21_lt_vTop : un21.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
+    let hi2 := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+    let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
+               else q0c
+    q0'.toNat < 2^32 := by
+  intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
+  -- Reuse Phase 1 lemma with uHi := un21.
+  have h_q0c_le : q0c.toNat ≤ 2^32 :=
+    div128Quot_q1c_le_pow32 un21 dHi dLo hdHi_ge hdLo_lt hun21_lt_vTop
+  by_cases h_eq : q0c.toNat = 2^32
+  · -- q0c = 2^32: Phase 2b check fires.
+    have hdHi_ne : dHi ≠ 0 := by
+      intro heq; rw [heq] at hdHi_ge; simp at hdHi_ge
+    have h_post : q0c.toNat * dHi.toNat + rhat2c.toNat = un21.toNat :=
+      div128Quot_first_round_post un21 dHi hdHi_ne hdHi_lt
+    have h_rhat2c_lt_dLo : rhat2c.toNat < dLo.toNat := by
+      rw [h_eq] at h_post
+      omega
+    have h_rhat2c_lt_pow32 : rhat2c.toNat < 2^32 := by omega
+    have h_div_un0_lt : div_un0.toNat < 2^32 := by
+      show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
+      rw [BitVec.toNat_ushiftRight]
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [h32, Nat.shiftRight_eq_div_pow]
+      have h_shl_isLt : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+        (uLo <<< (32 : BitVec 6).toNat : Word).isLt
+      have h_eq_64 : (2^64 : Nat) = 2^32 * 2^32 := by decide
+      exact Nat.div_lt_of_lt_mul (by omega)
+    -- rhat2Un0.toNat = rhat2c.toNat * 2^32 + div_un0.toNat.
+    have h_rhat2Un0_eq : rhat2Un0.toNat =
+        rhat2c.toNat * 2^32 + div_un0.toNat := by
+      show ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0).toNat = _
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [h32]
+      exact EvmWord.halfword_combine rhat2c div_un0 h_rhat2c_lt_pow32 h_div_un0_lt
+    -- (q0c * dLo).toNat = q0c.toNat * dLo.toNat (no wrap).
+    have h_q0Dlo_eq : (q0c * dLo).toNat = q0c.toNat * dLo.toNat := by
+      rw [BitVec.toNat_mul]
+      apply Nat.mod_eq_of_lt
+      rw [h_eq]
+      calc 2^32 * dLo.toNat < 2^32 * 2^32 := by
+              apply Nat.mul_lt_mul_left (by decide : 0 < 2^32) |>.mpr hdLo_lt
+        _ = 2^64 := by decide
+    have h_ult : rhat2Un0.toNat < (q0c * dLo).toNat := by
+      rw [h_rhat2Un0_eq, h_q0Dlo_eq, h_eq]
+      calc rhat2c.toNat * 2^32 + div_un0.toNat
+          < rhat2c.toNat * 2^32 + 2^32 := by omega
+        _ = (rhat2c.toNat + 1) * 2^32 := by ring
+        _ ≤ dLo.toNat * 2^32 := Nat.mul_le_mul_right _ (by omega)
+        _ = 2^32 * dLo.toNat := by ring
+    have h_check : BitVec.ult rhat2Un0 (q0c * dLo) := by
+      show decide (rhat2Un0.toNat < (q0c * dLo).toNat) = true
+      exact decide_eq_true h_ult
+    show (if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
+          else q0c).toNat < 2^32
+    rw [if_pos h_check]
+    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se_neg1]
+    have h_q0c_lt_word : q0c.toNat - 1 < 2^64 := by have := q0c.isLt; omega
+    rw [show q0c.toNat + (2^64 - 1) = (q0c.toNat - 1) + 2^64 from by omega,
+        Nat.add_mod_right, Nat.mod_eq_of_lt h_q0c_lt_word]
+    omega
+  · -- q0c < 2^32 case: q0' ≤ q0c < 2^32.
+    have h_q0c_lt : q0c.toNat < 2^32 := by omega
+    have h_q0'_le_q0c : q0'.toNat ≤ q0c.toNat :=
+      div128Quot_q1_prime_le_q1c q0c dLo rhat2Un0
+    omega
+
 /-- **KB-3f: No-wraparound for `q1' * dLo`.** Under the call-trial
     precondition, the Word-level product equals the Nat-level product:
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -410,6 +410,108 @@ theorem div128Quot_q1_prime_le_pow32 (uHi dHi dLo rhatUn1 : Word)
     div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
   omega
 
+/-- **KB-3e''': Strict q1' bound `< 2^32` under hcall (Knuth tightening
+    closed).** Closes the last gap in the Phase 1 tightening chain:
+
+    ```
+    q1'.toNat < 2^32
+    ```
+
+    Case analysis on `q1c.toNat`:
+    - **q1c < 2^32**: Phase 1b monotonicity (KB-3d2) gives `q1' ≤ q1c < 2^32`.
+    - **q1c = 2^32**: The Euclidean equation `q1c * dHi + rhatc = uHi` combined
+      with `uHi < dHi * 2^32 + dLo` forces `rhatc < dLo < 2^32`. Then
+      `rhatUn1.toNat = rhatc.toNat * 2^32 + div_un1.toNat` (halfword_combine)
+      and `(q1c * dLo).toNat = 2^32 * dLo.toNat` (no wrap). The Phase 1b
+      check `rhatUn1 < q1c * dLo` fires (since
+      `rhatc * 2^32 + div_un1 < dLo * 2^32 = q1c * dLo`), making
+      `q1' = q1c - 1 = 2^32 - 1 < 2^32`.
+
+    This is Knuth's multiplication-check correctness for Phase 1b at the
+    Word level — the last piece needed to get `q1' < 2^32` so that
+    `halfword_combine` (not just `halfword_combine_mod`) applies to the
+    `cu_rhat_un1` construction.
+
+    Precondition `hdHi_lt : dHi.toNat < 2^32` added (needed for
+    `div128Quot_first_round_post`); automatically satisfied when
+    `dHi = vTop >>> 32` (the algorithm's actual instantiation). -/
+theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
+    (hdHi_ge : dHi.toNat ≥ 2^31)
+    (hdHi_lt : dHi.toNat < 2^32)
+    (hdLo_lt : dLo.toNat < 2^32)
+    (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let div_un1 := uLo >>> (32 : BitVec 6).toNat
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+    let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+               else q1c
+    q1'.toNat < 2^32 := by
+  intro q1 rhat hi1 q1c rhatc div_un1 rhatUn1 q1'
+  have h_q1c_le : q1c.toNat ≤ 2^32 :=
+    div128Quot_q1c_le_pow32 uHi dHi dLo hdHi_ge hdLo_lt huHi_lt_vTop
+  by_cases h_eq : q1c.toNat = 2^32
+  · -- q1c = 2^32: Phase 1b check fires.
+    have hdHi_ne : dHi ≠ 0 := by
+      intro heq; rw [heq] at hdHi_ge; simp at hdHi_ge
+    have h_post : q1c.toNat * dHi.toNat + rhatc.toNat = uHi.toNat :=
+      div128Quot_first_round_post uHi dHi hdHi_ne hdHi_lt
+    have h_rhatc_lt_dLo : rhatc.toNat < dLo.toNat := by
+      rw [h_eq] at h_post
+      omega
+    have h_rhatc_lt_pow32 : rhatc.toNat < 2^32 := by omega
+    have h_div_un1_lt : div_un1.toNat < 2^32 := by
+      show (uLo >>> (32 : BitVec 6).toNat).toNat < 2^32
+      rw [BitVec.toNat_ushiftRight]
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [h32, Nat.shiftRight_eq_div_pow]
+      have h_ulo_isLt : uLo.toNat < 2^64 := uLo.isLt
+      have h_eq : (2^64 : Nat) = 2^32 * 2^32 := by decide
+      exact Nat.div_lt_of_lt_mul (by omega)
+    -- rhatUn1.toNat = rhatc.toNat * 2^32 + div_un1.toNat.
+    have h_rhatUn1_eq : rhatUn1.toNat =
+        rhatc.toNat * 2^32 + div_un1.toNat := by
+      show ((rhatc <<< (32 : BitVec 6).toNat) ||| div_un1).toNat = _
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      rw [h32]
+      exact EvmWord.halfword_combine rhatc div_un1 h_rhatc_lt_pow32 h_div_un1_lt
+    -- (q1c * dLo).toNat = q1c.toNat * dLo.toNat (no wrap: 2^32 * dLo < 2^64).
+    have h_qDlo_eq : (q1c * dLo).toNat = q1c.toNat * dLo.toNat := by
+      rw [BitVec.toNat_mul]
+      apply Nat.mod_eq_of_lt
+      rw [h_eq]
+      calc 2^32 * dLo.toNat < 2^32 * 2^32 := by
+              apply Nat.mul_lt_mul_left (by decide : 0 < 2^32) |>.mpr hdLo_lt
+        _ = 2^64 := by decide
+    -- Phase 1b check fires.
+    have h_ult : rhatUn1.toNat < (q1c * dLo).toNat := by
+      rw [h_rhatUn1_eq, h_qDlo_eq, h_eq]
+      calc rhatc.toNat * 2^32 + div_un1.toNat
+          < rhatc.toNat * 2^32 + 2^32 := by omega
+        _ = (rhatc.toNat + 1) * 2^32 := by ring
+        _ ≤ dLo.toNat * 2^32 := Nat.mul_le_mul_right _ (by omega)
+        _ = 2^32 * dLo.toNat := by ring
+    have h_check : BitVec.ult rhatUn1 (q1c * dLo) := by
+      show decide (rhatUn1.toNat < (q1c * dLo).toNat) = true
+      exact decide_eq_true h_ult
+    show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
+          else q1c).toNat < 2^32
+    rw [if_pos h_check]
+    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
+    rw [BitVec.toNat_add, h_se_neg1]
+    have h_q1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
+    rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
+        Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt_word]
+    omega
+  · -- q1c < 2^32 case: q1' ≤ q1c < 2^32.
+    have h_q1c_lt : q1c.toNat < 2^32 := by omega
+    have h_q1'_le_q1c : q1'.toNat ≤ q1c.toNat :=
+      div128Quot_q1_prime_le_q1c q1c dLo rhatUn1
+    omega
+
 /-- **KB-3f: No-wraparound for `q1' * dLo`.** Under the call-trial
     precondition, the Word-level product equals the Nat-level product:
 


### PR DESCRIPTION
## Summary

Two tightening lemmas strict-improving KB-3c/KB-3e by 1:

- `div128Quot_q1c_le_pow32`: `q1c.toNat ≤ 2^32` under hcall. Phase 1a's `hi1` correction absorbs the `q1 = 2^32 + 1` overshoot, leaving `q1c ∈ [0, 2^32]`.
- `div128Quot_q1_prime_le_pow32`: `q1'.toNat ≤ 2^32` under hcall. Phase 1b monotonicity (KB-3d2) preserves the q1c bound.

Strict tightening of KB-3e (`q1' ≤ 2^32 + 1`) by 1. Brings us one step closer to Knuth's `q1' < 2^32` invariant, which is the last gap for applying plain `halfword_combine` (instead of `halfword_combine_mod`) to the div128Quot output — avoiding the `% 2^32` in KB-6a.

Independent of the pending KB-3l..KB-5 stacked chain and KB-6a (#1023) — uses only main-branch infrastructure (KB-3c, KB-3d1, KB-3d2). Targets \`main\` directly.

Ref: \`memory/project_knuth_theorem_b_plan.md\`

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.Div128QuotientBounds\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)