### PR TITLE
refactor: anonymize 8 single-use isLt bare renames (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -230,8 +230,8 @@ private theorem sub_limb_toNat {aLimb bLimb borrow : Word}
     (aLimb - bLimb - borrow).toNat =
     (aLimb.toNat + 2^64 - bLimb.toNat + 2^64 - borrow.toNat) % 2^64 := by
   simp only [BitVec.toNat_sub]
-  have ha := aLimb.isLt
-  have hb := bLimb.isLt
+  have := aLimb.isLt
+  have := bLimb.isLt
   rcases hborrow with h | h <;> simp only [h] <;> omega
 
 /-- Each limb of a - b equals the borrow-chain result at that limb position. -/

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -91,7 +91,7 @@ theorem mulsub_limb_carry_strict_lt {q v_i u_i carryIn : Word} :
   suffices ba_n + bs_n ≤ 1 by omega
   have h_fs_val : fullSub.toNat = ((q * v_i).toNat + carryIn.toNat) % 2^64 :=
     BitVec.toNat_add (q * v_i) carryIn
-  have h_ci := carryIn.isLt
+  have := carryIn.isLt
   -- Case: ba_n = 0 → immediate
   by_cases h_ba_0 : ba_n = 0
   · omega

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean
@@ -35,7 +35,7 @@ theorem val128_zero_hi (uLo : Word) : val128 0 uLo = uLo.toNat := by
     produces a trial quotient q̂ ∈ {0, 1}. -/
 theorem div_nat_le_one_of_msb (uLo d : Word) (hd : d.toNat ≥ 2^63) :
     uLo.toNat / d.toNat ≤ 1 := by
-  have hulo := uLo.isLt
+  have := uLo.isLt
   have : uLo.toNat / d.toNat < 2 := by
     rw [Nat.div_lt_iff_lt_mul (by omega : 0 < d.toNat)]
     nlinarith
@@ -93,7 +93,7 @@ theorem msb_imp_hi32_ge (b3 : Word) (hmsb : b3.toNat ≥ 2^63) :
     (hi32 b3).toNat ≥ 2^31 := by
   unfold hi32
   rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow]
-  have hb3 := b3.isLt
+  have := b3.isLt
   exact Nat.le_div_iff_mul_le (by positivity) |>.mpr (by omega)
 
 /-- If b3 ≥ 2^63, the full 256-bit divisor b satisfies b ≥ 2^63 * 2^192. -/

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -298,7 +298,7 @@ theorem mulsubN4_c3_le_one_v3_zero (q v0 v1 v2 u0 u1 u2 u3 : Word) :
   let c3 := ms.2.2.2.2
   have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have hv_bound := val256_lt_pow192 v0 v1 v2
-  have hq_bound := q.isLt
+  have := q.isLt
   have hqv_bound : q.toNat * val256 v0 v1 v2 0 < 2 ^ 256 := by nlinarith
   have hc3_bound : c3.toNat * 2 ^ 256 < 2 * 2 ^ 256 := by
     show ms.2.2.2.2.toNat * 2 ^ 256 < 2 * 2 ^ 256; nlinarith

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -302,9 +302,9 @@ theorem val256_split_top_limb (b0 b1 b2 b3 : Word) :
     ∃ v_rest, v_rest < 2^192 ∧
       val256 b0 b1 b2 b3 = b3.toNat * 2^192 + v_rest := by
   refine ⟨b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128, ?_, ?_⟩
-  · have h0 := b0.isLt
-    have h1 := b1.isLt
-    have h2 := b2.isLt
+  · have := b0.isLt
+    have := b1.isLt
+    have := b2.isLt
     -- b_i < 2^64, so b0 + b1*2^64 + b2*2^128 ≤ 2^192 - 1 < 2^192
     nlinarith
   · unfold val256; ring
@@ -585,7 +585,7 @@ theorem div128Quot_first_round_euclidean (uHi dHi : Word) (hdHi_ne : dHi ≠ 0) 
   have hq1_eq : q1.toNat = uHi.toNat / dHi.toNat := rv64_divu_toNat uHi dHi hdHi_ne
   have h_q1_mul_le : q1.toNat * dHi.toNat ≤ uHi.toNat := by
     rw [hq1_eq]; exact Nat.div_mul_le_self _ _
-  have huHi_lt := uHi.isLt
+  have := uHi.isLt
   have h_q1_mul_lt : q1.toNat * dHi.toNat < 2^64 := by omega
   have hmul_toNat : (q1 * dHi).toNat = q1.toNat * dHi.toNat := by
     rw [BitVec.toNat_mul]; exact Nat.mod_eq_of_lt h_q1_mul_lt

--- a/EvmAsm/Rv64/ControlFlow.lean
+++ b/EvmAsm/Rv64/ControlFlow.lean
@@ -199,7 +199,7 @@ theorem loadProgram_at_index {base : Word} {prog : List Instr} {k : Nat}
     (hk : k < prog.length) (h4k : 4 * k < 2^64) :
     loadProgram base prog (base + BitVec.ofNat 64 (4 * k)) = prog[k]? := by
   simp [loadProgram]
-  have hbase := base.isLt
+  have := base.isLt
   have : (18446744073709551616 - BitVec.toNat base + (BitVec.toNat base + 4 * k)) % 18446744073709551616
        = 4 * k := by omega
   rw [this]; simp [hk]; omega

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -309,7 +309,7 @@ theorem loadProgram_programAt {base : Word} {prog : List Instr}
     ProgramAt (loadProgram base prog) base prog := by
   intro i hi
   simp [loadProgram]
-  have hbase := base.isLt
+  have := base.isLt
   have : (18446744073709551616 - BitVec.toNat base + (BitVec.toNat base + 4 * i)) % 18446744073709551616
        = 4 * i := by omega
   rw [this]; simp [hi]; omega


### PR DESCRIPTION
## Summary
Each site binds \`have hX := x.isLt\` but never references \`hX\` by name — the fact is consumed by a subsequent \`omega\` / \`nlinarith\` that picks it up from the local context. Drop the name, leaving \`have := x.isLt\`, so the rename is visible but no longer occupies a named slot.

Matches the pattern from merged PR #844.

Sites (8 total):
- \`Rv64/ControlFlow.lean\` \`loadProgram_at_index\` — \`hbase\`
- \`Rv64/Execution.lean\` \`loadProgram_at_index\` sibling — \`hbase\`
- \`EvmWordArith/Arithmetic.lean\` \`sub_limb_toNat\` — \`ha\`, \`hb\`
- \`EvmWordArith/DivMulSubCarry.lean\` — \`h_ci\`
- \`EvmWordArith/DivN4Lemmas.lean\` — \`hulo\`, \`hb3\`
- \`EvmWordArith/KnuthTheoremB.lean\` \`val256_split_top_limb\` — 3 anon'd (\`h0\`, \`h1\`, \`h2\`)
- \`EvmWordArith/KnuthTheoremB.lean\` (second theorem) — \`huHi_lt\`
- \`EvmWordArith/DivN4Overestimate.lean\` — \`hq_bound\`

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)