### PR TITLE
refactor: anonymize 8 more unused proof bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -332,7 +332,7 @@ theorem clzResult_fst_eq_zero_iff {val : Word} :
     (clzResult val).1 = 0 ↔ val >>> (63 : Nat) ≠ 0 := by
   constructor
   · intro h
-    have hge := clz_zero_imp_msb h
+    have := clz_zero_imp_msb h
     intro heq
     have : (val >>> (63 : Nat)).toNat = 0 := by rw [heq]; rfl
     rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow] at this

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -33,7 +33,7 @@ namespace EvmWord
 private theorem prodLo_le_one_of_mulhu_max {q v_i : Word}
     (h : (rv64_mulhu q v_i).toNat = 2^64 - 2) :
     (q * v_i).toNat ≤ 1 := by
-  have hprod := partial_product_decompose q v_i
+  have := partial_product_decompose q v_i
   have hmax : q.toNat * v_i.toNat ≤ (2^64 - 1) * (2^64 - 1) :=
     Nat.mul_le_mul (by omega : q.toNat ≤ 2^64 - 1) (by omega : v_i.toNat ≤ 2^64 - 1)
   -- q * v_i = (2^64 - 2) * 2^64 + (q * v_i).toNat
@@ -62,7 +62,7 @@ theorem mulsub_limb_carry_strict_lt {q v_i u_i carryIn : Word} :
     let borrowSub := if BitVec.ult u_i fullSub then (1 : Word) else 0
     borrowAdd.toNat + prodHi.toNat + borrowSub.toNat < 2^64 := by
   intro prodLo prodHi fullSub borrowAdd borrowSub
-  have h_ph := mulhu_toNat_le q v_i
+  have := mulhu_toNat_le q v_i
   -- Work with Nat-level values: ba_n, bs_n ∈ {0, 1}
   set ba_n := if fullSub.toNat < carryIn.toNat then 1 else 0 with h_ba_def
   set bs_n := if u_i.toNat < fullSub.toNat then 1 else 0 with h_bs_def

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -28,7 +28,7 @@ open EvmAsm.Rv64.AddrNorm (word_toNat_0 word_toNat_1)
 theorem val256_div_lt_pow64 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) (hb3nz : b3 ≠ 0) :
     val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 ≤ 2^64 - 1 := by
   have hb_ge := val256_ge_pow192_of_limb3 b0 b1 b2 b3 hb3nz
-  have ha_lt := val256_bound a0 a1 a2 a3
+  have := val256_bound a0 a1 a2 a3
   -- val256(a) < 2^256 = 2^64 * 2^192 ≤ 2^64 * val256(b)
   -- So val256(a) / val256(b) < 2^64
   have hb_pos : 0 < val256 b0 b1 b2 b3 := by omega
@@ -262,7 +262,7 @@ theorem mulsubN4_c3_eq_zero_or_one {q v0 v1 v2 v3 u0 u1 u2 u3 : Word}
     (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 1) :
     (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 0 ∨
     (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1 := by
-  have hle := mulsubN4_c3_le_one hbnz hq_over
+  have := mulsubN4_c3_le_one hbnz hq_over
   rcases Nat.eq_zero_or_pos (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2.toNat with h | h
   · left; bv_omega
   · right; bv_omega

--- a/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivRemainderBound.lean
@@ -44,13 +44,13 @@ theorem quotient_le_of_euclidean {a b q r : Nat} (hb : 0 < b)
     gives `q = a/b`. Then `r = a - (a/b)*b = a mod b < b`. -/
 theorem remainder_lt_of_ge_floor {a b q r : Nat} (hb : 0 < b)
     (heq : a = q * b + r) (hge : a / b ≤ q) : q = a / b ∧ r < b := by
-  have hle := quotient_le_of_euclidean hb heq
+  have := quotient_le_of_euclidean hb heq
   have hqeq : q = a / b := by omega
   subst hqeq
   constructor
   · rfl
-  · have h1 := Nat.div_add_mod a b
-    have h2 := Nat.mod_lt a hb
+  · have := Nat.div_add_mod a b
+    have := Nat.mod_lt a hb
     nlinarith [Nat.mul_comm b (a / b)]
 
 -- ============================================================================
@@ -104,7 +104,7 @@ theorem mulsub_addback_correct {uVal vVal qNat rAbVal : Nat}
     (h_combined : uVal = rAbVal + (qNat - 1) * vVal)
     (hge : uVal / vVal + 1 ≤ qNat) :
     qNat - 1 = uVal / vVal ∧ rAbVal < vVal := by
-  have hge0 := Nat.zero_le (uVal / vVal)
+  have := Nat.zero_le (uVal / vVal)
   have hq1 : qNat ≥ 1 := by omega
   have heq : uVal = (qNat - 1) * vVal + rAbVal := by omega
   have hge' : uVal / vVal ≤ qNat - 1 := by omega


### PR DESCRIPTION
## Summary
Eight more \`have hX := ...\` bindings across 4 files where the name is never referenced. The fact is consumed by a following \`omega\`/\`nlinarith\`/\`bv_omega\` picking it up from local context. Pattern matches PR #1151/#1153/#1156/#1157/#1162 sweeps.

| File | Theorem | Renames |
|---|---|---|
| \`DivMulSubCarry.lean\` | \`prodLo_le_one_of_mulhu_max\` | \`hprod\` |
| \`DivMulSubCarry.lean\` | \`mulsub_limb_carry_strict_lt\` | \`h_ph\` |
| \`CLZLemmas.lean\` | \`clzResult_fst_eq_zero_iff\` | \`hge\` |
| \`DivRemainderBound.lean\` | \`remainder_lt_of_ge_floor\` | \`hle\`, \`h1\`, \`h2\` |
| \`DivRemainderBound.lean\` | \`mulsub_addback_correct\` | \`hge0\` |
| \`DivN4Overestimate.lean\` | \`val256_div_lt_pow64\` | \`ha_lt\` |
| \`DivN4Overestimate.lean\` | \`mulsubN4_c3_eq_zero_or_one\` | \`hle\` |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)