### PR TITLE
feat(divmod): add divK_div128_phase2b_guard_spec (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -47,6 +47,82 @@ def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
   if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
 
+/-- Phase 2b guard: 2-instruction cpsBranch that skips the Phase 2b mul-check
+    when `rhat2c ≥ 2^32`. Per Knuth TAOCP §4.3.1 Step D3 ("repeat this test
+    if r̂ < b") — when `rhat2c ≥ 2^32`, the 64-bit `<< 32` in `rhat2Un0`
+    truncates, so the downstream `BLTU` mul-check would false-positively
+    fire; this guard dispatches past the mul-check entirely in that case.
+
+    Assembly:
+    ```
+    [0] SRLI .x1 .x11 32       -- x1 = rhat2c >> 32
+    [4] BNE  .x1 .x0 guard_off -- if nonzero, branch past mul-check
+    ```
+
+    Branches:
+    - **Taken** (rhat2c_hi ≠ 0, guard fires): branches to `(base+4) +
+      signExtend13 guard_off`. Mul-check skipped.
+    - **Fall-through** (rhat2c_hi = 0): continues to `base + 8`, Phase 2b
+      mul-check runs normally.
+
+    Used by `divK_div128_step2_guarded_spec` (future) to compose
+    clamp_q0 + guard + prodcheck2 into a 17-instruction step2 block. -/
+theorem divK_div128_phase2b_guard_spec
+    (sp rhat2c v1Old : Word) (base : Word) (guard_off : BitVec 13) :
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x11 32))
+        (CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off))
+    cpsBranch base cr
+      ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+      ((base + 4) + signExtend13 guard_off)
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2c_hi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝)
+      (base + 8)
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2c_hi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝) := by
+  intro rhat2c_hi cr
+  -- Step 1: SRLI .x1 .x11 32  (cpsTriple base → base+4)
+  have hsrli_raw := srli_spec_gen .x1 .x11 v1Old rhat2c 32 base (by nofun)
+  -- Extend to the full cr (which includes the BNE).
+  have hcr_srli : ∀ a i,
+      CodeReq.singleton base (.SRLI .x1 .x11 32) a = some i → cr a = some i := by
+    intro a i h
+    simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
+    split at h
+    · rename_i hab; simp_all
+    · simp at h
+  have hsrli := cpsTriple_extend_code hcr_srli hsrli_raw
+  have hsrli_framed := cpsTriple_frameR
+    ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0))
+    (by pcFree) hsrli
+  -- Step 2: BNE .x1 .x0 guard_off  (cpsBranch base+4 → ...)
+  have hbne_raw := bne_spec_gen .x1 .x0 guard_off rhat2c_hi (0 : Word) (base + 4)
+  have hcr_bne : ∀ a i,
+      CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off) a = some i → cr a = some i := by
+    intro a i h
+    simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
+    split at h
+    · rename_i hab; rw [beq_iff_eq] at hab; subst hab
+      have : (base + 4 : Word) ≠ base := by bv_omega
+      simp_all
+    · simp at h
+  have hbne := cpsBranch_extend_code hcr_bne hbne_raw
+  have hbne_framed := cpsBranch_frameR
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c))
+    (by pcFree) hbne
+  -- Compose SRLI (cpsTriple) + BNE (cpsBranch).
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hsrli_framed hbne_framed
+  -- Weaken to the stated pre/post shapes (atom permutation, `base + 4 + 4 = base + 8`).
+  have h_addr_eq : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [h_addr_eq] at composed
+  exact cpsBranch_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
+
 /-- div128 product check 2: compute q0*dLo vs rhat2*2^32+un0, conditionally correct q0.
     Instrs [37]-[44]. Both BLTU paths merge at base+32. -/
 theorem divK_div128_prodcheck2_merged_spec


### PR DESCRIPTION
## Summary

Adds a standalone 2-instruction `cpsBranch` spec for the Phase 2b guard (SRLI + BNE) that will be inserted into `divK_div128` to fix the undershoot bug documented at \`~/.claude/plans/dynamic-strolling-riddle.md\`.

The spec describes the two-instruction sequence:
\`\`\`
[0] SRLI .x1 .x11 32       -- x1 = rhat2c >> 32
[4] BNE  .x1 .x0 guard_off -- if nonzero, branch past mul-check
\`\`\`

## Branches

- **Taken** (rhat2c_hi ≠ 0, guard fires): branches to \`(base+4) + signExtend13 guard_off\`. Mul-check skipped.
- **Fall-through** (rhat2c_hi = 0): continues to \`base + 8\`, Phase 2b mul-check runs normally.

## Proof

Composes \`srli_spec_gen\` (cpsTriple base → base+4) with \`bne_spec_gen\` (cpsBranch base+4 → ...) via \`cpsTriple_seq_cpsBranch_perm_same_cr\`, then weakens via \`cpsBranch_weaken\` to the stated atom permutation.

## Context

This spec is currently **unused** — it exists in isolation as the first prerequisite for the upcoming coordinated fix (assembly SRLI+BNE insertion + helper guard + step2_spec restructure). Follow-up PRs will:

1. Insert SRLI + BNE into \`divK_div128\` between [36] and [37].
2. Add the guard to \`div128Quot_phase2b_q0'\` helper body.
3. Rewrite \`divK_div128_step2_spec\` to compose clamp_q0 + this guard spec + prodcheck2 (17 instructions, guarded q0').
4. Shift \`Compose/Div128.lean\` and \`Compose/ModDiv128.lean\` offsets.

## Test plan

- [x] \`lake build EvmAsm.Evm64\` succeeds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)