### PR TITLE
refactor(Rv64/Tactics/XPerm): drop unused import PerfTrace

### DIFF
--- a/EvmAsm/Rv64/Tactics/XPerm.lean
+++ b/EvmAsm/Rv64/Tactics/XPerm.lean
@@ -32,7 +32,6 @@
 import Lean
 import Lean.Meta.Tactic.AC.Main
 import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Tactics.PerfTrace
 
 open Lean Meta Elab Tactic
 


### PR DESCRIPTION
## Summary

Drop `import EvmAsm.Rv64.Tactics.PerfTrace` from `Rv64/Tactics/XPerm.lean` — shake-flagged, verified unused (`grep -c PerfTrace = 1`, just the import line).

One small slice of #1045. Most of shake's other suggestions turned out to be blindly unsafe (macros / instances / transitive references not accounted for); this one is simple enough to verify by hand.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)