### PR TITLE
refactor(DivMod/Compose/Base): flip b arg on 26 shared_b*_{div,mod} private lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -122,79 +122,79 @@ abbrev sharedDivModCode (base : Word) : CodeReq :=
 
 -- Per-block subsumption: each shared block ⊆ divCode.
 -- Blocks 0-9 are at the same union positions; blocks 10-12 (shared) = blocks 11-13 (divCode).
-private theorem shared_b0_div (b : Word) : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode b) a = some i := by
+private theorem shared_b0_div {b : Word} : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
-private theorem shared_b1_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode b) a = some i := by
+private theorem shared_b1_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b2_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode b) a = some i := by
+private theorem shared_b2_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b3_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
+private theorem shared_b3_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b4_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode b) a = some i := by
+private theorem shared_b4_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b5_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode b) a = some i := by
+private theorem shared_b5_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b6_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode b) a = some i := by
+private theorem shared_b6_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b7_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (divCode b) a = some i := by
+private theorem shared_b7_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b8_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (divCode b) a = some i := by
+private theorem shared_b8_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b9_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode b) a = some i := by
+private theorem shared_b9_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b10_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode b) a = some i := by
+private theorem shared_b10_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b11_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (divCode b) a = some i := by
+private theorem shared_b11_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b12_div (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (divCode b) a = some i := by
+private theorem shared_b12_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (divCode b) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
 
 /-- sharedDivModCode ⊆ divCode: every shared block is also in divCode. -/
 theorem sharedDivModCode_sub_divCode {base : Word} :
     ∀ a i, (sharedDivModCode base) a = some i → (divCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_split_mono (shared_b0_div base)
-    (CodeReq.union_split_mono (shared_b1_div base)
-    (CodeReq.union_split_mono (shared_b2_div base)
-    (CodeReq.union_split_mono (shared_b3_div base)
-    (CodeReq.union_split_mono (shared_b4_div base)
-    (CodeReq.union_split_mono (shared_b5_div base)
-    (CodeReq.union_split_mono (shared_b6_div base)
-    (CodeReq.union_split_mono (shared_b7_div base)
-    (CodeReq.union_split_mono (shared_b8_div base)
-    (CodeReq.union_split_mono (shared_b9_div base)
-    (CodeReq.union_split_mono (shared_b10_div base)
-    (CodeReq.union_split_mono (shared_b11_div base)
-    (CodeReq.union_split_mono (shared_b12_div base)
+  exact CodeReq.union_split_mono (shared_b0_div)
+    (CodeReq.union_split_mono (shared_b1_div)
+    (CodeReq.union_split_mono (shared_b2_div)
+    (CodeReq.union_split_mono (shared_b3_div)
+    (CodeReq.union_split_mono (shared_b4_div)
+    (CodeReq.union_split_mono (shared_b5_div)
+    (CodeReq.union_split_mono (shared_b6_div)
+    (CodeReq.union_split_mono (shared_b7_div)
+    (CodeReq.union_split_mono (shared_b8_div)
+    (CodeReq.union_split_mono (shared_b9_div)
+    (CodeReq.union_split_mono (shared_b10_div)
+    (CodeReq.union_split_mono (shared_b11_div)
+    (CodeReq.union_split_mono (shared_b12_div)
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
 
 -- Per-block subsumption for modCode. Same pattern as shared_b*_div — the
 -- shared blocks occupy the same union positions in modCode as in divCode.
-private theorem shared_b0_mod (b : Word) : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode b) a = some i := by
+private theorem shared_b0_mod {b : Word} : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
-private theorem shared_b1_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode b) a = some i := by
+private theorem shared_b1_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b2_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode b) a = some i := by
+private theorem shared_b2_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b3_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
+private theorem shared_b3_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b4_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode b) a = some i := by
+private theorem shared_b4_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b5_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode b) a = some i := by
+private theorem shared_b5_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b6_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode b) a = some i := by
+private theorem shared_b6_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b7_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (modCode b) a = some i := by
+private theorem shared_b7_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b8_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (modCode b) a = some i := by
+private theorem shared_b8_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b9_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode b) a = some i := by
+private theorem shared_b9_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b10_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode b) a = some i := by
+private theorem shared_b10_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b11_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (modCode b) a = some i := by
+private theorem shared_b11_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
-private theorem shared_b12_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (modCode b) a = some i := by
+private theorem shared_b12_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (modCode b) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
 
 /-- sharedDivModCode ⊆ modCode: every shared block is also in modCode.
@@ -202,19 +202,19 @@ private theorem shared_b12_mod (b : Word) : ∀ a i, (CodeReq.ofProg (b + div128
 theorem sharedDivModCode_sub_modCode {base : Word} :
     ∀ a i, (sharedDivModCode base) a = some i → (modCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_split_mono (shared_b0_mod base)
-    (CodeReq.union_split_mono (shared_b1_mod base)
-    (CodeReq.union_split_mono (shared_b2_mod base)
-    (CodeReq.union_split_mono (shared_b3_mod base)
-    (CodeReq.union_split_mono (shared_b4_mod base)
-    (CodeReq.union_split_mono (shared_b5_mod base)
-    (CodeReq.union_split_mono (shared_b6_mod base)
-    (CodeReq.union_split_mono (shared_b7_mod base)
-    (CodeReq.union_split_mono (shared_b8_mod base)
-    (CodeReq.union_split_mono (shared_b9_mod base)
-    (CodeReq.union_split_mono (shared_b10_mod base)
-    (CodeReq.union_split_mono (shared_b11_mod base)
-    (CodeReq.union_split_mono (shared_b12_mod base)
+  exact CodeReq.union_split_mono (shared_b0_mod)
+    (CodeReq.union_split_mono (shared_b1_mod)
+    (CodeReq.union_split_mono (shared_b2_mod)
+    (CodeReq.union_split_mono (shared_b3_mod)
+    (CodeReq.union_split_mono (shared_b4_mod)
+    (CodeReq.union_split_mono (shared_b5_mod)
+    (CodeReq.union_split_mono (shared_b6_mod)
+    (CodeReq.union_split_mono (shared_b7_mod)
+    (CodeReq.union_split_mono (shared_b8_mod)
+    (CodeReq.union_split_mono (shared_b9_mod)
+    (CodeReq.union_split_mono (shared_b10_mod)
+    (CodeReq.union_split_mono (shared_b11_mod)
+    (CodeReq.union_split_mono (shared_b12_mod)
     (fun _ _ h => by simp [CodeReq.unionAll_nil, CodeReq.empty] at h)))))))))))))
 
 -- ============================================================================


### PR DESCRIPTION
## Summary

Flip `(b : Word)` to implicit on 26 private per-block subsumption lemmas:
- `shared_b0_div` through `shared_b12_div`
- `shared_b0_mod` through `shared_b12_mod`

All 26 call sites inside the same file (within `sharedDivModCode_sub_{div,mod}Code` proofs) drop the `base` arg — Lean infers `b` from the expected type at `CodeReq.union_split_mono`'s argument position.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)