### PR TITLE
refactor(Compose/ModDiv128): reuse div128SpecPost in mod_div128_spec (#1139)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.Compose.Base
+import EvmAsm.Evm64.DivMod.Compose.Div128
 
 /-!
 # DivMod Compose: div128 subroutine composition (modCode)
@@ -56,41 +57,6 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
-    -- Phase 1 intermediates
-    let dHi := d >>> (32 : BitVec 6).toNat
-    let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := uLo >>> (32 : BitVec 6).toNat
-    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    -- Step 1 intermediates
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    -- Compute un21 intermediates (x5, x1 values after compute_un21)
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    -- Step 2 intermediates
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
-    -- Exit values depend on whether the Phase 2b guard fires.
-    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-    let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
-    -- End: combine q1' and q0'
-    let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + div128Off) retAddr (modCode base)
       (-- Precondition: caller registers + scratch memory
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
@@ -101,19 +67,45 @@ theorem mod_div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      (-- Postcondition: x11=quotient, all regs/mem updated
-       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1') **
-       (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
-       (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
-       (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ retAddr) **
-       (sp + signExtend12 3960 ↦ₘ d) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ un0)) := by
-  -- Introduce all let bindings
-  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' cu_rhat_un1
-    cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0 rhat2cHi q0' x7Exit
-    x1Exit x11Exit q
+      (div128SpecPost sp retAddr d uLo uHi) := by
+  -- Reuse the bundled post from Compose/Div128.lean (the post is identical
+  -- for div128_spec and mod_div128_spec — only the CodeReq subsumption
+  -- differs). Unfold to expose the lets so the proof body can reference
+  -- q1', q0', x7Exit, etc. by name.
+  unfold div128SpecPost
+  -- Phase 1 intermediates
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  -- Step 1 intermediates
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- compute_un21 intermediates
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  -- Step 2 intermediates
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- ================================================================
   -- Block 1: Phase 1 (base+1072 → base+1112)
   -- Saves ret/d, splits d and uLo into halves.


### PR DESCRIPTION
## Summary

Third spec from #1139. `mod_div128_spec` has the exact same post as `div128_spec` (only the CodeReq differs: `modCode` vs `sharedDivModCode`), so reuse the existing `div128SpecPost` from `Compose/Div128.lean` rather than duplicate it.

Theorem signature shrinks from "25 lets + cpsTriple" to a clean `cpsTriple (base + div128Off) retAddr (modCode base) P (div128SpecPost sp retAddr d uLo uHi)`.

Adds `import EvmAsm.Evm64.DivMod.Compose.Div128` to bring the bundled post into scope. Proof body re-introduces the lets locally after `unfold div128SpecPost`.

## Status of #1139

- ✅ `divK_div128_step2_spec` (#1140)
- ✅ `div128_spec` (#1141)
- ✅ `mod_div128_spec` (this PR)
- 🔜 `divK_trial_call_path_spec`
- 🔜 `divK_trial_call_full_spec`

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)