### PR TITLE
refactor(Rv64/Execution): flip base/prog on loadProgram_programAt to implicit

### DIFF
--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -304,7 +304,7 @@ theorem ProgramAt.fetch {code : CodeMem} {base : Word} {prog : List Instr}
   rw [← haddr, ← hinstr]; exact h i hi
 
 /-- loadProgram produces a ProgramAt. -/
-theorem loadProgram_programAt (base : Word) (prog : List Instr)
+theorem loadProgram_programAt {base : Word} {prog : List Instr}
     (hlen : 4 * prog.length < 2^64) :
     ProgramAt (loadProgram base prog) base prog := by
   intro i hi


### PR DESCRIPTION
## Summary

Flip `(base : Word) (prog : List Instr)` to implicit on unused `loadProgram_programAt` (scaffolding).

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)