### PR TITLE
refactor: anonymize 3 more isLt renames in MultiLimb, Arithmetic (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -321,7 +321,7 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
   have := a3.isLt; have := b3.isLt
   have ha_sum := toNat_eq_limb_sum a
   have hb_sum := toNat_eq_limb_sum b
-  have hab_lt : b.toNat < 2^256 := b.isLt
+  have := b.isLt
   have hab_le : b.toNat ≤ a.toNat + 2^256 := by omega
   -- diff0 toNat
   have hdiff0_nat : diff0.toNat = (a0.toNat + 2^64 - b0.toNat) % 2^64 := by

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -166,7 +166,7 @@ theorem val256_eq_toNat (v : EvmWord) :
 /-- Word subtraction wraps mod 2^64. -/
 theorem word_sub_toNat {a b : Word} :
     (a - b).toNat = (a.toNat + 2 ^ 64 - b.toNat) % 2 ^ 64 := by
-  rw [BitVec.toNat_sub]; have hb := b.isLt; omega
+  rw [BitVec.toNat_sub]; have := b.isLt; omega
 
 /-- When a ≥ b at Nat level, subtraction is exact. -/
 theorem word_sub_toNat_of_le (a b : Word) (h : b.toNat ≤ a.toNat) :
@@ -192,7 +192,7 @@ theorem word_sub_cases (a b : Word) :
   · left; exact ⟨BitVec.toNat_sub_of_le (BitVec.le_def.mpr h), h⟩
   · right
     constructor
-    · rw [word_sub_toNat]; have ha := a.isLt; have hb := b.isLt; omega
+    · rw [word_sub_toNat]; have := a.isLt; have := b.isLt; omega
     · omega
 
 -- ============================================================================


### PR DESCRIPTION
## Summary
Three more \`have hX := x.isLt\` / \`have hX : T := x.isLt\` renames where the name is never referenced by name. The fact is consumed by a subsequent \`omega\` picking it up from local context. Matches PR #1151 / #1153 / #1156.

| File | Theorem | Rename |
|---|---|---|
| \`MultiLimb.lean\` | \`word_sub_toNat\` | \`hb\` |
| \`MultiLimb.lean\` | \`word_sub_cases\` (wrap branch) | \`ha\`, \`hb\` |
| \`Arithmetic.lean\` | \`sub_borrow_chain_correct\` | \`hab_lt\` |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)