### PR TITLE
refactor(Evm64/Basic): flip v/k args on getLimbN_{lt,ge} to implicit

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -164,11 +164,11 @@ theorem toNat_eq_getLimb0_of_high_zero {v : EvmWord}
 def getLimbN (v : EvmWord) (k : Nat) : Word :=
   if h : k < 4 then v.getLimb ⟨k, h⟩ else 0
 
-theorem getLimbN_lt (v : EvmWord) (k : Nat) (h : k < 4) :
+theorem getLimbN_lt {v : EvmWord} {k : Nat} (h : k < 4) :
     v.getLimbN k = v.getLimb ⟨k, h⟩ := by
   simp [getLimbN, h]
 
-theorem getLimbN_ge (v : EvmWord) (k : Nat) (h : k ≥ 4) :
+theorem getLimbN_ge {v : EvmWord} {k : Nat} (h : k ≥ 4) :
     v.getLimbN k = 0 := by
   simp [getLimbN, show ¬(k < 4) from by omega]
 

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -532,8 +532,8 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight, hL_div,
-      getLimbN_lt value (i.val + L) hiL,
-      getLimbN_lt value (i.val + L + 1) hiL1]
+      getLimbN_lt hiL,
+      getLimbN_lt hiL1]
   by_cases hmod0 : s0.toNat % 64 = 0
   · have hmask : mask = 0 := by
       simp only [mask]; have : BitVec.ult (0 : Word) bs = false := by simp [BitVec.ult]; omega
@@ -566,7 +566,7 @@ private theorem shr_bridge_last (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight, hL_div, hiL,
-      getLimbN_lt value 3 (by omega), getLimbN_ge value 4 (by omega)]
+      getLimbN_lt (by omega : 3 < 4), getLimbN_ge (by omega : 4 ≥ 4)]
   simp [show bs.toNat % 64 = s0.toNat % 64 from by omega]
 
 -- Zero limb bridge: for limbs beyond the shift (i+L >= 4, result is 0).
@@ -581,8 +581,8 @@ private theorem shr_bridge_zero (value : EvmWord) (s0 : Word)
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight, hL_div,
-      getLimbN_ge value (i.val + L) (by omega),
-      getLimbN_ge value (i.val + L + 1) (by omega)]
+      getLimbN_ge (by omega),
+      getLimbN_ge (by omega)]
   simp
 
 open EvmWord in

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -662,8 +662,8 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
   -- sshiftRight agrees with ushiftRight for merge limbs
   rw [getLimb_sshiftRight_eq_ushiftRight (by omega)]
   rw [getLimb_ushiftRight, hL_div,
-      getLimbN_lt value (i.val + L) (by omega),
-      getLimbN_lt value (i.val + L + 1) hiL1]
+      getLimbN_lt (by omega : i.val + L < 4),
+      getLimbN_lt hiL1]
   by_cases hmod0 : s0.toNat % 64 = 0
   · have hmask : mask = 0 := by
       simp only [mask]; have : BitVec.ult (0 : Word) bs = false := by simp [BitVec.ult]; omega

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -499,8 +499,8 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft: i*64 >= s0.toNat since i >= L+1 and s0.toNat = L*64 + bs < (L+1)*64
   rw [getLimb_shiftLeft (by omega), hL_div,
-      getLimbN_lt value (i.val - L) hiLsub,
-      getLimbN_lt value (i.val - L - 1) hiLsub1]
+      getLimbN_lt hiLsub,
+      getLimbN_lt hiLsub1]
   -- Now match the masks and shift amounts
   by_cases hmod0 : s0.toNat % 64 = 0
   · -- bs = 0 case: mask = 0, helper mask = 0
@@ -538,7 +538,7 @@ private theorem shl_bridge_first (value : EvmWord) (s0 : Word)
   -- Use getLimb_shiftLeft_eq_div: i.val = n / 64
   rw [getLimb_shiftLeft_eq_div (by omega)]
   -- getLimbN v 0 = getLimb v ⟨0, _⟩
-  rw [getLimbN_lt value 0 (by omega)]
+  rw [getLimbN_lt (by omega : 0 < 4)]
   -- Shift amounts match: bs.toNat % 64 = s0.toNat % 64
   congr 1; omega
 

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -693,7 +693,7 @@ theorem signext_body_spec (sp base : Word)
   -- getLimbN = getLimb for in-range indices
   have hlimbIdx_lt4 : limbIdx.toNat < 4 := by rw [hlimbIdx_eq]; omega
   have hLN_eq : x.getLimbN (b.toNat / 8) = x.getLimb ⟨b.toNat / 8, by omega⟩ :=
-    EvmWord.getLimbN_lt x (b.toNat / 8) (by omega)
+    EvmWord.getLimbN_lt (by omega : b.toNat / 8 < 4)
   -- signextLimb and signextFill in terms of body output
   -- signextLimb (x.getLimbN (b.toNat/8)) (BitVec.ofNat 64 (56-(b.toNat%8)*8))
   --   = sshiftRight (getLimbN <<< sa_mod) sa_mod


### PR DESCRIPTION
## Summary

Flip `(v : EvmWord) (k : Nat)` to implicit on `getLimbN_lt` and `getLimbN_ge` in `Evm64/Basic.lean`. The proof term `h : k < 4` / `h : k ≥ 4` stays explicit.

Callers across `Shift/Compose`, `Shift/SarCompose`, `Shift/ShlCompose`, and `SignExtend/Compose` used them term-mode inside `rw [getLimbN_lt value K hK, ...]`. After the flip, Lean's `rw` infers `v` and `k` by unifying the lemma's LHS against the goal.

10 call sites updated.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)