### PR TITLE
refactor: flip Nat args on 2 lemmas to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -288,7 +288,7 @@ theorem div128Quot_vTop_decomp (vTop : Word) :
   omega
 
 /-- Utility: multiplying a Nat by `2^32` decomposes via Nat.div_add_mod. -/
-theorem Nat_mul_pow32_split (x : Nat) :
+theorem Nat_mul_pow32_split {x : Nat} :
     x * 2^32 = (x / 2^32) * 2^64 + (x % 2^32) * 2^32 := by
   have hdiv : x = (x / 2^32) * 2^32 + x % 2^32 := by
     have := Nat.div_add_mod x (2^32); linarith
@@ -355,7 +355,7 @@ theorem div128Quot_un21_abstract_dividend
   -- Sub-lemma 1: rhat' * 2^32 decomposes.
   have h_rhat_split : rhat'.toNat * 2^32 =
       (rhat'.toNat / 2^32) * 2^64 + (rhat'.toNat % 2^32) * 2^32 :=
-    Nat_mul_pow32_split rhat'.toNat
+    Nat_mul_pow32_split
   -- Sub-lemma 2: rhat' = uHi - q1' * dHi at Nat (from h_eucl).
   have h_rhat_eq : rhat'.toNat = uHi.toNat - q1'.toNat * dHi.toNat := by omega
   -- Sub-lemma 3: q1' * vTop expanded.
@@ -440,7 +440,7 @@ theorem div128Quot_un21_additive_identity
   rw [← h_dHi_eq, ← h_dLo_eq] at h_vtop
   have h_rhat_split : rhat'.toNat * 2^32 =
       (rhat'.toNat / 2^32) * 2^64 + (rhat'.toNat % 2^32) * 2^32 :=
-    Nat_mul_pow32_split rhat'.toNat
+    Nat_mul_pow32_split
   have h_rhat_eq : rhat'.toNat = uHi.toNat - q1'.toNat * dHi.toNat := by omega
   have h_rhat_mul : rhat'.toNat * 2^32 =
       uHi.toNat * 2^32 - q1'.toNat * dHi.toNat * 2^32 := by

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -24,7 +24,7 @@ namespace EvmAsm.Rv64.SailEquiv
 -- ============================================================================
 
 /-- to_bits_truncate on a non-negative integer = BitVec.ofNat. -/
-theorem to_bits_truncate_natCast (n : Nat) :
+theorem to_bits_truncate_natCast {n : Nat} :
     to_bits_truncate (l := 64) (↑n : Int) = BitVec.ofNat 64 n := by
   simp [to_bits_truncate, get_slice_int]; apply BitVec.eq_of_toNat_eq; simp
 


### PR DESCRIPTION
## Summary
- `to_bits_truncate_natCast (n : Nat)` → `{n : Nat}` (`EvmAsm/Rv64/SailEquiv/MExtProofs.lean`): 3 call sites, all bare in `rw`/`simp` — no change needed.
- `Nat_mul_pow32_split (x : Nat)` → `{x : Nat}` (`EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean`): 2 call sites with expected type — drop the positional `rhat'.toNat` arg (Lean infers `x` from the ascribed type).
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)