### PR TITLE
refactor(DivMod/SpecCall): flip a b args on 3 Shift0Evm_def lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -561,7 +561,7 @@ def isSkipBorrowN4Shift0Evm (a b : EvmWord) : Prop :=
   isSkipBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                        (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
-theorem isSkipBorrowN4Shift0Evm_def (a b : EvmWord) :
+theorem isSkipBorrowN4Shift0Evm_def {a b : EvmWord} :
     isSkipBorrowN4Shift0Evm a b =
     isSkipBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                          (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
@@ -723,7 +723,7 @@ def isAddbackBorrowN4Shift0Evm (a b : EvmWord) : Prop :=
   isAddbackBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
-theorem isAddbackBorrowN4Shift0Evm_def (a b : EvmWord) :
+theorem isAddbackBorrowN4Shift0Evm_def {a b : EvmWord} :
     isAddbackBorrowN4Shift0Evm a b =
     isAddbackBorrowN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                             (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
@@ -733,7 +733,7 @@ def isAddbackCarry2NzN4Shift0Evm (a b : EvmWord) : Prop :=
   isAddbackCarry2NzN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                             (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
-theorem isAddbackCarry2NzN4Shift0Evm_def (a b : EvmWord) :
+theorem isAddbackCarry2NzN4Shift0Evm_def {a b : EvmWord} :
     isAddbackCarry2NzN4Shift0Evm a b =
     isAddbackCarry2NzN4Shift0 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                               (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on 3 EVM-level borrow/carry predicate unfolds in `SpecCall.lean`:
- `isSkipBorrowN4Shift0Evm_def`
- `isAddbackBorrowN4Shift0Evm_def`
- `isAddbackCarry2NzN4Shift0Evm_def`

All three currently have no external callers — scaffolding for the shift-0 full-path specs.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)