### PR TITLE
refactor: drop 5 unused 'with h…_def' annotations from set tactics

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -80,7 +80,7 @@ theorem div128Quot_q_true_1_lt_pow32
     (h_div_un1_lt : div_un1.toNat < 2^32)
     (huHi_lt_vTop : uHi.toNat < dHi.toNat * 2^32 + dLo.toNat) :
     (uHi.toNat * 2^32 + div_un1.toNat) / (dHi.toNat * 2^32 + dLo.toNat) < 2^32 := by
-  set vTop_nat := dHi.toNat * 2^32 + dLo.toNat with h_vTop_def
+  set vTop_nat := dHi.toNat * 2^32 + dLo.toNat
   have h_vTop_pos : 0 < vTop_nat :=
     Nat.lt_of_le_of_lt (Nat.zero_le _) huHi_lt_vTop
   have h_num_lt : uHi.toNat * 2^32 + div_un1.toNat < vTop_nat * 2^32 := by

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -62,14 +62,14 @@ theorem hq_over_from_second_carry_one (q : Word) {v0 v1 v2 v3 u0 u1 u2 u3 : Word
   rw [show (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = (1 : Word) from hc3_one] at hmulsub
   rw [word_toNat_1] at hmulsub
   -- First addback: val256(un) + val256(v) = val256(ab1) + 0 * 2^256 = val256(ab1)
-  set ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3 with hms_def
+  set ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
   have hab1 := addbackN4_val256_eq ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
   simp only [] at hab1
   have hc1_val : (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3).toNat = 0 := by
     rw [hcarry_zero]; decide
   rw [hc1_val] at hab1
   -- Second addback: val256(ab1) + val256(v) = val256(ab') + 1 * 2^256
-  set ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3 with hab_def
+  set ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
   have hab' := addbackN4_val256_eq ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3
   simp only [] at hab'
   rw [hcarry2_one] at hab'

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -221,7 +221,7 @@ theorem knuth_q_r_v_nat_bound
     (hu_next_lt : u_next < 2^64) :
     (u_top * 2^64 + u_next) / v_top * v_nat < u_nat + 2 * v_nat := by
   set u_hat := u_top * 2^64 + u_next with hu_hat_def
-  set q_r := u_hat / v_top with hq_r_def
+  set q_r := u_hat / v_top
   -- Basic facts
   have hv_top_pos : 0 < v_top := by
     have : (0:Nat) < 2^63 := by positivity
@@ -616,7 +616,7 @@ theorem div128Quot_first_round_correction (uHi dHi : Word)
     (rv64_divu uHi dHi + signExtend12 4095).toNat * dHi.toNat +
       (uHi - rv64_divu uHi dHi * dHi + dHi).toNat = uHi.toNat := by
   set q1 := rv64_divu uHi dHi with hq1_def
-  set rhat := uHi - q1 * dHi with hrhat_def
+  set rhat := uHi - q1 * dHi
   -- Nat-level facts
   have hq1_eq : q1.toNat = uHi.toNat / dHi.toNat := rv64_divu_toNat uHi dHi hdHi_ne
   have h_eucl : q1.toNat * dHi.toNat + rhat.toNat = uHi.toNat := by


### PR DESCRIPTION
## Summary
Five \`set X := … with hXd\` invocations across 3 files where \`hXd\` is never referenced anywhere else in the proof. The \`with hXd\` clause adds an extra hypothesis binding only useful when downstream tactics rewrite using it.

| File | Theorem | Annotation |
|---|---|---|
| \`DivN4DoubleAddback.lean\` | \`mulsub_double_addback_val256_combined\` | \`hms_def\`, \`hab_def\` |
| \`KnuthTheoremB.lean\` | \`knuth_q_r_v_nat_bound\` | \`hq_r_def\` |
| \`KnuthTheoremB.lean\` | \`div128Quot_first_round_euclidean_aux\` | \`hrhat_def\` |
| \`Div128KnuthLower.lean\` | \`div128Quot_q_true_1_lt_pow32\` | \`h_vTop_def\` |

No semantic change; just drops dead names.

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)