### PR TITLE
refactor(MulCorrect): replace ring with ring_nf to silence build info

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
@@ -107,7 +107,7 @@ theorem mul_correct_limb1 (a b : EvmWord) :
     norm_num [ Nat.shiftRight_eq_div_pow ];
   · rw [ toNat_eq_limb_sum a, toNat_eq_limb_sum b ];
     norm_num [ BitVec.toNat_add, BitVec.toNat_mul, rv64_mulhu_toNat, mul_toNat ];
-    ring;
+    ring_nf;
     omega
 
 -- ============================================================================
@@ -139,7 +139,7 @@ theorem mul_correct_limb2 (a b : EvmWord) :
   · unfold EvmWord.getLimb;
     norm_num [ Nat.shiftRight_eq_div_pow ];
   · rw [ toNat_eq_limb_sum a, toNat_eq_limb_sum b ];
-    norm_num [ BitVec.toNat_add, BitVec.toNat_mul, rv64_mulhu_toNat, mul_toNat, carry_toNat ] ; ring; omega;
+    norm_num [ BitVec.toNat_add, BitVec.toNat_mul, rv64_mulhu_toNat, mul_toNat, carry_toNat ] ; ring_nf; omega;
 
 -- ============================================================================
 -- Limb 3 helpers


### PR DESCRIPTION
## Summary

Addresses the last 2 `info:` lines from `lake build`:

```
info: MulCorrect.lean:110:4: Try this:
  [apply] ring_nf
  The \`ring\` tactic failed to close the goal. Use \`ring_nf\` to obtain a normal form.
info: MulCorrect.lean:142:96: Try this: ...
```

In both `mul_correct_limb1` (line 110) and `mul_correct_limb2` (line 142), `ring` is followed by `omega` — so it was never actually closing the goal on its own; the advisory was firing because `ring` saw a leftover and suggested `ring_nf` as the normal-form variant.

Replace `ring; omega` with `ring_nf; omega` at both sites — same proof structure, no advisory.

Companion to #1129 (which removed the `#eval` info lines). Together these drop `lake build | grep '^info:' | wc -l` from 36 → 0 once both merge.

## Test plan
- [x] `lake build` passes
- [x] `lake build 2>&1 | grep '^info:.*Try this'` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)