### PR TITLE
refactor(EvmWordArith/Comparison): flip a b args on 2 chain-correct lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Comparison.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Comparison.lean
@@ -16,7 +16,7 @@ namespace EvmWord
 -- LT correctness: borrow chain = unsigned less-than
 -- ============================================================================
 
-theorem lt_borrow_chain_correct (a b : EvmWord) :
+theorem lt_borrow_chain_correct {a b : EvmWord} :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
     let a1 := a.getLimb 1; let b1 := b.getLimb 1
     let a2 := a.getLimb 2; let b2 := b.getLimb 2
@@ -108,7 +108,7 @@ theorem lt_borrow_chain_correct (a b : EvmWord) :
 -- ============================================================================
 
 /-- The SLT result equals `if BitVec.slt a b then 1 else 0`. -/
-theorem slt_result_correct (a b : EvmWord) :
+theorem slt_result_correct {a b : EvmWord} :
     let a0 := a.getLimb 0; let b0 := b.getLimb 0
     let a1 := a.getLimb 1; let b1 := b.getLimb 1
     let a2 := a.getLimb 2; let b2 := b.getLimb 2

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -117,7 +117,7 @@ theorem evm_gt_stack_spec (sp base : Word)
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
                  ite_self,
-                 ← EvmWord.lt_borrow_chain_correct b a]
+                 ← EvmWord.lt_borrow_chain_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       rw [spAddr32_8, spAddr32_16, spAddr32_24]

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -117,7 +117,7 @@ theorem evm_lt_stack_spec (sp base : Word)
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
                  ite_self,
-                 ← EvmWord.lt_borrow_chain_correct a b]
+                 ← EvmWord.lt_borrow_chain_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       rw [spAddr32_8, spAddr32_16, spAddr32_24]

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -157,7 +157,7 @@ theorem evm_sgt_stack_spec (sp base : Word)
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
                  ite_self,
-                 ← EvmWord.slt_result_correct b a]
+                 ← EvmWord.slt_result_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       rw [spAddr32_8, spAddr32_16, spAddr32_24]

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -155,7 +155,7 @@ theorem evm_slt_stack_spec (sp base : Word)
                  EvmWord.getLimbN_one_zero, EvmWord.getLimbN_one_one,
                  EvmWord.getLimbN_one_two, EvmWord.getLimbN_one_three,
                  ite_self,
-                 ← EvmWord.slt_result_correct a b]
+                 ← EvmWord.slt_result_correct]
       simp only [EvmWord.getLimb_as_getLimbN_0, EvmWord.getLimb_as_getLimbN_1,
                  EvmWord.getLimb_as_getLimbN_2, EvmWord.getLimb_as_getLimbN_3]
       rw [spAddr32_8, spAddr32_16, spAddr32_24]


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on:
- `EvmWord.lt_borrow_chain_correct`
- `EvmWord.slt_result_correct`

Both used term-mode at 4 `rw [← ... a b]` sites across `Lt/Spec.lean`, `Gt/Spec.lean`, `Sgt/Spec.lean`, `Slt/Spec.lean`. Flipping lets callers drop the positional args — Lean infers `a`, `b` from the goal.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)