### PR TITLE
refactor: flip Word args on body_post_weaken local helpers to implicit (#331)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -773,7 +773,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
   -- For each body, we keep the concrete memory values and weaken regs to regOwn
-  have body_post_weaken : ∀ (r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word),
+  have body_post_weaken : ∀ {r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word},
       ∀ h, ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ r5v) ** (.x6 ↦ᵣ r6v) ** (.x7 ↦ᵣ r7v) **
             (.x10 ↦ᵣ r10v) ** (.x11 ↦ᵣ r11v) **
             ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) ** ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56) **
@@ -791,13 +791,13 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
     exact (congrFun (show _ = _ from by xperm) h).mp w5
   -- Apply weakening to each body (keep concrete mem values)
   have hbody0_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody0_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody0_f
   have hbody1_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody1_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody1_f
   have hbody2_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody2_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody2_f
   have hbody3_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -929,7 +929,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
-  have body_post_weaken : ∀ (r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word),
+  have body_post_weaken : ∀ {r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word},
       ∀ h, ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ r5v) ** (.x6 ↦ᵣ r6v) ** (.x7 ↦ᵣ r7v) **
             (.x10 ↦ᵣ r10v) ** (.x11 ↦ᵣ r11v) **
             ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) ** ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56) **
@@ -947,13 +947,13 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
     exact (congrFun (show _ = _ from by xperm) h).mp w5
   -- Apply weakening to each body (keep concrete mem values)
   have hbody0_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody0_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody0_f
   have hbody1_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody1_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody1_f
   have hbody2_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody2_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody2_f
   have hbody3_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -747,7 +747,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have ha56' : (sp + 32 : Word) + 24 = sp + 56 := by bv_omega
   simp only [ha40', ha48', ha56'] at hbody3_f hbody2_f hbody1_f hbody0_f
   -- Helper: weaken regs to regOwn while keeping concrete mem values
-  have body_post_weaken : ∀ (r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word),
+  have body_post_weaken : ∀ {r5v r6v r7v r10v r11v m32 m40 m48 m56 : Word},
       ∀ h, ((.x12 ↦ᵣ (sp + 32)) ** (.x5 ↦ᵣ r5v) ** (.x6 ↦ᵣ r6v) ** (.x7 ↦ᵣ r7v) **
             (.x10 ↦ᵣ r10v) ** (.x11 ↦ᵣ r11v) **
             ((sp + 32) ↦ₘ m32) ** ((sp + 40) ↦ₘ m40) ** ((sp + 48) ↦ₘ m48) ** ((sp + 56) ↦ₘ m56) **
@@ -765,13 +765,13 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
     exact (congrFun (show _ = _ from by xperm) h).mp w5
   -- Apply weakening to each body (keep concrete mem values)
   have hbody0_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody0_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody0_f
   have hbody1_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody1_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody1_f
   have hbody2_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody2_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody2_f
   have hbody3_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbody3_f
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
   have hshift_toNat : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -585,7 +585,7 @@ theorem signext_body_spec (sp base : Word)
   have hse32 : sp + signExtend12 (32 : BitVec 12) = sp + 32 := by rw [signExtend12_32]
   -- Helper: weaken body+done postconditions to regOwn + concrete mem values
   -- For bodies 0,1,2 (which have x10 in postcondition):
-  have body_post_weaken : ∀ (r5v r6v r10v m32 m40 m48 m56 : Word),
+  have body_post_weaken : ∀ {r5v r6v r10v m32 m40 m48 m56 : Word},
       ∀ h, ((.x12 ↦ᵣ (sp + signExtend12 32)) ** (.x5 ↦ᵣ r5v) ** (.x6 ↦ᵣ r6v) **
             (.x10 ↦ᵣ r10v) **
             (.x0 ↦ᵣ (0 : Word)) ** bmem **
@@ -602,11 +602,11 @@ theorem signext_body_spec (sp base : Word)
     xperm_hyp w3
   -- Apply weakening to each body+done
   have hbd0_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbd0
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbd0
   have hbd1_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbd1
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbd1
   have hbd2_w := cpsTriple_weaken
-    (fun h hp => hp) (fun h hq => body_post_weaken _ _ _ _ _ _ _ h (by xperm_hyp hq)) hbd2
+    (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbd2
   -- Body 3 has no x10 — need to introduce regOwn .x10 from x10 in Phase C frame
   -- After merge, the precondition will include (.x10 ↦ᵣ _) from Phase C exit post.
   -- So we use cpsTriple_of_forall_regIs_to_regOwn to absorb x10 in precondition


### PR DESCRIPTION
## Summary
- Four compose files (\`Shift/{Compose,ShlCompose,SarCompose}.lean\` and \`SignExtend/Compose.lean\`) define a local \`body_post_weaken\` helper that weakens each per-limb body's postcondition to a \`regOwn\`-based form before the final merge.
- Each helper binds 7 or 9 \`Word\` arguments (\`r5v r6v r7v? r10v r11v? m32 m40 m48 m56\`). Every call site passes an underscore for each of them (\`_ _ _ _ _ _ _ _ _ h ...\`) — the values are fully determined by the input hypothesis type.
- Flip the \`∀ (...)\` binders to \`∀ {...}\`. Call sites collapse from \`body_post_weaken _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq)\` to \`body_post_weaken h (by xperm_hyp hq)\`. 14 call sites total across the 4 files.

**#331 scope check**: these are purely-local \`have\`s; no literals are ever passed at any call site (all 14 call sites use the same \`_ _ _ _ _ h (by xperm_hyp hq)\` shape). Not affected by the \"don't flip if any caller uses a literal\" guidance from PR #922's lessons.

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)