### PR TITLE
refactor(EvmWordArith/Div): flip a b args on div_mod_add_eq to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -140,7 +140,7 @@ theorem bv_udiv_umod_unique {n : Nat} {a b q r : BitVec n}
 -- ============================================================================
 
 /-- EvmWord Euclidean division property: `b * (div a b) + mod a b = a` when b ≠ 0. -/
-theorem div_mod_add_eq (a b : EvmWord) (hbnz : b ≠ 0) :
+theorem div_mod_add_eq {a b : EvmWord} (hbnz : b ≠ 0) :
     b * (div a b) + mod a b = a := by
   simp only [div, mod, if_neg hbnz]
   exact bv_udiv_add_umod


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on `div_mod_add_eq` in `EvmWordArith/Div.lean`. Lemma currently unused (scaffolding).

## Test plan

- [x] `lake build` succeeds locally (3561 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)