### PR TITLE
refactor(Rv64/SepLogic): flip a/v args on memIs_implies_memOwn to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -432,8 +432,8 @@ theorem divScratchValues_implies_divScratchOwn
         shiftMem nMem jMem h → divScratchOwn sp h := by
   unfold divScratchValues divScratchOwn
   -- Weaken each of the 15 memIs cells to memOwn, left to right.
-  iterate 14 apply sepConj_mono (memIs_implies_memOwn _ _)
-  exact memIs_implies_memOwn _ _
+  iterate 14 apply sepConj_mono (memIs_implies_memOwn)
+  exact memIs_implies_memOwn
 
 /-- Call-path weakening: the 19-cell `divScratchValuesCall` implies the
     value-agnostic `divScratchOwnCall`. Used by the forthcoming
@@ -451,8 +451,8 @@ theorem divScratchValuesCall_implies_divScratchOwnCall
   apply sepConj_mono (divScratchValues_implies_divScratchOwn
     sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem)
   -- Tail: 4 memIs → memOwn, same pattern as the 15-cell weakener.
-  iterate 3 apply sepConj_mono (memIs_implies_memOwn _ _)
-  exact memIs_implies_memOwn _ _
+  iterate 3 apply sepConj_mono (memIs_implies_memOwn)
+  exact memIs_implies_memOwn
 
 /-- Postcondition for the shift≠0 path from entry to loop setup.
     Encapsulates the shift/antiShift computation, normalized b'[0..3],

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -74,8 +74,8 @@ private theorem mul_stack_weaken (sp : Word) (a b : EvmWord)
   delta evmMulStackPost
   refine sepConj_mono_right ?_ h hp
   iterate 5 apply sepConj_mono (regIs_implies_regOwn _ _)
-  iterate 3 apply sepConj_mono (memIs_implies_memOwn _ _)
-  exact sepConj_mono_left (memIs_implies_memOwn _ _)
+  iterate 3 apply sepConj_mono (memIs_implies_memOwn)
+  exact sepConj_mono_left (memIs_implies_memOwn)
 
 -- ============================================================================
 -- Stack-level MUL spec

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -468,7 +468,7 @@ theorem holdsFor_memOwn {a : Word} {s : MachineState} :
 theorem regIs_implies_regOwn (r : Reg) (v : Word) :
     ∀ h, regIs r v h → regOwn r h := fun _ hp => ⟨v, hp⟩
 
-theorem memIs_implies_memOwn (a : Word) (v : Word) :
+theorem memIs_implies_memOwn {a : Word} {v : Word} :
     ∀ h, memIs a v h → memOwn a h := fun _ hp => ⟨v, hp⟩
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Flip `(a : Word) (v : Word)` to implicit on `memIs_implies_memOwn`. 6 call sites passing `_ _` placeholders drop them — Lean infers from the expected type at `sepConj_mono`'s argument position.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)