### PR TITLE
refactor(DivMod/Compose/Base): flip base arg on sharedDivModCode_sub_{div,mod}Code to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -150,7 +150,7 @@ private theorem shared_b12_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
 
 /-- sharedDivModCode ⊆ divCode: every shared block is also in divCode. -/
-theorem sharedDivModCode_sub_divCode (base : Word) :
+theorem sharedDivModCode_sub_divCode {base : Word} :
     ∀ a i, (sharedDivModCode base) a = some i → (divCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_split_mono (shared_b0_div base)
@@ -199,7 +199,7 @@ private theorem shared_b12_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128
 
 /-- sharedDivModCode ⊆ modCode: every shared block is also in modCode.
     Mirror of `sharedDivModCode_sub_divCode`. -/
-theorem sharedDivModCode_sub_modCode (base : Word) :
+theorem sharedDivModCode_sub_modCode {base : Word} :
     ∀ a i, (sharedDivModCode base) a = some i → (modCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_split_mono (shared_b0_mod base)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Loop.lean
@@ -146,7 +146,7 @@ theorem divK_loop_n1_unified_divCode (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
         retMem dMem dloMem scratch_un0)
       (loopN1UnifiedPost bltu_3 bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_2 u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) :=
-  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_n1_unified_spec bltu_3 bltu_2 bltu_1 bltu_0
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_2 u0_orig_1 u0_orig_0

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -123,7 +123,7 @@ theorem divK_loop_n2_unified_divCode (bltu_2 bltu_1 bltu_0 : Bool)
         retMem dMem dloMem scratch_un0)
       (loopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop
         u0_orig_1 u0_orig_0 retMem dMem dloMem scratch_un0) :=
-  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_n2_unified_spec bltu_2 bltu_1 bltu_0
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0_orig_1 u0_orig_0 q2Old q1Old q0Old

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -80,7 +80,7 @@ theorem divK_loop_n3_unified_divCode (bltu_1 bltu_0 : Bool)
         retMem dMem dloMem scratch_un0)
       (loopN3UnifiedPost bltu_1 bltu_0 sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig
         retMem dMem dloMem scratch_un0) :=
-  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_n3_unified_spec bltu_1 bltu_0
       sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop u0Orig q1Old q0Old

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -100,7 +100,7 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
        (qAddr ↦ₘ qOld))
       (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
-  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_body_n4_max_skip_j0_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
 
@@ -167,7 +167,7 @@ theorem divK_loop_body_n4_max_skip_j0_modCode
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
         v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
+  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode)
     (divK_loop_body_n4_max_skip_j0_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow)
   refine cpsTriple_weaken ?_ (fun _ hq => hq) h
@@ -276,7 +276,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
-  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_body_n4_call_skip_j0_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hborrow)
@@ -310,7 +310,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
        (qAddr ↦ₘ qOld))
       (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
-  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_body_n4_max_addback_j0_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hcarry2_nz hborrow)
 
@@ -377,7 +377,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
         qAddr hborrow
-  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode base)
+  exact cpsTriple_extend_code (hmono := sharedDivModCode_sub_divCode)
     (divK_loop_body_n4_call_addback_j0_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hcarry2_nz hborrow)
@@ -495,7 +495,7 @@ theorem divK_loop_body_n4_call_skip_j0_modCode
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   -- Apply the underlying spec (which has the algorithm's let-chain unfolded)
-  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
+  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode)
     (divK_loop_body_n4_call_skip_j0_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hborrow)
@@ -617,7 +617,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_modCode
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode base)
+  have h := cpsTriple_extend_code (hmono := sharedDivModCode_sub_modCode)
     (divK_loop_body_n4_call_addback_j0_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign hbltu hcarry2_nz hborrow)


### PR DESCRIPTION
## Summary

Flip `(base : Word)` to implicit on two subsumption bridge lemmas in `Compose/Base.lean`:
- `sharedDivModCode_sub_divCode`
- `sharedDivModCode_sub_modCode`

Called via named-arg `(hmono := ... base)` at 7 sites across `FullPathN{1,2,3,4}Loop.lean`. Lean infers `base` from the expected `hmono` type at `cpsTriple_extend_code`.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)