### PR TITLE
refactor(ControlFlow): flip args to implicit on if_eq_length

### DIFF
--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -205,7 +205,7 @@ theorem loadProgram_at_index {base : Word} {prog : List Instr} {k : Nat}
   rw [this]; simp [hk]; omega
 
 /-- The length of an if_eq program. -/
-theorem if_eq_length (rs1 rs2 : Reg) (tb eb : Program) :
+theorem if_eq_length {rs1 rs2 : Reg} {tb eb : Program} :
     (if_eq rs1 rs2 tb eb).length = tb.length + eb.length + 2 := by
   simp only [if_eq, Program.length_append, List.length_cons, List.length_nil]; omega
 


### PR DESCRIPTION
## Summary
- Flip `(rs1 rs2 : Reg) (tb eb : Program)` → `{rs1 rs2 : Reg} {tb eb : Program}` on `if_eq_length` in `EvmAsm/Rv64/ControlFlow.lean`.
- Used bare in `simp only [if_eq_length]`; simp matches on LHS pattern.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)