### PR TITLE
refactor(SailEquiv/MExtProofs): flip a/b on 4 BitVec 64 bridges to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -34,13 +34,13 @@ theorem to_bits_truncate_neg1 :
   simp [to_bits_truncate, get_slice_int, BitVec.allOnes]
 
 /-- to_bits_truncate roundtrips through toNatInt (unsigned interpretation). -/
-theorem to_bits_truncate_toNatInt (a : BitVec 64) :
+theorem to_bits_truncate_toNatInt {a : BitVec 64} :
     to_bits_truncate (l := 64) (BitVec.toNatInt a) = a := by
   simp [BitVec.toNatInt, to_bits_truncate, get_slice_int]
   apply BitVec.eq_of_toNat_eq; simp; omega
 
 /-- BEq bridge: Int.ofNat b.toNat == 0 ↔ b == 0#64. -/
-theorem int_ofNat_beq_zero (b : BitVec 64) :
+theorem int_ofNat_beq_zero {b : BitVec 64} :
     (Int.ofNat b.toNat == (0 : Int)) = (b == 0#64) := by
   simp [BEq.beq, decide_eq_decide]
   constructor
@@ -90,12 +90,12 @@ theorem signed_rem_equiv (a b : BitVec 64) :
   exact BitVec.ofInt_toInt
 
 /-- to_bits_truncate roundtrips through toInt (signed interpretation). -/
-theorem to_bits_truncate_toInt (a : BitVec 64) :
+theorem to_bits_truncate_toInt {a : BitVec 64} :
     to_bits_truncate (l := 64) a.toInt = a := by
   rw [to_bits_truncate_eq_ofInt]; exact BitVec.ofInt_toInt
 
 /-- BEq bridge for signed zero check: b.toInt == 0 ↔ b == 0#64. -/
-theorem int_toInt_beq_zero (b : BitVec 64) :
+theorem int_toInt_beq_zero {b : BitVec 64} :
     (b.toInt == (0 : Int)) = (b == 0#64) := by
   simp [BEq.beq, decide_eq_decide, BitVec.toInt]
   constructor


### PR DESCRIPTION
## Summary

Flip `(a : BitVec 64)` / `(b : BitVec 64)` to implicit on 4 bridge lemmas in `SailEquiv/MExtProofs.lean`:
- `to_bits_truncate_toNatInt` — unused
- `int_ofNat_beq_zero` — 2 `rw` sites
- `to_bits_truncate_toInt` — 1 `simp` site
- `int_toInt_beq_zero` — 2 `rw` sites

All callers use them bare via `rw [...]` / `simp [...]`.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)