### PR TITLE
refactor: drop 2 more unused 'with h…' annotations from set tactics

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -401,7 +401,7 @@ theorem div128Quot_call_skip_mul_val256_b_le_val256_a
   -- mulsubN4 Euclidean: val256(u) + c3 * 2^256 = val256(un) + qHat * val256(v')
   have h_mulsub := mulsubN4_val256_eq qHat b0' b1' b2' b3' u0 u1 u2 u3
   simp only [] at h_mulsub
-  set ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3 with hms
+  set ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
   -- Normalization: val256(u) + u4 * 2^256 = val256(a) * 2^shift.
   have h_norm_u := u_val256_eq_scaled_with_overflow a0 a1 a2 a3 b3 hshift_nz
   have h_norm_v := b3_prime_val256_eq_scaled b0 b1 b2 b3 hshift_nz

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -109,7 +109,7 @@ theorem mulsub_limb_nat_eq {q v_i u_i carryIn : Word} :
   -- Combine: normalize 2^64 to the literal everywhere
   have hB : (2:Nat)^64 = 18446744073709551616 := by norm_num
   -- Use B as shorthand for 2^64 literal
-  set B := (18446744073709551616 : Nat) with hBdef
+  set B := (18446744073709551616 : Nat)
   rw [show (2:Nat)^64 = B from by omega] at h_ba h_fs h_prod hdm hu hfs h_un ⊢
   -- Key: from hdm, (prodLo + carryIn) / B * B + fullSub = prodLo + carryIn
   have hkey : (prodLo.toNat + carryIn.toNat) / B * B =


### PR DESCRIPTION
## Summary
Companion to PR #1160 (same pattern, caught by a subsequent scan for unused \`set ... with ...\` names without the \`_def\` suffix).

| File | Theorem | Annotation |
|---|---|---|
| \`Div128CallSkipClose.lean\` | \`div128Quot_call_skip_eq_val256_div\` | \`hms\` |
| \`DivMulSubLimb.lean\` | \`mulsub_limb_nat_eq\` | \`hBdef\` |

No semantic change; just drops dead names.

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)