### PR TITLE
refactor(EvmWordArith/Div128Lemmas): flip limb args on val256_eq_val128_pair + val256_top_zero to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -299,12 +299,12 @@ theorem trial_quotient_ge_general (uHi u_rest dHi d_rest Bk : Nat)
 -- ============================================================================
 
 /-- val256 decomposes into two val128 halves: val256 l0 l1 l2 l3 = val128 l3 l2 * 2^128 + val128 l1 l0. -/
-theorem val256_eq_val128_pair (l0 l1 l2 l3 : Word) :
+theorem val256_eq_val128_pair {l0 l1 l2 l3 : Word} :
     val256 l0 l1 l2 l3 = val128 l3 l2 * 2 ^ 128 + val128 l1 l0 := by
   unfold val256 val128; ring
 
 /-- val256 with top limb zero: val256 l0 l1 l2 0 = l2 * 2^128 + val128 l1 l0. -/
-theorem val256_top_zero (l0 l1 l2 : Word) :
+theorem val256_top_zero {l0 l1 l2 : Word} :
     val256 l0 l1 l2 0 = l2.toNat * 2 ^ 128 + val128 l1 l0 := by
   unfold val256 val128; simp; ring
 
@@ -317,7 +317,7 @@ theorem val256_top_zero (l0 l1 l2 : Word) :
     This is the 256→128 analogue of `trial_quotient_ge`. -/
 theorem trial_quotient_ge_256 (u0 u1 u2 u3 v0 v1 v2 : Word) (hv2 : v2 ≠ 0) :
     val256 u0 u1 u2 u3 / val256 v0 v1 v2 0 ≤ val128 u3 u2 / v2.toNat := by
-  rw [val256_eq_val128_pair u0 u1 u2 u3, val256_top_zero v0 v1 v2]
+  rw [val256_eq_val128_pair, val256_top_zero]
   exact trial_quotient_ge_general (val128 u3 u2) (val128 u1 u0)
     v2.toNat (val128 v1 v0) (2 ^ 128)
     (Nat.pos_of_ne_zero (by intro h; apply hv2; exact BitVec.eq_of_toNat_eq h))


### PR DESCRIPTION
## Summary

Flip limb args to implicit on two val256 decomposition lemmas:
- `val256_eq_val128_pair {l0, l1, l2, l3}`
- `val256_top_zero {l0, l1, l2}`

Single `rw` call site in `trial_quotient_ge_256` drops the positional args.

## Test plan

- [x] `lake build` succeeds locally (3562 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)