### PR TITLE
refactor(Evm64/Stack): flip sp arg on evmStackIs_congr to implicit

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -185,7 +185,7 @@ theorem evmWordIs_congr_addr {a b : Word} (v : EvmWord) (ha : a = b) :
     `evmStackIs` at the same sp agrees. Useful when `List.map` / spec-side
     computation produces a list that matches another up to propositional
     equality but not definitionally. -/
-theorem evmStackIs_congr (sp : Word) {xs ys : List EvmWord} (hxy : xs = ys) :
+theorem evmStackIs_congr {sp : Word} {xs ys : List EvmWord} (hxy : xs = ys) :
     evmStackIs sp xs = evmStackIs sp ys :=
   congrArg (evmStackIs sp) hxy
 


### PR DESCRIPTION
## Summary

Flip `(sp : Word)` to implicit on `evmStackIs_congr` in `Stack.lean`. Unused scaffolding.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)