### PR TITLE
refactor: dedupe 12 'have h_se_neg1 := by decide' uses

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -144,8 +144,7 @@ theorem div128Quot_q1c_ge_q_true_1
       rfl
     show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≥ _
     rw [if_neg h_hi1]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
     rw [show q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
@@ -384,8 +383,7 @@ theorem div128Quot_q1_prime_ge_q_true_1_small_rhatc
     rw [if_pos h_check]
     have h_q1c_pos : q1c.toNat ≥ 1 :=
       div128Quot_phase1b_check_implies_q1c_pos q1c dLo rhatUn1 h_check
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_q1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
     rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt_word]

--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -117,8 +117,7 @@ theorem div128Quot_phase1b_quotient_bound (uHi dHi : Word)
     have h_q1'_eq : q1'.toNat = q1c.toNat - 1 := by
       show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat = _
       rw [if_pos h_check]
-      have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-      rw [BitVec.toNat_add, h_se_neg1]
+      rw [BitVec.toNat_add, signExtend12_4095_toNat]
       have h_q1c_lt : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
       rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
           Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt]
@@ -184,8 +183,7 @@ theorem div128Quot_q1_prime_lt_pow33 (uHi dHi : Word)
     have h_q1'_eq : q1'.toNat = q1c.toNat - 1 := by
       show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat = _
       rw [if_pos h_check]
-      have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-      rw [BitVec.toNat_add, h_se_neg1]
+      rw [BitVec.toNat_add, signExtend12_4095_toNat]
       have h_q1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
       rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
           Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt_word]
@@ -264,8 +262,7 @@ theorem div128Quot_q1c_le_q1 (uHi dHi : Word) :
       rfl
     show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
     rw [if_neg h_hi1]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
     rw [show q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
@@ -290,8 +287,7 @@ theorem div128Quot_q1_prime_le_q1c (q1c dLo rhatUn1 : Word) :
   · have h_q1c_pos := div128Quot_phase1b_check_implies_q1c_pos q1c dLo rhatUn1 h_check
     show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095 else q1c).toNat ≤ _
     rw [if_pos h_check]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_q1c_lt : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
     rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt]
@@ -383,8 +379,7 @@ theorem div128Quot_q1c_le_pow32 (uHi dHi dLo : Word)
       rfl
     show (if hi1 = 0 then q1 else q1 + signExtend12 4095).toNat ≤ _
     rw [if_neg h_hi1]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
     rw [show q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt hq1_lt_word]
@@ -509,8 +504,7 @@ theorem div128Quot_q1_prime_lt_pow32 (uHi dHi dLo uLo : Word)
     show (if BitVec.ult rhatUn1 (q1c * dLo) then q1c + signExtend12 4095
           else q1c).toNat < 2^32
     rw [if_pos h_check]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_q1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega
     rw [show q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt h_q1c_lt_word]
@@ -620,8 +614,7 @@ theorem div128Quot_q0_prime_lt_pow32 (un21 dHi dLo uLo : Word)
     unfold div128Quot_phase2b_q0'
     rw [if_pos h_rhat2c_hi_zero]
     rw [if_pos h_check]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_q0c_lt_word : q0c.toNat - 1 < 2^64 := by have := q0c.isLt; omega
     rw [show q0c.toNat + (2^64 - 1) = (q0c.toNat - 1) + 2^64 from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt h_q0c_lt_word]

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -650,9 +650,8 @@ theorem div128Quot_first_round_correction (uHi dHi : Word)
     rw [Nat.div_eq_of_lt h]
     rfl
   -- q1c.toNat = q1.toNat - 1
-  have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
   have hq1c_toNat : (q1 + signExtend12 4095).toNat = q1.toNat - 1 := by
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have : q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 := by omega
     rw [this, Nat.add_mod_right]
     exact Nat.mod_eq_of_lt (by have := q1.isLt; omega)
@@ -733,7 +732,6 @@ theorem div128Quot_q1c_lt_pow33 (uHi dHi : Word) (hdHi_ge : dHi.toNat ≥ 2^31) 
     exact hq1_lt
   · -- q1c = q1 + (-1). q1 ≥ 1, so q1c.toNat = q1.toNat - 1 < q1.toNat < 2^33.
     simp only [q1c, h_hi1, ↓reduceIte]
-    have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
     -- q1.toNat ≥ 2^32 (from hi1 ≠ 0)
     have hq1_ge : q1.toNat ≥ 2^32 := by
       by_contra h
@@ -745,7 +743,7 @@ theorem div128Quot_q1c_lt_pow33 (uHi dHi : Word) (hdHi_ge : dHi.toNat ≥ 2^31) 
       show q1.toNat / 2^32 = (0 : Word).toNat
       rw [Nat.div_eq_of_lt h]
       rfl
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_eq : q1.toNat + (2^64 - 1) = (q1.toNat - 1) + 2^64 := by omega
     rw [h_eq, Nat.add_mod_right]
     have hq1_lt_word : q1.toNat - 1 < 2^64 := by have := q1.isLt; omega
@@ -849,9 +847,8 @@ theorem div128Quot_phase1b_correction_eucl
     (q1c + signExtend12 4095).toNat * dHi.toNat +
       (rhatc + dHi).toNat = uHi.toNat := by
   -- q1' = q1c - 1
-  have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide
   have hq1'_toNat : (q1c + signExtend12 4095).toNat = q1c.toNat - 1 := by
-    rw [BitVec.toNat_add, h_se_neg1]
+    rw [BitVec.toNat_add, signExtend12_4095_toNat]
     have h_eq : q1c.toNat + (2^64 - 1) = (q1c.toNat - 1) + 2^64 := by omega
     rw [h_eq, Nat.add_mod_right]
     have hq1c_lt_word : q1c.toNat - 1 < 2^64 := by have := q1c.isLt; omega


### PR DESCRIPTION
## Summary
Companion to PR #1158 (\`bv6_toNat_32\` dedupe). 12 repetitions of
\`have h_se_neg1 : (signExtend12 (4095 : BitVec 12) : Word).toNat = 2^64 - 1 := by decide\`
across three Div128/Knuth files. The theorem \`signExtend12_4095_toNat\` in \`DivN4Overestimate.lean\` already provides this fact.

Delete each local \`have h_se_neg1\` and replace \`rw [..., h_se_neg1]\` with \`rw [..., signExtend12_4095_toNat]\`.

Net: **-12 lines**, **-12 duplicate \`by decide\` invocations**.

| File | Sites |
|---|--:|
| \`KnuthTheoremB.lean\` | 3 |
| \`Div128QuotientBounds.lean\` | 7 |
| \`Div128KnuthLower.lean\` | 2 |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)