### PR TITLE
refactor(MultiLimb): flip limb args on val256_eq_fromLimbs_toNat to implicit

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -292,9 +292,9 @@ theorem div_of_val256_eq_div
       match i with | 0 => q0 | 1 => q1 | 2 => q2 | 3 => q3
     q = EvmWord.div a b := by
   intro a b q
-  have ha : a.toNat = val256 a0 a1 a2 a3 := (val256_eq_fromLimbs_toNat a0 a1 a2 a3).symm
-  have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
-  have hq_val : q.toNat = val256 q0 q1 q2 q3 := (val256_eq_fromLimbs_toNat q0 q1 q2 q3).symm
+  have ha : a.toNat = val256 a0 a1 a2 a3 := val256_eq_fromLimbs_toNat.symm
+  have hb : b.toNat = val256 b0 b1 b2 b3 := val256_eq_fromLimbs_toNat.symm
+  have hq_val : q.toNat = val256 q0 q1 q2 q3 := val256_eq_fromLimbs_toNat.symm
   have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   -- q.toNat = a.toNat / b.toNat
   have hq_nat : q.toNat = a.toNat / b.toNat := by rw [hq_val, ha, hb]; exact hq
@@ -318,9 +318,9 @@ theorem mod_of_val256_eq_mod
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     r = EvmWord.mod a b := by
   intro a b r
-  have ha : a.toNat = val256 a0 a1 a2 a3 := (val256_eq_fromLimbs_toNat a0 a1 a2 a3).symm
-  have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
-  have hr_val : r.toNat = val256 r0 r1 r2 r3 := (val256_eq_fromLimbs_toNat r0 r1 r2 r3).symm
+  have ha : a.toNat = val256 a0 a1 a2 a3 := val256_eq_fromLimbs_toNat.symm
+  have hb : b.toNat = val256 b0 b1 b2 b3 := val256_eq_fromLimbs_toNat.symm
+  have hr_val : r.toNat = val256 r0 r1 r2 r3 := val256_eq_fromLimbs_toNat.symm
   have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   have hr_nat : r.toNat = a.toNat % b.toNat := by rw [hr_val, ha, hb]; exact hr
   have hmod : (EvmWord.mod a b).toNat = a.toNat % b.toNat := by

--- a/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivBridge.lean
@@ -82,7 +82,7 @@ theorem fromLimbs_single_toNat {q : Word} :
 theorem val256_fromLimbs (l0 l1 l2 l3 : Word) :
     val256 l0 l1 l2 l3 =
     (fromLimbs fun i : Fin 4 => match i with | 0 => l0 | 1 => l1 | 2 => l2 | 3 => l3).toNat :=
-  val256_eq_fromLimbs_toNat l0 l1 l2 l3
+  val256_eq_fromLimbs_toNat
 
 /-- Connecting val256 to EvmWord operations via toNat. -/
 theorem val256_mul_single (q v0 v1 v2 v3 : Word) :

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -155,10 +155,10 @@ theorem val256_euclidean_to_div_mod
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have ha : a.toNat = val256 a0 a1 a2 a3 := (val256_eq_fromLimbs_toNat a0 a1 a2 a3).symm
-  have hb : b.toNat = val256 b0 b1 b2 b3 := (val256_eq_fromLimbs_toNat b0 b1 b2 b3).symm
-  have hq : q.toNat = val256 q0 q1 q2 q3 := (val256_eq_fromLimbs_toNat q0 q1 q2 q3).symm
-  have hr : r.toNat = val256 r0 r1 r2 r3 := (val256_eq_fromLimbs_toNat r0 r1 r2 r3).symm
+  have ha : a.toNat = val256 a0 a1 a2 a3 := val256_eq_fromLimbs_toNat.symm
+  have hb : b.toNat = val256 b0 b1 b2 b3 := val256_eq_fromLimbs_toNat.symm
+  have hq : q.toNat = val256 q0 q1 q2 q3 := val256_eq_fromLimbs_toNat.symm
+  have hr : r.toNat = val256 r0 r1 r2 r3 := val256_eq_fromLimbs_toNat.symm
   have hbnz' : b ≠ 0 := fromLimbs_ne_zero_of_or hbnz
   have h_nat_eq : a.toNat = b.toNat * q.toNat + r.toNat := by
     rw [ha, hb, hq, hr]; nlinarith [Nat.mul_comm (val256 q0 q1 q2 q3) (val256 b0 b1 b2 b3)]

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -143,7 +143,7 @@ theorem val128_lt_of_hi_lt (hi lo : Word) (d : Nat) (hhi : hi.toNat < d) :
 def val256 (l0 l1 l2 l3 : Word) : Nat :=
   l0.toNat + l1.toNat * 2 ^ 64 + l2.toNat * 2 ^ 128 + l3.toNat * 2 ^ 192
 
-theorem val256_eq_fromLimbs_toNat (l0 l1 l2 l3 : Word) :
+theorem val256_eq_fromLimbs_toNat {l0 l1 l2 l3 : Word} :
     val256 l0 l1 l2 l3 = (fromLimbs (fun i : Fin 4 =>
       match i with | 0 => l0 | 1 => l1 | 2 => l2 | 3 => l3)).toNat := by
   unfold val256; rw [fromLimbs_toNat]


### PR DESCRIPTION
## Summary
- Flip `(l0 l1 l2 l3 : Word)` → `{l0 l1 l2 l3 : Word}` on `val256_eq_fromLimbs_toNat` in `EvmAsm/Evm64/EvmWordArith/MultiLimb.lean`.
- 11 positional-arg call sites across `DivAccumulate`, `DivBridge`, `DivRemainderBound` all have type ascription, so Lean can infer the limb args. Drop them and clean up `(lemma).symm` parens.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)