### PR TITLE
refactor(Stack): flip args to implicit on evmStackIs_cons

### DIFF
--- a/EvmAsm/Evm64/Stack.lean
+++ b/EvmAsm/Evm64/Stack.lean
@@ -45,7 +45,7 @@ instance (addr : Word) (v : EvmWord) : Assertion.PCFree (evmWordIs addr v) :=
 instance (sp : Word) (values : List EvmWord) : Assertion.PCFree (evmStackIs sp values) :=
   ⟨pcFree_evmStackIs⟩
 
-theorem evmStackIs_cons (sp : Word) (v : EvmWord) (vs : List EvmWord) :
+theorem evmStackIs_cons {sp : Word} {v : EvmWord} {vs : List EvmWord} :
     evmStackIs sp (v :: vs) = (evmWordIs sp v ** evmStackIs (sp + 32) vs) := rfl
 
 /-- Mid-tree variant of `evmStackIs_cons`: threads a remainder `Q` through


### PR DESCRIPTION
## Summary
- Flip `(sp : Word) (v : EvmWord) (vs : List EvmWord)` → implicit on `evmStackIs_cons` in `EvmAsm/Evm64/Stack.lean`.
- All 9 call sites use bare `simp` or `rw`; simp matches on LHS pattern.
- Part of #331.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)