### PR TITLE
refactor: remove stale file-size-exception from FullPathN4

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -1,4 +1,3 @@
--- file-size-exception: tracked by issue #312 (Compose subtree split). Pre-loop / loop-body / post-loop composition lives together; grandfathered pending split.
 /-
   EvmAsm.Evm64.DivMod.Compose.FullPathN4
 


### PR DESCRIPTION
## Summary
- `EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean` is 922 lines — well under the 1200-line Compose cap — so the grandfather exception line (referring to #312) is obsolete.
- Part of #1078. Follows #1079, which cleaned up 4 other stale exceptions; this leaves `LoopBody.lean` (1948 lines, tracked by #283/#266) as the only remaining exempted file.

## Test plan
- [x] `lake build` passes
- [x] `scripts/check-file-size.sh` passes without the exception line

🤖 Generated with [Claude Code](https://claude.com/claude-code)