### PR TITLE
feat(divmod): divScratchValuesCall_implies_divScratchOwnCall (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -435,6 +435,25 @@ theorem divScratchValues_implies_divScratchOwn
   iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
   exact memIs_implies_memOwn _ _
 
+/-- Call-path weakening: the 19-cell `divScratchValuesCall` implies the
+    value-agnostic `divScratchOwnCall`. Used by the forthcoming
+    `div_n4_call_skip_stack_weaken` and friends to hide the call-trial
+    scratch state (including the 4 `div128`-subroutine cells at
+    `sp + 3968/3960/3952/3944`) on stack-spec exit. -/
+theorem divScratchValuesCall_implies_divScratchOwnCall
+    (sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem
+     retMem dMem dloMem scratch_un0 : Word) :
+    ∀ h, divScratchValuesCall sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0 h →
+      divScratchOwnCall sp h := by
+  unfold divScratchValuesCall divScratchOwnCall
+  -- Head: divScratchValues → divScratchOwn via the 15-cell weakener.
+  apply sepConj_mono (divScratchValues_implies_divScratchOwn
+    sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
+  -- Tail: 4 memIs → memOwn, same pattern as the 15-cell weakener.
+  iterate 3 apply sepConj_mono (memIs_implies_memOwn _ _)
+  exact memIs_implies_memOwn _ _
+
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/antiShift computation, normalized b'[0..3],
     and normalized u[0..4] as internal let bindings.

--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -151,6 +151,71 @@ instance (sp : Word) (a b : EvmWord) :
     Assertion.PCFree (modN4CallSkipStackPost sp a b) :=
   ⟨pcFree_modN4CallSkipStackPost sp a b⟩
 
+/-- Call-path counterpart to `div_n4_max_skip_stack_weaken`. Weakens a
+    concrete post state (19-cell `divScratchValuesCall` + 7 register
+    values) to `divN4CallSkipStackPost`. Structural mirror of the
+    max-path weakener, with `divScratchValuesCall_implies_divScratchOwnCall`
+    handling the 19-cell scratch weakening (4 extra cells beyond the 15
+    of `divScratchValues`).
+
+    Used by the forthcoming `evm_div_n4_call_skip_stack_spec` — the
+    remaining semantic bridge (connecting `div128Quot`'s output to
+    `(EvmWord.div a b).getLimbN 0..3`) depends on Knuth B.  -/
+theorem div_n4_call_skip_stack_weaken
+    (sp : Word) (a b : EvmWord)
+    (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
+    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+     shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p : Word) :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
+       (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
+       divScratchValuesCall sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
+         u5_p u6_p u7_p shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p) h →
+      divN4CallSkipStackPost sp a b h := by
+  intro h hp
+  delta divN4CallSkipStackPost
+  refine sepConj_mono_right ?_ h hp
+  iterate 7 apply sepConj_mono (regIs_implies_regOwn _ _)
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+    shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p
+
+/-- MOD counterpart of `div_n4_call_skip_stack_weaken`. Same structural
+    weakening; only the second operand slot holds `EvmWord.mod a b`
+    instead of `EvmWord.div a b`. -/
+theorem mod_n4_call_skip_stack_weaken
+    (sp : Word) (a b : EvmWord)
+    (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
+    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+     shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p : Word) :
+    ∀ h,
+      ((.x12 ↦ᵣ (sp + 32)) **
+       (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
+       (.x5 ↦ᵣ v5_p) ** (.x6 ↦ᵣ v6_p) ** (.x7 ↦ᵣ v7_p) **
+       (.x10 ↦ᵣ v10_p) ** (.x11 ↦ᵣ v11_p) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
+       divScratchValuesCall sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p
+         u5_p u6_p u7_p shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p) h →
+      modN4CallSkipStackPost sp a b h := by
+  intro h hp
+  delta modN4CallSkipStackPost
+  refine sepConj_mono_right ?_ h hp
+  iterate 7 apply sepConj_mono (regIs_implies_regOwn _ _)
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  apply sepConj_mono_right
+  exact divScratchValuesCall_implies_divScratchOwnCall
+    sp q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+    shift_p n_p j_p retMem_p dMem_p dloMem_p scratch_un0_p
+
 -- ============================================================================
 -- DIV n=4 call+skip full-path stack-pre wrappers
 -- ============================================================================


### PR DESCRIPTION
## Summary

19-cell call-path weakener mirroring \`divScratchValues_implies_divScratchOwn\` (15 cells). Decomposes into:

- **Head** (15 cells): apply \`divScratchValues_implies_divScratchOwn\`.
- **Tail** (4 extra cells at \`sp + 3968/3960/3952/3944\`): memIs → memOwn.

Used by the forthcoming \`div_n4_call_skip_stack_weaken\` family (and the shift0 / addback_beq / MOD variants) to hide the call-trial scratch state on stack-spec exit. Critical-path scaffolding for call-path stack specs (whose semantic content is blocked on Knuth-B per the plan memo).

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.Compose.Base\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)