### PR TITLE
refactor(RLP): flip args to implicit on 2 post_unfold lemmas

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -57,7 +57,7 @@ def rlp_phase2_long_acc_post (len byte : Word) : Assertion :=
   let length' := (len <<< 8) + byte
   (.x11 ↦ᵣ length') ** (.x12 ↦ᵣ byte)
 
-theorem rlp_phase2_long_acc_post_unfold (len byte : Word) :
+theorem rlp_phase2_long_acc_post_unfold {len byte : Word} :
     rlp_phase2_long_acc_post len byte =
     ((.x11 ↦ᵣ ((len <<< 8) + byte)) ** (.x12 ↦ᵣ byte)) := by
   delta rlp_phase2_long_acc_post; rfl

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -64,7 +64,7 @@ def rlp_phase2_long_iter_post
     (.x12 ↦ᵣ byteZext) ** (dwordAddr ↦ₘ wordVal)
 
 theorem rlp_phase2_long_iter_post_unfold
-    (len ptr cnt byteZext wordVal dwordAddr : Word) :
+    {len ptr cnt byteZext wordVal dwordAddr : Word} :
     rlp_phase2_long_iter_post len ptr cnt byteZext wordVal dwordAddr =
     ((.x11 ↦ᵣ ((len <<< 8) + byteZext)) **
      (.x13 ↦ᵣ (ptr + 1)) **


### PR DESCRIPTION
## Summary
- Flip all explicit args → implicit on 2 post_unfold lemmas:
  - `rlp_phase2_long_iter_post_unfold` (`Phase2LongIter.lean`)
  - `rlp_phase2_long_acc_post_unfold` (`Phase2LongAcc.lean`)
- Both used bare as simp lemmas; simp matches on LHS pattern.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)