### PR TITLE
refactor: anonymize 30+ more single-use isLt bare renames (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -20,7 +20,7 @@ namespace EvmWord
 theorem carry_toNat {x y : Word} :
     (if BitVec.ult (x + y) y then (1 : Word) else 0).toNat =
     (x.toNat + y.toNat) / 2^64 := by
-  have hx := x.isLt; have hy := y.isLt
+  have := x.isLt; have := y.isLt
   have hsum : (x + y).toNat = (x.toNat + y.toNat) % 2^64 := BitVec.toNat_add x y
   split
   · rename_i h; have := (ult_iff).mp h; rw [hsum] at this
@@ -46,7 +46,7 @@ private theorem combined_carry_toNat {x y cin : Word} (hcin : cin.toNat ≤ 1) :
     let cb := if BitVec.ult res cin then (1 : Word) else 0
     (ca ||| cb).toNat = (x.toNat + y.toNat + cin.toNat) / 2^64 := by
   intro psum ca res cb
-  have hx := x.isLt; have hy := y.isLt
+  have := x.isLt; have := y.isLt
   have hca : ca.toNat = (x.toNat + y.toNat) / 2^64 := carry_toNat
   have hpsum : psum.toNat = (x.toNat + y.toNat) % 2^64 := BitVec.toNat_add x y
   have hcb : cb.toNat = (psum.toNat + cin.toNat) / 2^64 := carry_toNat
@@ -103,10 +103,10 @@ theorem add_carry_chain_correct (a b : EvmWord) :
            (b0.toNat + b1.toNat * 2^64 + b2.toNat * 2^128 + b3.toNat * 2^192)
   have hS : (a + b).toNat = S % 2^256 := by rw [hab, ha, hb]
   -- limb bounds
-  have ha0 := a0.isLt; have hb0 := b0.isLt
-  have ha1 := a1.isLt; have hb1 := b1.isLt
-  have ha2 := a2.isLt; have hb2 := b2.isLt
-  have ha3 := a3.isLt; have hb3 := b3.isLt
+  have := a0.isLt; have := b0.isLt
+  have := a1.isLt; have := b1.isLt
+  have := a2.isLt; have := b2.isLt
+  have := a3.isLt; have := b3.isLt
   -- getLimb toNat for (a+b) at each index
   have key0 : ((a + b).getLimb 0).toNat = S % 2^256 % 2^64 := by
     simp only [getLimb, BitVec.extractLsb'_toNat, Nat.shiftRight_eq_div_pow]; rw [hS]; norm_num
@@ -315,10 +315,10 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
     rw [hb2_nat]; split <;> simp
   -- Now prove each limb
   -- Useful bounds
-  have ha0 := a0.isLt; have hb0' := b0.isLt
-  have ha1 := a1.isLt; have hb1' := b1.isLt
-  have ha2 := a2.isLt; have hb2' := b2.isLt
-  have ha3 := a3.isLt; have hb3' := b3.isLt
+  have := a0.isLt; have := b0.isLt
+  have := a1.isLt; have := b1.isLt
+  have := a2.isLt; have := b2.isLt
+  have := a3.isLt; have := b3.isLt
   have ha_sum := toNat_eq_limb_sum a
   have hb_sum := toNat_eq_limb_sum b
   have hab_lt : b.toNat < 2^256 := b.isLt

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -51,7 +51,7 @@ theorem toNat_eq_limb_sum (v : EvmWord) :
   simp only [getLimb, BitVec.extractLsb'_toNat,
     fin4_val_0, fin4_val_1, fin4_val_2, fin4_val_3,
     Nat.zero_mul, Nat.shiftRight_zero]
-  have hv := v.isLt  -- v.toNat < 2^256
+  have := v.isLt  -- v.toNat < 2^256
   omega
 
 -- BitVec.ult ↔ toNat comparison

--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -331,7 +331,7 @@ theorem trial_quotient_ge_256 (u0 u1 u2 u3 v0 v1 v2 : Word) (hv2 : v2 ≠ 0) :
 theorem val256_lt_pow192 (l0 l1 l2 : Word) :
     val256 l0 l1 l2 0 < 2 ^ 192 := by
   unfold val256; simp
-  have h0 := l0.isLt; have h1 := l1.isLt; have h2 := l2.isLt
+  have := l0.isLt; have := l1.isLt; have := l2.isLt
   nlinarith
 
 end EvmWord

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
@@ -60,7 +60,7 @@ private theorem addback_carries_exclusive (u_i v_i carryIn : Word)
   -- Convert to Nat
   have h_ac1 : ac1.toNat = (u_i.toNat + carryIn.toNat) / 2^64 := by
     show (if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0).toNat = _
-    have hci_lt := carryIn.isLt; have hui := u_i.isLt
+    have := carryIn.isLt; have := u_i.isLt
     by_cases h : u_i.toNat + carryIn.toNat < 2^64
     · have : uPlusCarry.toNat ≥ carryIn.toNat := by
         show (u_i + carryIn).toNat ≥ _
@@ -76,7 +76,7 @@ private theorem addback_carries_exclusive (u_i v_i carryIn : Word)
       omega
   have h_ac2 : ac2.toNat = (uPlusCarry.toNat + v_i.toNat) / 2^64 := by
     show (if BitVec.ult uNew v_i then (1 : Word) else 0).toNat = _
-    have hv := v_i.isLt; have hupc := uPlusCarry.isLt
+    have := v_i.isLt; have := uPlusCarry.isLt
     by_cases h : uPlusCarry.toNat + v_i.toNat < 2^64
     · have : uNew.toNat ≥ v_i.toNat := by
         show (uPlusCarry + v_i).toNat ≥ _
@@ -92,7 +92,7 @@ private theorem addback_carries_exclusive (u_i v_i carryIn : Word)
       omega
   rw [h_ac1, h_ac2]
   -- Total: u_i + v_i + carryIn < 2 * 2^64 (since each < 2^64 and carryIn ≤ 1)
-  have hui := u_i.isLt; have hv := v_i.isLt
+  have := u_i.isLt; have := v_i.isLt
   have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
   -- c1 + c2 = (u_i + ci) / B + (upc + v) / B where upc = (u_i + ci) % B
   have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
@@ -140,7 +140,7 @@ theorem addback_limb_nat_word_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat �
     -- Connect ac1, ac2 to division values
     have h_ac1_div : ac1.toNat = (u_i.toNat + carryIn.toNat) / 2^64 := by
       show (if BitVec.ult uPlusCarry carryIn then (1 : Word) else 0).toNat = _
-      have hci_lt := carryIn.isLt; have hui := u_i.isLt
+      have := carryIn.isLt; have := u_i.isLt
       by_cases h : u_i.toNat + carryIn.toNat < 2^64
       · have : ¬(uPlusCarry.toNat < carryIn.toNat) := by
           have : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
@@ -157,7 +157,7 @@ theorem addback_limb_nat_word_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat �
         omega
     have h_ac2_div : ac2.toNat = (uPlusCarry.toNat + v_i.toNat) / 2^64 := by
       show (if BitVec.ult uNew v_i then (1 : Word) else 0).toNat = _
-      have hv := v_i.isLt; have hupc := uPlusCarry.isLt
+      have := v_i.isLt; have := uPlusCarry.isLt
       by_cases h : uPlusCarry.toNat + v_i.toNat < 2^64
       · have : ¬(uNew.toNat < v_i.toNat) := by
           have : uNew.toNat = (uPlusCarry.toNat + v_i.toNat) % 2^64 :=

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
@@ -56,7 +56,7 @@ theorem addback_limb_nat_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat ≤ 1)
   have hc2_01 := add_carry_01 uPlusCarry v_i
   -- Total: u_i + v_i + carryIn = (c1 + c2) * 2^64 + uNew
   -- But c1 + c2 ≤ 1 (the two carries are exclusive)
-  have hu := u_i.isLt; have hv := v_i.isLt
+  have := u_i.isLt; have := v_i.isLt
   have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
   have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
     BitVec.toNat_add u_i carryIn

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -73,7 +73,7 @@ theorem mulsub_limb_nat_eq {q v_i u_i carryIn : Word} :
     BitVec.toNat_add prodLo carryIn
   -- borrowAdd = (prodLo + carryIn) / 2^64 (is 0 or 1)
   have h_ba : borrowAdd.toNat = (prodLo.toNat + carryIn.toNat) / 2^64 := by
-    have hpl := prodLo.isLt; have hci := carryIn.isLt
+    have := prodLo.isLt; have := carryIn.isLt
     by_cases hov : prodLo.toNat + carryIn.toNat < 2^64
     · -- no overflow
       have hge : fullSub.toNat ≥ carryIn.toNat := by rw [h_fs, Nat.mod_eq_of_lt hov]; omega

--- a/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
@@ -30,7 +30,7 @@ theorem add_carry_nat (a b : Word) :
 /-- The carry from addition is 0 or 1. -/
 theorem add_carry_01 (a b : Word) :
     (a.toNat + b.toNat) / 2^64 = 0 ∨ (a.toNat + b.toNat) / 2^64 = 1 := by
-  have ha := a.isLt; have hb := b.isLt
+  have := a.isLt; have := b.isLt
   have : a.toNat + b.toNat < 2 * 2^64 := by omega
   have : (a.toNat + b.toNat) / 2^64 < 2 := Nat.div_lt_of_lt_mul this
   omega
@@ -42,7 +42,7 @@ theorem sub_borrow_nat (a b : Word) :
     let borrow := if a.toNat < b.toNat then 1 else 0
     a.toNat + borrow * 2^64 = (a - b).toNat + b.toNat := by
   intro borrow
-  have ha := a.isLt; have hb := b.isLt
+  have := a.isLt; have := b.isLt
   rw [BitVec.toNat_sub]
   by_cases h : a.toNat < b.toNat
   · simp only [borrow, h, ite_true]; omega

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -49,7 +49,7 @@ theorem halfword_decompose {x : Word} :
       Nat.shiftRight_eq_div_pow, Nat.shiftRight_eq_div_pow]
   simp only [Nat.shiftLeft_eq]
   have h_lo : x.toNat * 2 ^ 32 % 2 ^ 64 / 2 ^ 32 = x.toNat % 2 ^ 32 := by
-    have hx := x.isLt; omega
+    have := x.isLt; omega
   rw [h_lo]
   have := Nat.div_add_mod x.toNat (2 ^ 32)
   omega
@@ -96,7 +96,7 @@ theorem rv64_mulhu_toNat {a b : Word} :
   unfold rv64_mulhu
   simp only [BitVec.toNat_setWidth, BitVec.toNat_ushiftRight,
              BitVec.toNat_mul (n := 128), Nat.shiftRight_eq_div_pow]
-  have ha := a.isLt; have hb := b.isLt
+  have := a.isLt; have := b.isLt
   have hprod : a.toNat * b.toNat < 2 ^ 128 := by nlinarith
   rw [Nat.mod_eq_of_lt (show a.toNat < 2 ^ 128 by omega),
       Nat.mod_eq_of_lt (show b.toNat < 2 ^ 128 by omega),
@@ -128,12 +128,12 @@ theorem partial_product_decompose (q vi : Word) :
 def val128 (hi lo : Word) : Nat := hi.toNat * 2 ^ 64 + lo.toNat
 
 theorem val128_bound {hi lo : Word} : val128 hi lo < 2 ^ 128 := by
-  unfold val128; have hhi := hi.isLt; have hlo := lo.isLt; nlinarith
+  unfold val128; have := hi.isLt; have := lo.isLt; nlinarith
 
 /-- If the high half is less than d, the 128-bit value is less than d * 2^64. -/
 theorem val128_lt_of_hi_lt (hi lo : Word) (d : Nat) (hhi : hi.toNat < d) :
     val128 hi lo < d * 2 ^ 64 := by
-  unfold val128; have hlo := lo.isLt; nlinarith
+  unfold val128; have := lo.isLt; nlinarith
 
 -- ============================================================================
 -- Multi-limb (256-bit) value representation
@@ -150,8 +150,8 @@ theorem val256_eq_fromLimbs_toNat {l0 l1 l2 l3 : Word} :
 
 theorem val256_bound (l0 l1 l2 l3 : Word) : val256 l0 l1 l2 l3 < 2 ^ 256 := by
   unfold val256
-  have h0 := l0.isLt; have h1 := l1.isLt
-  have h2 := l2.isLt; have h3 := l3.isLt
+  have := l0.isLt; have := l1.isLt
+  have := l2.isLt; have := l3.isLt
   nlinarith
 
 /-- Connecting val256 to EvmWord.toNat via getLimb decomposition. -/

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -310,7 +310,7 @@ theorem mulhu_high_equiv (a b : BitVec 64) :
   simp only [to_bits_truncate, get_slice_int, Sail.BitVec.extractLsb, rv64_mulhu, BitVec.toNatInt]
   apply BitVec.eq_of_toNat_eq
   simp
-  have ha := a.isLt; have hb := b.isLt
+  have := a.isLt; have := b.isLt
   omega
 
 theorem mulhu_sail_equiv (sRv : MachineState) (sSail : SailState)


### PR DESCRIPTION
## Summary
Second-pass sweep for \`have hX := x.isLt\` renames where the name is never referenced. Follows the same pattern as merged PR #844 and in-flight PR #1151. Each site binds a name only consumed by a following \`omega\` / \`nlinarith\` that picks it up from local context; dropping the name silences the rename without changing proof behavior.

## Sites (9 files, 30+ renames)
- \`Arithmetic.lean\` — 12 renames in \`carry_toNat\`, \`combined_carry_toNat\`, \`add_carry_chain_correct\`, \`sub_borrow_chain_correct\`
- \`Common.lean\` — 1 rename in \`toNat_eq_limb_sum\`
- \`Div128Lemmas.lean\` — 3 renames in \`val256_lt_pow192\`
- \`DivAddbackCarry.lean\` — 6 renames
- \`DivAddbackLimb.lean\` — 2 renames
- \`DivMulSubLimb.lean\` — 2 renames (only anonymized \`hpl\`/\`hci\` — \`hu\`/\`hfs\` elsewhere are passed to \`rw\` by name)
- \`MulSubChain.lean\` — 4 renames
- \`MultiLimb.lean\` — 8 renames
- \`SailEquiv/MExtProofs.lean\` — 2 renames in \`mulhu_high_equiv\`

## Not touched (named references exist)
- \`ModBridgeUtop.val256_lt_of_b3_bound\` — passes \`h0 h1 h2\` positionally to \`nlinarith [h0, h1, h2, ...]\`
- \`DivMulSubLimb.mulsub_limb_nat_eq\` — \`hu\` and \`hfs\` are rewritten by name in \`rw [... hu hfs ...]\`

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)