### PR TITLE
refactor(Rv64/{HalfwordOps,WordOps}): replace Mathlib.Tactic with 3 specific imports

### DIFF
--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -9,7 +9,9 @@ import EvmAsm.Rv64.Basic
 import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SepLogic
 import EvmAsm.Rv64.CPSSpec
-import Mathlib.Tactic
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.FinCases
+import Mathlib.Data.Fintype.Basic
 
 namespace EvmAsm.Rv64
 

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -9,7 +9,9 @@ import EvmAsm.Rv64.Basic
 import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SepLogic
 import EvmAsm.Rv64.CPSSpec
-import Mathlib.Tactic
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.FinCases
+import Mathlib.Data.Fintype.Basic
 
 namespace EvmAsm.Rv64
 


### PR DESCRIPTION
## Summary

Shake flagged `import Mathlib.Tactic` in `Rv64/HalfwordOps.lean` and `Rv64/WordOps.lean` as unnecessarily broad. Replace with the 3 specific modules actually used:
- `Mathlib.Tactic.IntervalCases` (for `interval_cases`)
- `Mathlib.Tactic.FinCases` (for `fin_cases`)
- `Mathlib.Data.Fintype.Basic` (for the `Fintype (Fin n)` instance that `fin_cases` needs)

First step of a broader import-hygiene pass prompted by a local `lake exe shake` run.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)