### PR TITLE
refactor(Div128): prefix 3 unused variables with underscore

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -593,7 +593,7 @@ theorem knuth_compose_weak_lower_nat
     (q1' q0' un21 uHi uLo_hi uLo_lo vTop : Nat)
     (hvTop_pos : 0 < vTop)
     (h_ph1_tight : q1' * vTop + un21 = uHi * 2^32 + uLo_hi)
-    (h_un21_lt : un21 < vTop)
+    (_h_un21_lt : un21 < vTop)
     (h_ph2_weak : q0' + 2 ≥ (un21 * 2^32 + uLo_lo) / vTop) :
     (q1' * 2^32 + q0') + 2 ≥ (uHi * 2^64 + uLo_hi * 2^32 + uLo_lo) / vTop := by
   -- From Phase 1 tight: full dividend = q1' * vTop * 2^32 + un21 * 2^32 + uLo_lo.

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -61,7 +61,7 @@ theorem div128Quot_phase1a_quotient_bound (uHi dHi : Word)
     let rhat := uHi - q1 * dHi
     let hi1 := q1 >>> (32 : BitVec 6).toNat
     let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let _rhatc := if hi1 = 0 then rhat else rhat + dHi
     q1c.toNat ≤ uHi.toNat / dHi.toNat ∧
     uHi.toNat / dHi.toNat ≤ q1c.toNat + 1 := by
   intro q1 rhat hi1 q1c rhatc
@@ -148,7 +148,7 @@ theorem div128Quot_phase1b_no_underflow (uHi dHi : Word)
     (h_rhatc_lt : rhatc.toNat < 2 * dHi.toNat) :
     let q1' := if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
                else q1c
-    let rhat' := if BitVec.ult rhatUn1 (q1c * dLo) then rhatc + dHi else rhatc
+    let _rhat' := if BitVec.ult rhatUn1 (q1c * dLo) then rhatc + dHi else rhatc
     q1'.toNat * dHi.toNat ≤ uHi.toNat := by
   intro q1' rhat'
   -- Extract Phase 1b Euclidean at the right types (matching our local lets).


### PR DESCRIPTION
## Summary

Silence 3 `unused variable` warnings from `lake build`:

- `Div128QuotientBounds.lean:64` — `rhatc` let-binding → `_rhatc`. The let is intro'd into the proof body but its value isn't referenced in the conclusion or proof, so the Lean linter warns.
- `Div128QuotientBounds.lean:151` — same treatment for `rhat'`.
- `Div128KnuthLower.lean:596` — `h_un21_lt` hypothesis in `knuth_compose_weak_lower_nat` (currently unused in the proof) → `_h_un21_lt`. Kept rather than removed: the hypothesis reflects a real algorithmic constraint, likely needed when this theorem gets composed into Phase 1 tight bounds.

Companion to #1132 (push_neg deprecation). Together these drop `lake build | grep warning | wc -l` from 6 → 0.

## Test plan
- [x] `lake build` passes
- [x] `lake build 2>&1 | grep 'unused variable'` returns empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)