### PR TITLE
refactor(Evm64/Basic): flip v/n/i args on 3 shift-by-≥256 lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -276,7 +276,7 @@ private theorem extractLsb'_split_64 (v : BitVec 256) (base bs : Nat) (hbs : bs 
       congr 1; omega
 
 /-- Shifting a 256-bit word right by `≥ 256` yields zero. -/
-theorem ushiftRight_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) :
+theorem ushiftRight_geq_256 {v : EvmWord} {n : Nat} (h : n ≥ 256) :
     v >>> n = (0 : EvmWord) := by
   ext j
   simp only [BitVec.getElem_ushiftRight]
@@ -285,7 +285,7 @@ theorem ushiftRight_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) :
   calc v.toNat < 2 ^ 256 := v.isLt
     _ ≤ 2 ^ (n + ↑j) := Nat.pow_le_pow_right (by omega) (by omega)
 
-theorem shiftLeft_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) :
+theorem shiftLeft_geq_256 {v : EvmWord} {n : Nat} (h : n ≥ 256) :
     v <<< n = (0 : EvmWord) := by
   ext j
   simp only [BitVec.getElem_shiftLeft]
@@ -553,7 +553,7 @@ theorem getLimb_sshiftRight_sign' {v : EvmWord} {n : Nat} {i : Fin 4}
                show (64 : Nat) - 1 - 0 < 64 from by omega, decide_true, Bool.true_and]
 
 /-- Shifting a 256-bit word arithmetically right by `≥ 256` yields sign extension on each limb. -/
-theorem getLimb_sshiftRight_geq_256 (v : EvmWord) (n : Nat) (h : n ≥ 256) (i : Fin 4) :
+theorem getLimb_sshiftRight_geq_256 {v : EvmWord} {n : Nat} (h : n ≥ 256) {i : Fin 4} :
     getLimb (BitVec.sshiftRight v n) i =
     BitVec.sshiftRight (v.getLimb ⟨3, by omega⟩) 63 :=
   getLimb_sshiftRight_sign' (by omega)


### PR DESCRIPTION
## Summary

Flip args on 3 shift-by-≥256 bound lemmas in `Evm64/Basic.lean`:
- `ushiftRight_geq_256 {v, n} (h : n ≥ 256)` — v, n → implicit
- `shiftLeft_geq_256 {v, n} (h : n ≥ 256)` — v, n → implicit
- `getLimb_sshiftRight_geq_256 {v, n} (h) {i : Fin 4}` — v, n, i → implicit

All three unused externally (scaffolding). `h : n ≥ 256` pins `n`; `v` and `i` appear in the goal's equation shape.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)