### PR TITLE
feat(divmod): KB-LB4 Knuth Theorem C abstract-algebra form (#61)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -742,4 +742,34 @@ theorem div128Quot_q1c_ge_q_true_1
         Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
     omega
 
+/-- **KB-LB4: Knuth Theorem C (abstract algebra form).** The
+    multiplication-check inequality implies the trial overshoots the
+    true first digit:
+
+    ```
+    rhatc * 2^32 + div_un1 < q1c * dLo
+      → uHi * 2^32 + div_un1 < q1c * (dHi * 2^32 + dLo)
+    ```
+
+    Proof: use Phase 1a Euclidean (`q1c * dHi + rhatc = uHi`) to
+    substitute `rhatc = uHi - q1c * dHi`, then rearrange. Pure Nat
+    algebra on abstract (uHi, dHi, dLo, div_un1, rhatc, q1c). -/
+theorem knuth_theorem_c_abstract
+    (uHi dHi dLo div_un1 rhatc q1c : Word)
+    (h_eucl : q1c.toNat * dHi.toNat + rhatc.toNat = uHi.toNat)
+    (h_check : rhatc.toNat * 2^32 + div_un1.toNat < q1c.toNat * dLo.toNat) :
+    uHi.toNat * 2^32 + div_un1.toNat <
+    q1c.toNat * (dHi.toNat * 2^32 + dLo.toNat) := by
+  -- Multiply Euclidean by 2^32: q1c * dHi * 2^32 + rhatc * 2^32 = uHi * 2^32.
+  have h_eucl_mul : q1c.toNat * dHi.toNat * 2^32 + rhatc.toNat * 2^32 =
+      uHi.toNat * 2^32 := by
+    have := congr_arg (· * 2^32) h_eucl
+    simp only [Nat.add_mul] at this
+    exact this
+  -- Distribute q1c * vTop:
+  have h_expand : q1c.toNat * (dHi.toNat * 2^32 + dLo.toNat) =
+      q1c.toNat * dHi.toNat * 2^32 + q1c.toNat * dLo.toNat := by ring
+  rw [h_expand]
+  linarith
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Abstract algebra core of **Knuth TAOCP Theorem C**: the multiplication-check inequality implies the trial overshoots the true first digit.

\`\`\`
rhatc * 2^32 + div_un1 < q1c * dLo
  → uHi * 2^32 + div_un1 < q1c * (dHi * 2^32 + dLo)
\`\`\`

Proof: use Phase 1a Euclidean (\`q1c * dHi + rhatc = uHi\`) to substitute \`rhatc = uHi - q1c * dHi\`, then rearrange. Pure Nat algebra on abstract (uHi, dHi, dLo, div_un1, rhatc, q1c).

This is the abstract-level content of Knuth Theorem C. **Lifting to the Word-level Phase 1b check still requires handling the \`rhatc < 2^32\` vs \`rhatc ≥ 2^32\` cases separately** (Word truncation in rhatUn1), planned for subsequent iterations.

Independent on main; continues the Knuth lower-bound chain (KB-LB1/2/3 landed in #1040/#1043).

Ref: \`memory/project_un21_lt_vTop_plan.md\`

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.Div128QuotientBounds\` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)