### PR TITLE
refactor(Compose/Div128): bundle div128_spec post into @[irreducible] def (#1139)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -53,45 +53,61 @@ private theorem d128_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
 -- Entry: base+1072, Exit: retAddr (via JALR), CodeReq: sharedDivModCode base.
 -- ============================================================================
 
+/-- Bundled postcondition for `div128_spec` (and `mod_div128_spec`).
+    Hides the 25-let chain that computes Phase 1 / compute-un21 / Phase 2 /
+    Phase 2b-guarded / end-combine intermediates so the theorem signature
+    stays a clean `cpsTriple A B C P (div128SpecPost …)` instead of a
+    let-chain immediately preceding the triple (anti-pattern, slows
+    elaboration). Marked `@[irreducible]` so callers see only the bundled
+    assertion; `unfold` to expose the lets when threading downstream.
+    Part of #1139. -/
+@[irreducible]
+def div128SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
+  -- Phase 1 intermediates
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  -- Step 1 intermediates
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- compute_un21 intermediates
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  -- Step 2 intermediates
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
+  (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
+  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
+  (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3968 ↦ₘ retAddr) **
+  (sp + signExtend12 3960 ↦ₘ d) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0)
+
 theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
-    -- Phase 1 intermediates
-    let dHi := d >>> (32 : BitVec 6).toNat
-    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := uLo >>> (32 : BitVec 6).toNat
-    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    -- Step 1 intermediates
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    -- Compute un21 intermediates (x5, x1 values after compute_un21)
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    -- Step 2 intermediates
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
-    -- Exit values depend on whether the Phase 2b guard fires.
-    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
-    -- End: combine q1' and q0'
-    let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (sharedDivModCode base)
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
@@ -102,19 +118,41 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      (-- Postcondition: x11=quotient, all regs/mem updated
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ retAddr) **
-       (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ un0)) := by
-  -- Introduce all let bindings
-  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
-    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit
-    x1Exit x11Exit q
+      (div128SpecPost sp retAddr d uLo uHi) := by
+  unfold div128SpecPost
+  -- Phase 1 intermediates
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  -- Step 1 intermediates
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- compute_un21 intermediates
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  -- Step 2 intermediates
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -864,7 +864,7 @@ theorem divK_trial_call_path_spec
   have D := div128_spec sp (base + 516) vTop uLo uHi base
     j vtopBase v11Old retMem dMem dloMem un0Mem
     halign
-  dsimp only [] at D
+  unfold div128SpecPost at D
   -- 3. Frame JAL with all registers/memory for div128
   have Jf := cpsTriple_frameR
     ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **


### PR DESCRIPTION
## Summary

Second spec from #1139. Bundles `div128_spec`'s 25-let postcondition chain (Phase 1 / compute-un21 / Phase 2 / Phase 2b-guarded / end-combine intermediates) into a single `@[irreducible] def`:

- `div128SpecPost (sp retAddr d uLo uHi : Word) : Assertion`

Theorem signature shrinks from "25 lets + cpsTriple" to a clean `cpsTriple (base + div128Off) retAddr (sharedDivModCode base) P (div128SpecPost sp retAddr d uLo uHi)`.

## Approach

Same recipe as #1140:

- Proof body re-introduces the lets locally (after `unfold div128SpecPost`) so the existing intro-based proof structure works unchanged.
- Sole call site `divK_trial_call_path_spec` in `LoopBody.lean` swaps `dsimp only [] at D` for `unfold div128SpecPost at D` so the downstream composition / xperm can see the underlying sepConj atoms.

## Scope

Part of #1139. After this lands, the 5 flagged sites status is:
- ✅ `divK_div128_step2_spec` (#1140, queued)
- ✅ `div128_spec` (this PR)
- 🔜 `mod_div128_spec` (mirror of `div128_spec`, can reuse `div128SpecPost`)
- 🔜 `divK_trial_call_path_spec` (caller of `div128_spec`, separate post needed)
- 🔜 `divK_trial_call_full_spec` (similar to trial_call_path)

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)