### PR TITLE
refactor(EvmWordArith): flip Word args to implicit on 4 Nat-level lemmas

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -17,7 +17,7 @@ namespace EvmWord
 -- ============================================================================
 
 -- Carry from 64-bit addition: (if ult (a+b) b then 1 else 0).toNat = (a.toNat + b.toNat) / 2^64
-theorem carry_toNat (x y : Word) :
+theorem carry_toNat {x y : Word} :
     (if BitVec.ult (x + y) y then (1 : Word) else 0).toNat =
     (x.toNat + y.toNat) / 2^64 := by
   have hx := x.isLt; have hy := y.isLt
@@ -47,9 +47,9 @@ private theorem combined_carry_toNat {x y cin : Word} (hcin : cin.toNat ≤ 1) :
     (ca ||| cb).toNat = (x.toNat + y.toNat + cin.toNat) / 2^64 := by
   intro psum ca res cb
   have hx := x.isLt; have hy := y.isLt
-  have hca : ca.toNat = (x.toNat + y.toNat) / 2^64 := carry_toNat x y
+  have hca : ca.toNat = (x.toNat + y.toNat) / 2^64 := carry_toNat
   have hpsum : psum.toNat = (x.toNat + y.toNat) % 2^64 := BitVec.toNat_add x y
-  have hcb : cb.toNat = (psum.toNat + cin.toNat) / 2^64 := carry_toNat psum cin
+  have hcb : cb.toNat = (psum.toNat + cin.toNat) / 2^64 := carry_toNat
   rw [or_01_toNat ca cb (ite_word_01 _) (ite_word_01 _), hca, hcb, hpsum]
   have : (x.toNat + y.toNat) % 2^64 < 2^64 := Nat.mod_lt _ (by omega)
   omega
@@ -80,7 +80,7 @@ theorem add_carry_chain_correct (a b : EvmWord) :
     (a + b).getLimb 3 = result3 := by
   intro a0 b0 a1 b1 a2 b2 a3 b3 sum0 carry0 psum1 carry1a result1 carry1b carry1 psum2 carry2a result2 carry2b carry2 psum3 result3
   -- toNat of carry chain
-  have hc0 : carry0.toNat = (a0.toNat + b0.toNat) / 2^64 := carry_toNat a0 b0
+  have hc0 : carry0.toNat = (a0.toNat + b0.toNat) / 2^64 := carry_toNat
   have hc0_le : carry0.toNat ≤ 1 := by
     have := a0.isLt; have := b0.isLt; rw [hc0]; omega
   have hc1 : carry1.toNat = (a1.toNat + b1.toNat + carry0.toNat) / 2^64 :=

--- a/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
@@ -372,17 +372,17 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
         c2_lo c2_hi c2_r2 c2_c c2_rc c2_r3 r3_final
         D0 D1 D2 D3 C1 C2 C3
   -- Phase 1: leaf mulhu/mul → Nat
-  have h_mu00 : (rv64_mulhu a0 b0).toNat = a0.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat a0 b0
-  have h_lo10 : (a1 * b0).toNat = a1.toNat * b0.toNat % 2^64 := mul_toNat a1 b0
-  have h_mu10 : (rv64_mulhu a1 b0).toNat = a1.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat a1 b0
-  have h_lo20 : (a2 * b0).toNat = a2.toNat * b0.toNat % 2^64 := mul_toNat a2 b0
-  have h_mu20 : (rv64_mulhu a2 b0).toNat = a2.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat a2 b0
+  have h_mu00 : (rv64_mulhu a0 b0).toNat = a0.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat
+  have h_lo10 : (a1 * b0).toNat = a1.toNat * b0.toNat % 2^64 := mul_toNat
+  have h_mu10 : (rv64_mulhu a1 b0).toNat = a1.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat
+  have h_lo20 : (a2 * b0).toNat = a2.toNat * b0.toNat % 2^64 := mul_toNat
+  have h_mu20 : (rv64_mulhu a2 b0).toNat = a2.toNat * b0.toNat / 2^64 := rv64_mulhu_toNat
   -- Phase 2: col0 carry chain
-  have h_lo30 : (a3 * b0).toNat = a3.toNat * b0.toNat % 2^64 := mul_toNat a3 b0
+  have h_lo30 : (a3 * b0).toNat = a3.toNat * b0.toNat % 2^64 := mul_toNat
   have h_c0_r1 : c0_r1.toNat = ((rv64_mulhu a0 b0).toNat + (a1 * b0).toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a0 b0) (a1 * b0)
   have h_c0_c1 : c0_c1.toNat = ((rv64_mulhu a0 b0).toNat + (a1 * b0).toNat) / 2^64 :=
-    carry_toNat (rv64_mulhu a0 b0) (a1 * b0)
+    carry_toNat
   -- expand inner sums so omega sees them, not opaque atoms
   have h_sum10_c1 : (rv64_mulhu a1 b0 + c0_c1).toNat =
       ((rv64_mulhu a1 b0).toNat + c0_c1.toNat) % 2^64 :=
@@ -390,7 +390,7 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   have h_c0_r2 : c0_r2.toNat = ((rv64_mulhu a1 b0 + c0_c1).toNat + (a2 * b0).toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a1 b0 + c0_c1) (a2 * b0)
   have h_c0_c2 : c0_c2.toNat = ((rv64_mulhu a1 b0 + c0_c1).toNat + (a2 * b0).toNat) / 2^64 :=
-    carry_toNat (rv64_mulhu a1 b0 + c0_c1) (a2 * b0)
+    carry_toNat
   -- c0_r3p = c0_hi_a2b0 + c0_c2 + a3 * b0
   have h_sum20_c2 : (rv64_mulhu a2 b0 + c0_c2).toNat =
       ((rv64_mulhu a2 b0).toNat + c0_c2.toNat) % 2^64 :=
@@ -398,12 +398,12 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   have h_c0_r3p : c0_r3p.toNat = ((rv64_mulhu a2 b0 + c0_c2).toNat + (a3 * b0).toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a2 b0 + c0_c2) (a3 * b0)
   -- Phase 3: col1 leaf + r1/c1 carries
-  have h_lo01 : (a0 * b1).toNat = a0.toNat * b1.toNat % 2^64 := mul_toNat a0 b1
-  have h_mu01 : (rv64_mulhu a0 b1).toNat = a0.toNat * b1.toNat / 2^64 := rv64_mulhu_toNat a0 b1
+  have h_lo01 : (a0 * b1).toNat = a0.toNat * b1.toNat % 2^64 := mul_toNat
+  have h_mu01 : (rv64_mulhu a0 b1).toNat = a0.toNat * b1.toNat / 2^64 := rv64_mulhu_toNat
   have h_c1_r1 : c1_r1.toNat = (c0_r1.toNat + (a0 * b1).toNat) % 2^64 :=
     BitVec.toNat_add c0_r1 (a0 * b1)
   have h_c1_c1 : c1_c1.toNat = (c0_r1.toNat + (a0 * b1).toNat) / 2^64 :=
-    carry_toNat c0_r1 (a0 * b1)
+    carry_toNat
   -- c1_rc = c1_hi + c1_c1 = rv64_mulhu a0 b1 + c1_c1
   have h_c1_rc : c1_rc.toNat = ((rv64_mulhu a0 b1).toNat + c1_c1.toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a0 b1) c1_c1
@@ -411,20 +411,20 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   have h_c1_r2a : c1_r2a.toNat = (c0_r2.toNat + c1_rc.toNat) % 2^64 :=
     BitVec.toNat_add c0_r2 c1_rc
   have h_c1_cr1 : c1_cr1.toNat = (c0_r2.toNat + c1_rc.toNat) / 2^64 :=
-    carry_toNat c0_r2 c1_rc
+    carry_toNat
   -- col1 b1×a1 leaf values
-  have h_lo11 : (a1 * b1).toNat = a1.toNat * b1.toNat % 2^64 := mul_toNat a1 b1
-  have h_mu11 : (rv64_mulhu a1 b1).toNat = a1.toNat * b1.toNat / 2^64 := rv64_mulhu_toNat a1 b1
+  have h_lo11 : (a1 * b1).toNat = a1.toNat * b1.toNat % 2^64 := mul_toNat
+  have h_mu11 : (rv64_mulhu a1 b1).toNat = a1.toNat * b1.toNat / 2^64 := rv64_mulhu_toNat
   -- c1_r2 = c1_r2a + c1_lo2 = c1_r2a + a1 * b1
   have h_c1_r2 : c1_r2.toNat = (c1_r2a.toNat + (a1 * b1).toNat) % 2^64 :=
     BitVec.toNat_add c1_r2a (a1 * b1)
   have h_c1_cr2 : c1_cr2.toNat = (c1_r2a.toNat + (a1 * b1).toNat) / 2^64 :=
-    carry_toNat c1_r2a (a1 * b1)
+    carry_toNat
   -- c1_rc2 = c1_hi2 + c1_cr2 = rv64_mulhu a1 b1 + c1_cr2
   have h_c1_rc2 : c1_rc2.toNat = ((rv64_mulhu a1 b1).toNat + c1_cr2.toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a1 b1) c1_cr2
   -- a2 * b1 leaf; c1_r3p outer split
-  have h_lo21 : (a2 * b1).toNat = a2.toNat * b1.toNat % 2^64 := mul_toNat a2 b1
+  have h_lo21 : (a2 * b1).toNat = a2.toNat * b1.toNat % 2^64 := mul_toNat
   have h_c1_r3p : c1_r3p.toNat = ((c1_cr1 + c1_rc2 + a2 * b1).toNat + c0_r3p.toNat) % 2^64 :=
     BitVec.toNat_add (c1_cr1 + c1_rc2 + a2 * b1) c0_r3p
   -- expand the inner 3-way sum
@@ -434,14 +434,14 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   have h_c1_cr1rc2 : (c1_cr1 + c1_rc2).toNat = (c1_cr1.toNat + c1_rc2.toNat) % 2^64 :=
     BitVec.toNat_add c1_cr1 c1_rc2
   -- col2 leaf values
-  have h_lo02 : (a0 * b2).toNat = a0.toNat * b2.toNat % 2^64 := mul_toNat a0 b2
-  have h_mu02 : (rv64_mulhu a0 b2).toNat = a0.toNat * b2.toNat / 2^64 := rv64_mulhu_toNat a0 b2
-  have h_lo12 : (a1 * b2).toNat = a1.toNat * b2.toNat % 2^64 := mul_toNat a1 b2
+  have h_lo02 : (a0 * b2).toNat = a0.toNat * b2.toNat % 2^64 := mul_toNat
+  have h_mu02 : (rv64_mulhu a0 b2).toNat = a0.toNat * b2.toNat / 2^64 := rv64_mulhu_toNat
+  have h_lo12 : (a1 * b2).toNat = a1.toNat * b2.toNat % 2^64 := mul_toNat
   -- col2 carry chain
   have h_c2_r2 : c2_r2.toNat = (c1_r2.toNat + (a0 * b2).toNat) % 2^64 :=
     BitVec.toNat_add c1_r2 (a0 * b2)
   have h_c2_c : c2_c.toNat = (c1_r2.toNat + (a0 * b2).toNat) / 2^64 :=
-    carry_toNat c1_r2 (a0 * b2)
+    carry_toNat
   have h_c2_rc_inner : (rv64_mulhu a0 b2 + c2_c).toNat = ((rv64_mulhu a0 b2).toNat + c2_c.toNat) % 2^64 :=
     BitVec.toNat_add (rv64_mulhu a0 b2) c2_c
   have h_c2_rc : c2_rc.toNat = ((rv64_mulhu a0 b2 + c2_c).toNat + (a1 * b2).toNat) % 2^64 :=
@@ -449,7 +449,7 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
   have h_c2_r3 : c2_r3.toNat = (c1_r3p.toNat + c2_rc.toNat) % 2^64 :=
     BitVec.toNat_add c1_r3p c2_rc
   -- col3: r3_final = c2_r3 + a0 * b3
-  have h_lo03 : (a0 * b3).toNat = a0.toNat * b3.toNat % 2^64 := mul_toNat a0 b3
+  have h_lo03 : (a0 * b3).toNat = a0.toNat * b3.toNat % 2^64 := mul_toNat
   have h_r3 : r3_final.toNat = (c2_r3.toNat + (a0 * b3).toNat) % 2^64 :=
     BitVec.toNat_add c2_r3 (a0 * b3)
   -- Euclidean approach: convert every div/mod pair into carry*W + result = inputs

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -91,7 +91,7 @@ theorem rv64_divu_euclidean (a b : Word) (hb : b ≠ 0) :
 -- ============================================================================
 
 /-- rv64_mulhu gives the high 64 bits of the full 128-bit product. -/
-theorem rv64_mulhu_toNat (a b : Word) :
+theorem rv64_mulhu_toNat {a b : Word} :
     (rv64_mulhu a b).toNat = (a.toNat * b.toNat) / 2 ^ 64 := by
   unfold rv64_mulhu
   simp only [BitVec.toNat_setWidth, BitVec.toNat_ushiftRight,
@@ -104,7 +104,7 @@ theorem rv64_mulhu_toNat (a b : Word) :
   exact Nat.div_lt_of_lt_mul (by linarith)
 
 /-- MUL gives the low 64 bits of the product (mod 2^64). -/
-theorem mul_toNat (a b : Word) : (a * b).toNat = (a.toNat * b.toNat) % 2 ^ 64 :=
+theorem mul_toNat {a b : Word} : (a * b).toNat = (a.toNat * b.toNat) % 2 ^ 64 :=
   BitVec.toNat_mul a b
 
 /-- MULHU * 2^64 + MUL = full product (Nat level). -/
@@ -164,7 +164,7 @@ theorem val256_eq_toNat (v : EvmWord) :
 -- ============================================================================
 
 /-- Word subtraction wraps mod 2^64. -/
-theorem word_sub_toNat (a b : Word) :
+theorem word_sub_toNat {a b : Word} :
     (a - b).toNat = (a.toNat + 2 ^ 64 - b.toNat) % 2 ^ 64 := by
   rw [BitVec.toNat_sub]; have hb := b.isLt; omega
 


### PR DESCRIPTION
## Summary
- Flip `(a b : Word)` → `{a b : Word}` on four Nat-level bridge lemmas:
  - `carry_toNat` (`Arithmetic.lean`)
  - `mul_toNat`, `rv64_mulhu_toNat`, `word_sub_toNat` (`MultiLimb.lean`)
- Drop positional args at all `have h : T := lemma a b` sites (type ascription provides inference). `rw` / `norm_num` usages are bare and unaffected.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)