### PR TITLE
refactor: strip spurious double parens around single assertion atoms (#1075)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -147,7 +147,7 @@ theorem divK_div128_step1_spec
                     · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
                     · simp at h)
   have h3f := cpsTriple_frameR
-    ((.x0 ↦ᵣ 0))
+    (.x0 ↦ᵣ 0)
     (by pcFree) h3
   have h123 := cpsTriple_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 h3f

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Tail.lean
@@ -109,8 +109,8 @@ theorem divK_div128_correct_q0_single_spec (q0 : Word) (base : Word) :
     let q0' := q0 + signExtend12 4095
     let cr := CodeReq.singleton base (.ADDI .x5 .x5 4095)
     cpsTriple base (base + 4) cr
-      ((.x5 ↦ᵣ q0))
-      ((.x5 ↦ᵣ q0')) := by
+      (.x5 ↦ᵣ q0)
+      (.x5 ↦ᵣ q0') := by
   intro q0' cr
   have I0 := addi_spec_gen_same .x5 q0 4095 base (by nofun)
   runBlock I0

--- a/EvmAsm/Evm64/SignExtend/LimbSpec.lean
+++ b/EvmAsm/Evm64/SignExtend/LimbSpec.lean
@@ -189,8 +189,8 @@ theorem signext_done_spec (sp : Word) (base : Word) :
     let nsp := sp + signExtend12 (32 : BitVec 12)
     let code := CodeReq.singleton base (.ADDI .x12 .x12 32)
     cpsTriple base (base + 4) code
-      ((.x12 ↦ᵣ sp))
-      ((.x12 ↦ᵣ nsp)) := by
+      (.x12 ↦ᵣ sp)
+      (.x12 ↦ᵣ nsp) := by
   exact addi_spec_gen_same .x12 sp 32 base (by nofun)
 
 -- ============================================================================


### PR DESCRIPTION
## Summary
- Five call sites wrapped a single-atom assertion `(.xN ↦ᵣ v)` in an extra layer of parens — leftover from earlier refactors that composed multiple atoms here.
- Strips the outer parens in `SignExtend/LimbSpec.lean` (`signext_done_spec`), `DivMod/LimbSpec/Div128Tail.lean` (`divK_div128_correct_q0_single_spec`), and `DivMod/LimbSpec/Div128Step1.lean` (one `cpsTriple_frameR` call).

Partial progress on #1075.

## Test plan
- [x] `lake build` — full 3564-job build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)