### PR TITLE
refactor(EvmWordArith/DivN4Lemmas): flip a b args on 4 trivial-quotient lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
@@ -49,12 +49,12 @@ private theorem bnz_of_lt {a b : EvmWord} (h : a.toNat < b.toNat) : b ≠ 0 := b
   intro heq; subst heq; simp at h
 
 /-- When a < b, the quotient is 0. -/
-theorem div_zero_of_lt (a b : EvmWord) (h_lt : a.toNat < b.toNat) :
+theorem div_zero_of_lt {a b : EvmWord} (h_lt : a.toNat < b.toNat) :
     EvmWord.div a b = 0 :=
   (div_of_nat_euclidean a b 0 a (bnz_of_lt h_lt) (by simp) h_lt).symm
 
 /-- When a < b, the remainder is a itself. -/
-theorem mod_self_of_lt (a b : EvmWord) (h_lt : a.toNat < b.toNat) :
+theorem mod_self_of_lt {a b : EvmWord} (h_lt : a.toNat < b.toNat) :
     EvmWord.mod a b = a :=
   (mod_of_nat_euclidean a b 0 a (bnz_of_lt h_lt) (by simp) h_lt).symm
 
@@ -66,7 +66,7 @@ private theorem bnz_of_lt2 {a b : EvmWord} (h : a.toNat < 2 * b.toNat) : b ≠ 0
   intro heq; subst heq; simp at h
 
 /-- When b ≤ a < 2b, the quotient is 1. -/
-theorem div_one_of_ge_lt (a b : EvmWord)
+theorem div_one_of_ge_lt {a b : EvmWord}
     (h_ge : b.toNat ≤ a.toNat) (h_lt2 : a.toNat < 2 * b.toNat) :
     EvmWord.div a b = 1 := by
   have h1 : (1 : EvmWord).toNat = 1 := by decide
@@ -75,7 +75,7 @@ theorem div_one_of_ge_lt (a b : EvmWord)
     (by rw [BitVec.toNat_sub_of_le (BitVec.le_def.mpr h_ge)]; omega)).symm
 
 /-- When b ≤ a < 2b, the remainder is a - b. -/
-theorem mod_sub_of_ge_lt (a b : EvmWord)
+theorem mod_sub_of_ge_lt {a b : EvmWord}
     (h_ge : b.toNat ≤ a.toNat) (h_lt2 : a.toNat < 2 * b.toNat) :
     EvmWord.mod a b = a - b := by
   have h1 : (1 : EvmWord).toNat = 1 := by decide


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on 4 trivial-quotient / remainder lemmas:
- `div_zero_of_lt`, `mod_self_of_lt` (a < b path)
- `div_one_of_ge_lt`, `mod_sub_of_ge_lt` (b ≤ a < 2b path)

All four are currently unused (scaffolding for shift=0 divmod correctness chain). Hypothesis types (`h_lt : a.toNat < b.toNat`, `h_ge : b.toNat ≤ a.toNat`, etc.) pin `a`, `b`.

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)