### PR TITLE
refactor(LoopBody): bundle divK_trial_call_full_spec post into @[irreducible] def (#1139)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1727,6 +1727,56 @@ theorem divK_trial_max_full_spec
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
+/-- Bundled postcondition for `divK_trial_call_full_spec` (#1139). Inlines
+    the 30+ let chain so xperm / seqFrame see all atoms in one flat sepConj
+    when bridging. Marked `@[irreducible]` so the theorem *signature* hides
+    the bundle from consumers; call-sites that need per-limb atoms must
+    `unfold divKTrialCallFullPost at TF` after invoking the spec. -/
+@[irreducible]
+def divKTrialCallFullPost (sp j n uHi uLo vTop base : Word) : Assertion :=
+  let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
+  let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0Div := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
+  (.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
+  (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
+  (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
+  (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
+  (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
+  (vtopBase + signExtend12 32 ↦ₘ vTop) **
+  (sp + signExtend12 3968 ↦ₘ (base + 516)) **
+  (sp + signExtend12 3960 ↦ₘ vTop) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0Div)
+
+set_option maxRecDepth 4096 in
 /-- Trial quotient call path: save j + load + BLTU taken + JAL + div128.
     When uHi < vTop, computes qHat = div128(uHi, uLo, vTop).
     Entry: base+448, Exit: base+516, CodeReq: sharedDivModCode base. -/
@@ -1738,35 +1788,6 @@ theorem divK_trial_call_full_spec
     (hbltu : BitVec.ult uHi vTop) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    -- div128 intermediates
-    let dHi := vTop >>> (32 : BitVec 6).toNat
-    let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let un1 := uLo >>> (32 : BitVec 6).toNat
-    let un0Div := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0Dlo := q0c * dLo
-    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
-    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
-    let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-    let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-    let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
@@ -1779,21 +1800,41 @@ theorem divK_trial_call_full_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem))
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ x1Exit) **
-       (.x5 ↦ᵣ q0') ** (.x6 ↦ᵣ dHi) **
-       (.x7 ↦ᵣ x7Exit) ** (.x10 ↦ᵣ q1') ** (.x11 ↦ᵣ q) **
-       (.x2 ↦ᵣ (base + 516)) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j) ** (sp + signExtend12 3984 ↦ₘ n) **
-       (uAddr ↦ₘ uHi) ** ((uAddr + 8) ↦ₘ uLo) **
-       (vtopBase + signExtend12 32 ↦ₘ vTop) **
-       (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-       (sp + signExtend12 3960 ↦ₘ vTop) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ un0Div)) := by
+      (divKTrialCallFullPost sp j n uHi uLo vTop base) := by
   intro uAddr vtopBase
-        dHi dLo un1 un0Div q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0Dlo rhat2Un0
-        rhat2cHi q0' x7Exit x1Exit q
+  -- Define the same lets locally so the proof body (unchanged from before
+  -- bundling) can still reference q0', x1Exit, x7Exit, etc. by name. The
+  -- goal's post stays `divKTrialCallFullPost ...` (opaque) throughout the
+  -- intermediate `seqFrame` steps — keeping it opaque is what avoids the
+  -- `maxRecDepth` blowup a naive `unfold`-at-start would hit.
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0Div := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0Div
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0Div
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- 1. Save j + trial load (base+448 → base+500)
   have STL := divK_save_trial_load_spec sp j n jOld v5Old v6Old v7Old v10Old uHi uLo vTop
     base
@@ -1829,7 +1870,8 @@ theorem divK_trial_call_full_spec
   seqFrame STLf taken_clean
   -- 6. Compose (save_trial_load + BLTU) + trial_call_path
   seqFrame STLftaken_clean TCP
-  -- 7. Final permutation
+  -- 7. Final permutation — unfold the bundled post so xperm sees all atoms.
+  unfold divKTrialCallFullPost
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -148,6 +148,7 @@ theorem divK_trial_call_full_spec_n1
   have TF := divK_trial_call_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF

--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -367,6 +367,7 @@ theorem divK_loop_body_n2_call_skip_spec
   have TF := divK_trial_call_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -516,6 +517,7 @@ theorem divK_loop_body_n2_call_addback_spec
   have TF := divK_trial_call_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -370,6 +370,7 @@ theorem divK_loop_body_n3_call_skip_spec
   have TF := divK_trial_call_full_spec sp j (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF
@@ -520,6 +521,7 @@ theorem divK_loop_body_n3_call_addback_spec
   have TF := divK_trial_call_full_spec sp j (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -373,6 +373,7 @@ theorem divK_loop_body_n4_call_skip_spec
   have TF := divK_trial_call_full_spec sp j (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n4] at TF
   rw [u_addr8_eq_n4] at TF
@@ -522,6 +523,7 @@ theorem divK_loop_body_n4_call_addback_spec
   have TF := divK_trial_call_full_spec sp j (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n4] at TF
   rw [u_addr8_eq_n4] at TF

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -80,6 +80,7 @@ theorem divK_loop_body_n1_call_skip_j0_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -206,6 +207,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -332,6 +334,7 @@ theorem divK_loop_body_n1_call_skip_j2_spec
   have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -458,6 +461,7 @@ theorem divK_loop_body_n1_call_skip_j3_spec
   have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -81,6 +81,7 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -202,6 +203,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -323,6 +325,7 @@ theorem divK_loop_body_n1_call_addback_j2_beq_spec
   have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
@@ -444,6 +447,7 @@ theorem divK_loop_body_n1_call_addback_j3_beq_spec
   have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -195,6 +195,7 @@ theorem divK_loop_body_n2_call_skip_j0_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -416,6 +417,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -632,6 +634,7 @@ theorem divK_loop_body_n2_call_skip_j2_spec
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -865,6 +868,7 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -1078,6 +1082,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
@@ -1285,6 +1290,7 @@ theorem divK_loop_body_n2_call_addback_j2_beq_spec
   have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF

--- a/EvmAsm/Evm64/DivMod/LoopIterN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN3.lean
@@ -191,6 +191,7 @@ theorem divK_loop_body_n3_call_skip_j0_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF
@@ -430,6 +431,7 @@ theorem divK_loop_body_n3_call_skip_j1_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF
@@ -673,6 +675,7 @@ theorem divK_loop_body_n3_call_addback_beq_j0_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF
@@ -898,6 +901,7 @@ theorem divK_loop_body_n3_call_addback_beq_j1_spec
   have TF := divK_trial_call_full_spec sp (1 : Word) (3 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u3 u2 v2 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n3] at TF
   rw [u_addr8_eq_n3] at TF

--- a/EvmAsm/Evm64/DivMod/LoopIterN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN4.lean
@@ -218,6 +218,7 @@ theorem divK_loop_body_n4_call_skip_j0_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n4] at TF
   rw [u_addr8_eq_n4] at TF
@@ -457,6 +458,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_spec
   have TF := divK_trial_call_full_spec sp (0 : Word) (4 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     uTop u3 v3 retMem dMem dloMem scratch_un0 base
     halign hbltu
+  unfold divKTrialCallFullPost at TF
   dsimp only [] at TF
   rw [u_addr_eq_n4] at TF
   rw [u_addr8_eq_n4] at TF


### PR DESCRIPTION
## Summary
Completes the 5th and final site for #1139. Introduces \`divKTrialCallFullPost : Assertion\` bundling the 30-let postcondition previously inlined in \`divK_trial_call_full_spec\`'s signature. The theorem shrinks from a ~60-line signature with an opaque 30-let chain to a clean:

\`\`\`lean
cpsTriple (base + loopBodyOff) (base + 516) (sharedDivModCode base)
  (⟨precondition⟩)
  (divKTrialCallFullPost sp j n uHi uLo vTop base)
\`\`\`

## Why earlier attempts failed, and why this one works
- **v1** (reverted): bundled the post but naïve \`unfold\` at proof start caused \`maxRecDepth\` during \`seqFrame\` composition (seqFrame's \`isDefEq\` walked through 30 lets).
- **v2** (reverted): same bundled def, kept opaque through seqFrame; hit \`maxRecDepth\` because the per-declaration \`set_option maxRecDepth 4096 in\` got moved to the def, not the theorem.
- **v3 (this PR)**: keep post opaque during seqFrame (as in v2, with proof-local lets matching the def's body by name), \`unfold divKTrialCallFullPost\` only at the final \`cpsTriple_weaken\` post bridge, and **preserve \`set_option maxRecDepth 4096\` on the theorem itself**. Clean build.

## Caller impact
~13 call sites across \`LoopBody{N1,N2,N3,N4}.lean\`, \`LoopIterN{2,3,4}.lean\`, \`LoopIterN1/{Call,CallBeq}.lean\`. Each site follows the same shape:

\`\`\`lean
  have TF := divK_trial_call_full_spec ...
  unfold divKTrialCallFullPost at TF  -- NEW: unfold before dsimp
  dsimp only [] at TF
  rw [u_addr_eq_n* ...] at TF
  ...
\`\`\`

The \`unfold\`-before-\`dsimp\` ordering is load-bearing: \`unfold\` emits inner \`have\`-bindings that \`dsimp only []\` then zeta-reduces into the outer context's lets, so downstream \`rw [u_addr_eq_n*]\` rewrites land on the substituted addresses.

## Test plan
- [x] \`lake build\` — full 3564-job build passes

Closes #1139 (5/5 sites done).

🤖 Generated with [Claude Code](https://claude.com/claude-code)