### PR TITLE
refactor: flip stack-slot args to implicit on 8 zero-path specs (#331)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -231,7 +231,7 @@ private theorem shr_body0_exit {base : Word} : ((base + 240 : Word) + 96) + sign
 /-- Zero path via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is zero.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → zero_path. -/
 theorem evm_shr_zero_high_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     cpsTriple base (base + 360) (shrCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -336,7 +336,7 @@ theorem evm_shr_zero_high_spec (sp base : Word)
 /-- Zero path via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is zero.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(ntaken) → LD s0 → SLTIU → BEQ(taken) → zero_path. -/
 theorem evm_shr_zero_large_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     cpsTriple base (base + 360) (shrCode base)

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -273,7 +273,7 @@ private theorem sar_body0_exit {base : Word} : ((base + 252 : Word) + 96) + sign
 /-- Sign-fill via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is sign extension.
     Execution: LD s1 → LD/OR s2 → LD/OR s3 → BNE(taken) → sign_fill_path. -/
 theorem evm_sar_sign_fill_high_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     let sign_ext := BitVec.sshiftRight v3 63
     cpsTriple base (base + 380) (sarCode base)
@@ -370,7 +370,7 @@ theorem evm_sar_sign_fill_high_spec (sp base : Word)
 
 /-- Sign-fill via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is sign extension. -/
 theorem evm_sar_sign_fill_large_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     let sign_ext := BitVec.sshiftRight v3 63

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -159,7 +159,7 @@ theorem evm_sar_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact sar_sign_fill_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_sar_sign_fill_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
+        (evm_sar_sign_fill_high_spec sp base r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -173,7 +173,7 @@ theorem evm_sar_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact sar_sign_fill_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_sar_sign_fill_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
+        (evm_sar_sign_fill_large_spec sp base r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = sshiftRight value shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -145,7 +145,7 @@ theorem evm_shr_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact shr_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shr_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
+        (evm_shr_zero_high_spec sp base r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -162,7 +162,7 @@ theorem evm_shr_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact shr_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shr_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
+        (evm_shr_zero_large_spec sp base r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = value >>> shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -220,7 +220,7 @@ private theorem shl_body0_exit {base : Word} : ((base + 240 : Word) + 96) + sign
 
 /-- Zero path via BNE taken: high shift limbs are nonzero → shift ≥ 256 → result is zero. -/
 theorem evm_shl_zero_high_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hhigh : s1 ||| s2 ||| s3 ≠ 0) :
     cpsTriple base (base + 360) (shlCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -324,7 +324,7 @@ theorem evm_shl_zero_high_spec (sp base : Word)
 
 /-- Zero path via BEQ taken: s1=s2=s3=0 but s0 ≥ 256 → result is zero. -/
 theorem evm_shl_zero_large_spec (sp base : Word)
-    (s0 s1 s2 s3 v0 v1 v2 v3 r5 r10 : Word)
+    {s0 s1 s2 s3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hlow : s1 ||| s2 ||| s3 = 0)
     (hlarge : BitVec.ult s0 (signExtend12 (256 : BitVec 12)) = false) :
     cpsTriple base (base + 360) (shlCode base)

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -145,7 +145,7 @@ theorem evm_shl_stack_spec (sp base : Word)
     -- Sub-case: high limbs nonzero or s0 ≥ 256
     by_cases hhigh : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 ≠ 0
     · exact shl_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shl_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
+        (evm_shl_zero_high_spec sp base r5 r10 hhigh)
         result hresult
     · have hhigh' : shift.getLimb 1 ||| shift.getLimb 2 ||| shift.getLimb 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -159,7 +159,7 @@ theorem evm_shl_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact shl_zero_lift sp base shift value r5 r6 r7 r10 r11
-        (evm_shl_zero_large_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
+        (evm_shl_zero_large_spec sp base r5 r10 hhigh' hlarge)
         result hresult
   · -- shift < 256: result = value <<< shift.toNat
     have hlt : shift.toNat < 256 := Nat.lt_of_not_le hge

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -191,7 +191,7 @@ private theorem se_done_exit {base : Word} : (base + 188 : Word) + 4 = base + 19
 /-- No-change path via BNE taken: high b limbs are nonzero → b >= 31 → x unchanged.
     Execution: LD b1 → LD/OR b2 → LD/OR b3 → BNE(taken) → done. -/
 theorem signext_nochange_high_spec (sp base : Word)
-    (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
+    {b0 b1 b2 b3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hhigh : b1 ||| b2 ||| b3 ≠ 0) :
     cpsTriple base (base + 192) (signextCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ r5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ r10) **
@@ -285,7 +285,7 @@ theorem signext_nochange_high_spec (sp base : Word)
 /-- No-change path via BEQ taken: b1=b2=b3=0 but b[0] >= 31 → x unchanged.
     Execution: LD b1 → LD/OR b2 → LD/OR b3 → BNE(ntaken) → LD b0 → SLTIU → BEQ(taken) → done. -/
 theorem signext_nochange_geq31_spec (sp base : Word)
-    (b0 b1 b2 b3 v0 v1 v2 v3 r5 r10 : Word)
+    {b0 b1 b2 b3 v0 v1 v2 v3 : Word} (r5 r10 : Word)
     (hlow : b1 ||| b2 ||| b3 = 0)
     (hlarge : BitVec.ult b0 (signExtend12 (31 : BitVec 12)) = false) :
     cpsTriple base (base + 192) (signextCode base)

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -77,7 +77,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
     have hresult : result = x := by simp [result, EvmWord.signextend_ge31 b x hge]
     by_cases hhigh : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0
     · exact signext_nochange_lift sp base b x r5 r6 r10
-        (signext_nochange_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh)
+        (signext_nochange_high_spec sp base r5 r10 hhigh)
         result hresult
     · have hhigh' : b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 = 0 :=
         Classical.byContradiction (fun h => hhigh h)
@@ -91,7 +91,7 @@ theorem evm_signextend_stack_spec (sp base : Word)
         · rfl
         · simp at h; omega
       exact signext_nochange_lift sp base b x r5 r6 r10
-        (signext_nochange_geq31_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh' hlarge)
+        (signext_nochange_geq31_spec sp base r5 r10 hhigh' hlarge)
         result hresult
   · -- b < 31: body path
     push Not at hge


### PR DESCRIPTION
## Summary
Four pairs of zero-path / no-change specs take 8 \`Word\` stack-slot args \`s0..v3\` (or \`b0..v3\` for SignExtend) that name the cpsTriple's pre/post memory atoms. Every call site passes \`_ _ _ _ _ _ _ _\` for these 8 slots — they're fully determined by the hypothesis shape.

Theorems updated (each called exactly once):
- \`evm_shr_zero_high_spec\` / \`evm_shr_zero_large_spec\` — \`Shift/Compose.lean\`, called in \`Shift/Semantic.lean\`
- \`evm_shl_zero_high_spec\` / \`evm_shl_zero_large_spec\` — \`Shift/ShlCompose.lean\`, called in \`Shift/ShlSemantic.lean\`
- \`evm_sar_sign_fill_high_spec\` / \`evm_sar_sign_fill_large_spec\` — \`Shift/SarCompose.lean\`, called in \`Shift/SarSemantic.lean\`
- \`signext_nochange_high_spec\` / \`signext_nochange_geq31_spec\` — \`SignExtend/Compose.lean\`, called in \`SignExtend/Spec.lean\`

Each call site collapses from
\`evm_shr_zero_high_spec sp base _ _ _ _ _ _ _ _ r5 r10 hhigh\`
to
\`evm_shr_zero_high_spec sp base r5 r10 hhigh\`.

**#331 literal-safety check**: every spec has a single call site, none pass a concrete literal for the flipped args (always \`_\`). Not affected by the PR #922 guidance.

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)