### PR TITLE
refactor(ShlCompose): flip base arg to implicit on 15 sub_shlCode lemmas

### DIFF
--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -66,7 +66,7 @@ abbrev shlCode (base : Word) : CodeReq :=
 -- and lives in `ComposeBase`.
 
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by shlCode (block 1). -/
-private theorem phase_b_sub_shlCode (base : Word) :
+private theorem phase_b_sub_shlCode {base : Word} :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shlCode base a = some i := by
   unfold shr_phase_b_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock
@@ -75,48 +75,48 @@ private theorem phase_b_sub_shlCode (base : Word) :
 -- Phase C union-chain ⊆ ofProg bridge (`shr_phase_c_code_sub_ofProg`) is shared
 -- and lives in `ComposeBase`.
 
-private theorem ofProg_phase_c_sub_shlCode (base : Word) :
+private theorem ofProg_phase_c_sub_shlCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shlCode base a = some i := by
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Phase C code (union chain, 5 instrs at +64) is subsumed by shlCode (block 2). -/
-private theorem phase_c_sub_shlCode (base : Word) :
+private theorem phase_c_sub_shlCode {base : Word} :
     ∀ a i, shr_phase_c_code (base + 64) a = some i → shlCode base a = some i := by
   intro a i h
-  exact ofProg_phase_c_sub_shlCode base a i (shr_phase_c_code_sub_ofProg a i h)
+  exact ofProg_phase_c_sub_shlCode a i (shr_phase_c_code_sub_ofProg a i h)
 
 /-- SHL Body 3 code (7 instrs at +84) is subsumed by shlCode (block 3). -/
-private theorem shl_body_3_sub_shlCode (base : Word) :
+private theorem shl_body_3_sub_shlCode {base : Word} :
     ∀ a i, shl_body_3_code (base + 84) 252 a = some i → shlCode base a = some i := by
   unfold shl_body_3_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 2 code (13 instrs at +112) is subsumed by shlCode (block 4). -/
-private theorem shl_body_2_sub_shlCode (base : Word) :
+private theorem shl_body_2_sub_shlCode {base : Word} :
     ∀ a i, shl_body_2_code (base + 112) 200 a = some i → shlCode base a = some i := by
   unfold shl_body_2_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 1 code (19 instrs at +164) is subsumed by shlCode (block 5). -/
-private theorem shl_body_1_sub_shlCode (base : Word) :
+private theorem shl_body_1_sub_shlCode {base : Word} :
     ∀ a i, shl_body_1_code (base + 164) 124 a = some i → shlCode base a = some i := by
   unfold shl_body_1_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- SHL Body 0 code (25 instrs at +240) is subsumed by shlCode (block 6). -/
-private theorem shl_body_0_sub_shlCode (base : Word) :
+private theorem shl_body_0_sub_shlCode {base : Word} :
     ∀ a i, shl_body_0_code (base + 240) 24 a = some i → shlCode base a = some i := by
   unfold shl_body_0_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _
 
 /-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shlCode (block 7). -/
-private theorem zero_path_sub_shlCode (base : Word) :
+private theorem zero_path_sub_shlCode {base : Word} :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shlCode base a = some i := by
   unfold shr_zero_path_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
@@ -124,7 +124,7 @@ private theorem zero_path_sub_shlCode (base : Word) :
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
 
-private theorem ld_s1_sub_shlCode (base : Word) :
+private theorem ld_s1_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton base (.LD .x5 .x12 8) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
@@ -132,7 +132,7 @@ private theorem ld_s1_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_16_sub_shlCode (base : Word) :
+private theorem ld_or_16_sub_shlCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shlCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
@@ -140,7 +140,7 @@ private theorem ld_or_16_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_or_24_sub_shlCode (base : Word) :
+private theorem ld_or_24_sub_shlCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shlCode base a = some i := by
   intro a i h; unfold shr_ld_or_acc_code at h
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
@@ -148,7 +148,7 @@ private theorem ld_or_24_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem bne_sub_shlCode (base : Word) :
+private theorem bne_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
@@ -156,7 +156,7 @@ private theorem bne_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem ld_s0_sub_shlCode (base : Word) :
+private theorem ld_s0_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
@@ -164,7 +164,7 @@ private theorem ld_s0_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem sltiu_sub_shlCode (base : Word) :
+private theorem sltiu_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
@@ -172,7 +172,7 @@ private theorem sltiu_sub_shlCode (base : Word) :
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   exact CodeReq.union_mono_left _ _ a i h1
 
-private theorem beq_sub_shlCode (base : Word) :
+private theorem beq_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shlCode base a = some i := by
   intro a i h
   have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
@@ -230,16 +230,16 @@ theorem evm_shl_zero_high_spec (sp base : Word)
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
   -- Step 1: LD x5 x12 8 at base → extend to shlCode
-  have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
+  have h1 := cpsTriple_extend_code ld_s1_sub_shlCode
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
   simp only [signExtend12_8] at h1
   -- Step 2: LD/OR at base+4 → extend to shlCode
-  have h2 := cpsTriple_extend_code (ld_or_16_sub_shlCode base)
+  have h2 := cpsTriple_extend_code ld_or_16_sub_shlCode
     (shr_ld_or_acc_spec sp s1 r10 s2 16 (base + 4))
   simp only [signExtend12_16] at h2
   rw [shl_off_4] at h2
   -- Step 3: LD/OR at base+12 → extend to shlCode
-  have h3 := cpsTriple_extend_code (ld_or_24_sub_shlCode base)
+  have h3 := cpsTriple_extend_code ld_or_24_sub_shlCode
     (shr_ld_or_acc_spec sp (s1 ||| s2) s2 s3 24 (base + 12))
   simp only [signExtend12_24] at h3
   rw [shl_off_12] at h3
@@ -266,7 +266,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
   -- Step 4: BNE at base+20 → extend to shlCode, eliminate ntaken
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
-  have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
+  have hbne := cpsBranch_extend_code bne_sub_shlCode hbne_raw
   -- Eliminate ntaken path (s1|||s2|||s3 = 0 contradicts hhigh)
   have hbne_taken := cpsBranch_takenStripPure2 hbne
     (fun hp hQf => by
@@ -282,7 +282,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
   have hAB := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hbne_framed
   -- Step 5: Zero path (base+340 → base+360) → extend to shlCode
-  have hzp := cpsTriple_extend_code (zero_path_sub_shlCode base)
+  have hzp := cpsTriple_extend_code zero_path_sub_shlCode
     (shr_zero_path_spec sp v0 v1 v2 v3 (base + 340))
   rw [shl_off_340_20] at hzp
   -- Frame zero path with remaining state
@@ -335,13 +335,13 @@ theorem evm_shl_zero_large_spec (sp base : Word)
        (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
        ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) ** ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word))) := by
   -- Steps 1-3: Same linear chain as zero_high
-  have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
+  have h1 := cpsTriple_extend_code ld_s1_sub_shlCode
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
   simp only [signExtend12_8] at h1
-  have h2 := cpsTriple_extend_code (ld_or_16_sub_shlCode base)
+  have h2 := cpsTriple_extend_code ld_or_16_sub_shlCode
     (shr_ld_or_acc_spec sp s1 r10 s2 16 (base + 4))
   simp only [signExtend12_16] at h2; rw [shl_off_4] at h2
-  have h3 := cpsTriple_extend_code (ld_or_24_sub_shlCode base)
+  have h3 := cpsTriple_extend_code ld_or_24_sub_shlCode
     (shr_ld_or_acc_spec sp (s1 ||| s2) s2 s3 24 (base + 12))
   simp only [signExtend12_24] at h3; rw [shl_off_12] at h3
   -- Frame + compose linear chain
@@ -365,7 +365,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   -- Step 4: BNE at base+20 → eliminate TAKEN (s1|||s2|||s3 = 0 contradicts ≠ 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
-  have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
+  have hbne := cpsBranch_extend_code bne_sub_shlCode hbne_raw
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -382,11 +382,11 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
   rw [word_add_zero, shl_off_24] at hld_raw
-  have hld := cpsTriple_extend_code (ld_s0_sub_shlCode base) hld_raw
+  have hld := cpsTriple_extend_code ld_s0_sub_shlCode hld_raw
   -- Step 6: SLTIU at base+28 → extend to shlCode
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
   rw [shl_off_28] at hsltiu_raw
-  have hsltiu := cpsTriple_extend_code (sltiu_sub_shlCode base) hsltiu_raw
+  have hsltiu := cpsTriple_extend_code sltiu_sub_shlCode hsltiu_raw
   -- Frame + compose LD → SLTIU
   have hld_f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ s3) **
@@ -405,7 +405,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   let sltiuVal := (if BitVec.ult s0 (signExtend12 (256 : BitVec 12)) then (1 : Word) else (0 : Word))
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)
   rw [shl_beq_target, shl_off_32] at hbeq_raw
-  have hbeq := cpsBranch_extend_code (beq_sub_shlCode base) hbeq_raw
+  have hbeq := cpsBranch_extend_code beq_sub_shlCode hbeq_raw
   -- sltiuVal = 0 (since s0 ≥ 256 → ult is false)
   have hsltiu_eq : sltiuVal = (0 : Word) := by
     simp only [sltiuVal, hlarge]; decide
@@ -423,7 +423,7 @@ theorem evm_shl_zero_large_spec (sp base : Word)
   -- Compose h123456 → BEQ(taken)
   have h1234567 := cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) h123456 hbeq_framed
   -- Step 8: Zero path (base+340 → base+360)
-  have hzp := cpsTriple_extend_code (zero_path_sub_shlCode base)
+  have hzp := cpsTriple_extend_code zero_path_sub_shlCode
     (shr_zero_path_spec sp v0 v1 v2 v3 (base + 340))
   rw [shl_off_340_20] at hzp
   have hzp_framed := cpsTriple_frameR
@@ -617,13 +617,13 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have ha48 : sp + 48 = (sp + 32 : Word) + 16 := by bv_omega
   have ha56 : sp + 56 = (sp + 32 : Word) + 24 := by bv_omega
   -- Phase A: linear chain base -> base+36
-  have h1 := cpsTriple_extend_code (ld_s1_sub_shlCode base)
+  have h1 := cpsTriple_extend_code ld_s1_sub_shlCode
     (ld_spec_gen .x5 .x12 sp r5 s1 8 base (by nofun))
   simp only [signExtend12_8] at h1
-  have h2 := cpsTriple_extend_code (ld_or_16_sub_shlCode base)
+  have h2 := cpsTriple_extend_code ld_or_16_sub_shlCode
     (shr_ld_or_acc_spec sp s1 r10 s2 16 (base + 4))
   simp only [signExtend12_16] at h2; rw [shl_off_4] at h2
-  have h3 := cpsTriple_extend_code (ld_or_24_sub_shlCode base)
+  have h3 := cpsTriple_extend_code ld_or_24_sub_shlCode
     (shr_ld_or_acc_spec sp (s1 ||| s2) s2 s3 24 (base + 12))
   simp only [signExtend12_24] at h3; rw [shl_off_12] at h3
   have h1f := cpsTriple_frameR
@@ -646,7 +646,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   -- BNE at base+20: eliminate TAKEN (s1|||s2|||s3=0 contradicts ne 0)
   have hbne_raw := bne_spec_gen .x5 .x0 320 (s1 ||| s2 ||| s3) (0 : Word) (base + 20)
   rw [shl_bne_target, shl_off_20] at hbne_raw
-  have hbne := cpsBranch_extend_code (bne_sub_shlCode base) hbne_raw
+  have hbne := cpsBranch_extend_code bne_sub_shlCode hbne_raw
   have hbne_ntaken := cpsBranch_ntakenStripPure2 hbne
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -661,11 +661,11 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hld_raw := ld_spec_gen .x5 .x12 sp (s1 ||| s2 ||| s3) s0 0 (base + 24) (by nofun)
   simp only [signExtend12_0] at hld_raw
   rw [word_add_zero, shl_off_24] at hld_raw
-  have hld := cpsTriple_extend_code (ld_s0_sub_shlCode base) hld_raw
+  have hld := cpsTriple_extend_code ld_s0_sub_shlCode hld_raw
   -- SLTIU at base+28
   have hsltiu_raw := sltiu_spec_gen .x10 .x5 s3 s0 256 (base + 28) (by nofun)
   rw [shl_off_28] at hsltiu_raw
-  have hsltiu := cpsTriple_extend_code (sltiu_sub_shlCode base) hsltiu_raw
+  have hsltiu := cpsTriple_extend_code sltiu_sub_shlCode hsltiu_raw
   have hld_f := cpsTriple_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ s3) ** (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11) **
      ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -683,7 +683,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hsltiu_eq : sltiuVal = (1 : Word) := by simp only [sltiuVal, hlt_s0]; decide
   have hbeq_raw := beq_spec_gen .x10 .x0 308 sltiuVal (0 : Word) (base + 32)
   rw [shl_beq_target, shl_off_32] at hbeq_raw
-  have hbeq := cpsBranch_extend_code (beq_sub_shlCode base) hbeq_raw
+  have hbeq := cpsBranch_extend_code beq_sub_shlCode hbeq_raw
   have hbeq_ntaken := cpsBranch_ntakenStripPure2 hbeq
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt
@@ -702,7 +702,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   let mask := (0 : Word) - cond
   let antiShift := (64 : Word) - bitShift
   have hphaseB_raw := shr_phase_b_spec s0 sp r6 r7 r11 (base + 36)
-  have hphaseB := cpsTriple_extend_code (phase_b_sub_shlCode base) hphaseB_raw
+  have hphaseB := cpsTriple_extend_code phase_b_sub_shlCode hphaseB_raw
   rw [shl_off_36_28] at hphaseB
   simp only [signExtend12_32] at hphaseB
   have hphaseB_f := cpsTriple_frameR
@@ -715,18 +715,18 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hphaseC_raw := shr_phase_c_spec_pure limbShift sltiuVal (base + 64)
     (base + 240) (base + 164) (base + 112) (base + 84)
     (shl_c_e0 base) (shl_c_e1 base) (shl_c_e2 base) (shl_c_e3 base)
-  have hphaseC := cpsNBranch_extend_code (phase_c_sub_shlCode base) hphaseC_raw
+  have hphaseC := cpsNBranch_extend_code phase_c_sub_shlCode hphaseC_raw
   -- Body specs extended to shlCode
-  have hbody3 := cpsTriple_extend_code (shl_body_3_sub_shlCode base)
+  have hbody3 := cpsTriple_extend_code shl_body_3_sub_shlCode
     (shl_body_3_spec (sp + 32) limbShift ((0 : Word) + signExtend12 2) bitShift antiShift mask
       v0 v1 v2 v3 (base + 84) (base + 360) 252 (shl_body3_exit base))
-  have hbody2 := cpsTriple_extend_code (shl_body_2_sub_shlCode base)
+  have hbody2 := cpsTriple_extend_code shl_body_2_sub_shlCode
     (shl_body_2_spec (sp + 32) limbShift ((0 : Word) + signExtend12 2) bitShift antiShift mask
       v0 v1 v2 v3 (base + 112) (base + 360) 200 (shl_body2_exit base))
-  have hbody1 := cpsTriple_extend_code (shl_body_1_sub_shlCode base)
+  have hbody1 := cpsTriple_extend_code shl_body_1_sub_shlCode
     (shl_body_1_spec (sp + 32) limbShift ((0 : Word) + signExtend12 1) bitShift antiShift mask
       v0 v1 v2 v3 (base + 164) (base + 360) 124 (shl_body1_exit base))
-  have hbody0 := cpsTriple_extend_code (shl_body_0_sub_shlCode base)
+  have hbody0 := cpsTriple_extend_code shl_body_0_sub_shlCode
     (shl_body_0_spec (sp + 32) limbShift sltiuVal bitShift antiShift mask
       v0 v1 v2 v3 (base + 240) (base + 360) 24 (shl_body0_exit base))
   -- Frame each body with (x0=0 ** shiftMem)


### PR DESCRIPTION
## Summary
- Flip `(base : Word)` → `{base : Word}` on 15 private `*_sub_shlCode` lemmas in `EvmAsm/Evm64/Shift/ShlCompose.lean`.
- Mirror of PRs #1087 (SignExtend/Compose) and #1103 (SarCompose).
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)