### PR TITLE
refactor(CLZLemmas): flip val arg to implicit on clzPipeline_unfold

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -95,7 +95,7 @@ private def clzS2 (val : Word) :=
 private def clzS3 (val : Word) :=
   clzStep 60 4  (signExtend12  4) (clzS2 val)
 
-private theorem clzPipeline_unfold (val : Word) :
+private theorem clzPipeline_unfold {val : Word} :
     clzPipeline val = clzStep 62 2 (signExtend12 2) (clzS3 val) := by
   unfold clzPipeline clzS3 clzS2 clzS1 clzS0; rfl
 


### PR DESCRIPTION
## Summary
- Flip `(val : Word)` → `{val : Word}` on private `clzPipeline_unfold` in `EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean`.
- 4 call sites use bare `rw [clzPipeline_unfold]`.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)