### PR TITLE
refactor(LoopBody): reuse div128SpecPost in divK_trial_call_path_spec (#1139)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -806,35 +806,6 @@ theorem divK_trial_call_path_spec
     (v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516) :
-    -- div128 intermediates (same as div128_spec)
-    let dHi := vTop >>> (32 : BitVec 6).toNat
-    let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := uLo >>> (32 : BitVec 6).toNat
-    let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
-    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-    let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + 512) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
@@ -844,17 +815,41 @@ theorem divK_trial_call_path_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
-       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') **
-       (.x2 ↦ᵣ (base + 516)) ** (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ vTop) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ un0)) := by
-  intro dHi dLo un1 un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
-        rhat2cHi q0' x7Exit x1Exit q
+      (div128SpecPost sp (base + 516) vTop uLo uHi) := by
+  -- Reuse the bundled `div128SpecPost` from `Compose/Div128.lean`. The
+  -- post atoms here are identical to div128's (with retAddr ↦ base+516,
+  -- d ↦ vTop) — just a permutation that the final `xperm_hyp` handles.
+  -- Re-introduce the lets so the proof body can reference q1', q0', etc.
+  -- by name.
+  unfold div128SpecPost
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
   have J := jal_spec .x2 v2Old (560 : BitVec 21) (base + 512) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
@@ -1821,7 +1816,7 @@ theorem divK_trial_call_full_spec
   have TCP := divK_trial_call_path_spec sp j uLo uHi vTop vtopBase base
     v2Old v11Old retMem dMem dloMem un0Mem
     halign
-  dsimp only [] at TCP
+  unfold div128SpecPost at TCP
   -- 4. Frame save_trial_load with x2, x11, x0, scratch memory
   have STLf := cpsTriple_frameR
     ((.x11 ↦ᵣ v11Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **


### PR DESCRIPTION
## Summary

Fourth spec from #1139. `divK_trial_call_path_spec` composes JAL + `div128_spec`; its post is the same atoms as `div128_spec`'s post (with `retAddr` ↦ `base+516`, `d` ↦ `vTop`) — just permuted. So reuse `div128SpecPost` from `Compose/Div128.lean` rather than introduce a fresh post def.

Theorem signature shrinks from "26 lets + cpsTriple" to a clean `cpsTriple (base + 512) (base + 516) (sharedDivModCode base) P (div128SpecPost sp (base + 516) vTop uLo uHi)`. The existing final `cpsTriple_weaken` + `xperm_hyp` handles the post-atom permutation.

Caller `divK_trial_call_full_spec` swaps `dsimp only [] at TCP` for `unfold div128SpecPost at TCP` (mirrors the change at the `D` site from #1141).

## Status of #1139

- ✅ `divK_div128_step2_spec` (#1140)
- ✅ `div128_spec` (#1141)
- ✅ `mod_div128_spec` (#1142)
- ✅ `divK_trial_call_path_spec` (this PR)
- 🔜 `divK_trial_call_full_spec`

## Test plan
- [x] `lake build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)