### PR TITLE
refactor: anonymize 3 more typed isLt bare renames (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -326,7 +326,7 @@ theorem div128Quot_q1_prime_ge_q_true_1_small_rhatc
     rw [BitVec.toNat_ushiftRight]
     have h32 : (32 : BitVec 6).toNat = 32 := by decide
     rw [h32, Nat.shiftRight_eq_div_pow]
-    have h_ulo : uLo.toNat < 2^64 := uLo.isLt
+    have : uLo.toNat < 2^64 := uLo.isLt
     have h_eq : (2^64 : Nat) = 2^32 * 2^32 := by decide
     exact Nat.div_lt_of_lt_mul (by omega)
   -- KB-LB3: q_true_1 ≤ q1c (instantiated at our div_un1 value).

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -477,7 +477,7 @@ theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
       rw [BitVec.toNat_ushiftRight]
       have h32 : (32 : BitVec 6).toNat = 32 := by decide
       rw [h32, Nat.shiftRight_eq_div_pow]
-      have h_ulo_isLt : uLo.toNat < 2^64 := uLo.isLt
+      have : uLo.toNat < 2^64 := uLo.isLt
       have h_eq : (2^64 : Nat) = 2^32 * 2^32 := by decide
       exact Nat.div_lt_of_lt_mul (by omega)
     -- rhatUn1.toNat = rhatc.toNat * 2^32 + div_un1.toNat.

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -558,7 +558,7 @@ theorem div128Quot_q1_lt_pow33 (uHi dHi : Word)
   have hdHi_ne : dHi ≠ 0 := by
     intro heq; rw [heq] at hdHi_ge; simp at hdHi_ge
   rw [rv64_divu_toNat uHi dHi hdHi_ne]
-  have huHi_lt : uHi.toNat < 2^64 := uHi.isLt
+  have : uHi.toNat < 2^64 := uHi.isLt
   have h_pow : (2:Nat)^33 * 2^31 = 2^64 := by rw [← pow_add]
   set q1 := uHi.toNat / dHi.toNat with hq1_def
   have hq_mul : q1 * dHi.toNat ≤ uHi.toNat := Nat.div_mul_le_self _ _


### PR DESCRIPTION
## Summary
Three more \`have hX : T := x.isLt\` renames (with explicit type annotation) where the bound name is never referenced by name — the fact is consumed by a following \`omega\` picking it up from local context.

Matches the pattern from merged PR #844 and in-flight PR #1151 / #1153. Previous sweeps targeted only untyped \`have hX := x.isLt\`; this one handles the annotated form.

| File | Theorem | Rename |
|---|---|---|
| \`KnuthTheoremB.lean\` | \`div128Quot_q1_lt_pow33\` | \`huHi_lt\` |
| \`Div128QuotientBounds.lean\` | \`div128Quot_q1_prime_lt_pow32\` | \`h_ulo_isLt\` |
| \`Div128KnuthLower.lean\` | \`div128Quot_q1_prime_ge_q_true_1\` | \`h_ulo\` |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)