### PR TITLE
ci: revert #1038 — our .lake/build cache is redundant with lean-action's

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,20 +15,6 @@ jobs:
       - uses: actions/checkout@v4
       - name: File-size guardrail
         run: scripts/check-file-size.sh
-      # Cache evm-asm's own olean artifacts under .lake/build between runs.
-      # `leanprover/lean-action` already pulls mathlib's prebuilt cache via
-      # `use-mathlib-cache: true`, but our own ~3540 oleans were rebuilt cold
-      # on every PR. Keying on source + toolchain + manifest hashes lets
-      # `lake build` do its normal incremental rebuild (only touched modules
-      # + their downstream dependents) when restoring a near-miss.
-      - name: Cache evm-asm build artifacts
-        uses: actions/cache@v4
-        with:
-          path: .lake/build
-          key: evm-asm-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-${{ hashFiles('EvmAsm/**/*.lean') }}
-          restore-keys: |
-            evm-asm-build-${{ runner.os }}-${{ hashFiles('lean-toolchain', 'lake-manifest.json') }}-
-            evm-asm-build-${{ runner.os }}-
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true


### PR DESCRIPTION
## Summary

Revert #1038. The `actions/cache@v4` step I added for `.lake/build` turns out to be fully subsumed by the cache that `leanprover/lean-action@v1` already sets up internally.

## Evidence from CI logs

Looking at a recent green run on main, the log shows two distinct cache restores:

| Step                                  | Path                   | Cache size |
|---------------------------------------|------------------------|-----------:|
| **My step** — "Cache evm-asm build artifacts" | `.lake/build` (evm-asm oleans only) | ~55 MB |
| **lean-action's step** — via its own `actions/cache/restore@v5` with key `lake-Linux-X64-...` | full `.lake/` subtree | ~2271 MB |

lean-action@v1 defaults `use-github-cache: true`, which triggers that second cache (even though our workflow only sets `use-mathlib-cache: true` explicitly). Its tar extract runs *after* my step, so when the keys both hit, the larger restore overwrites whatever my step put into `.lake/build`.

Consequence: my step adds 1-2 s of cache restore/save overhead with no incremental benefit — lean-action's cache already covers evm-asm's `.lake/build` as a subset.

## Test plan

- [x] YAML is valid
- [ ] CI for this PR should complete in about the same time as before #1038 landed (we'll be watching whether removing the redundant cache step measurably speeds things up or is a wash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)