### PR TITLE
refactor(SailEquiv/MonadLemmas): flip args on runSail_{pure,bind} to implicit

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -18,12 +18,12 @@ namespace EvmAsm.Rv64.SailEquiv
 -- ============================================================================
 
 @[simp]
-theorem runSail_pure (a : α) (s : SailState) :
+theorem runSail_pure {a : α} {s : SailState} :
     runSail (pure a : SailM α) s = some (a, s) := by
   simp [runSail, pure, EStateM.pure]
 
 @[simp]
-theorem runSail_bind (m : SailM α) (f : α → SailM β) (s : SailState) :
+theorem runSail_bind {m : SailM α} {f : α → SailM β} {s : SailState} :
     runSail (m >>= f) s =
       match runSail m s with
       | some (a, s') => runSail (f a) s'


### PR DESCRIPTION
## Summary

Flip args on two `@[simp]` monad bridge lemmas:
- `runSail_pure {a, s}`
- `runSail_bind {m, f, s}`

Used in 56 `simp only [...]` sites across `BranchProofs`, `ImmProofs`, `ALUProofs`, `ShiftProofs`, `MExtProofs`. All callers are bare.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)