### PR TITLE
fix(divmod): add Phase 2b guard (Knuth TAOCP §4.3.1 Step D3) for div128 correctness [#61]

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -34,7 +34,7 @@ theorem divK_denorm_len : divK_denorm.length = 25 := by decide
 theorem divK_divEpilogue_len : (divK_div_epilogue 24).length = 10 := by decide
 theorem divK_zeroPath_len : divK_zeroPath.length = 5 := by decide
 theorem divK_nop_len : (ADDI .x0 .x0 0 : Program).length = 1 := by decide
-theorem divK_div128_len : divK_div128.length = 49 := by decide
+theorem divK_div128_len : divK_div128.length = 51 := by decide
 theorem divK_modEpilogue_len : (divK_mod_epilogue 24).length = 10 := by decide
 
 /-- Skip one ofProg block in a right-nested union via range disjointness.

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -84,7 +84,12 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+    -- Exit values depend on whether the Phase 2b guard fires.
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (sharedDivModCode base)
@@ -99,15 +104,17 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0Dlo) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ q) **
+       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7_exit) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
-  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
+  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
+    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit
+    x1_exit x11_exit q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
@@ -189,15 +196,17 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hcuf
   -- ================================================================
-  -- Block 4: Step 2 (base+1192 → base+1252)
-  -- Trial division q0, clamp, product check.
+  -- Block 4: Step 2 (base+1192 → base+1260)
+  -- Trial division q0, clamp, Phase 2b guard, product check.
   -- Params: un21(x7), dHi(x6), v1Old=cu_q1_dlo(x1),
   --         v5Old=cu_rhat_un1(x5), v11Old=un1(x11),
   --         dlo=dLo(mem[3952]), un0(mem[3944])
+  -- NOTE: 17 instructions (was 15) — SRLI+BNE guard added between clamp
+  -- and mul-check per Knuth TAOCP §4.3.1 Step D3.
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
-  rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
+  rw [show (base + 1192 : Word) + 68 = base + 1260 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub 30 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub 31 _ _ (by decide) (by bv_addr) (by decide))
@@ -213,7 +222,9 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
      (CodeReq.union_sub (d128_sub 41 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub 42 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub 43 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+     (CodeReq.union_sub (d128_sub 44 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 45 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 46 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
@@ -224,22 +235,22 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
-  -- Block 5: End (base+1252 → retAddr via JALR)
+  -- Block 5: End (base+1260 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
   -- Params: q1=q1'(x10), q0=q0'(x5), v2Old=retAddr(x2),
-  --         v11Old=un0(x11), retAddr(mem[3968])
+  --         v11Old=x11_exit(x11), retAddr(mem[3968])
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
-    (base + 1252) halign
+  have hend := divK_div128_end_spec sp q1' q0' retAddr x11_exit retAddr
+    (base + 1260) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub 47 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub 48 _ _ (by decide) (by bv_addr) (by decide)))))
+    exact CodeReq.union_sub (d128_sub 47 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 48 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub 49 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub 50 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) **
+    ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -84,12 +84,12 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
     -- Exit values depend on whether the Phase 2b guard fires.
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
-    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (sharedDivModCode base)
@@ -104,8 +104,8 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7_exit) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ q) **
+       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
@@ -113,8 +113,8 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
-    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit
-    x1_exit x11_exit q
+    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit
+    x1Exit x11Exit q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
@@ -238,9 +238,9 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- Block 5: End (base+1260 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
   -- Params: q1=q1'(x10), q0=q0'(x5), v2Old=retAddr(x2),
-  --         v11Old=x11_exit(x11), retAddr(mem[3968])
+  --         v11Old=x11Exit(x11), retAddr(mem[3968])
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' retAddr x11_exit retAddr
+  have hend := divK_div128_end_spec sp q1' q0' retAddr x11Exit retAddr
     (base + 1260) halign
   have hende := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub 47 _ _ (by decide) (by bv_addr) (by decide))
@@ -250,7 +250,7 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) **
+    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -83,7 +83,12 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+    -- Exit values depend on whether the Phase 2b guard fires.
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (modCode base)
@@ -98,15 +103,17 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ q0Dlo) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ q) **
+       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7_exit) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
-  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
+  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
+    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit
+    x1_exit x11_exit q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
@@ -188,12 +195,13 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hcuf
   -- ================================================================
-  -- Block 4: Step 2 (base+1192 → base+1252)
-  -- Trial division q0, clamp, product check.
+  -- Block 4: Step 2 (base+1192 → base+1260)
+  -- Trial division q0, clamp, Phase 2b guard, product check.
+  -- 17 instructions (was 15) — SRLI+BNE guard added per Knuth TAOCP §4.3.1 Step D3.
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
-  rw [show (base + 1192 : Word) + 60 = base + 1252 from by bv_addr] at hst2
+  rw [show (base + 1192 : Word) + 68 = base + 1260 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub_mod 30 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub_mod 31 _ _ (by decide) (by bv_addr) (by decide))
@@ -209,7 +217,9 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
      (CodeReq.union_sub (d128_sub_mod 41 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub_mod 42 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_sub_mod 43 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod 44 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))
+     (CodeReq.union_sub (d128_sub_mod 44 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 45 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 46 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))
     hst2
   -- Frame step2 with x10, x2, mem[3968], mem[3960]
   have hst2f := cpsTriple_frameR
@@ -220,20 +230,20 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have h1234 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- ================================================================
-  -- Block 5: End (base+1252 → retAddr via JALR)
+  -- Block 5: End (base+1260 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' retAddr un0 retAddr
-    (base + 1252) halign
+  have hend := divK_div128_end_spec sp q1' q0' retAddr x11_exit retAddr
+    (base + 1260) halign
   have hende := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_sub_mod 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_sub_mod 47 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_sub_mod 48 _ _ (by decide) (by bv_addr) (by decide)))))
+    exact CodeReq.union_sub (d128_sub_mod 47 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 48 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_sub_mod 49 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_sub_mod 50 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ rhat2Un0) **
+    ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -83,12 +83,12 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
     -- Exit values depend on whether the Phase 2b guard fires.
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
-    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
     -- End: combine q1' and q0'
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (modCode base)
@@ -103,8 +103,8 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem))
       (-- Postcondition: x11=quotient, all regs/mem updated
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7_exit) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ q) **
+       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
+       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
        (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ retAddr) **
        (sp + signExtend12 3960 ↦ₘ d) **
@@ -112,8 +112,8 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   -- Introduce all let bindings
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
-    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit
-    x1_exit x11_exit q
+    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit
+    x1Exit x11Exit q
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.
@@ -233,7 +233,7 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- Block 5: End (base+1260 → retAddr via JALR)
   -- Combine q1'|q0' into q, restore return addr, return.
   -- ================================================================
-  have hend := divK_div128_end_spec sp q1' q0' retAddr x11_exit retAddr
+  have hend := divK_div128_end_spec sp q1' q0' retAddr x11Exit retAddr
     (base + 1260) halign
   have hende := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub_mod 47 _ _ (by decide) (by bv_addr) (by decide))
@@ -243,7 +243,7 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     hend
   -- Frame end with x7, x6, x1, x0, mem[3960], mem[3952], mem[3944]
   have hendf := cpsTriple_frameR
-    ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1_exit) **
+    ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -32,10 +32,16 @@ open EvmAsm.Rv64
 
 /-- Phase 2b refined quotient digit in `div128Quot`.
 
-    Factored standalone so the Knuth TAOCP §4.3.1 Step D3 guard
-    (`rhat2c < 2^32`) can be added in a follow-up iteration without
-    rewriting the entire `div128Quot` body. **Currently matches legacy
-    (buggy) semantics**; the bug is documented at
+    Guards the multiplication-check decrement with `rhat2c < 2^32` per
+    Knuth TAOCP §4.3.1 Step D3 ("repeat this test if r̂ < b"). When
+    `rhat2c ≥ 2^32`, the 64-bit `<< 32` in `rhat2Un0` truncates, and
+    the Word `BLTU rhat2Un0 q0Dlo` comparison can false-positively fire
+    (since the abstract quantity `rhat2c * 2^32 + div_un0` is actually
+    ≥ 2^64 > q0Dlo in that regime). The guard skips the decrement in
+    that case.
+
+    Matches the assembly's `SRLI .x1 .x11 32 ;; BNE .x1 .x0 36` guard
+    that precedes the Phase 2b mul-check. See counterexample at
     `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
 
     Lives in `Div128ProdCheck2.lean` (the lowest-level file that
@@ -43,9 +49,11 @@ open EvmAsm.Rv64
     `LimbSpec.Div128Step2`, `Compose/Base` (transitively via `LimbSpec`),
     and `LoopDefs.Iter` (where `div128Quot` calls it). -/
 def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+    let q0Dlo := q0c * dLo
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+  else q0c
 
 /-- Phase 2b guard: 2-instruction cpsBranch that skips the Phase 2b mul-check
     when `rhat2c ≥ 2^32`. Per Knuth TAOCP §4.3.1 Step D3 ("repeat this test
@@ -129,7 +137,11 @@ theorem divK_div128_prodcheck2_merged_spec
     (sp q0 rhat2 v1Old v7Old dlo un0 : Word) (base : Word) :
     let q0Dlo := q0 * dlo
     let rhat2Un0 := (rhat2 <<< (32 : BitVec 6).toNat) ||| un0
-    let q0' := div128Quot_phase2b_q0' q0 rhat2 dlo un0
+    -- NOTE: describes the UNGUARDED 8-instruction Phase 2b mul-check.
+    -- The `div128Quot_phase2b_q0'` helper (guarded form) is used at
+    -- the step2 level, where the upstream `phase2b_guard_spec` cpsBranch
+    -- gates this mul-check.
+    let q0' := if BitVec.ult rhat2Un0 q0Dlo then q0 + signExtend12 4095 else q0
     let cr :=
       CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x7 .x5 .x1))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck2.lean
@@ -68,28 +68,28 @@ def div128Quot_phase2b_q0' (q0c rhat2c dLo div_un0 : Word) : Word :=
     ```
 
     Branches:
-    - **Taken** (rhat2c_hi ≠ 0, guard fires): branches to `(base+4) +
+    - **Taken** (rhat2cHi ≠ 0, guard fires): branches to `(base+4) +
       signExtend13 guard_off`. Mul-check skipped.
-    - **Fall-through** (rhat2c_hi = 0): continues to `base + 8`, Phase 2b
+    - **Fall-through** (rhat2cHi = 0): continues to `base + 8`, Phase 2b
       mul-check runs normally.
 
     Used by `divK_div128_step2_guarded_spec` (future) to compose
     clamp_q0 + guard + prodcheck2 into a 17-instruction step2 block. -/
 theorem divK_div128_phase2b_guard_spec
     (sp rhat2c v1Old : Word) (base : Word) (guard_off : BitVec 13) :
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x11 32))
         (CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off))
     cpsBranch base cr
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
       ((base + 4) + signExtend13 guard_off)
-        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2c_hi) **
-         (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝)
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝)
       (base + 8)
-        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2c_hi) **
-         (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝) := by
-  intro rhat2c_hi cr
+        ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) := by
+  intro rhat2cHi cr
   -- Step 1: SRLI .x1 .x11 32  (cpsTriple base → base+4)
   have hsrli_raw := srli_spec_gen .x1 .x11 v1Old rhat2c 32 base (by nofun)
   -- Extend to the full cr (which includes the BNE).
@@ -105,7 +105,7 @@ theorem divK_div128_phase2b_guard_spec
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0))
     (by pcFree) hsrli
   -- Step 2: BNE .x1 .x0 guard_off  (cpsBranch base+4 → ...)
-  have hbne_raw := bne_spec_gen .x1 .x0 guard_off rhat2c_hi (0 : Word) (base + 4)
+  have hbne_raw := bne_spec_gen .x1 .x0 guard_off rhat2cHi (0 : Word) (base + 4)
   have hcr_bne : ∀ a i,
       CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off) a = some i → cr a = some i := by
     intro a i h

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -1,10 +1,11 @@
 /-
   EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2
 
-  Full-step composition for instrs [30]-[44] of the `div128` subroutine —
+  Full-step composition for instrs [30]-[46] of the `div128` subroutine —
   combining step-2-init (DIVU+MUL+SUB), clamp-q0 (SRLI+BEQ+ADDI+ADD),
-  and prodcheck2 (LD+MUL+SLLI+LD+OR + BLTU+JAL + ADDI) into a single
-  refined `q0` computation for the low 64 bits.
+  Phase 2b guard (SRLI+BNE — Knuth TAOCP §4.3.1 Step D3), and prodcheck2
+  (LD+MUL+SLLI+LD+OR + BLTU+JAL + ADDI) into a single refined `q0`
+  computation for the low 64 bits.
 
   Thirtieth chunk of the `LimbSpec.lean` split tracked by issue #312.
   The consumer surface is unchanged: `LimbSpec.lean` re-exports this file
@@ -27,9 +28,22 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- div128 step 2: trial division q0, clamp, product check. Instrs [30]-[44].
+/-- div128 step 2: trial division q0, clamp, Phase 2b guard, product check.
+    Instrs [30]-[46] (17 instructions). Includes the Knuth TAOCP §4.3.1
+    Step D3 guard (SRLI + BNE at instrs [37]-[38]) that skips the
+    product check when `rhat2c >= 2^32`.
+
     Input: un21 in x7, dHi in x6, dlo/un0 in memory.
-    Output: refined q0 in x5. -/
+    Output: refined q0 in x5 (= `div128Quot_phase2b_q0' q0c rhat2c dlo un0`).
+
+    **NOTE**: output's x7, x1, x11 values differ between guard-fires and
+    guard-doesn't-fire paths:
+    - Guard fires (rhat2c_hi ≠ 0): x7 = un21 (unchanged), x1 = rhat2c_hi,
+      x11 = rhat2c.
+    - Guard doesn't fire (rhat2c_hi = 0): x7 = q0Dlo, x1 = rhat2Un0,
+      x11 = un0.
+
+    The postcondition uses `rhat2c_hi = 0`-aware selectors to capture this. -/
 theorem divK_div128_step2_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
@@ -39,7 +53,15 @@ theorem divK_div128_step2_spec
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dlo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+    -- Exit values for registers that differ between guard-fires/doesn't
+    -- paths. On guard-fires: x7 keeps un21 (MUL not run), x1 keeps
+    -- rhat2c_hi (loaded by SRLI), x11 keeps rhat2c (un0 not loaded).
+    -- On guard-doesn't-fire: x7 holds q0Dlo, x1 holds rhat2Un0, x11 holds un0.
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -48,113 +70,34 @@ theorem divK_div128_step2_spec
       (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
       (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.BLTU .x1 .x7 8))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.JAL .x0 8))
-       (CodeReq.singleton (base + 56) (.ADDI .x5 .x5 4095)))))))))))))))
-    cpsTriple base (base + 60) cr
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
+       (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
+    cpsTriple base (base + 68) cr
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
        (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-      ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+      ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 q0' cr
-  have hcr_eq : cr =
-      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.BLTU .x1 .x7 8))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.JAL .x0 8))
-       (CodeReq.singleton (base + 56) (.ADDI .x5 .x5 4095))))))))))))))) := rfl
-  have h1_raw := divK_div128_step2_init_spec un21 dHi v1Old v5Old v11Old base
-  have h1 : cpsTriple base (base + 12) cr _ _ :=
-    cpsTriple_extend_code (h := h1_raw) (hmono := by
-      rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))
-  have h1f := cpsTriple_frameR
-    ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
-     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-    (by pcFree) h1
-  have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 dHi (q0 * dHi) (base + 12)
-  have : (base + 12 : Word) + 4 = base + 16 := by bv_addr
-  have : (base + 12 : Word) + 8 = base + 20 := by bv_addr
-  have : (base + 12 : Word) + 12 = base + 24 := by bv_addr
-  have : (base + 12 : Word) + 16 = base + 28 := by bv_addr
-  simp only [*] at h2_raw
-  have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
-    cpsTriple_extend_code (h := h2_raw) (hmono := by
-      rw [hcr_eq]; intro a i
-      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
-      split at h
-      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-      · split at h
-        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-        · split at h
-          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-          · split at h
-            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-            · simp at h)
-  have h2f := cpsTriple_frameR
-    ((.x7 ↦ᵣ un21) ** (.x12 ↦ᵣ sp) **
-     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-    (by pcFree) h2
-  have h12 := cpsTriple_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) h1f h2f
-  have h3_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c hi
-    un21 dlo un0 (base + 28)
-  have : (base + 28 : Word) + 4 = base + 32 := by bv_addr
-  have : (base + 28 : Word) + 8 = base + 36 := by bv_addr
-  have : (base + 28 : Word) + 12 = base + 40 := by bv_addr
-  have : (base + 28 : Word) + 16 = base + 44 := by bv_addr
-  have : (base + 28 : Word) + 20 = base + 48 := by bv_addr
-  have : (base + 28 : Word) + 24 = base + 52 := by bv_addr
-  have : (base + 28 : Word) + 28 = base + 56 := by bv_addr
-  have : (base + 28 : Word) + 32 = base + 60 := by bv_addr
-  simp only [*] at h3_raw
-  have h3 : cpsTriple (base + 28) (base + 60) cr _ _ :=
-    cpsTriple_extend_code (h := h3_raw) (hmono := by
-      rw [hcr_eq]; intro a i
-      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
-      split at h
-      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-      · split at h
-        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-        · split at h
-          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-          · split at h
-            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-            · split at h
-              · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-              · split at h
-                · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-                · split at h
-                  · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-                  · split at h
-                    · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
-                    · simp at h)
-  have h3f := cpsTriple_frameR
-    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0))
-    (by pcFree) h3
-  have h123 := cpsTriple_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) h12 h3f
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by xperm_hyp hp)
-    h123
+  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit x1_exit x11_exit cr
+  -- TODO(#61 Phase 2b coordinated fix): compose step2_init + clamp_q0 +
+  -- phase2b_guard (cpsBranch) + prodcheck2_merged (on fall-through), then
+  -- merge via cpsBranch_merge_same_cr into this unified cpsTriple. The
+  -- `div128Quot_phase2b_q0'` helper now guards the mul-check with
+  -- `rhat2c >>> 32 = 0`, so under the guard-fires leg, `q0' = q0c`; under
+  -- the guard-doesn't-fire leg, `q0' = (if BitVec.ult rhat2Un0 q0Dlo then
+  -- q0c + signExtend12 4095 else q0c)` matching the unguarded
+  -- `divK_div128_prodcheck2_merged_spec` post.
+  sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -108,6 +108,229 @@ theorem divK_div128_step2_upto_guard_spec
     (fun h hp => by xperm_hyp hp)
     h12
 
+/-- div128 step 2 thru-guard: init + clamp_q0 + phase2b_guard composition
+    for instrs [30]-[38]. Produces a cpsBranch at base+28 that either takes
+    the taken path to base+68 (skipping mul-check when rhat2c_hi ≠ 0) or
+    falls through to base+36 (rhat2c_hi = 0) where mul-check will run. -/
+theorem divK_div128_step2_thru_guard_spec
+    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
+    let hi := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+    let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+       (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36)))))))))
+    cpsBranch base cr
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
+       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (base + 68)
+        ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (base + 36)
+        ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  intro q0 rhat2 hi q0c rhat2c rhat2c_hi cr
+  have hcr_eq : cr =
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+       (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))))))))) := rfl
+  -- h1 = step2_upto_guard_spec (cpsTriple base..base+28, 7-singleton cr).
+  -- Its cr is a STRUCTURAL PREFIX of thru_guard's cr: same 7 singletons,
+  -- ending in `singleton (base+24) ADD` vs thru_guard's `union (sing 24 ADD)
+  -- (union (sing 28 SRLI) (sing 32 BNE))`. So 6 union_mono_tails + 1
+  -- union_mono_left (peeling sing 24 ADD from the head).
+  have h1_raw := divK_div128_step2_upto_guard_spec sp un21 dHi v1Old v5Old v11Old
+    dlo un0 base
+  have h1 : cpsTriple base (base + 28) cr _ _ :=
+    cpsTriple_extend_code (h := h1_raw) (hmono := by
+      rw [hcr_eq]
+      exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_left _ _)))))))
+  -- h2 = phase2b_guard_spec at base+28 (2-singleton cr).
+  have h2_raw := divK_div128_phase2b_guard_spec sp rhat2c hi (base + 28) (36 : BitVec 13)
+  have ha_bne : (base + 28 : Word) + 4 = base + 32 := by bv_addr
+  have ha_t : (base + 32 : Word) + signExtend13 (36 : BitVec 13) = base + 68 := by rv64_addr
+  have ha_f : (base + 28 : Word) + 8 = base + 36 := by bv_addr
+  simp only [ha_bne, ha_t, ha_f] at h2_raw
+  -- phase2b_guard's 2-singleton cr is the innermost pair of thru_guard's 9-cr.
+  -- Use split+simp pattern (only 2 levels deep, bounded heartbeats).
+  have h2 : cpsBranch (base + 28) cr _ _ _ _ _ :=
+    cpsBranch_extend_code (h := h2_raw) (hmono := by
+      rw [hcr_eq]; intro a i
+      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
+      split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · simp at h)
+  have h2f := cpsBranch_frameR
+    ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+    (by pcFree) h2
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1 h2f
+  exact cpsBranch_weaken
+    (fun h hp => hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
+
+/-- div128 step 2 branch-merged: composes thru_guard + prodcheck2_merged into
+    a cpsBranch where BOTH legs end at base+68 (guard-fires skips directly;
+    guard-doesn't-fire runs the mul-check). -/
+theorem divK_div128_step2_branch_merged_spec
+    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
+    let hi := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+    let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+    let q0Dlo := q0c * dlo
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let q0'_unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
+       (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
+    cpsBranch base cr
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
+       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (base + 68)  -- guard-fires path
+        ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      (base + 68)  -- guard-doesn't-fire + prodcheck2 (carries ⌜rhat2c_hi = 0⌝)
+        ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'_unguarded) **
+         (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0'_unguarded cr
+  have hcr_eq : cr =
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
+       (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095))))))))))))))))) := rfl
+  -- h1 = thru_guard_spec (cpsBranch base..base+68|base+36, 9-singleton cr).
+  -- Its cr is a STRUCTURAL PREFIX of branch_merged's 17-cr: same 8 outer unions,
+  -- innermost differs (thru_guard = sing 32 BNE, branch_merged = union (sing 32 BNE) REST).
+  -- So 8 union_mono_tails + 1 union_mono_left.
+  have h1_raw := divK_div128_step2_thru_guard_spec sp un21 dHi v1Old v5Old v11Old
+    dlo un0 base
+  have h1 : cpsBranch base cr _ _ _ _ _ :=
+    cpsBranch_extend_code (h := h1_raw) (hmono := by
+      rw [hcr_eq]
+      exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))))))))
+  -- h2 = prodcheck2_merged_spec at base+36 (8-singleton cr, positions 9-16
+  -- of the 17-cr). Use split+simp pattern (8 levels deep but each level is
+  -- cheap — heads don't match the prodcheck2 cr's head).
+  have h2_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c rhat2c_hi un21
+    dlo un0 (base + 36)
+  have hb4 : (base + 36 : Word) + 4 = base + 40 := by bv_addr
+  have hb8 : (base + 36 : Word) + 8 = base + 44 := by bv_addr
+  have hb12 : (base + 36 : Word) + 12 = base + 48 := by bv_addr
+  have hb16 : (base + 36 : Word) + 16 = base + 52 := by bv_addr
+  have hb20 : (base + 36 : Word) + 20 = base + 56 := by bv_addr
+  have hb24 : (base + 36 : Word) + 24 = base + 60 := by bv_addr
+  have hb28 : (base + 36 : Word) + 28 = base + 64 := by bv_addr
+  have hb32 : (base + 36 : Word) + 32 = base + 68 := by bv_addr
+  simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32] at h2_raw
+  -- prodcheck2's 8-cr ⊆ 17-cr: use split+simp pattern (8 levels, matching
+  -- the old pre-guard step2 proof's pattern for the prodcheck block).
+  have h2 : cpsTriple (base + 36) (base + 68) cr _ _ :=
+    cpsTriple_extend_code (h := h2_raw) (hmono := by
+      rw [hcr_eq]; intro a i
+      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
+      split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · split at h
+          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+          · split at h
+            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+            · split at h
+              · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+              · split at h
+                · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                · split at h
+                  · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                  · split at h
+                    · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                    · simp at h)
+  -- Frame h2 with (x6, x0) and ⌜rhat2c_hi = 0⌝ so the pure fact is carried
+  -- through the composition and ends up in branch_merged's fall-through post.
+  have h2f := cpsTriple_frameR
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝)
+    (by pcFree) h2
+  -- hperm: permute thru_guard's Q_f (incl. pure fact) to h2f's pre order.
+  have composed := cpsBranch_seq_cpsTriple_with_perm_same_cr
+    (h1 := h1)
+    (hperm := fun h hp => by xperm_hyp hp)
+    (h2 := h2f)
+    (ht1 := fun h hp => hp)
+  -- Reshape h2f's left-associated post to our natural right-associated post.
+  exact cpsBranch_weaken
+    (fun h hp => hp)
+    (fun h hp => hp)  -- Q_t unchanged
+    (fun h hp => by xperm_hyp hp)  -- Q_f_final reshaped
+    composed
+
 /-- div128 step 2: trial division q0, clamp, Phase 2b guard, product check.
     Instrs [30]-[46] (17 instructions). Includes the Knuth TAOCP §4.3.1
     Step D3 guard (SRLI + BNE at instrs [37]-[38]) that skips the
@@ -170,20 +393,108 @@ theorem divK_div128_step2_spec
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit x1_exit x11_exit cr
-  -- TODO(#61 Phase 2b coordinated fix, iteration 2026-04-23):
-  -- `divK_div128_step2_upto_guard_spec` above covers the base..base+28 section
-  -- (cleanly replacing the old step2 pattern). Remaining composition:
-  --   h1 = divK_div128_step2_upto_guard_spec (cpsTriple base..base+28) ✓ available
-  --   h2 = phase2b_guard_spec at base+28 (cpsBranch → base+68 | base+36)
-  --   h3 = prodcheck2_merged_spec at base+36 (cpsTriple base+36..base+68)
-  --   compose h1+h2 via cpsTriple_seq_cpsBranch_perm_same_cr
-  --   compose + h3 via cpsBranch_seq_cpsTriple_with_perm_same_cr
-  --   merge via cpsBranch_merge_same_cr with cpsTriple_refl bridges
-  -- Empirical finding: attempting the full composition in one elab step
-  -- times out at maxHeartbeats (200000) at the first cpsTriple_seq_cpsBranch
-  -- xperm_hyp call (too many atoms to permute). Next iteration needs to
-  -- factor the composition into additional intermediate sub-lemmas to split
-  -- the elaboration cost.
-  sorry
+  -- Apply branch_merged to get a cpsBranch with both legs at base+68.
+  have hbr := divK_div128_step2_branch_merged_spec sp un21 dHi v1Old v5Old v11Old
+    dlo un0 base
+  -- Target post as a local assertion.
+  let R : Assertion :=
+    (.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+    (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
+  -- Helper: cpsTriple_refl at base+68 is a zero-step identity triple; we
+  -- extend it from empty cr to our cr (vacuous) and use it for both branches.
+  have refl_of {P : Assertion} (h : ∀ hp, P hp → R hp) :
+      cpsTriple (base + 68) (base + 68) cr P R :=
+    cpsTriple_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
+      (cpsTriple_refl h)
+  -- Bridge for taken path (rhat2c_hi ≠ 0): strip pure fact, rewrite x7/x1/x11
+  -- exits to un21/rhat2c_hi/rhat2c, rewrite q0' to q0c via helper unfolding.
+  have h_t : cpsTriple (base + 68) (base + 68) cr _ R := refl_of (P :=
+    (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+    (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
+    intro hp hP
+    have h_hi_ne : rhat2c_hi ≠ 0 := by
+      -- Extract ⌜rhat2c_hi ≠ 0⌝ from position 7 in the sepConj chain.
+      obtain ⟨_, _, _, _, _, hrest⟩ := hP
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, ⟨_, hpure⟩, _⟩ := hrest
+      exact hpure
+    have hq0' : q0' = q0c := by
+      show div128Quot_phase2b_q0' q0c rhat2c dlo un0 = q0c
+      unfold div128Quot_phase2b_q0'
+      exact if_neg h_hi_ne
+    have hx7 : x7_exit = un21 := if_neg h_hi_ne
+    have hx1 : x1_exit = rhat2c_hi := if_neg h_hi_ne
+    have hx11 : x11_exit = rhat2c := if_neg h_hi_ne
+    show R hp
+    show ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+         (sp + signExtend12 3952 ↦ₘ dlo) **
+         (sp + signExtend12 3944 ↦ₘ un0)) hp
+    rw [hq0', hx7, hx1, hx11]
+    -- Strip the pure fact and permute.
+    have hP' : ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+                (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+                (sp + signExtend12 3952 ↦ₘ dlo) **
+                (sp + signExtend12 3944 ↦ₘ un0)) hp :=
+      sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (fun h' hp' => ((sepConj_pure_left h').1 hp').2))))))) hp hP
+    xperm_hyp hP')
+  -- Bridge for fall-through path: the post carries ⌜rhat2c_hi = 0⌝ so we
+  -- can extract it and rewrite the exit selectors to their then-branch values.
+  have h_f : cpsTriple (base + 68) (base + 68) cr _ R := refl_of (P :=
+    (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ
+      (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c)) **
+    (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
+    intro hp hP
+    have h_hi_eq : rhat2c_hi = 0 := by
+      -- Extract ⌜rhat2c_hi = 0⌝ from position 7 in the sepConj chain.
+      obtain ⟨_, _, _, _, _, hrest⟩ := hP
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, ⟨_, hpure⟩, _⟩ := hrest
+      exact hpure
+    have hq0' : q0' = (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c) := by
+      show div128Quot_phase2b_q0' q0c rhat2c dlo un0 = _
+      unfold div128Quot_phase2b_q0'
+      rw [if_pos h_hi_eq]
+    have hx7 : x7_exit = q0Dlo := if_pos h_hi_eq
+    have hx1 : x1_exit = rhat2Un0 := if_pos h_hi_eq
+    have hx11 : x11_exit = un0 := if_pos h_hi_eq
+    show ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+         (sp + signExtend12 3952 ↦ₘ dlo) **
+         (sp + signExtend12 3944 ↦ₘ un0)) hp
+    rw [hq0', hx7, hx1, hx11]
+    -- Strip the pure fact and permute remaining atoms.
+    have hP' : ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ
+                (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c)) **
+                (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+                (sp + signExtend12 3952 ↦ₘ dlo) **
+                (sp + signExtend12 3944 ↦ₘ un0)) hp :=
+      sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (fun h' hp' => ((sepConj_pure_left h').1 hp').2))))))) hp hP
+    xperm_hyp hP')
+  exact cpsBranch_merge_same_cr hbr h_t h_f
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -28,6 +28,86 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- div128 step 2 upto-guard: init + clamp_q0 composition for instrs [30]-[36].
+    Output at base+28 with x5=q0c, x11=rhat2c, x1=hi ready for the Phase 2b
+    guard to consume.
+
+    Note: proof pattern matches the pre-guard (main-branch) step2_spec's first
+    two sub-specs; this sub-lemma exists so the full `divK_div128_step2_spec`
+    can compose it with the new `phase2b_guard_spec` + `prodcheck2_merged_spec`
+    without re-stating the init/clamp code subsumption every time. -/
+theorem divK_div128_step2_upto_guard_spec
+    (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
+    let q0 := rv64_divu un21 dHi
+    let rhat2 := un21 - q0 * dHi
+    let hi := q0 >>> (32 : BitVec 6).toNat
+    let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+    let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+       (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6)))))))
+    cpsTriple base (base + 28) cr
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
+       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+       (.x1 ↦ᵣ hi) ** (.x11 ↦ᵣ rhat2c) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
+  intro q0 rhat2 hi q0c rhat2c cr
+  have hcr_eq : cr =
+      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+       (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))))))) := rfl
+  have h1_raw := divK_div128_step2_init_spec un21 dHi v1Old v5Old v11Old base
+  have h1 : cpsTriple base (base + 12) cr _ _ :=
+    cpsTriple_extend_code (h := h1_raw) (hmono := by
+      rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_left _ _)))
+  have h1f := cpsTriple_frameR
+    ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+    (by pcFree) h1
+  have h2_raw := divK_div128_clamp_q0_merged_spec q0 rhat2 dHi (q0 * dHi) (base + 12)
+  have ha4 : (base + 12 : Word) + 4 = base + 16 := by bv_addr
+  have ha8 : (base + 12 : Word) + 8 = base + 20 := by bv_addr
+  have ha12 : (base + 12 : Word) + 12 = base + 24 := by bv_addr
+  have ha16 : (base + 12 : Word) + 16 = base + 28 := by bv_addr
+  simp only [ha4, ha8, ha12, ha16] at h2_raw
+  have h2 : cpsTriple (base + 12) (base + 28) cr _ _ :=
+    cpsTriple_extend_code (h := h2_raw) (hmono := by
+      rw [hcr_eq]; intro a i
+      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
+      split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · split at h
+          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+          · split at h
+            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+            · simp at h)
+  have h2f := cpsTriple_frameR
+    ((.x7 ↦ᵣ un21) ** (.x12 ↦ᵣ sp) **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+    (by pcFree) h2
+  have h12 := cpsTriple_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1f h2f
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    h12
+
 /-- div128 step 2: trial division q0, clamp, Phase 2b guard, product check.
     Instrs [30]-[46] (17 instructions). Includes the Knuth TAOCP §4.3.1
     Step D3 guard (SRLI + BNE at instrs [37]-[38]) that skips the
@@ -90,14 +170,20 @@ theorem divK_div128_step2_spec
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit x1_exit x11_exit cr
-  -- TODO(#61 Phase 2b coordinated fix): compose step2_init + clamp_q0 +
-  -- phase2b_guard (cpsBranch) + prodcheck2_merged (on fall-through), then
-  -- merge via cpsBranch_merge_same_cr into this unified cpsTriple. The
-  -- `div128Quot_phase2b_q0'` helper now guards the mul-check with
-  -- `rhat2c >>> 32 = 0`, so under the guard-fires leg, `q0' = q0c`; under
-  -- the guard-doesn't-fire leg, `q0' = (if BitVec.ult rhat2Un0 q0Dlo then
-  -- q0c + signExtend12 4095 else q0c)` matching the unguarded
-  -- `divK_div128_prodcheck2_merged_spec` post.
+  -- TODO(#61 Phase 2b coordinated fix, iteration 2026-04-23):
+  -- `divK_div128_step2_upto_guard_spec` above covers the base..base+28 section
+  -- (cleanly replacing the old step2 pattern). Remaining composition:
+  --   h1 = divK_div128_step2_upto_guard_spec (cpsTriple base..base+28) ✓ available
+  --   h2 = phase2b_guard_spec at base+28 (cpsBranch → base+68 | base+36)
+  --   h3 = prodcheck2_merged_spec at base+36 (cpsTriple base+36..base+68)
+  --   compose h1+h2 via cpsTriple_seq_cpsBranch_perm_same_cr
+  --   compose + h3 via cpsBranch_seq_cpsTriple_with_perm_same_cr
+  --   merge via cpsBranch_merge_same_cr with cpsTriple_refl bridges
+  -- Empirical finding: attempting the full composition in one elab step
+  -- times out at maxHeartbeats (200000) at the first cpsTriple_seq_cpsBranch
+  -- xperm_hyp call (too many atoms to permute). Next iteration needs to
+  -- factor the composition into additional intermediate sub-lemmas to split
+  -- the elaboration cost.
   sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -110,8 +110,8 @@ theorem divK_div128_step2_upto_guard_spec
 
 /-- div128 step 2 thru-guard: init + clamp_q0 + phase2b_guard composition
     for instrs [30]-[38]. Produces a cpsBranch at base+28 that either takes
-    the taken path to base+68 (skipping mul-check when rhat2c_hi ≠ 0) or
-    falls through to base+36 (rhat2c_hi = 0) where mul-check will run. -/
+    the taken path to base+68 (skipping mul-check when rhat2cHi ≠ 0) or
+    falls through to base+36 (rhat2cHi = 0) where mul-check will run. -/
 theorem divK_div128_step2_thru_guard_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
@@ -119,7 +119,7 @@ theorem divK_div128_step2_thru_guard_spec
     let hi := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -137,15 +137,15 @@ theorem divK_div128_step2_thru_guard_spec
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 68)
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 36)
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro q0 rhat2 hi q0c rhat2c rhat2c_hi cr
+  intro q0 rhat2 hi q0c rhat2c rhat2cHi cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -210,8 +210,8 @@ theorem divK_div128_step2_branch_merged_spec
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dlo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0'_unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+    let q0'Unguarded := if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -237,15 +237,15 @@ theorem divK_div128_step2_branch_merged_spec
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
       (base + 68)  -- guard-fires path
         ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-         (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+         (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-      (base + 68)  -- guard-doesn't-fire + prodcheck2 (carries ⌜rhat2c_hi = 0⌝)
-        ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'_unguarded) **
+      (base + 68)  -- guard-doesn't-fire + prodcheck2 (carries ⌜rhat2cHi = 0⌝)
+        ((.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0'Unguarded) **
          (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0'_unguarded cr
+  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0'Unguarded cr
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -279,7 +279,7 @@ theorem divK_div128_step2_branch_merged_spec
   -- h2 = prodcheck2_merged_spec at base+36 (8-singleton cr, positions 9-16
   -- of the 17-cr). Use split+simp pattern (8 levels deep but each level is
   -- cheap — heads don't match the prodcheck2 cr's head).
-  have h2_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c rhat2c_hi un21
+  have h2_raw := divK_div128_prodcheck2_merged_spec sp q0c rhat2c rhat2cHi un21
     dlo un0 (base + 36)
   have hb4 : (base + 36 : Word) + 4 = base + 40 := by bv_addr
   have hb8 : (base + 36 : Word) + 8 = base + 44 := by bv_addr
@@ -313,10 +313,10 @@ theorem divK_div128_step2_branch_merged_spec
                   · split at h
                     · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
                     · simp at h)
-  -- Frame h2 with (x6, x0) and ⌜rhat2c_hi = 0⌝ so the pure fact is carried
+  -- Frame h2 with (x6, x0) and ⌜rhat2cHi = 0⌝ so the pure fact is carried
   -- through the composition and ends up in branch_merged's fall-through post.
   have h2f := cpsTriple_frameR
-    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝)
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝)
     (by pcFree) h2
   -- hperm: permute thru_guard's Q_f (incl. pure fact) to h2f's pre order.
   have composed := cpsBranch_seq_cpsTriple_with_perm_same_cr
@@ -341,12 +341,12 @@ theorem divK_div128_step2_branch_merged_spec
 
     **NOTE**: output's x7, x1, x11 values differ between guard-fires and
     guard-doesn't-fire paths:
-    - Guard fires (rhat2c_hi ≠ 0): x7 = un21 (unchanged), x1 = rhat2c_hi,
+    - Guard fires (rhat2cHi ≠ 0): x7 = un21 (unchanged), x1 = rhat2cHi,
       x11 = rhat2c.
-    - Guard doesn't fire (rhat2c_hi = 0): x7 = q0Dlo, x1 = rhat2Un0,
+    - Guard doesn't fire (rhat2cHi = 0): x7 = q0Dlo, x1 = rhat2Un0,
       x11 = un0.
 
-    The postcondition uses `rhat2c_hi = 0`-aware selectors to capture this. -/
+    The postcondition uses `rhat2cHi = 0`-aware selectors to capture this. -/
 theorem divK_div128_step2_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
     let q0 := rv64_divu un21 dHi
@@ -356,15 +356,15 @@ theorem divK_div128_step2_spec
     let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dlo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
     -- Exit values for registers that differ between guard-fires/doesn't
     -- paths. On guard-fires: x7 keeps un21 (MUL not run), x1 keeps
-    -- rhat2c_hi (loaded by SRLI), x11 keeps rhat2c (un0 not loaded).
+    -- rhat2cHi (loaded by SRLI), x11 keeps rhat2c (un0 not loaded).
     -- On guard-doesn't-fire: x7 holds q0Dlo, x1 holds rhat2Un0, x11 holds un0.
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
-    let x11_exit := if rhat2c_hi = 0 then un0 else rhat2c
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
     let cr :=
       CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
@@ -388,36 +388,36 @@ theorem divK_div128_step2_spec
        (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-      ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+      ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2c_hi q0' x7_exit x1_exit x11_exit cr
+  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit x1Exit x11Exit cr
   -- Apply branch_merged to get a cpsBranch with both legs at base+68.
   have hbr := divK_div128_step2_branch_merged_spec sp un21 dHi v1Old v5Old v11Old
     dlo un0 base
   -- Target post as a local assertion.
-  let R : Assertion :=
-    (.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-    (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+  let tgtPost : Assertion :=
+    (.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+    (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
   -- Helper: cpsTriple_refl at base+68 is a zero-step identity triple; we
   -- extend it from empty cr to our cr (vacuous) and use it for both branches.
-  have refl_of {P : Assertion} (h : ∀ hp, P hp → R hp) :
-      cpsTriple (base + 68) (base + 68) cr P R :=
+  have refl_of {P : Assertion} (h : ∀ hp, P hp → tgtPost hp) :
+      cpsTriple (base + 68) (base + 68) cr P tgtPost :=
     cpsTriple_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
       (cpsTriple_refl h)
-  -- Bridge for taken path (rhat2c_hi ≠ 0): strip pure fact, rewrite x7/x1/x11
-  -- exits to un21/rhat2c_hi/rhat2c, rewrite q0' to q0c via helper unfolding.
-  have h_t : cpsTriple (base + 68) (base + 68) cr _ R := refl_of (P :=
+  -- Bridge for taken path (rhat2cHi ≠ 0): strip pure fact, rewrite x7/x1/x11
+  -- exits to un21/rhat2cHi/rhat2c, rewrite q0' to q0c via helper unfolding.
+  have h_t : cpsTriple (base + 68) (base + 68) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-    (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
-    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi ≠ 0⌝ **
+    (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
     intro hp hP
-    have h_hi_ne : rhat2c_hi ≠ 0 := by
-      -- Extract ⌜rhat2c_hi ≠ 0⌝ from position 7 in the sepConj chain.
+    have h_hi_ne : rhat2cHi ≠ 0 := by
+      -- Extract ⌜rhat2cHi ≠ 0⌝ from position 7 in the sepConj chain.
       obtain ⟨_, _, _, _, _, hrest⟩ := hP
       obtain ⟨_, _, _, _, _, hrest⟩ := hrest
       obtain ⟨_, _, _, _, _, hrest⟩ := hrest
@@ -431,19 +431,19 @@ theorem divK_div128_step2_spec
       show div128Quot_phase2b_q0' q0c rhat2c dlo un0 = q0c
       unfold div128Quot_phase2b_q0'
       exact if_neg h_hi_ne
-    have hx7 : x7_exit = un21 := if_neg h_hi_ne
-    have hx1 : x1_exit = rhat2c_hi := if_neg h_hi_ne
-    have hx11 : x11_exit = rhat2c := if_neg h_hi_ne
-    show R hp
-    show ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+    have hx7 : x7Exit = un21 := if_neg h_hi_ne
+    have hx1 : x1Exit = rhat2cHi := if_neg h_hi_ne
+    have hx11 : x11Exit = rhat2c := if_neg h_hi_ne
+    show tgtPost hp
+    show ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
          (sp + signExtend12 3952 ↦ₘ dlo) **
          (sp + signExtend12 3944 ↦ₘ un0)) hp
     rw [hq0', hx7, hx1, hx11]
     -- Strip the pure fact and permute.
     have hP' : ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
-                (.x1 ↦ᵣ rhat2c_hi) ** (.x11 ↦ᵣ rhat2c) **
+                (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
                 (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
                 (sp + signExtend12 3952 ↦ₘ dlo) **
                 (sp + signExtend12 3944 ↦ₘ un0)) hp :=
@@ -451,17 +451,17 @@ theorem divK_div128_step2_spec
         (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
         (sepConj_mono_right (fun h' hp' => ((sepConj_pure_left h').1 hp').2))))))) hp hP
     xperm_hyp hP')
-  -- Bridge for fall-through path: the post carries ⌜rhat2c_hi = 0⌝ so we
+  -- Bridge for fall-through path: the post carries ⌜rhat2cHi = 0⌝ so we
   -- can extract it and rewrite the exit selectors to their then-branch values.
-  have h_f : cpsTriple (base + 68) (base + 68) cr _ R := refl_of (P :=
+  have h_f : cpsTriple (base + 68) (base + 68) cr _ tgtPost := refl_of (P :=
     (.x7 ↦ᵣ q0Dlo) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ
       (if BitVec.ult rhat2Un0 q0Dlo then q0c + signExtend12 4095 else q0c)) **
     (.x1 ↦ᵣ rhat2Un0) ** (.x11 ↦ᵣ un0) **
-    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2c_hi = 0⌝ **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) (by
     intro hp hP
-    have h_hi_eq : rhat2c_hi = 0 := by
-      -- Extract ⌜rhat2c_hi = 0⌝ from position 7 in the sepConj chain.
+    have h_hi_eq : rhat2cHi = 0 := by
+      -- Extract ⌜rhat2cHi = 0⌝ from position 7 in the sepConj chain.
       obtain ⟨_, _, _, _, _, hrest⟩ := hP
       obtain ⟨_, _, _, _, _, hrest⟩ := hrest
       obtain ⟨_, _, _, _, _, hrest⟩ := hrest
@@ -475,11 +475,11 @@ theorem divK_div128_step2_spec
       show div128Quot_phase2b_q0' q0c rhat2c dlo un0 = _
       unfold div128Quot_phase2b_q0'
       rw [if_pos h_hi_eq]
-    have hx7 : x7_exit = q0Dlo := if_pos h_hi_eq
-    have hx1 : x1_exit = rhat2Un0 := if_pos h_hi_eq
-    have hx11 : x11_exit = un0 := if_pos h_hi_eq
-    show ((.x7 ↦ᵣ x7_exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-         (.x1 ↦ᵣ x1_exit) ** (.x11 ↦ᵣ x11_exit) **
+    have hx7 : x7Exit = q0Dlo := if_pos h_hi_eq
+    have hx1 : x1Exit = rhat2Un0 := if_pos h_hi_eq
+    have hx11 : x11Exit = un0 := if_pos h_hi_eq
+    show ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
          (sp + signExtend12 3952 ↦ₘ dlo) **
          (sp + signExtend12 3944 ↦ₘ un0)) hp

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -830,7 +830,10 @@ theorem divK_trial_call_path_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -841,16 +844,17 @@ theorem divK_trial_call_path_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') **
+       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') **
        (.x2 ↦ᵣ (base + 516)) ** (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ vTop) **
        (sp + signExtend12 3952 ↦ₘ dLo) **
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
+        rhat2c_hi q0' x7_exit x1_exit q
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
   have J := jal_spec .x2 v2Old (560 : BitVec 21) (base + 512) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
@@ -1763,7 +1767,10 @@ theorem divK_trial_call_full_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -1777,9 +1784,9 @@ theorem divK_trial_call_full_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
+       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
@@ -1790,7 +1797,8 @@ theorem divK_trial_call_full_spec
        (sp + signExtend12 3944 ↦ₘ un0Div)) := by
   intro uAddr vtopBase
         dHi dLo un1 un0Div q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' q
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
+        rhat2c_hi q0' x7_exit x1_exit q
   -- 1. Save j + trial load (base+448 → base+500)
   have STL := divK_save_trial_load_spec sp j n jOld v5Old v6Old v7Old v10Old uHi uLo vTop
     base

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -830,10 +830,10 @@ theorem divK_trial_call_path_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -844,9 +844,9 @@ theorem divK_trial_call_path_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') **
+       (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') **
        (.x2 ↦ᵣ (base + 516)) ** (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3968 ↦ₘ (base + 516)) **
        (sp + signExtend12 3960 ↦ₘ vTop) **
@@ -854,7 +854,7 @@ theorem divK_trial_call_path_spec
        (sp + signExtend12 3944 ↦ₘ un0)) := by
   intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
-        rhat2c_hi q0' x7_exit x1_exit q
+        rhat2cHi q0' x7Exit x1Exit q
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
   have J := jal_spec .x2 v2Old (560 : BitVec 21) (base + 512) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
@@ -1767,10 +1767,10 @@ theorem divK_trial_call_full_spec
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
     let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -1784,9 +1784,9 @@ theorem divK_trial_call_full_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
+       (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
        (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
@@ -1798,7 +1798,7 @@ theorem divK_trial_call_full_spec
   intro uAddr vtopBase
         dHi dLo un1 un0Div q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
-        rhat2c_hi q0' x7_exit x1_exit q
+        rhat2cHi q0' x7Exit x1Exit q
   -- 1. Save j + trial load (base+448 → base+500)
   have STL := divK_save_trial_load_spec sp j n jOld v5Old v6Old v7Old v10Old uHi uLo vTop
     base

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -113,7 +113,10 @@ theorem divK_trial_call_full_spec_n1
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -127,9 +130,9 @@ theorem divK_trial_call_full_spec_n1
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ rhat2Un0) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ q0Dlo) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ qHat) **
+       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ qHat) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
        ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -140,7 +143,8 @@ theorem divK_trial_call_full_spec_n1
        (sp + signExtend12 3944 ↦ₘ div_un0)) := by
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 q0' qHat
+        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
+        rhat2c_hi q0' x7_exit x1_exit qHat
   have TF := divK_trial_call_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
@@ -392,7 +396,10 @@ theorem divK_loop_body_n1_call_skip_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   -- Expand mulsub computation locally for intermediate steps
@@ -431,7 +438,7 @@ theorem divK_loop_body_n1_call_skip_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -533,7 +540,10 @@ theorem divK_loop_body_n1_call_addback_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
@@ -560,7 +570,7 @@ theorem divK_loop_body_n1_call_addback_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -113,10 +113,10 @@ theorem divK_trial_call_full_spec_n1
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let q0Dlo := q0c * dLo
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-    let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
@@ -130,9 +130,9 @@ theorem divK_trial_call_full_spec_n1
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1_exit) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
        (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ x7_exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ qHat) **
+       (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ qHat) **
        (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
        (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
        ((uBase + signExtend12 4088) ↦ₘ u1) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -144,7 +144,7 @@ theorem divK_trial_call_full_spec_n1
   intro uBase
         dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
-        rhat2c_hi q0' x7_exit x1_exit qHat
+        rhat2cHi q0' x7Exit x1Exit qHat
   have TF := divK_trial_call_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
@@ -396,10 +396,10 @@ theorem divK_loop_body_n1_call_skip_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   -- Expand mulsub computation locally for intermediate steps
@@ -438,7 +438,7 @@ theorem divK_loop_body_n1_call_skip_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -540,10 +540,10 @@ theorem divK_loop_body_n1_call_addback_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
@@ -570,7 +570,7 @@ theorem divK_loop_body_n1_call_addback_spec
   dsimp only [] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -332,6 +332,9 @@ theorem divK_loop_body_n2_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -370,7 +373,7 @@ theorem divK_loop_body_n2_call_skip_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -491,6 +494,9 @@ theorem divK_loop_body_n2_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -516,7 +522,7 @@ theorem divK_loop_body_n2_call_addback_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -332,9 +332,9 @@ theorem divK_loop_body_n2_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -373,7 +373,7 @@ theorem divK_loop_body_n2_call_skip_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -494,9 +494,9 @@ theorem divK_loop_body_n2_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -522,7 +522,7 @@ theorem divK_loop_body_n2_call_addback_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -335,6 +335,9 @@ theorem divK_loop_body_n3_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -373,7 +376,7 @@ theorem divK_loop_body_n3_call_skip_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -495,6 +498,9 @@ theorem divK_loop_body_n3_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -520,7 +526,7 @@ theorem divK_loop_body_n3_call_addback_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -335,9 +335,9 @@ theorem divK_loop_body_n3_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -376,7 +376,7 @@ theorem divK_loop_body_n3_call_skip_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -498,9 +498,9 @@ theorem divK_loop_body_n3_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -526,7 +526,7 @@ theorem divK_loop_body_n3_call_addback_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -337,6 +337,9 @@ theorem divK_loop_body_n4_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -376,7 +379,7 @@ theorem divK_loop_body_n4_call_skip_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -497,6 +500,9 @@ theorem divK_loop_body_n4_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -522,7 +528,7 @@ theorem divK_loop_body_n4_call_addback_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -337,9 +337,9 @@ theorem divK_loop_body_n4_call_skip_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   -- Expand mulsub computation locally for intermediate steps
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -379,7 +379,7 @@ theorem divK_loop_body_n4_call_skip_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -500,9 +500,9 @@ theorem divK_loop_body_n4_call_addback_spec
         qAddr ms ab hcarry2_nz hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   -- Local lets matching beq_spec structure
   let c3 := ms.2.2.2.2
   let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
@@ -528,7 +528,7 @@ theorem divK_loop_body_n4_call_addback_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   have MCA0 := MCA hcarry2_nz hborrow

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -70,6 +70,9 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -82,7 +85,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -193,6 +196,9 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -205,7 +211,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -316,6 +322,9 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -328,7 +337,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -439,6 +448,9 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -451,7 +463,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -70,9 +70,9 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -85,7 +85,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -196,9 +196,9 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -211,7 +211,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -322,9 +322,9 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -337,7 +337,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -448,9 +448,9 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
@@ -463,7 +463,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -71,6 +71,9 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -98,7 +101,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -189,6 +192,9 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -216,7 +222,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -307,6 +313,9 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -334,7 +343,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -425,6 +434,9 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -452,7 +464,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -71,9 +71,9 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -101,7 +101,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -192,9 +192,9 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -222,7 +222,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -313,9 +313,9 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -343,7 +343,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -434,9 +434,9 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
@@ -464,7 +464,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -183,6 +183,9 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -198,7 +201,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -403,6 +406,9 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
@@ -415,7 +421,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -616,6 +622,9 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
@@ -628,7 +637,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -829,6 +838,9 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -859,7 +871,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1041,6 +1053,9 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
@@ -1068,7 +1083,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1245,6 +1260,9 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
@@ -1272,7 +1290,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -183,9 +183,9 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -201,7 +201,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -406,9 +406,9 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
@@ -421,7 +421,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -622,9 +622,9 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
@@ -637,7 +637,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -838,9 +838,9 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -871,7 +871,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   rw [vtop_eq_v1_n2] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1053,9 +1053,9 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
@@ -1083,7 +1083,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -1260,9 +1260,9 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN2Call div128Quot at hborrow
@@ -1290,7 +1290,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -179,6 +179,9 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
@@ -194,7 +197,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -415,6 +418,9 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -430,7 +436,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -639,6 +645,9 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
@@ -670,7 +679,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -861,6 +870,9 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -892,7 +904,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -179,9 +179,9 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
@@ -197,7 +197,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -418,9 +418,9 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -436,7 +436,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -645,9 +645,9 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition to match proof-level qHat
@@ -679,7 +679,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz
@@ -870,9 +870,9 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- Unfold borrow condition
@@ -904,7 +904,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   rw [vtop_eq_v2_n3] at TF
   -- 2. Mulsub + correction addback + BEQ (base+516 → base+884)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN3Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -190,6 +190,9 @@ theorem divK_loop_body_n4_call_skip_j0_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
 
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -221,7 +224,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -430,6 +433,9 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
+  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
   -- Local lets matching beq_spec structure
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -457,7 +463,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    rhat2Un0 q0' dHi q0Dlo q1' (base + 516) base
+    x1_exit q0' dHi x7_exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -190,9 +190,9 @@ theorem divK_loop_body_n4_call_skip_j0_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
 
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
   let fs0 := p0_lo + (signExtend12 0 : Word)
@@ -224,7 +224,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Mulsub + correction skip (base+516 → base+880)
   have MCS := divK_mulsub_correction_skip_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
@@ -433,9 +433,9 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
         qAddr hborrow
   let q0Dlo := q0c * dLo
   let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7_exit := if rhat2c_hi = 0 then q0Dlo else un21
-  let x1_exit := if rhat2c_hi = 0 then rhat2Un0 else rhat2c_hi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   -- Local lets matching beq_spec structure
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -463,7 +463,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   rw [vtop_eq_v3_n4] at TF
   -- 2. Use beq_spec instead of old spec (NO sorry!)
   have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (0 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1_exit q0' dHi x7_exit q1' (base + 516) base
+    x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN4Call isAddbackCarry2Nz div128Quot at hcarry2_nz

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -101,22 +101,28 @@ def divK_div128 : Program :=
   single (.BEQ .x1 .x0 12) ;;                -- [34] skip if q0 < 2^32 → [37]
   ADDI .x5 .x5 4095 ;;                        -- [35] q0--
   single (.ADD .x11 .x11 .x6) ;;             -- [36] rhat2 += dHi
-  -- [37] Product check for q0
-  LD .x1 .x12 3952 ;;                         -- [37] dLo
-  single (.MUL .x7 .x5 .x1) ;;               -- [38] x7 = q0 * dLo
-  SLLI .x1 .x11 32 ;;                         -- [39] rhat2 << 32
-  LD .x11 .x12 3944 ;;                        -- [40] un0
-  single (.OR .x1 .x1 .x11) ;;               -- [41] x1 = rhat2*2^32 + un0
-  single (.BLTU .x1 .x7 8) ;;                -- [42] if rhs < lhs → correct [44]
-  JAL .x0 8 ;;                                 -- [43] skip → [45]
-  ADDI .x5 .x5 4095 ;;                        -- [44] q0--
+  -- [37] Phase 2b guard (Knuth TAOCP §4.3.1 Step D3): skip mul-check
+  --      when rhat2c ≥ 2^32 to avoid Word `<< 32` truncation causing
+  --      the BLTU to false-positive fire. See counterexample at
+  --      `/home/zksecurity/.claude/plans/dynamic-strolling-riddle.md`.
+  SRLI .x1 .x11 32 ;;                         -- [37] x1 = rhat2c >> 32
+  single (.BNE .x1 .x0 36) ;;                -- [38] if nonzero → skip to [47]
+  -- [39] Product check for q0 (only reached when rhat2c < 2^32)
+  LD .x1 .x12 3952 ;;                         -- [39] dLo
+  single (.MUL .x7 .x5 .x1) ;;               -- [40] x7 = q0 * dLo
+  SLLI .x1 .x11 32 ;;                         -- [41] rhat2 << 32
+  LD .x11 .x12 3944 ;;                        -- [42] un0
+  single (.OR .x1 .x1 .x11) ;;               -- [43] x1 = rhat2*2^32 + un0
+  single (.BLTU .x1 .x7 8) ;;                -- [44] if rhs < lhs → correct [46]
+  JAL .x0 8 ;;                                 -- [45] skip → [47]
+  ADDI .x5 .x5 4095 ;;                        -- [46] q0--
   -- Combine: q = q1*2^32 + q0
-  SLLI .x11 .x10 32 ;;                        -- [45] q1 << 32
-  single (.OR .x11 .x11 .x5) ;;              -- [46] x11 = q
+  SLLI .x11 .x10 32 ;;                        -- [47] q1 << 32
+  single (.OR .x11 .x11 .x5) ;;              -- [48] x11 = q
   -- Restore and return
-  LD .x2 .x12 3968 ;;                         -- [47] restore return addr
-  JALR .x0 .x2 0                              -- [48] return
-  -- Total: 49 instructions
+  LD .x2 .x12 3968 ;;                         -- [49] restore return addr
+  JALR .x0 .x2 0                              -- [50] return
+  -- Total: 51 instructions
 
 -- ============================================================================
 -- Main division program phases

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -174,8 +174,7 @@ theorem div128Quot_qHat_vTop_le
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
     q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →
@@ -208,8 +207,10 @@ theorem div128Quot_qHat_vTop_le
   have h_post2a := div128Quot_first_round_post un21 dHi hdHi_ne hdHi_lt
   have h_rhat2c_lt := div128Quot_rhatc_lt_2dHi un21 dHi hdHi_ne hdHi_lt
   -- Phase 2b Euclidean against un21: q0' * dHi + rhat2' = un21.
-  have h_ph2b : q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat :=
-    div128Quot_phase1b_post un21 dHi q0c rhat2c dLo rhat2Un0 hdHi_lt h_post2a h_rhat2c_lt
+  -- TODO(#61 Phase 2b coordinated fix): q0' is the guarded helper —
+  -- Phase 1b post applies to the unguarded form. Need case-split on
+  -- rhat2c_hi = 0 to align.
+  have h_ph2b : q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat := by sorry
   -- Combine h_ph2b + h_un21 to feed KB-Compose V2.
   have h_un21_ph2 : q0'.toNat * dHi.toNat + rhat2'.toNat =
       (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat - q1'.toNat * dLo.toNat := by
@@ -289,8 +290,7 @@ theorem div128Quot_le_val256_div_plus_two
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
     q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -174,15 +174,20 @@ theorem div128Quot_qHat_vTop_le
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
+    -- rhat2' mirrors the Phase 2b guard: fires → no check adjustment
+    -- (rhat2c); fall-through → the Phase 1b check may have added dHi.
+    let rhat2' := if rhat2c_hi = 0 then
+                    (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
+                  else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
     q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →
     q0'.toNat < 2^32 →
     (div128Quot uHi uLo vTop).toNat * vTop.toNat ≤
       uHi.toNat * 2^64 + uLo.toNat := by
   intro dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc rhatUn1 q1' rhat'
-    cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0 q0' rhat2'
+    cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0 rhat2c_hi q0' rhat2'
     h_ph1_no_wrap_lo h_ph2_no_wrap hq0_lt
   -- Algorithm-level setup.
   have hdHi_ne : dHi ≠ 0 := by
@@ -206,11 +211,11 @@ theorem div128Quot_qHat_vTop_le
   -- Phase 2a invariants (instantiate Phase 1a on un21).
   have h_post2a := div128Quot_first_round_post un21 dHi hdHi_ne hdHi_lt
   have h_rhat2c_lt := div128Quot_rhatc_lt_2dHi un21 dHi hdHi_ne hdHi_lt
-  -- Phase 2b Euclidean against un21: q0' * dHi + rhat2' = un21.
-  -- TODO(#61 Phase 2b coordinated fix): q0' is the guarded helper —
-  -- Phase 1b post applies to the unguarded form. Need case-split on
-  -- rhat2c_hi = 0 to align.
-  have h_ph2b : q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat := by sorry
+  -- Phase 2b Euclidean against un21: q0' * dHi + rhat2' = un21. Uses
+  -- div128Quot_phase2b_post (KB-5a), which accommodates the guard via the
+  -- guarded rhat2' definition.
+  have h_ph2b : q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat :=
+    div128Quot_phase2b_post un21 dHi hdHi_lt q0c rhat2c dLo h_post2a h_rhat2c_lt
   -- Combine h_ph2b + h_un21 to feed KB-Compose V2.
   have h_un21_ph2 : q0'.toNat * dHi.toNat + rhat2'.toNat =
       (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat - q1'.toNat * dLo.toNat := by
@@ -290,8 +295,11 @@ theorem div128Quot_le_val256_div_plus_two
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
+    let rhat2' := if rhat2c_hi = 0 then
+                    (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
+                  else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
     q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →
     q0'.toNat < 2^32 →
@@ -299,7 +307,7 @@ theorem div128Quot_le_val256_div_plus_two
       val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
   intro shift antiShift u4 un3 b3' dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc
     rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0
-    q0' rhat2' h_ph1_no_wrap h_ph2_no_wrap hq0_lt
+    rhat2c_hi q0' rhat2' h_ph1_no_wrap h_ph2_no_wrap hq0_lt
   -- Discharge Task 1 preconditions.
   have hb3prime_ge_pow63 : b3'.toNat ≥ 2^63 := b3_prime_ge_pow63 b3 b2 hb3nz _
   have hdHi_ge : dHi.toNat ≥ 2^31 := div128Quot_dHi_ge_pow31 b3' hb3prime_ge_pow63

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -174,11 +174,11 @@ theorem div128Quot_qHat_vTop_le
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     -- rhat2' mirrors the Phase 2b guard: fires → no check adjustment
     -- (rhat2c); fall-through → the Phase 1b check may have added dHi.
-    let rhat2' := if rhat2c_hi = 0 then
+    let rhat2' := if rhat2cHi = 0 then
                     (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
                   else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
@@ -187,7 +187,7 @@ theorem div128Quot_qHat_vTop_le
     (div128Quot uHi uLo vTop).toNat * vTop.toNat ≤
       uHi.toNat * 2^64 + uLo.toNat := by
   intro dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc rhatUn1 q1' rhat'
-    cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0 rhat2c_hi q0' rhat2'
+    cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0 rhat2cHi q0' rhat2'
     h_ph1_no_wrap_lo h_ph2_no_wrap hq0_lt
   -- Algorithm-level setup.
   have hdHi_ne : dHi ≠ 0 := by
@@ -295,9 +295,9 @@ theorem div128Quot_le_val256_div_plus_two
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if rhat2c_hi = 0 then
+    let rhat2' := if rhat2cHi = 0 then
                     (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
                   else rhat2c
     q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat →
@@ -307,7 +307,7 @@ theorem div128Quot_le_val256_div_plus_two
       val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
   intro shift antiShift u4 un3 b3' dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc
     rhatUn1 q1' rhat' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c rhat2Un0
-    rhat2c_hi q0' rhat2' h_ph1_no_wrap h_ph2_no_wrap hq0_lt
+    rhat2cHi q0' rhat2' h_ph1_no_wrap h_ph2_no_wrap hq0_lt
   -- Discharge Task 1 preconditions.
   have hb3prime_ge_pow63 : b3'.toNat ≥ 2^63 := b3_prime_ge_pow63 b3 b2 hb3nz _
   have hdHi_ge : dHi.toNat ≥ 2^31 := div128Quot_dHi_ge_pow31 b3' hb3prime_ge_pow63

--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -520,11 +520,17 @@ theorem div128Quot_phase2b_post (un21 dHi : Word)
     (hdHi_lt : dHi.toNat < 2^32) (q0c rhat2c dLo rhat2Un0 : Word)
     (h_post : q0c.toNat * dHi.toNat + rhat2c.toNat = un21.toNat)
     (h_rhat2c_lt : rhat2c.toNat < 2 * dHi.toNat) :
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
-    q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat :=
-  div128Quot_phase1b_post un21 dHi q0c rhat2c dLo rhat2Un0 hdHi_lt h_post h_rhat2c_lt
+    q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat := by
+  -- TODO(#61 Phase 2b coordinated fix): under helper's guard-fires case
+  -- (rhat2c_hi ≠ 0, i.e., rhat2c ≥ 2^32), q0' = q0c. The Euclidean
+  -- equation q0' * dHi + rhat2' = un21 then becomes q0c * dHi + rhat2'
+  -- = un21. Need to verify rhat2' value matches (it's the Phase 1b's
+  -- rhat', computed from the check which may not fire in this regime).
+  -- Guard-doesn't-fire case: helper = unguarded check, same as
+  -- div128Quot_phase1b_post. Need case split on rhat2c_hi = 0.
+  sorry
 
 /-- **KB-5b: Phase 2b check implies q0c ≥ 1.** Instantiation of
     `div128Quot_phase1b_check_implies_q1c_pos`. -/
@@ -541,11 +547,13 @@ theorem div128Quot_phase2b_quotient_bound (un21 dHi : Word)
     let q0 := rv64_divu un21 dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat + 2 ≥ un21.toNat / dHi.toNat ∧
-    q0'.toNat ≤ un21.toNat / dHi.toNat :=
-  div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo rhat2Un0
+    q0'.toNat ≤ un21.toNat / dHi.toNat := by
+  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
+  -- q0' = q0c ≤ q1c ≤ un21/dHi + 2 via KB-3c. Guard-doesn't-fire case
+  -- reduces to div128Quot_phase1b_quotient_bound. Case-split on rhat2c_hi = 0.
+  sorry
 
 /-- **KB-5d: Phase 2b output bound.** Instantiation of
     `div128Quot_q1_prime_lt_pow33` with `uHi := un21`: `q0' < 2^33`. -/
@@ -554,10 +562,12 @@ theorem div128Quot_phase2b_q0_prime_lt_pow33 (un21 dHi : Word)
     let q0 := rv64_divu un21 dHi
     let hi2 := q0 >>> (32 : BitVec 6).toNat
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
-    q0'.toNat < 2^33 :=
-  div128Quot_q1_prime_lt_pow33 un21 dHi hdHi_ge dLo rhat2Un0
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+    q0'.toNat < 2^33 := by
+  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
+  -- q0' = q0c < 2^33 (via div128Quot_q1c_lt_pow33). Guard-doesn't-fire
+  -- case reduces to div128Quot_q1_prime_lt_pow33. Case-split.
+  sorry
 
 /-- **KB-6a: div128Quot output Nat formula.** Unfolds `div128Quot` and
     applies `halfword_combine_mod` to yield the output's Nat value:

--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -517,20 +517,52 @@ theorem div128Quot_phase2a_q0c_lt_pow33 (un21 dHi : Word)
     correction), the corrected quotient `q0'` and remainder `rhat2'`
     still satisfy the Euclidean equation against `un21`. -/
 theorem div128Quot_phase2b_post (un21 dHi : Word)
-    (hdHi_lt : dHi.toNat < 2^32) (q0c rhat2c dLo rhat2Un0 : Word)
+    (hdHi_lt : dHi.toNat < 2^32) (q0c rhat2c dLo : Word)
     (h_post : q0c.toNat * dHi.toNat + rhat2c.toNat = un21.toNat)
     (h_rhat2c_lt : rhat2c.toNat < 2 * dHi.toNat) :
+    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c
+    -- rhat2' mirrors the guard: fires → no check adjustment (rhat2c);
+    -- fall-through → the Phase 1b check may have added dHi.
+    let rhat2' := if rhat2c_hi = 0 then
+                    (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
+                  else rhat2c
     q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat := by
-  -- TODO(#61 Phase 2b coordinated fix): under helper's guard-fires case
-  -- (rhat2c_hi ≠ 0, i.e., rhat2c ≥ 2^32), q0' = q0c. The Euclidean
-  -- equation q0' * dHi + rhat2' = un21 then becomes q0c * dHi + rhat2'
-  -- = un21. Need to verify rhat2' value matches (it's the Phase 1b's
-  -- rhat', computed from the check which may not fire in this regime).
-  -- Guard-doesn't-fire case: helper = unguarded check, same as
-  -- div128Quot_phase1b_post. Need case split on rhat2c_hi = 0.
-  sorry
+  intro rhat2c_hi rhat2Un0 q0' rhat2'
+  show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat * dHi.toNat +
+       rhat2'.toNat = un21.toNat
+  unfold div128Quot_phase2b_q0'
+  by_cases h_guard : rhat2c_hi = 0
+  · show (if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+            (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+                (q0c * dLo) then q0c + signExtend12 4095 else q0c)
+          else q0c).toNat * dHi.toNat + rhat2'.toNat = un21.toNat
+    rw [if_pos h_guard]
+    show (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+              (q0c * dLo) then q0c + signExtend12 4095 else q0c).toNat *
+         dHi.toNat + rhat2'.toNat = un21.toNat
+    have hrhat2' : rhat2' = (if BitVec.ult rhat2Un0 (q0c * dLo)
+                             then rhat2c + dHi else rhat2c) := by
+      show (if rhat2c_hi = 0 then
+              (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
+            else rhat2c) = _
+      rw [if_pos h_guard]
+    rw [hrhat2']
+    exact div128Quot_phase1b_post un21 dHi q0c rhat2c dLo rhat2Un0 hdHi_lt
+      h_post h_rhat2c_lt
+  · show (if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+            (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+                (q0c * dLo) then q0c + signExtend12 4095 else q0c)
+          else q0c).toNat * dHi.toNat + rhat2'.toNat = un21.toNat
+    rw [if_neg h_guard]
+    have hrhat2' : rhat2' = rhat2c := by
+      show (if rhat2c_hi = 0 then
+              (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
+            else rhat2c) = _
+      rw [if_neg h_guard]
+    rw [hrhat2']
+    exact h_post
 
 /-- **KB-5b: Phase 2b check implies q0c ≥ 1.** Instantiation of
     `div128Quot_phase1b_check_implies_q1c_pos`. -/
@@ -550,10 +582,20 @@ theorem div128Quot_phase2b_quotient_bound (un21 dHi : Word)
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat + 2 ≥ un21.toNat / dHi.toNat ∧
     q0'.toNat ≤ un21.toNat / dHi.toNat := by
-  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
-  -- q0' = q0c ≤ q1c ≤ un21/dHi + 2 via KB-3c. Guard-doesn't-fire case
-  -- reduces to div128Quot_phase1b_quotient_bound. Case-split on rhat2c_hi = 0.
-  sorry
+  intro q0 hi2 q0c q0'
+  show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat + 2 ≥
+         un21.toNat / dHi.toNat ∧
+       (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat ≤ un21.toNat / dHi.toNat
+  unfold div128Quot_phase2b_q0'
+  split
+  · -- Guard doesn't fire: helper yields unguarded check.
+    exact div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo
+      ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+  · -- Guard fires: helper = q0c. Use KB-1 (phase1a quotient bound).
+    have h_kb1 : q0c.toNat ≤ un21.toNat / dHi.toNat ∧
+                 un21.toNat / dHi.toNat ≤ q0c.toNat + 1 :=
+      div128Quot_phase1a_quotient_bound un21 dHi hdHi_ne hdHi_lt
+    exact ⟨by omega, h_kb1.1⟩
 
 /-- **KB-5d: Phase 2b output bound.** Instantiation of
     `div128Quot_q1_prime_lt_pow33` with `uHi := un21`: `q0' < 2^33`. -/
@@ -564,10 +606,19 @@ theorem div128Quot_phase2b_q0_prime_lt_pow33 (un21 dHi : Word)
     let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat < 2^33 := by
-  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
-  -- q0' = q0c < 2^33 (via div128Quot_q1c_lt_pow33). Guard-doesn't-fire
-  -- case reduces to div128Quot_q1_prime_lt_pow33. Case-split.
-  sorry
+  intro q0 hi2 q0c q0'
+  show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat < 2^33
+  unfold div128Quot_phase2b_q0'
+  split
+  · -- Guard doesn't fire: helper yields unguarded check — use KB-3e for Phase 2.
+    show (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+              (q0c * dLo) then q0c + signExtend12 4095 else q0c).toNat < 2^33
+    exact div128Quot_q1_prime_lt_pow33 un21 dHi hdHi_ge dLo
+      ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
+  · -- Guard fires: helper yields q0c. Note q0c < 2^33 via KB-3e' at Phase 2.
+    have h_q0c_lt : q0c.toNat < 2^33 :=
+      div128Quot_q1c_lt_pow33 un21 dHi hdHi_ge
+    exact h_q0c_lt
 
 /-- **KB-6a: div128Quot output Nat formula.** Unfolds `div128Quot` and
     applies `halfword_combine_mod` to yield the output's Nat value:

--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -520,20 +520,20 @@ theorem div128Quot_phase2b_post (un21 dHi : Word)
     (hdHi_lt : dHi.toNat < 2^32) (q0c rhat2c dLo : Word)
     (h_post : q0c.toNat * dHi.toNat + rhat2c.toNat = un21.toNat)
     (h_rhat2c_lt : rhat2c.toNat < 2 * dHi.toNat) :
-    let rhat2c_hi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
     let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     -- rhat2' mirrors the guard: fires → no check adjustment (rhat2c);
     -- fall-through → the Phase 1b check may have added dHi.
-    let rhat2' := if rhat2c_hi = 0 then
+    let rhat2' := if rhat2cHi = 0 then
                     (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
                   else rhat2c
     q0'.toNat * dHi.toNat + rhat2'.toNat = un21.toNat := by
-  intro rhat2c_hi rhat2Un0 q0' rhat2'
+  intro rhat2cHi rhat2Un0 q0' rhat2'
   show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat * dHi.toNat +
        rhat2'.toNat = un21.toNat
   unfold div128Quot_phase2b_q0'
-  by_cases h_guard : rhat2c_hi = 0
+  by_cases h_guard : rhat2cHi = 0
   · show (if rhat2c >>> (32 : BitVec 6).toNat = 0 then
             (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
                 (q0c * dLo) then q0c + signExtend12 4095 else q0c)
@@ -544,7 +544,7 @@ theorem div128Quot_phase2b_post (un21 dHi : Word)
          dHi.toNat + rhat2'.toNat = un21.toNat
     have hrhat2' : rhat2' = (if BitVec.ult rhat2Un0 (q0c * dLo)
                              then rhat2c + dHi else rhat2c) := by
-      show (if rhat2c_hi = 0 then
+      show (if rhat2cHi = 0 then
               (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
             else rhat2c) = _
       rw [if_pos h_guard]
@@ -557,7 +557,7 @@ theorem div128Quot_phase2b_post (un21 dHi : Word)
           else q0c).toNat * dHi.toNat + rhat2'.toNat = un21.toNat
     rw [if_neg h_guard]
     have hrhat2' : rhat2' = rhat2c := by
-      show (if rhat2c_hi = 0 then
+      show (if rhat2cHi = 0 then
               (if BitVec.ult rhat2Un0 (q0c * dLo) then rhat2c + dHi else rhat2c)
             else rhat2c) = _
       rw [if_neg h_guard]

--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -464,14 +464,16 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_pow63
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     (un21.toNat * 2^32 + div_un0.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) ≤ q0'.toNat := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  exact div128Quot_q1_prime_ge_q_true_1_of_uHi_lt_pow63 un21 dHi dLo
-    (uLo <<< (32 : BitVec 6).toNat)
-    hdHi_ge hdHi_lt hdLo_lt h_un21_lt hun21_lt_vTop
+  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
+  -- q0' = q0c; KB-LB7 (applied at Phase 2 uHi := un21) gives q0c ≥
+  -- q_true already, since q0c is always ≥ the unguarded q1' (check fires
+  -- only when q1c > q_true, correction decrements; q0c pre-correction
+  -- matches un-corrected q0c). Guard-doesn't-fire case reduces directly.
+  sorry
 
 /-- **KB-LB9: Weak Phase 2 lower bound, unconditional.** Phase 2's output
     `q0'` satisfies the abstract Knuth trial bound off by 2:
@@ -501,14 +503,15 @@ theorem div128Quot_q0_prime_plus_2_ge_q_true_0_abstract
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat + 2 ≥ (un21.toNat * 2^32 + div_un0.toNat) /
                      (dHi.toNat * 2^32 + dLo.toNat) := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
   -- KB-2 at Phase 2 (uHi := un21, rhatUn1 := rhat2Un0).
-  have h_q0_bound : q0'.toNat + 2 ≥ un21.toNat / dHi.toNat :=
-    (div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo rhat2Un0).1
+  -- TODO(#61 Phase 2b coordinated fix): case-split on rhat2c_hi = 0.
+  -- Guard fires: q0' = q0c, and q0c + 2 ≥ un21/dHi via KB-3c.
+  -- Guard doesn't fire: q0' = phase1b's q1' which satisfies the bound.
+  have h_q0_bound : q0'.toNat + 2 ≥ un21.toNat / dHi.toNat := by sorry
   -- div_un0 < 2^32.
   have h_div_un0_lt : div_un0.toNat < 2^32 := by
     show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
@@ -754,13 +757,13 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_dHi_mul_pow32
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     (un21.toNat * 2^32 + div_un0.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) ≤ q0'.toNat := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  exact div128Quot_q1_prime_ge_q_true_1_of_uHi_lt_dHi_mul_pow32 un21 dHi dLo
-    (uLo <<< (32 : BitVec 6).toNat)
-    hdHi_ge hdHi_lt hdLo_lt h_un21_lt hun21_lt_vTop
+  -- TODO(#61 Phase 2b coordinated fix): case-split on rhat2c_hi = 0.
+  -- Guard doesn't fire: reduces to KB-LB8's un-guarded form.
+  -- Guard fires: q0' = q0c, which is ≥ q_true since q0c ≥ q1' (by mono).
+  sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -468,12 +468,29 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_pow63
     (un21.toNat * 2^32 + div_un0.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) ≤ q0'.toNat := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  -- TODO(#61 Phase 2b coordinated fix): helper's guard-fires case gives
-  -- q0' = q0c; KB-LB7 (applied at Phase 2 uHi := un21) gives q0c ≥
-  -- q_true already, since q0c is always ≥ the unguarded q1' (check fires
-  -- only when q1c > q_true, correction decrements; q0c pre-correction
-  -- matches un-corrected q0c). Guard-doesn't-fire case reduces directly.
-  sorry
+  -- div_un0 < 2^32 (from `uLo << 32 >> 32`).
+  have h_div_un0_lt : div_un0.toNat < 2^32 := by
+    show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
+    rw [BitVec.toNat_ushiftRight]
+    have h32 : (32 : BitVec 6).toNat = 32 := by decide
+    rw [h32, Nat.shiftRight_eq_div_pow]
+    have h_shl : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+      (uLo <<< (32 : BitVec 6).toNat : Word).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  show (un21.toNat * 2^32 + div_un0.toNat) /
+         (dHi.toNat * 2^32 + dLo.toNat) ≤
+       (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat
+  unfold div128Quot_phase2b_q0'
+  split
+  · -- Guard doesn't fire: helper yields unguarded check.
+    exact div128Quot_q1_prime_ge_q_true_1_of_uHi_lt_pow63 un21 dHi dLo
+      (uLo <<< (32 : BitVec 6).toNat)
+      hdHi_ge hdHi_lt hdLo_lt h_un21_lt hun21_lt_vTop
+  · -- Guard fires: helper = q0c. Use KB-LB3 at Phase 2 (uHi := un21).
+    have hdHi_ne : dHi ≠ 0 := by
+      intro heq; rw [heq] at hdHi_ge; simp at hdHi_ge
+    exact div128Quot_q1c_ge_q_true_1 un21 dHi dLo div_un0 hdHi_ne
+      h_div_un0_lt hun21_lt_vTop
 
 /-- **KB-LB9: Weak Phase 2 lower bound, unconditional.** Phase 2's output
     `q0'` satisfies the abstract Knuth trial bound off by 2:
@@ -507,11 +524,22 @@ theorem div128Quot_q0_prime_plus_2_ge_q_true_0_abstract
     q0'.toNat + 2 ≥ (un21.toNat * 2^32 + div_un0.toNat) /
                      (dHi.toNat * 2^32 + dLo.toNat) := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  -- KB-2 at Phase 2 (uHi := un21, rhatUn1 := rhat2Un0).
-  -- TODO(#61 Phase 2b coordinated fix): case-split on rhat2c_hi = 0.
-  -- Guard fires: q0' = q0c, and q0c + 2 ≥ un21/dHi via KB-3c.
-  -- Guard doesn't fire: q0' = phase1b's q1' which satisfies the bound.
-  have h_q0_bound : q0'.toNat + 2 ≥ un21.toNat / dHi.toNat := by sorry
+  -- Case-split on helper's guard: rhat2c_hi = 0.
+  -- Guard fires: q0' = q0c, and q0c + 2 ≥ un21/dHi via KB-1 (Phase 1a bound).
+  -- Guard doesn't fire: q0' = phase1b's un-guarded q1' at Phase 2, which
+  -- satisfies the bound via div128Quot_phase1b_quotient_bound.
+  have h_q0_bound : q0'.toNat + 2 ≥ un21.toNat / dHi.toNat := by
+    show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat + 2 ≥
+      un21.toNat / dHi.toNat
+    unfold div128Quot_phase2b_q0'
+    split
+    · -- Guard doesn't fire (rhat2c_hi = 0): helper yields the un-guarded check.
+      exact (div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo
+        rhat2Un0).1
+    · -- Guard fires (rhat2c_hi ≠ 0): helper yields q0c. Use KB-1 at Phase 2.
+      have h_kb1 := div128Quot_phase1a_quotient_bound un21 dHi hdHi_ne hdHi_lt
+      have h_lower_q0c : un21.toNat / dHi.toNat ≤ q0c.toNat + 1 := h_kb1.2
+      omega
   -- div_un0 < 2^32.
   have h_div_un0_lt : div_un0.toNat < 2^32 := by
     show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
@@ -761,9 +789,28 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_dHi_mul_pow32
     (un21.toNat * 2^32 + div_un0.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) ≤ q0'.toNat := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  -- TODO(#61 Phase 2b coordinated fix): case-split on rhat2c_hi = 0.
-  -- Guard doesn't fire: reduces to KB-LB8's un-guarded form.
-  -- Guard fires: q0' = q0c, which is ≥ q_true since q0c ≥ q1' (by mono).
-  sorry
+  -- div_un0 < 2^32 (from `uLo << 32 >> 32`).
+  have h_div_un0_lt : div_un0.toNat < 2^32 := by
+    show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
+    rw [BitVec.toNat_ushiftRight]
+    have h32 : (32 : BitVec 6).toNat = 32 := by decide
+    rw [h32, Nat.shiftRight_eq_div_pow]
+    have h_shl : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+      (uLo <<< (32 : BitVec 6).toNat : Word).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  show (un21.toNat * 2^32 + div_un0.toNat) /
+         (dHi.toNat * 2^32 + dLo.toNat) ≤
+       (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat
+  unfold div128Quot_phase2b_q0'
+  split
+  · -- Guard doesn't fire: helper yields unguarded check.
+    exact div128Quot_q1_prime_ge_q_true_1_of_uHi_lt_dHi_mul_pow32 un21 dHi dLo
+      (uLo <<< (32 : BitVec 6).toNat)
+      hdHi_ge hdHi_lt hdLo_lt h_un21_lt hun21_lt_vTop
+  · -- Guard fires: helper = q0c. Use KB-LB3 at Phase 2.
+    have hdHi_ne : dHi ≠ 0 := by
+      intro heq; rw [heq] at hdHi_ge; simp at hdHi_ge
+    exact div128Quot_q1c_ge_q_true_1 un21 dHi dLo div_un0 hdHi_ne
+      h_div_un0_lt hun21_lt_vTop
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -524,7 +524,7 @@ theorem div128Quot_q0_prime_plus_2_ge_q_true_0_abstract
     q0'.toNat + 2 ≥ (un21.toNat * 2^32 + div_un0.toNat) /
                      (dHi.toNat * 2^32 + dLo.toNat) := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
-  -- Case-split on helper's guard: rhat2c_hi = 0.
+  -- Case-split on helper's guard: rhat2cHi = 0.
   -- Guard fires: q0' = q0c, and q0c + 2 ≥ un21/dHi via KB-1 (Phase 1a bound).
   -- Guard doesn't fire: q0' = phase1b's un-guarded q1' at Phase 2, which
   -- satisfies the bound via div128Quot_phase1b_quotient_bound.
@@ -533,10 +533,10 @@ theorem div128Quot_q0_prime_plus_2_ge_q_true_0_abstract
       un21.toNat / dHi.toNat
     unfold div128Quot_phase2b_q0'
     split
-    · -- Guard doesn't fire (rhat2c_hi = 0): helper yields the un-guarded check.
+    · -- Guard doesn't fire (rhat2cHi = 0): helper yields the un-guarded check.
       exact (div128Quot_phase1b_quotient_bound un21 dHi hdHi_ne hdHi_lt dLo
         rhat2Un0).1
-    · -- Guard fires (rhat2c_hi ≠ 0): helper yields q0c. Use KB-1 at Phase 2.
+    · -- Guard fires (rhat2cHi ≠ 0): helper yields q0c. Use KB-1 at Phase 2.
       have h_kb1 := div128Quot_phase1a_quotient_bound un21 dHi hdHi_ne hdHi_lt
       have h_lower_q0c : un21.toNat / dHi.toNat ≤ q0c.toNat + 1 := h_kb1.2
       omega

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -559,8 +559,7 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
     let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-    let q0' := if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-               else q0c
+    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
     q0'.toNat < 2^32 := by
   intro q0 rhat2 hi2 q0c rhat2c div_un0 rhat2Un0 q0'
   -- Reuse Phase 1 lemma with uHi := un21.
@@ -610,8 +609,16 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     have h_check : BitVec.ult rhat2Un0 (q0c * dLo) := by
       show decide (rhat2Un0.toNat < (q0c * dLo).toNat) = true
       exact decide_eq_true h_ult
-    show (if BitVec.ult rhat2Un0 (q0c * dLo) then q0c + signExtend12 4095
-          else q0c).toNat < 2^32
+    -- Guard `rhat2c_hi = 0` holds since rhat2c < 2^32.
+    have h_rhat2c_hi_zero : rhat2c >>> (32 : BitVec 6).toNat = 0 := by
+      have h32 : (32 : BitVec 6).toNat = 32 := by decide
+      apply BitVec.eq_of_toNat_eq
+      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      show rhat2c.toNat / 2^32 = 0
+      exact Nat.div_eq_of_lt h_rhat2c_lt_pow32
+    show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat < 2^32
+    unfold div128Quot_phase2b_q0'
+    rw [if_pos h_rhat2c_hi_zero]
     rw [if_pos h_check]
     have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
     rw [BitVec.toNat_add, h_se_neg1]
@@ -621,8 +628,14 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     omega
   · -- q0c < 2^32 case: q0' ≤ q0c < 2^32.
     have h_q0c_lt : q0c.toNat < 2^32 := by omega
-    have h_q0'_le_q0c : q0'.toNat ≤ q0c.toNat :=
-      div128Quot_q1_prime_le_q1c q0c dLo rhat2Un0
+    -- The helper's q0' is either the unguarded check result (≤ q0c) or q0c
+    -- itself — both paths bound by q0c.
+    have h_q0'_le_q0c : q0'.toNat ≤ q0c.toNat := by
+      show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat ≤ q0c.toNat
+      unfold div128Quot_phase2b_q0'
+      split
+      · exact div128Quot_q1_prime_le_q1c q0c dLo rhat2Un0
+      · exact Nat.le_refl _
     omega
 
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -609,7 +609,7 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     have h_check : BitVec.ult rhat2Un0 (q0c * dLo) := by
       show decide (rhat2Un0.toNat < (q0c * dLo).toNat) = true
       exact decide_eq_true h_ult
-    -- Guard `rhat2c_hi = 0` holds since rhat2c < 2^32.
+    -- Guard `rhat2cHi = 0` holds since rhat2c < 2^32.
     have h_rhat2c_hi_zero : rhat2c >>> (32 : BitVec 6).toNat = 0 := by
       have h32 : (32 : BitVec 6).toNat = 32 := by decide
       apply BitVec.eq_of_toNat_eq


### PR DESCRIPTION
## Summary
- Resolves a verified counterexample where `div128Quot` returns the wrong quotient (off by 1) for specific inputs. The bug: Phase 2b's `BLTU rhat2Un0 q0Dlo` mul-check false-positively fires when `rhat2c ≥ 2^32` due to Word `<< 32` truncation.
- Adds a Knuth TAOCP §4.3.1 Step D3 guard (`SRLI .x1 .x11 32 ;; BNE .x1 .x0 36`) in the assembly that skips the mul-check when `rhat2c ≥ 2^32`.
- Coordinates the fix across: assembly (Program.lean), length lemma (Compose/Base.lean), helper body (Div128ProdCheck2.lean), step2 composition proof (Div128Step2.lean via 3 factored sub-lemmas), downstream Compose files, LoopBody/LoopIter specs, and EvmWordArith Div128* bound lemmas.

## Counterexample resolved

Before: `(div128Quot 0xFFFFFFFF 0x100000001 0xFFFFFFFF00000002).toNat = 4294967294` (wrong, off by 1).
After: `(div128Quot 0xFFFFFFFF 0x100000001 0xFFFFFFFF00000002).toNat = 4294967295` (correct, provable by `decide`).

## Changes

- **Assembly** (`divK_div128` in `Program.lean`): inserted SRLI+BNE guard between [36] and [37]; 49 → 51 instructions.
- **Length lemma**: `divK_div128_len = 51`.
- **Helper**: `div128Quot_phase2b_q0'` now guards the mul-check decrement with `rhat2c >>> 32 = 0`.
- **Step2 composition**: proved via 3 factored sub-lemmas:
  1. `divK_div128_step2_upto_guard_spec` (cpsTriple base..base+28)
  2. `divK_div128_step2_thru_guard_spec` (cpsBranch)
  3. `divK_div128_step2_branch_merged_spec` (cpsBranch with both legs at base+68)
  - `divK_div128_step2_spec` merges via `cpsBranch_merge_same_cr` with helper-unfolding bridges.
- **Compose/Div128.lean and Compose/ModDiv128.lean**: step2 ends base+1260 (was 1252); end block at base+1260; d128_sub ranges 30-46 / 47-50; framing uses `x7_exit`/`x1_exit`/`x11_exit` guard-fires-aware selectors.
- **Downstream specs** (18 files): threaded `x7_exit`/`x1_exit` through `divK_trial_call_full_spec` and the mulsub_correction_skip/addback chain.
- **EvmWordArith Div128*** bound lemmas (KB-LB8/LB8'/LB9/KB-5a/5c/5d/KB-6b/Task1/Task2): resolved via case-split on `rhat2c_hi = 0`. Under guard-fires: helper = q0c; under guard-doesn't-fire: helper = unguarded check.

## Build status

- Build clean: `lake build EvmAsm.Evm64` succeeds (3564 jobs).
- **Zero sorrys** across the branch.

## Test plan
- [x] `lake build` succeeds
- [x] Counterexample resolved: `example : (div128Quot ...) = 4294967295 := by decide` compiles
- [ ] CI passes
- [ ] Manual review of the composition proof in `Div128Step2.lean` (~340 lines across 4 theorems)

🤖 Generated with [Claude Code](https://claude.com/claude-code)