### PR TITLE
refactor: anonymize 6 more unused proof bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128QuotientBounds.lean
@@ -78,7 +78,7 @@ theorem div128Quot_phase1a_quotient_bound (uHi dHi : Word)
     exact (Nat.le_div_iff_mul_le hdHi_pos).mpr (by nlinarith)
   · -- uHi.toNat / dHi.toNat ≤ q1c.toNat + 1: from uHi < (q1c+2)*dHi.
     have h_lt : uHi.toNat < (q1c.toNat + 2) * dHi.toNat := by nlinarith
-    have h_div_lt := (Nat.div_lt_iff_lt_mul hdHi_pos).mpr h_lt
+    have := (Nat.div_lt_iff_lt_mul hdHi_pos).mpr h_lt
     omega
 
 /-- **KB-2: Phase 1b quotient bound.** After Phase 1b's multiplication-check

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -228,7 +228,7 @@ theorem mulsub_4limb_euclidean_div (qNat : Nat)
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have h_chain := mulsub_chain_no_underflow qNat u0 u1 u2 u3 v0 v1 v2 v3
+  have := mulsub_chain_no_underflow qNat u0 u1 u2 u3 v0 v1 v2 v3
     r0 r1 r2 r3 cb0 cb1 cb2 h0 h1 h2 h3
   -- Connect fromLimbs.toNat to val256
   have ha : a.toNat = val256 u0 u1 u2 u3 := by

--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -248,7 +248,7 @@ theorem n4_max_double_addback_correct {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
       0 b0 b1 b2 b3
     simp only [] at hab'_eq
     rw [hcarry2_lem] at hab'_eq
-    have hab_lem_bound := val256_bound
+    have := val256_bound
       (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).1
       (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.1
       (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0 b1 b2 b3).2.2.1

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -363,7 +363,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   -- Bounds
   have hv_pos := val256_pos_of_or_ne_zero hbnz
   have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
-  have hab1_bound := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+  have := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
   have hab'_result_bound := val256_bound
     (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).1
     (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).2.1
@@ -502,7 +502,7 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have hv_bound := val256_bound v0 v1 v2 v3
   have hu_bound := val256_bound u0 u1 u2 u3
-  have hab_bound := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
+  have := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
   have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero hbnz
   -- q * val256(v) > val256(u) (from c3 = 1, i.e., borrow)
   have hqv_gt_u : q.toNat * val256 v0 v1 v2 v3 > val256 u0 u1 u2 u3 := by nlinarith

--- a/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MaxTrialVacuity.lean
@@ -130,7 +130,7 @@ theorem u_top_lt_pow63_of_shift_nz (a3 shift : Word)
 theorem b3_shifted_ge_pow63 {b3 : Word} (hb3nz : b3 ≠ 0) :
     (b3 <<< ((clzResult b3).1.toNat % 64)).toNat ≥ 2^63 := by
   obtain ⟨hinv, hcount⟩ := clzPipeline_invariant b3
-  have hsnd_ge := clzPipeline_snd_ge_pow62 hb3nz
+  have := clzPipeline_snd_ge_pow62 hb3nz
   have hsnd_lt : (clzPipeline b3).2.toNat < 2^64 := (clzPipeline b3).2.isLt
   rw [clzResult_fst_eq]
   by_cases h5 : (clzPipeline b3).2 >>> 63 ≠ 0


### PR DESCRIPTION
## Summary
Six more \`have hX := …\` bindings where the name is never referenced, extending the #694 sweep pattern. All sites have tactics consuming the fact via context (\`omega\`/\`nlinarith\`/\`linarith\`).

| File | Theorem | Rename |
|---|---|---|
| \`MaxTrialVacuity.lean\` | \`b3_shifted_ge_pow63\` | \`hsnd_ge\` |
| \`DivMulSubLimb.lean\` | \`mulsub_4limb_euclidean_div_no_underflow\` | \`h_chain\` |
| \`DivN4DoubleAddback.lean\` | \`n4_max_double_addback_correct\` | \`hab_lem_bound\` |
| \`Div128QuotientBounds.lean\` | \`div128Quot_phase1a_quotient_bound\` | \`h_div_lt\` |
| \`DivN4Overestimate.lean\` | \`n4_max_addback_correct\` | \`hab1_bound\` |
| \`DivN4Overestimate.lean\` | (second site in same file) | \`hab_bound\` |

## Test plan
- [x] \`lake build\` — full 3564-job build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)