### PR TITLE
refactor(Evm64/Stack): flip addr arg on evmWordIs_congr to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -63,12 +63,12 @@ open EvmAsm.Rv64.AddrNorm (word_add_zero word_toNat_0)
     bzero spec's postcondition site. -/
 theorem evmWordIs_div_zero_right {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.div a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr addr EvmWord.div_zero_right
+  evmWordIs_congr EvmWord.div_zero_right
 
 /-- MOD counterpart of `evmWordIs_div_zero_right`. -/
 theorem evmWordIs_mod_zero_right {addr : Word} {a : EvmWord} :
     evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr addr EvmWord.mod_zero_right
+  evmWordIs_congr EvmWord.mod_zero_right
 
 /-- Full unfold of `evmWordIs addr (EvmWord.div a 0)` straight to four zero
     memIs atoms, bundling `evmWordIs_div_zero_right` + `evmWordIs_zero`

--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -169,7 +169,7 @@ theorem evmStackIs_triple_flat_right {sp : Word} {a b c : EvmWord}
     address agrees. Trivial `congrArg` application, but named for use
     with `rw [evmWordIs_congr hv]` style rewriting where `hv : v = w`
     is a hypothesis produced by an upstream bridge lemma. -/
-theorem evmWordIs_congr (addr : Word) {v w : EvmWord} (hv : v = w) :
+theorem evmWordIs_congr {addr : Word} {v w : EvmWord} (hv : v = w) :
     evmWordIs addr v = evmWordIs addr w :=
   congrArg (evmWordIs addr) hv
 


### PR DESCRIPTION
## Summary

Flip `(addr : Word)` to implicit on `evmWordIs_congr` in `EvmAsm/Evm64/Stack.lean`.

Called term-mode at 2 sites in `DivMod/Spec.lean` (the zero-divisor bridge lemma bodies). Flipping lets callers drop the `addr` positional arg; Lean infers it from the expected type (both sides of the equation mention `evmWordIs addr _`).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)