### PR TITLE
refactor(RLP/Phase2LongIter): flip base arg on iter_code_split to implicit

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -78,7 +78,7 @@ theorem rlp_phase2_long_iter_post_unfold
 
 /-- Split `ofProg base iter_prog` into five singleton CodeReqs plus an
     `empty` tail. Each instruction lives at a distinct 4-byte offset. -/
-private theorem iter_code_split (base : Word) :
+private theorem iter_code_split {base : Word} :
     CodeReq.ofProg base rlp_phase2_long_iter_prog =
     (CodeReq.singleton base (.LBU .x12 .x13 0)).union
     ((CodeReq.singleton (base + 4) (.SLLI .x11 .x11 8)).union


### PR DESCRIPTION
## Summary
- Flip `(base : Word)` → `{base : Word}` on private `iter_code_split` in `EvmAsm/Rv64/RLP/Phase2LongIter.lean`.
- Used bare in `rw [iter_code_split]`.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)