### PR TITLE
refactor(divmod): factor div128Quot Phase 2b helper (prep for #61 bug fix)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -30,6 +30,23 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- Phase 2b refined quotient digit in `div128Quot`.
+
+    Factored standalone so the Knuth TAOCP §4.3.1 Step D3 guard
+    (`rhat2c < 2^32`) can be added in a follow-up iteration without
+    rewriting the entire `div128Quot` body. **Currently matches legacy
+    (buggy) semantics**; the bug is documented at
+    `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
+
+    Lives in `Div128ProdCheck2.lean` (the lowest-level file that
+    naturally talks about Phase 2b's mul-check). Visible from
+    `LimbSpec.Div128Step2`, `Compose/Base` (transitively via `LimbSpec`),
+    and `LoopDefs.Iter` (where `div128Quot` calls it). -/
+def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+
 /-- div128 product check 2: compute q0*dLo vs rhat2*2^32+un0, conditionally correct q0.
     Instrs [37]-[44]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck2_merged_spec

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -467,11 +467,11 @@ theorem divK_loop_body_n1_call_skip_spec
   exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (cpsTriple_seq_cpsBranch_perm_same_cr
@@ -595,11 +595,11 @@ theorem divK_loop_body_n1_call_addback_spec
   exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (cpsTriple_seq_cpsBranch_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -149,9 +149,7 @@ def div128Quot (uHi uLo vTop : Word) : Word :=
   let hi2 := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   (q1' <<< (32 : BitVec 6).toNat) ||| q0'
 
 /-- Low 32 bits of vTop, stored to scratch during div128 call path. -/

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -132,7 +132,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -255,7 +255,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -378,7 +378,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -501,7 +501,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -131,7 +131,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -249,7 +249,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -367,7 +367,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -485,7 +485,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -254,7 +254,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -465,7 +465,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -678,7 +678,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -897,7 +897,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -1101,7 +1101,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -1305,7 +1305,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -250,7 +250,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallSkipPost div128Quot div128DLo div128Un0
+      delta loopBodyN3CallSkipPost div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -486,7 +486,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallSkipPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN3CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -708,7 +708,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallAddbackBeqPost div128Quot div128DLo div128Un0
+      delta loopBodyN3CallAddbackBeqPost div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -930,7 +930,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallAddbackBeqPostJ div128Quot div128DLo div128Un0
+      delta loopBodyN3CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
             loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full


### PR DESCRIPTION
## Summary

Pure structural refactor: extract Phase 2b's mul-check into a new standalone helper `div128Quot_phase2b_q0'` (defined in `LimbSpec/Div128ProdCheck2.lean`). **Semantics preserved exactly**.

## Why this refactor

A verified counterexample (documented at `~/.claude/plans/dynamic-strolling-riddle.md`) shows the Phase 2b mul-check false-positively fires when \`rhat2c ≥ 2^32\`, causing \`div128Quot\` to undershoot by 1. The proper fix per Knuth TAOCP §4.3.1 Step D3 is to guard the mul-check with \`rhat2c < 2^32\`.

Adding the guard directly to the inlined Phase 2b in \`div128Quot\` caused widespread \`maxHeartbeats\` / \`maxRecDepth\` failures across LoopBodyN{1..4}, LoopIterN{1..3}, etc. — the existing proofs implicitly rely on \`div128Quot\`'s exact let-chain shape during unification.

**Factoring Phase 2b into a helper FIRST** means the next iteration can add the guard locally to the helper without perturbing \`div128Quot\`'s top-level structure.

## What changed

- New helper \`div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word\` in \`LimbSpec/Div128ProdCheck2.lean\`. Currently identical to the legacy inlined logic.
- \`div128Quot\` (in \`LoopDefs/Iter.lean\`) calls the helper.
- \`div128Quot_phase2b_q0'\` added to the \`delta\` lists in 5 files (LoopBodyN1, LoopIterN{1Call,1CallBeq,2,3}) so existing unfold-based proofs continue to expose Phase 2b structure.

## Why \`Div128ProdCheck2.lean\` for the helper

It's the lowest-level file that naturally talks about Phase 2b's mul-check. Visible from:
- \`LimbSpec.Div128Step2\` (the limb-level step that uses it).
- \`Compose.Base\` (transitively via \`LimbSpec\` re-exports).
- \`LoopDefs.Iter\` (where \`div128Quot\` calls it).

## Next iteration

Add the actual guard to the helper:
\`\`\`lean
if BitVec.ult rhat2Un0 q0Dlo then
  (if rhat2c >>> 32 = 0 then q0c + signExtend12 4095 else q0c)
else q0c
\`\`\`
Plus the matching SRLI+BNE assembly instructions in \`divK_div128\`. Plus updates to \`Div128ProdCheck2\`'s proof and ~30 downstream Word-level specs.

## Test plan

- [x] \`lake build EvmAsm.Evm64\` succeeds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)