### PR TITLE
refactor(divmod): cascade div128Quot_phase2b_q0' to all Shape 1 sites (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -84,7 +84,7 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (sharedDivModCode base)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -247,7 +247,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
@@ -348,7 +348,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -83,7 +83,7 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (modCode base)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -53,7 +53,7 @@ theorem divK_div128_prodcheck2_merged_spec
     (sp q0 rhat2 v1Old v7Old dlo un0 : Word) (base : Word) :
     let q0Dlo := q0 * dlo
     let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
+    let q0' := div128Quot_phase2b_q0' q0 rhat2 dlo un0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -39,7 +39,7 @@ theorem divK_div128_step2_spec
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dlo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -830,7 +830,7 @@ theorem divK_trial_call_path_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -1763,7 +1763,7 @@ theorem divK_trial_call_full_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -113,7 +113,7 @@ theorem divK_trial_call_full_spec_n1
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -392,7 +392,7 @@ theorem divK_loop_body_n1_call_skip_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   -- Expand mulsub computation locally for intermediate steps
@@ -467,11 +467,11 @@ theorem divK_loop_body_n1_call_skip_spec
   exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (cpsTriple_seq_cpsBranch_perm_same_cr
@@ -533,7 +533,7 @@ theorem divK_loop_body_n1_call_addback_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
@@ -595,11 +595,11 @@ theorem divK_loop_body_n1_call_addback_spec
   exact cpsBranch_weaken
     (fun h hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     (cpsTriple_seq_cpsBranch_perm_same_cr

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -295,7 +295,7 @@ theorem divK_loop_body_n2_call_skip_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
@@ -449,7 +449,7 @@ theorem divK_loop_body_n2_call_addback_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -298,7 +298,7 @@ theorem divK_loop_body_n3_call_skip_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
@@ -453,7 +453,7 @@ theorem divK_loop_body_n3_call_addback_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -300,7 +300,7 @@ theorem divK_loop_body_n4_call_skip_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
@@ -455,7 +455,7 @@ theorem divK_loop_body_n4_call_addback_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -70,7 +70,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -132,7 +132,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -193,7 +193,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -255,7 +255,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -316,7 +316,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -378,7 +378,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -439,7 +439,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -501,7 +501,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -71,7 +71,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -131,7 +131,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -189,7 +189,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -249,7 +249,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -307,7 +307,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -367,7 +367,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -425,7 +425,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -485,7 +485,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -183,7 +183,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN2Call div128Quot at hborrow
@@ -254,7 +254,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -403,7 +403,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -465,7 +465,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -616,7 +616,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
@@ -678,7 +678,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -829,7 +829,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isAddbackBorrowN2Call div128Quot at hborrow
@@ -897,7 +897,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -1041,7 +1041,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
@@ -1101,7 +1101,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -1245,7 +1245,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
@@ -1305,7 +1305,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -179,7 +179,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
   unfold isSkipBorrowN3Call div128Quot at hborrow
@@ -250,7 +250,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallSkipPost div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN3CallSkipPost div128Quot div128DLo div128Un0
             loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -415,7 +415,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isSkipBorrowN3Call div128Quot at hborrow
@@ -486,7 +486,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallSkipPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN3CallSkipPostJ div128Quot div128DLo div128Un0
             loopBodyN3SkipPost loopBodySkipPost mulsubN4 loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -639,7 +639,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
   unfold isAddbackBorrowN3Call div128Quot at hborrow
@@ -708,7 +708,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallAddbackBeqPost div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN3CallAddbackBeqPost div128Quot div128DLo div128Un0
             loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
@@ -861,7 +861,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
   unfold isAddbackBorrowN3Call div128Quot at hborrow
@@ -930,7 +930,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by
-      delta loopBodyN3CallAddbackBeqPostJ div128Quot div128Quot_phase2b_q0' div128DLo div128Un0
+      delta loopBodyN3CallAddbackBeqPostJ div128Quot div128DLo div128Un0
             loopBodyN3AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN3 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -160,7 +160,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow = 0
@@ -400,7 +400,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     -- Hypothesis: borrow ≠ 0

--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -603,7 +603,7 @@ theorem div128Quot_toNat_eq (uHi uLo vTop : Word) :
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat < 2^32 →
     (div128Quot uHi uLo vTop).toNat = (q1'.toNat % 2^32) * 2^32 + q0'.toNat := by
   intro dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
@@ -656,7 +656,7 @@ theorem div128Quot_toNat_eq_strict (uHi uLo vTop : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat < 2^32 →
     (div128Quot uHi uLo vTop).toNat = q1'.toNat * 2^32 + q0'.toNat := by
   intro dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'


### PR DESCRIPTION
## Summary

Following #1131 (which extracted \`div128Quot_phase2b_q0'\` as a helper used by \`div128Quot\`), this PR cascades the helper to all 29 inlined Shape 1 references across the codebase.

**Pure refactor — semantics preserved.** This is the prerequisite cleanup before the actual Phase 2b guard fix can be added cleanly.

## Affected files

Single-line Shape 1 sites updated:
- \`LimbSpec/Div128ProdCheck2.lean\` (Phase 2b assembly spec)
- \`LimbSpec/Div128Step2.lean\`
- \`Compose/Div128.lean\`, \`Compose/ModDiv128.lean\`, \`Compose/FullPathN4Loop.lean\`
- \`LoopBody.lean\`, \`LoopBodyN{1,2,3,4}.lean\`
- \`LoopIterN{2,3,4}.lean\`, \`LoopIterN1/{Call,CallBeq}.lean\`

Replaces the inlined \`let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c\` with \`let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo (un0|div_un0|un0Div)\` depending on the caller's variable name.

## Delta-list reversion

Also reverts the \`div128Quot_phase2b_q0'\` addition to the \`delta\` lists in 5 files (LoopBodyN1, LoopIterN{1Call,1CallBeq,2,3}). Leaving the helper UN-expanded keeps RHS atoms in \`xperm_hyp\` matching the LHS atoms (which are now also helper-call shape post-bulk-replace).

## Remaining Shape 2 sites (deferred)

9 sites in \`EvmWordArith/Div128FinalAssembly.lean\`, \`Div128CallSkipClose.lean\`, \`Div128KnuthLower.lean\`, \`Div128QuotientBounds.lean\` use a different pattern (\`if BitVec.ult rhat2Un0 (q0c * dLo) then ... else q0c\`, with \`q0c * dLo\` inlined and no \`q0Dlo\` binding). These need case-by-case adaptation since their \`rhat2Un0\` is often an abstract parameter rather than \`(rhat2c <<< 32) ||| div_un0\` from a let-chain.

## Why this matters

The next iteration can add the actual Phase 2b guard to \`div128Quot_phase2b_q0'\`'s body — and now that all Shape 1 callers go through the helper, the change automatically propagates to them without any further refactoring (the assembly + Div128.lean composition will need updating; downstream Word-level specs that use Shape 2 still need cleanup first).

## Test plan

- [x] \`lake build EvmAsm.Evm64\` succeeds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)