### PR TITLE
refactor: anonymize 4 unused Nat.div_add_mod bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Lemmas.lean
@@ -70,7 +70,7 @@ theorem val128_mod_unique (uHi uLo : Word) (d q r : Nat)
     (heq : val128 uHi uLo = d * q + r) :
     r = val128 uHi uLo % d := by
   have hq := val128_div_unique uHi uLo d q r hr heq
-  have hdm := Nat.div_add_mod (val128 uHi uLo) d
+  have := Nat.div_add_mod (val128 uHi uLo) d
   subst hq; nlinarith [Nat.mul_comm d (val128 uHi uLo / d)]
 
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -127,7 +127,7 @@ theorem single_iteration_correct {uVal vVal q_digit r_val : Nat}
     q_digit = uVal / vVal ∧ r_val = uVal % vVal ∧ r_val < vVal := by
   have ⟨hq, hr_lt⟩ := remainder_lt_of_ge_floor hv heuclidean hge
   subst hq
-  have h_mod := Nat.div_add_mod uVal vVal
+  have := Nat.div_add_mod uVal vVal
   refine ⟨rfl, ?_, hr_lt⟩
   nlinarith [Nat.mul_comm vVal (uVal / vVal)]
 

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -83,7 +83,7 @@ theorem word_mod_lt (a b : Word) (hb : b ≠ 0) :
 theorem rv64_divu_euclidean (a b : Word) (hb : b ≠ 0) :
     a.toNat = (rv64_divu a b).toNat * b.toNat + a.toNat % b.toNat := by
   rw [rv64_divu_toNat a b hb]
-  have h := Nat.div_add_mod a.toNat b.toNat
+  have := Nat.div_add_mod a.toNat b.toNat
   linarith [Nat.mul_comm b.toNat (a.toNat / b.toNat)]
 
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -54,7 +54,7 @@ theorem val256_ms_un_eq_val256_mod_max_skip
   -- Substitute `qHat = val256(a)/val256(b)` into the mulsub equation, then
   -- compare with `Nat.div_add_mod` to conclude.
   rw [hq] at hmulsub
-  have hdam := Nat.div_add_mod (val256 a0 a1 a2 a3) (val256 b0 b1 b2 b3)
+  have := Nat.div_add_mod (val256 a0 a1 a2 a3) (val256 b0 b1 b2 b3)
   have hmulcomm : val256 b0 b1 b2 b3 * (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) =
       (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) * val256 b0 b1 b2 b3 := Nat.mul_comm _ _
   omega


### PR DESCRIPTION
## Summary
Four \`have X := Nat.div_add_mod …\` bindings where the bound name is never referenced. The fact is consumed by a following \`nlinarith\`/\`omega\`/\`linarith\` picking it up from local context. Same pattern as the \`.isLt\` sweeps in PR #844, #1151, #1153, #1156, #1157.

| File | Theorem | Rename |
|---|---|---|
| \`MultiLimb.lean\` | \`rv64_divu_euclidean\` | \`h\` |
| \`Div128Lemmas.lean\` | \`val128_mod_unique\` | \`hdm\` |
| \`DivRemainderBound.lean\` | \`q_digit_eq_div_and_rem\` | \`h_mod\` |
| \`Val256ModBridge.lean\` | \`val256_mod_eq_ms_un_val256_max_skip_core\` | \`hdam\` |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)