### PR TITLE
ci: cache .lake/build between runs to skip rebuilding evm-asm oleans

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,20 @@ jobs:
       - uses: actions/checkout@v4
       - name: File-size guardrail
         run: scripts/check-file-size.sh
+      # Cache evm-asm's own olean artifacts under .lake/build between runs.
+      # `leanprover/lean-action` already pulls mathlib's prebuilt cache via
+      # `use-mathlib-cache: true`, but our own ~3540 oleans were rebuilt cold
+      # on every PR. Keying on source + toolchain + manifest hashes lets
+      # `lake build` do its normal incremental rebuild (only touched modules
+      # + their downstream dependents) when restoring a near-miss.
+      - name: Cache evm-asm build artifacts
+        uses: actions/cache@v4
+        with:
+          path: .lake/build
+          key: evm-asm-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ hashFiles('EvmAsm/**/*.lean') }}
+          restore-keys: |
+            evm-asm-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
+            evm-asm-build-${{ runner.os }}-
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true


### PR DESCRIPTION
## Summary

Add `actions/cache@v4` caching of `.lake/build` in the Build workflow.

The existing workflow uses `leanprover/lean-action@v1` with `use-mathlib-cache: true`, which pulls mathlib's prebuilt oleans via `lake exe cache get`. But evm-asm's **own** build artifacts (~3540 oleans under `.lake/build`) were rebuilt from scratch on every run.

This PR keys the cache on `lean-toolchain` + `lake-manifest.json` + `EvmAsm/**/*.lean` hashes, with a restore-keys ladder that falls back to a manifest-only prefix then OS-only prefix. On a near-miss, `lake build`'s own incremental logic rebuilds only the touched modules and their downstream dependents — which for typical single-file PRs is a handful of oleans, not 3540.

## Expected savings

Most PRs should drop ~5–8 min off CI wall-clock.

## Risk

- **Zero build-semantics risk**: `lake build` already does source-hash-based incremental rebuilds; restoring a stale `.lake/build` just means `lake` finds outdated oleans and rebuilds them.
- **Cache-key collisions**: the `EvmAsm/**/*.lean` hash includes every source file, so any source change invalidates the exact key. The restore-keys ladder is where near-misses are served from.
- **Cache corruption**: `actions/cache@v4` is atomic per key; a bad cache would only affect the exact commit that wrote it.

## Test plan

- [x] Workflow syntax is valid YAML
- [ ] First green CI on this PR writes a cache entry; subsequent PRs (or pushes to this branch) should show `lake build` producing a much smaller incremental rebuild rather than the full ~3540-job cold build

🤖 Generated with [Claude Code](https://claude.com/claude-code)