### PR TITLE
refactor(DivMod/Spec): flip a b on n4MaxDoubleAddbackSemanticHolds_def to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -263,7 +263,7 @@ def n4MaxDoubleAddbackSemanticHolds (a b : EvmWord) : Prop :=
   (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)).toNat = 1
 
-theorem n4MaxDoubleAddbackSemanticHolds_def (a b : EvmWord) :
+theorem n4MaxDoubleAddbackSemanticHolds_def {a b : EvmWord} :
     n4MaxDoubleAddbackSemanticHolds a b =
     (let ms := mulsubN4 (signExtend12 4095)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)


### PR DESCRIPTION
## Summary

Flip `(a b : EvmWord)` to implicit on `n4MaxDoubleAddbackSemanticHolds_def` in `DivMod/Spec.lean`. Unused scaffolding — matches the 10 siblings landed via #1047.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)