### PR TITLE
refactor(Div128): replace deprecated push_neg with push Not

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -134,7 +134,7 @@ theorem div128Quot_q1c_ge_q_true_1
   · -- hi1 ≠ 0 ⟹ q1 ≥ 2^32. q1c = q1 - 1 ≥ 2^32 - 1 ≥ q_true_1.
     have hq1_ge : q1.toNat ≥ 2^32 := by
       by_contra h
-      push_neg at h
+      push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
       have h32 : (32 : BitVec 6).toNat = 32 := by decide

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -254,7 +254,7 @@ theorem div128Quot_q1c_le_q1 (uHi dHi : Word) :
     rw [if_pos h_hi1]
   · have hq1_ge : q1.toNat ≥ 2^32 := by
       by_contra h
-      push_neg at h
+      push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
       have h32 : (32 : BitVec 6).toNat = 32 := by decide
@@ -373,7 +373,7 @@ theorem div128Quot_q1c_le_pow32 (uHi dHi dLo : Word)
   · -- hi1 ≠ 0 ⟹ q1 ≥ 2^32. KB-3c gives q1 ≤ 2^32 + 1, so q1c = q1 - 1 ≤ 2^32.
     have hq1_ge : q1.toNat ≥ 2^32 := by
       by_contra h
-      push_neg at h
+      push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
       have h32 : (32 : BitVec 6).toNat = 32 := by decide


### PR DESCRIPTION
## Summary
- `push_neg` has been deprecated in favor of `push Not`. Replace 3 call sites:
  - `Div128QuotientBounds.lean` (lines 257, 376)
  - `Div128KnuthLower.lean` (line 137)
- Silences 3 deprecation warnings in `lake build`.

## Test plan
- [x] `lake build` passes
- [x] `lake build 2>&1 | grep 'push_neg'` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)