### PR TITLE
refactor(SailEquiv/MonadLemmas): flip s arg on runSail_rX_bits_x0 to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -56,7 +56,7 @@ private theorem bv5_toNat_12 : BitVec.toNat (12 : BitVec 5) = 12 := by decide
 -- rX_bits — per-register read lemmas
 -- ============================================================================
 
-theorem runSail_rX_bits_x0 (s : SailState) :
+theorem runSail_rX_bits_x0 {s : SailState} :
     runSail (rX_bits (regidx.Regidx 0)) s = some (0#64, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, zero_reg, zeros, regval_from_reg,
     pure, EStateM.pure, bind, EStateM.bind]


### PR DESCRIPTION
## Summary

Flip `(s : SailState)` to implicit on `runSail_rX_bits_x0`. Aligns with the 8 siblings (`runSail_rX_bits_x{1,2,5,6,7,10,11,12}`) which already use `{s : SailState}`.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)