### PR TITLE
refactor: flip register/scratch args on 6 *_stack_weaken helpers to implicit (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -580,9 +580,9 @@ instance (sp : Word) (a b : EvmWord) :
     pass through unchanged. -/
 theorem div_n4_max_skip_stack_weaken
     (sp : Word) (a b : EvmWord)
-    (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
-    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
-     shift_p n_p j_p : Word) :
+    {v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word}
+    {q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+     shift_p n_p j_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
        (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
@@ -778,9 +778,9 @@ instance (sp : Word) (a b : EvmWord) :
     `EvmWord.mod a b` instead of `EvmWord.div a b`. -/
 theorem mod_n4_max_skip_stack_weaken
     (sp : Word) (a b : EvmWord)
-    (v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word)
-    (q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
-     shift_p n_p j_p : Word) :
+    {v1_p v2_p v5_p v6_p v7_p v10_p v11_p : Word}
+    {q0P q1P q2_p q3_p u0P u1P u2P u3P u4_p u5_p u6_p u7_p
+     shift_p n_p j_p : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
        (.x1 ↦ᵣ v1_p) ** (.x2 ↦ᵣ v2_p) **
@@ -1332,8 +1332,7 @@ theorem evm_div_n4_max_skip_stack_spec (sp base : Word)
   -- (unlike `rw`, which gets blocked by them).
   simp only [fullDivN4MaxSkipPost_unfold, denormDivPost_unfold] at hq
   -- Apply the weakener — its input takes a specific explicit atom shape.
-  apply div_n4_max_skip_stack_weaken sp a b _ _ _ _ _ _ _
-    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h
+  apply div_n4_max_skip_stack_weaken sp a b h
   -- Unfold the `evmWordIs` / `divScratchValues` bundles on the goal side
   -- to expose matching atoms, then normalize addresses and use the
   -- semantic bridge to rewrite the four output-slot atoms.
@@ -1429,8 +1428,7 @@ theorem evm_mod_n4_max_skip_stack_spec (sp base : Word)
   refine cpsTriple_weaken (fun _ hp => hp) ?_ h_pre
   intro h hq
   simp only [fullModN4MaxSkipPost_unfold, denormModPost_unfold] at hq
-  apply mod_n4_max_skip_stack_weaken sp a b _ _ _ _ _ _ _
-    _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h
+  apply mod_n4_max_skip_stack_weaken sp a b h
   -- Expose address atoms on the goal side via unfolds.
   rw [show evmWordIs sp a =
       ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -61,7 +61,7 @@ def evmMulStackPost (sp : Word) (a b : EvmWord) : Assertion :=
 
     Proved once, invoked from `evm_mul_stack_spec`'s consequence callback. -/
 private theorem mul_stack_weaken (sp : Word) (a b : EvmWord)
-    (v5 v6 v7 v10 v11 sp_v sp8_v sp16_v sp24_v : Word) :
+    {v5 v6 v7 v10 v11 sp_v sp8_v sp16_v sp24_v : Word} :
     ∀ h,
       ((.x12 ↦ᵣ (sp + 32)) **
        (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
@@ -119,7 +119,7 @@ theorem evm_mul_stack_spec (sp base : Word)
       -- `evmWordIs (sp+32) (a*b)` via the mul_correct bridge equalities,
       -- then weaken the 5 scratch registers + 4 below-sp cells to *Own.
       rw [← evmWordIs_sp32_limbs_eq sp (a * b) _ _ _ _ h0 h1 h2 h3] at hq
-      exact mul_stack_weaken sp a b _ _ _ _ _ _ _ _ _ h (by xperm_hyp hq))
+      exact mul_stack_weaken sp a b h (by xperm_hyp hq))
     h_main
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -25,7 +25,8 @@ open EvmAsm.Rv64
 -- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: sign-fill result + frame regs → evmWordIs sign_fill + regOwn. -/
-private theorem sar_sign_fill_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 sign_ext : Word) :
+private theorem sar_sign_fill_evmWord_weaken (sp : Word) {s0 s1 s2 s3 : Word}
+    (r6 r7 r11 : Word) {sign_ext : Word} :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -126,7 +127,7 @@ private theorem sar_sign_fill_lift (sp base : Word)
          ((sp + 48) ↦ₘ BitVec.sshiftRight (value.getLimb 3) 63) **
          ((sp + 56) ↦ₘ BitVec.sshiftRight (value.getLimb 3) 63) **
          (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11)) h := by xperm_hyp hq
-      have hw := sar_sign_fill_evmWord_weaken sp _ _ _ _ r6 r7 r11 _ h hq'
+      have hw := sar_sign_fill_evmWord_weaken sp r6 r7 r11 h hq'
       xperm_hyp hw)
     hflat
 

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
 -- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
-private theorem shr_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
+private theorem shr_zero_evmWord_weaken (sp : Word) {s0 s1 s2 s3 : Word} (r6 r7 r11 : Word) :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -116,7 +116,7 @@ private theorem shr_zero_lift (sp base : Word)
          ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
          ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
          (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11)) h := by xperm_hyp hq
-      have hw := shr_zero_evmWord_weaken sp _ _ _ _ r6 r7 r11 h hq'
+      have hw := shr_zero_evmWord_weaken sp r6 r7 r11 h hq'
       xperm_hyp hw)
     hflat
 

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
 -- `regIs_to_regOwn` lives in `Rv64/SepLogic.lean` (shared).
 
 /-- Weaken: zero-result + frame regs → evmWordIs 0 + regOwn. -/
-private theorem shl_zero_evmWord_weaken (sp : Word) (s0 s1 s2 s3 r6 r7 r11 : Word) :
+private theorem shl_zero_evmWord_weaken (sp : Word) {s0 s1 s2 s3 : Word} (r6 r7 r11 : Word) :
     ∀ h,
     ((.x12 ↦ᵣ (sp + 32)) ** (regOwn .x5) ** (.x0 ↦ᵣ (0 : Word)) ** (regOwn .x10) **
      (sp ↦ₘ s0) ** ((sp + 8) ↦ₘ s1) ** ((sp + 16) ↦ₘ s2) ** ((sp + 24) ↦ₘ s3) **
@@ -116,7 +116,7 @@ private theorem shl_zero_lift (sp base : Word)
          ((sp + 32) ↦ₘ (0 : Word)) ** ((sp + 40) ↦ₘ (0 : Word)) **
          ((sp + 48) ↦ₘ (0 : Word)) ** ((sp + 56) ↦ₘ (0 : Word)) **
          (.x6 ↦ᵣ r6) ** (.x7 ↦ᵣ r7) ** (.x11 ↦ᵣ r11)) h := by xperm_hyp hq
-      have hw := shl_zero_evmWord_weaken sp _ _ _ _ r6 r7 r11 h hq'
+      have hw := shl_zero_evmWord_weaken sp r6 r7 r11 h hq'
       xperm_hyp hw)
     hflat
 


### PR DESCRIPTION
## Summary
Six post-weakening helpers bind register/scratch values then weaken them to \`regOwn\`/\`memOwn\`. Every call site passes \`_\` for all weakened args — the values are fully determined by the input hypothesis type.

Flipping the binders to implicit collapses call sites by 63 underscores total:

| Theorem | File | Flipped args |
|---|---|---|
| \`mul_stack_weaken\` | \`Multiply/Spec.lean\` (private) | 9 |
| \`div_n4_max_skip_stack_weaken\` | \`DivMod/Spec.lean\` | 22 |
| \`mod_n4_max_skip_stack_weaken\` | \`DivMod/Spec.lean\` | 22 |
| \`shr_zero_evmWord_weaken\` | \`Shift/Semantic.lean\` (private) | 4 |
| \`shl_zero_evmWord_weaken\` | \`Shift/ShlSemantic.lean\` (private) | 4 |
| \`sar_sign_fill_evmWord_weaken\` | \`Shift/SarSemantic.lean\` (private) | 5 (4 \`s*\` + \`sign_ext\`) |

Example, before:
\`\`\`lean
apply div_n4_max_skip_stack_weaken sp a b _ _ _ _ _ _ _
  _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ h
\`\`\`
After:
\`\`\`lean
apply div_n4_max_skip_stack_weaken sp a b h
\`\`\`

**#331 literal-safety check**: the 4 private helpers each have a single internal call site; the 2 DivMod weakeners are called once each from the same file. No caller passes a literal for any flipped arg (all are \`_\`).

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)