### PR TITLE
refactor: dedupe 23 'have h32 := by decide' uses, reuse bv6_toNat_32

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -30,6 +30,7 @@ import EvmAsm.Evm64.EvmWordArith.Div128QuotientBounds
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
 
 /-- **KB-3f: No-wraparound for `q1' * dLo`.** Under the call-trial
     precondition, the Word-level product equals the Nat-level product:
@@ -113,8 +114,7 @@ theorem halfword_combine_mod (a b : Word) (hb : b.toNat < 2^32) :
 theorem Word_ushiftRight_32_lt_pow32 {x : Word} :
     (x >>> (32 : BitVec 6).toNat).toNat < 2^32 := by
   rw [BitVec.toNat_ushiftRight]
-  have h32 : (32 : BitVec 6).toNat = 32 := by decide
-  rw [h32, Nat.shiftRight_eq_div_pow]
+  rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
   have : x.toNat < 2^64 := x.isLt
   have : x.toNat / 2^32 < 2^32 := by
     apply Nat.div_lt_of_lt_mul
@@ -140,10 +140,9 @@ theorem Word_ushiftRight_32_lt_pow32 {x : Word} :
 theorem div128Quot_cu_rhat_un1_toNat (rhat' uLo : Word) :
     ((rhat' <<< (32 : BitVec 6).toNat) ||| (uLo >>> (32 : BitVec 6).toNat)).toNat =
     (rhat'.toNat % 2^32) * 2^32 + (uLo >>> (32 : BitVec 6).toNat).toNat := by
-  have h32 : (32 : BitVec 6).toNat = 32 := by decide
-  rw [h32]
+  rw [bv6_toNat_32]
   apply halfword_combine_mod
-  rw [← h32]
+  rw [← bv6_toNat_32]
   exact Word_ushiftRight_32_lt_pow32
 
 /-- **KB-3i: un21.toNat Nat formula.** Composes KB-3f (q1' * dLo no-wrap
@@ -272,13 +271,12 @@ theorem div128Quot_vTop_decomp (vTop : Word) :
     let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     vTop.toNat = dHi.toNat * 2^32 + dLo.toNat := by
   intro dHi dLo
-  have h32 : (32 : BitVec 6).toNat = 32 := by decide
   have h_dHi : dHi.toNat = vTop.toNat / 2^32 := by
     show (vTop >>> (32 : BitVec 6).toNat).toNat = _
-    rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+    rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
   have h_dLo : dLo.toNat = vTop.toNat % 2^32 := by
     show ((vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat = _
-    rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow,
+    rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow,
         BitVec.toNat_shiftLeft]
     simp only [Nat.shiftLeft_eq]
     rw [show (2^64 : Nat) = 2^32 * 2^32 from by decide,
@@ -669,8 +667,7 @@ theorem div128Quot_toNat_eq (uHi uLo vTop : Word) :
         cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' hq0
   show ((q1' <<< (32 : BitVec 6).toNat) ||| q0').toNat =
     (q1'.toNat % 2^32) * 2^32 + q0'.toNat
-  have h32 : (32 : BitVec 6).toNat = 32 := by decide
-  rw [h32]
+  rw [bv6_toNat_32]
   exact halfword_combine_mod q1' q0' hq0
 
 /-- **KB-6a strict: div128Quot output Nat formula without mod.** Composes

--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -31,6 +31,7 @@ import EvmAsm.Evm64.EvmWordArith.Div128QuotientBounds
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
 
 /-- **KB-LB1: Knuth Phase 1 lower bound.** The raw Phase 1 trial
     `rv64_divu uHi dHi` never under-estimates the true first-digit
@@ -137,8 +138,7 @@ theorem div128Quot_q1c_ge_q_true_1
       push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       show q1.toNat / 2^32 = (0 : Word).toNat
       rw [Nat.div_eq_of_lt h]
       rfl
@@ -243,9 +243,8 @@ theorem div128Quot_rhatc_lt_pow32_of_uHi_lt_pow63
     div128Quot_q1_lt_pow32_of_uHi_lt_pow63 uHi dHi hdHi_ne h_uHi_lt hdHi_ge
   have h_hi1 : hi1 = 0 := by
     apply BitVec.eq_of_toNat_eq
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
     show (q1 >>> (32 : BitVec 6).toNat).toNat = (0 : Word).toNat
-    rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+    rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     rw [Nat.div_eq_of_lt h_q1_lt]
     rfl
   -- rhat = uHi mod dHi < dHi.
@@ -324,8 +323,7 @@ theorem div128Quot_q1_prime_ge_q_true_1_small_rhatc
   have h_div_un1_lt : div_un1.toNat < 2^32 := by
     show (uLo >>> (32 : BitVec 6).toNat).toNat < 2^32
     rw [BitVec.toNat_ushiftRight]
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
-    rw [h32, Nat.shiftRight_eq_div_pow]
+    rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     have h_ulo : uLo.toNat < 2^64 := uLo.isLt
     have h_eq : (2^64 : Nat) = 2^32 * 2^32 := by decide
     exact Nat.div_lt_of_lt_mul (by omega)
@@ -345,8 +343,7 @@ theorem div128Quot_q1_prime_ge_q_true_1_small_rhatc
     -- Step 1: Word check ⟺ Nat check (rhatc * 2^32 + div_un1 < q1c * dLo).
     have h_rhatUn1_eq : rhatUn1.toNat = rhatc.toNat * 2^32 + div_un1.toNat := by
       show ((rhatc <<< (32 : BitVec 6).toNat) ||| div_un1).toNat = _
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [h32]
+      rw [bv6_toNat_32]
       exact EvmWord.halfword_combine rhatc div_un1 h_rhatc_lt h_div_un1_lt
     have h_qDlo_eq : (q1c * dLo).toNat = q1c.toNat * dLo.toNat := by
       rw [BitVec.toNat_mul]
@@ -472,8 +469,7 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_pow63
   have h_div_un0_lt : div_un0.toNat < 2^32 := by
     show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
     rw [BitVec.toNat_ushiftRight]
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
-    rw [h32, Nat.shiftRight_eq_div_pow]
+    rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     have h_shl : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
       (uLo <<< (32 : BitVec 6).toNat : Word).isLt
     exact Nat.div_lt_of_lt_mul (by omega)
@@ -544,8 +540,7 @@ theorem div128Quot_q0_prime_plus_2_ge_q_true_0_abstract
   have h_div_un0_lt : div_un0.toNat < 2^32 := by
     show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
     rw [BitVec.toNat_ushiftRight]
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
-    rw [h32, Nat.shiftRight_eq_div_pow]
+    rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     have h_shl : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
       (uLo <<< (32 : BitVec 6).toNat : Word).isLt
     exact Nat.div_lt_of_lt_mul (by omega)
@@ -708,9 +703,8 @@ theorem div128Quot_rhatc_lt_pow32_of_uHi_lt_dHi_mul_pow32
     div128Quot_q1_lt_pow32_of_uHi_lt_dHi_mul_pow32 uHi dHi hdHi_ne h_uHi_lt
   have h_hi1 : hi1 = 0 := by
     apply BitVec.eq_of_toNat_eq
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
     show (q1 >>> (32 : BitVec 6).toNat).toNat = (0 : Word).toNat
-    rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+    rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     rw [Nat.div_eq_of_lt h_q1_lt]
     rfl
   have hdHi_pos : 0 < dHi.toNat :=
@@ -793,8 +787,7 @@ theorem div128Quot_q0_prime_ge_q_true_0_of_un21_lt_dHi_mul_pow32
   have h_div_un0_lt : div_un0.toNat < 2^32 := by
     show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
     rw [BitVec.toNat_ushiftRight]
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
-    rw [h32, Nat.shiftRight_eq_div_pow]
+    rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     have h_shl : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
       (uLo <<< (32 : BitVec 6).toNat : Word).isLt
     exact Nat.div_lt_of_lt_mul (by omega)

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -35,6 +35,7 @@ import EvmAsm.Evm64.EvmWordArith.KnuthTheoremB
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
 
 -- ============================================================================
 -- Piece B: Phase 1a quotient bound (KB-1)
@@ -257,8 +258,7 @@ theorem div128Quot_q1c_le_q1 (uHi dHi : Word) :
       push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       show q1.toNat / 2^32 = (0 : Word).toNat
       rw [Nat.div_eq_of_lt h]
       rfl
@@ -358,11 +358,10 @@ theorem div128Quot_q1c_le_pow32 (uHi dHi dLo : Word)
     div128Quot_q1_le_pow32_plus_one uHi dHi dLo hdHi_ge hdLo_lt huHi_lt_vTop
   by_cases h_hi1 : hi1 = 0
   · -- hi1 = 0 ⟹ q1 < 2^32 ⟹ q1c = q1 < 2^32.
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
     have h_hi1_toNat : hi1.toNat = 0 := by rw [h_hi1]; rfl
     have h_q1_div : q1.toNat / 2^32 = 0 := by
       have : hi1.toNat = q1.toNat / 2^32 := by
-        rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+        rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       omega
     have hq1_lt : q1.toNat < 2^32 := by
       have h_pos : (0 : Nat) < 2^32 := by decide
@@ -376,8 +375,7 @@ theorem div128Quot_q1c_le_pow32 (uHi dHi dLo : Word)
       push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       show q1.toNat / 2^32 = (0 : Word).toNat
       rw [Nat.div_eq_of_lt h]
       rfl
@@ -475,8 +473,7 @@ theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
     have h_div_un1_lt : div_un1.toNat < 2^32 := by
       show (uLo >>> (32 : BitVec 6).toNat).toNat < 2^32
       rw [BitVec.toNat_ushiftRight]
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [h32, Nat.shiftRight_eq_div_pow]
+      rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       have h_ulo_isLt : uLo.toNat < 2^64 := uLo.isLt
       have h_eq : (2^64 : Nat) = 2^32 * 2^32 := by decide
       exact Nat.div_lt_of_lt_mul (by omega)
@@ -484,8 +481,7 @@ theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
     have h_rhatUn1_eq : rhatUn1.toNat =
         rhatc.toNat * 2^32 + div_un1.toNat := by
       show ((rhatc <<< (32 : BitVec 6).toNat) ||| div_un1).toNat = _
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [h32]
+      rw [bv6_toNat_32]
       exact EvmWord.halfword_combine rhatc div_un1 h_rhatc_lt_pow32 h_div_un1_lt
     -- (q1c * dLo).toNat = q1c.toNat * dLo.toNat (no wrap: 2^32 * dLo < 2^64).
     have h_qDlo_eq : (q1c * dLo).toNat = q1c.toNat * dLo.toNat := by
@@ -578,8 +574,7 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     have h_div_un0_lt : div_un0.toNat < 2^32 := by
       show ((uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat < 2^32
       rw [BitVec.toNat_ushiftRight]
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [h32, Nat.shiftRight_eq_div_pow]
+      rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       have h_shl_isLt : (uLo <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
         (uLo <<< (32 : BitVec 6).toNat : Word).isLt
       have h_eq_64 : (2^64 : Nat) = 2^32 * 2^32 := by decide
@@ -588,8 +583,7 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     have h_rhat2Un0_eq : rhat2Un0.toNat =
         rhat2c.toNat * 2^32 + div_un0.toNat := by
       show ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0).toNat = _
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [h32]
+      rw [bv6_toNat_32]
       exact EvmWord.halfword_combine rhat2c div_un0 h_rhat2c_lt_pow32 h_div_un0_lt
     -- (q0c * dLo).toNat = q0c.toNat * dLo.toNat (no wrap).
     have h_q0Dlo_eq : (q0c * dLo).toNat = q0c.toNat * dLo.toNat := by
@@ -611,9 +605,8 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
       exact decide_eq_true h_ult
     -- Guard `rhat2cHi = 0` holds since rhat2c < 2^32.
     have h_rhat2c_hi_zero : rhat2c >>> (32 : BitVec 6).toNat = 0 := by
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
       apply BitVec.eq_of_toNat_eq
-      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       show rhat2c.toNat / 2^32 = 0
       exact Nat.div_eq_of_lt h_rhat2c_lt_pow32
     show (div128Quot_phase2b_q0' q0c rhat2c dLo div_un0).toNat < 2^32

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -78,6 +78,7 @@ import EvmAsm.Evm64.EvmWordArith.DenormLemmas
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64 EvmWord
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
 
 /-- Scale invariance of integer division on val256: multiplying both operands
     by `2^s` doesn't change the quotient. Entry point for lifting normalized
@@ -539,8 +540,7 @@ theorem knuth_theorem_b_from_clz
 theorem div128Quot_dHi_ge_pow31 (vTop : Word) (h : vTop.toNat ≥ 2^63) :
     (vTop >>> (32 : BitVec 6).toNat).toNat ≥ 2^31 := by
   rw [BitVec.toNat_ushiftRight]
-  have h32 : (32 : BitVec 6).toNat = 32 := by decide
-  rw [h32, Nat.shiftRight_eq_div_pow]
+  rw [bv6_toNat_32, Nat.shiftRight_eq_div_pow]
   have h1 : (2:Nat)^63 / 2^32 ≤ vTop.toNat / 2^32 := Nat.div_le_div_right h
   have h2 : (2:Nat)^63 / 2^32 = 2^31 := by decide
   omega
@@ -644,8 +644,7 @@ theorem div128Quot_first_round_correction (uHi dHi : Word)
     push Not at h
     apply hhi1_nz
     apply BitVec.eq_of_toNat_eq
-    have h32 : (32 : BitVec 6).toNat = 32 := by decide
-    rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+    rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
     show q1.toNat / 2^32 = (0 : Word).toNat
     rw [Nat.div_eq_of_lt h]
     rfl
@@ -740,8 +739,7 @@ theorem div128Quot_q1c_lt_pow33 (uHi dHi : Word) (hdHi_ge : dHi.toNat ≥ 2^31) 
       push Not at h
       apply h_hi1
       apply BitVec.eq_of_toNat_eq
-      have h32 : (32 : BitVec 6).toNat = 32 := by decide
-      rw [BitVec.toNat_ushiftRight, h32, Nat.shiftRight_eq_div_pow]
+      rw [BitVec.toNat_ushiftRight, bv6_toNat_32, Nat.shiftRight_eq_div_pow]
       show q1.toNat / 2^32 = (0 : Word).toNat
       rw [Nat.div_eq_of_lt h]
       rfl


### PR DESCRIPTION
## Summary
Each of the 4 Div128/Knuth files repeated \`have h32 : (32 : BitVec 6).toNat = 32 := by decide\` — **23 times** across multiple theorems. The theorem \`EvmAsm.Rv64.AddrNorm.bv6_toNat_32\` already provides this fact (tagged \`@[rv64_addr, grind =]\`).

Add \`open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)\` at the top of each file, then delete each local \`have h32\` and inline \`bv6_toNat_32\` into the immediately-following \`rw [h32, ...]\` (and the one \`rw [← h32]\` in \`div128Quot_cu_rhat_un1_toNat\`).

Net impact: **-19 lines**, **-23 duplicate \`by decide\` invocations** replaced with references to the cached theorem.

## Files
| File | Sites | Theorems touched |
|---|--:|---|
| \`Div128FinalAssembly.lean\` | 4 | \`Word_ushiftRight_32_lt_pow32\`, \`div128Quot_cu_rhat_un1_toNat\`, \`div128Quot_vTop_decompose\`, KB-6a |
| \`Div128QuotientBounds.lean\` | 8 | phase1a/phase1b decrement & phase2b bounds |
| \`Div128KnuthLower.lean\` | 8 | LB4-helpers, KB-LB5/LB6/LB7/LB8 |
| \`KnuthTheoremB.lean\` | 3 | \`vTop_ushift32_ge_pow31\`, \`q1_lt_pow33\` + phase1a decrement |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)