### PR TITLE
refactor(EvmWordArith/DivBridge): flip q arg on fromLimbs_single_toNat to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -74,7 +74,7 @@ theorem mod_of_nat_euclidean (a b q r : EvmWord) (hbnz : b ≠ 0)
 -- ============================================================================
 
 /-- fromLimbs with a single nonzero limb in position 0: toNat = q.toNat. -/
-theorem fromLimbs_single_toNat (q : Word) :
+theorem fromLimbs_single_toNat {q : Word} :
     (fromLimbs fun i : Fin 4 => match i with | 0 => q | _ => 0).toNat = q.toNat := by
   rw [fromLimbs_toNat]; simp
 


### PR DESCRIPTION
## Summary

Flip `(q : Word)` to implicit on `fromLimbs_single_toNat` in `EvmWordArith/DivBridge.lean`. Lemma is currently unused (scaffolding).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)