### PR TITLE
refactor(LimbSpec/Div128Step2): bundle step2 post + cr into @[irreducible] defs (#1139)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -206,6 +206,7 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
+  unfold divKDiv128Step2Code divKDiv128Step2Post at hst2
   rw [show (base + 1192 : Word) + 68 = base + 1260 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub 30 _ _ (by decide) (by bv_addr) (by decide))

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -201,6 +201,7 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
   -- ================================================================
   have hst2 := divK_div128_step2_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1192)
+  unfold divKDiv128Step2Code divKDiv128Step2Post at hst2
   rw [show (base + 1192 : Word) + 68 = base + 1260 from by bv_addr] at hst2
   have hst2e := cpsTriple_extend_code (hmono := by
     exact CodeReq.union_sub (d128_sub_mod 30 _ _ (by decide) (by bv_addr) (by decide))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -331,6 +331,54 @@ theorem divK_div128_step2_branch_merged_spec
     (fun h hp => by xperm_hyp hp)  -- Q_f_final reshaped
     composed
 
+/-- Bundled postcondition for `divK_div128_step2_spec`. Hides the
+    13-let chain (Step 2 trial-division intermediates + Phase 2b
+    exit selectors) so the theorem signature stays a clean
+    `cpsTriple A B cr P (divKDiv128Step2Post …)` instead of a
+    let-chain immediately preceding the triple. Marked
+    `@[irreducible]` so callers see only the bundled assertion;
+    `unfold` to expose the lets when bridging downstream. Part of #1139. -/
+@[irreducible]
+def divKDiv128Step2Post (sp un21 dHi dlo un0 : Word) : Assertion :=
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dlo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
+  (.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+  (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)
+
+/-- Bundled CodeReq for `divK_div128_step2_spec` (instrs [30]-[46], 17
+    singletons). Bundling avoids the let in the theorem signature. -/
+@[irreducible]
+def divKDiv128Step2Code (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
+  (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+  (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
+   (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
+
 /-- div128 step 2: trial division q0, clamp, Phase 2b guard, product check.
     Instrs [30]-[46] (17 instructions). Includes the Knuth TAOCP §4.3.1
     Step D3 guard (SRLI + BNE at instrs [37]-[38]) that skips the
@@ -339,60 +387,48 @@ theorem divK_div128_step2_branch_merged_spec
     Input: un21 in x7, dHi in x6, dlo/un0 in memory.
     Output: refined q0 in x5 (= `div128Quot_phase2b_q0' q0c rhat2c dlo un0`).
 
-    **NOTE**: output's x7, x1, x11 values differ between guard-fires and
-    guard-doesn't-fire paths:
-    - Guard fires (rhat2cHi ≠ 0): x7 = un21 (unchanged), x1 = rhat2cHi,
-      x11 = rhat2c.
-    - Guard doesn't fire (rhat2cHi = 0): x7 = q0Dlo, x1 = rhat2Un0,
-      x11 = un0.
-
-    The postcondition uses `rhat2cHi = 0`-aware selectors to capture this. -/
+    Postcondition is bundled as `divKDiv128Step2Post`; the per-register
+    breakdown is in that def's body. Bundling addresses the "many lets
+    before cpsTriple" elaboration anti-pattern (#1139). -/
 theorem divK_div128_step2_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 : Word) (base : Word) :
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-    let q0Dlo := q0c * dlo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
-    -- Exit values for registers that differ between guard-fires/doesn't
-    -- paths. On guard-fires: x7 keeps un21 (MUL not run), x1 keeps
-    -- rhat2cHi (loaded by SRLI), x11 keeps rhat2c (un0 not loaded).
-    -- On guard-doesn't-fire: x7 holds q0Dlo, x1 holds rhat2Un0, x11 holds un0.
-    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
-      (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
-       (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
-    cpsTriple base (base + 68) cr
+    cpsTriple base (base + 68) (divKDiv128Step2Code base)
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
        (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
-      ((.x7 ↦ᵣ x7Exit) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
-       (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro q0 rhat2 hi q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit x1Exit x11Exit cr
+      (divKDiv128Step2Post sp un21 dHi dlo un0) := by
+  unfold divKDiv128Step2Code divKDiv128Step2Post
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dlo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
+  let cr :=
+    CodeReq.union (CodeReq.singleton base (.DIVU .x5 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x1 .x5 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x11 .x7 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x1 .x5 32))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x1 .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x5 .x5 4095))
+    (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x11 .x11 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.SRLI .x1 .x11 32))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.BNE .x1 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.MUL .x7 .x5 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.SLLI .x1 .x11 32))
+    (CodeReq.union (CodeReq.singleton (base + 48) (.LD .x11 .x12 3944))
+    (CodeReq.union (CodeReq.singleton (base + 52) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 56) (.BLTU .x1 .x7 8))
+    (CodeReq.union (CodeReq.singleton (base + 60) (.JAL .x0 8))
+     (CodeReq.singleton (base + 64) (.ADDI .x5 .x5 4095)))))))))))))))))
   -- Apply branch_merged to get a cpsBranch with both legs at base+68.
   have hbr := divK_div128_step2_branch_merged_spec sp un21 dHi v1Old v5Old v11Old
     dlo un0 base


### PR DESCRIPTION
## Summary

First spec from #1139's plan. Bundles `divK_div128_step2_spec`'s 13-let postcondition chain and 17-singleton CodeReq into two `@[irreducible] def`s:

- `divKDiv128Step2Post (sp un21 dHi dlo un0 : Word) : Assertion` — the post (q0' / x7Exit / x1Exit / x11Exit selectors over the Phase 2b guard).
- `divKDiv128Step2Code (base : Word) : CodeReq` — the 17-singleton union for instrs [30]-[46].

Theorem signature shrinks from "13 lets + 17 cr-union lines + cpsTriple" to a clean `cpsTriple base (base + 68) (divKDiv128Step2Code base) P (divKDiv128Step2Post …)`.

## Approach

The proof body re-introduces the lets locally (after `unfold divKDiv128Step2Code divKDiv128Step2Post` opens the def) so the existing `intro`-based proof flow works unchanged.

Call sites in `Compose/{Div128,ModDiv128}.lean` add `unfold divKDiv128Step2Code divKDiv128Step2Post at hst2` after invoking `divK_div128_step2_spec`, so the downstream `cpsTriple_extend_code` and `xperm_hyp` can see the underlying union/atom structure.

## Scope

Part of #1139. Remaining 4 sites (`div128_spec`, `mod_div128_spec`, `divK_trial_call_path_spec`, `divK_trial_call_full_spec`) follow the same pattern and will land in separate PRs.

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)