### PR TITLE
refactor(Div128/ModDiv128): flip base arg to implicit on 4 sub lemmas

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -21,7 +21,7 @@ open EvmAsm.Rv64
 
 -- Master subsumption: ofProg (base+1072) divK_div128 ⊆ sharedDivModCode base
 -- Block 12 in sharedDivModCode's unionAll; skip blocks 0-11.
-private theorem divK_div128_ofProg_sub_sharedCode (base : Word) :
+private theorem divK_div128_ofProg_sub_sharedCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
       (sharedDivModCode base) a = some i := by
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
@@ -34,14 +34,14 @@ private theorem divK_div128_ofProg_sub_sharedCode (base : Word) :
 
 -- Helper: singleton at index k of divK_div128 with explicit instr ⊆ sharedDivModCode base.
 -- Used to prove each singleton in a block's cr is subsumed by sharedDivModCode.
-private theorem d128_sub (base : Word) (k : Nat) (addr : Word) (instr : Instr)
+private theorem d128_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < divK_div128.length)
     (h_addr : addr = (base + div128Off) + BitVec.ofNat 64 (4 * k))
     (h_instr : divK_div128.get ⟨k, hk⟩ = instr) :
     ∀ a i, CodeReq.singleton addr instr a = some i →
       (sharedDivModCode base) a = some i := by
   subst h_addr; subst h_instr
-  exact fun a i h => divK_div128_ofProg_sub_sharedCode base a i
+  exact fun a i h => divK_div128_ofProg_sub_sharedCode a i
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
@@ -118,16 +118,16 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- Extend phase1 cr to sharedDivModCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9
-    exact CodeReq.union_sub (d128_sub base 0 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 1 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 2 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 3 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 4 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 5 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 6 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 7 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 8 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub base 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
+    exact CodeReq.union_sub (d128_sub 0 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 8 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
     hph1
   -- Frame phase1 with x0=0 (not used by phase1)
   have hph1f := cpsTriple_frameR
@@ -141,21 +141,21 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub base 10 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 11 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 12 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 13 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 14 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 15 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 16 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 17 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 18 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 19 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 20 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 21 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 22 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 23 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub base 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+    exact CodeReq.union_sub (d128_sub 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 11 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 12 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 13 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 14 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 15 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 16 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 20 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 21 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 23 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
   have hst1f := cpsTriple_frameR
@@ -173,11 +173,11 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub base 25 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 26 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 27 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 28 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub base 29 _ _ (by decide) (by bv_addr) (by decide))))))
+    exact CodeReq.union_sub (d128_sub 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 28 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 29 _ _ (by decide) (by bv_addr) (by decide))))))
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
@@ -199,21 +199,21 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub base 30 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 31 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 32 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 33 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 34 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 35 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 36 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 37 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 38 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 39 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 42 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 43 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub base 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+    exact CodeReq.union_sub (d128_sub 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 31 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 32 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 33 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 34 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 38 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 39 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 42 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 43 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
@@ -232,10 +232,10 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub base 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub base 47 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub base 48 _ _ (by decide) (by bv_addr) (by decide)))))
+    exact CodeReq.union_sub (d128_sub 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 47 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 48 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -22,7 +22,7 @@ open EvmAsm.Rv64
 
 -- Master subsumption: ofProg (base+1072) divK_div128 ⊆ modCode base
 -- Block 13 in modCode's unionAll; skip blocks 0-12.
-private theorem divK_div128_ofProg_sub_modCode (base : Word) :
+private theorem divK_div128_ofProg_sub_modCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + div128Off) divK_div128) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
@@ -36,14 +36,14 @@ private theorem divK_div128_ofProg_sub_modCode (base : Word) :
 
 -- Helper: singleton at index k of divK_div128 with explicit instr ⊆ modCode base.
 -- Used to prove each singleton in a block's cr is subsumed by modCode.
-private theorem d128_sub_mod (base : Word) (k : Nat) (addr : Word) (instr : Instr)
+private theorem d128_sub_mod {base : Word} (k : Nat) (addr : Word) (instr : Instr)
     (hk : k < divK_div128.length)
     (h_addr : addr = (base + div128Off) + BitVec.ofNat 64 (4 * k))
     (h_instr : divK_div128.get ⟨k, hk⟩ = instr) :
     ∀ a i, CodeReq.singleton addr instr a = some i →
       (modCode base) a = some i := by
   subst h_addr; subst h_instr
-  exact fun a i h => divK_div128_ofProg_sub_modCode base a i
+  exact fun a i h => divK_div128_ofProg_sub_modCode a i
     (CodeReq.singleton_mono
       (CodeReq.ofProg_lookup (base + div128Off) divK_div128 k hk (by decide)) a i h)
 
@@ -117,16 +117,16 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- Extend phase1 cr to modCode
   have hph1e := cpsTriple_extend_code (hmono := by
     -- phase1 cr: 10 singletons at (base+1072)+{0,4,...,36}, indices 0-9
-    exact CodeReq.union_sub (d128_sub_mod base 0 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 1 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 2 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 3 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 4 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 5 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 6 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 7 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 8 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod base 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
+    exact CodeReq.union_sub (d128_sub_mod 0 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 8 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
     hph1
   -- Frame phase1 with x0=0 (not used by phase1)
   have hph1f := cpsTriple_frameR
@@ -140,21 +140,21 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1112)
   rw [show (base + 1112 : Word) + 60 = base + 1172 from by bv_addr] at hst1
   have hst1e := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub_mod base 10 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 11 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 12 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 13 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 14 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 15 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 16 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 17 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 18 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 19 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 20 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 21 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 22 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 23 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod base 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+    exact CodeReq.union_sub (d128_sub_mod 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 11 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 12 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 13 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 14 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 15 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 16 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 20 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 21 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 23 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 24 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst1
   -- Frame step1 with x2, mem[3968], mem[3960], mem[3944]
   have hst1f := cpsTriple_frameR
@@ -172,11 +172,11 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1172)
   rw [show (base + 1172 : Word) + 20 = base + 1192 from by bv_addr] at hcu
   have hcue := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub_mod base 25 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 26 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 27 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 28 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod base 29 _ _ (by decide) (by bv_addr) (by decide))))))
+    exact CodeReq.union_sub (d128_sub_mod 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 28 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 29 _ _ (by decide) (by bv_addr) (by decide))))))
     hcu
   -- Frame compute_un21 with x6, x0, x2, mem[3968], mem[3960], mem[3944]
   have hcuf := cpsTriple_frameR
@@ -195,21 +195,21 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (base + 1192)
   rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub_mod base 30 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 31 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 32 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 33 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 34 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 35 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 36 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 37 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 38 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 39 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 42 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 43 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod base 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+    exact CodeReq.union_sub (d128_sub_mod 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 31 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 32 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 33 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 34 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 38 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 39 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 42 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 43 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
@@ -226,10 +226,10 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
     (base + 1252) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub_mod base 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod base 47 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod base 48 _ _ (by decide) (by bv_addr) (by decide)))))
+    exact CodeReq.union_sub (d128_sub_mod 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 47 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 48 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR


### PR DESCRIPTION
## Summary
- Flip `(base : Word)` → `{base : Word}` on 4 private lemmas across `EvmAsm/Evm64/DivMod/Compose/Div128.lean` and `ModDiv128.lean`:
  - `divK_div128_ofProg_sub_sharedCode`, `d128_sub`
  - `divK_div128_ofProg_sub_modCode`, `d128_sub_mod`
- ~100 call sites drop the positional `base` arg.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)