### PR TITLE
refactor: anonymize 3 unused hbnd bindings in CLZLemmas (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -231,7 +231,7 @@ private theorem clzPipeline_zero {val : Word} (h : (clzPipeline val).1 = 0) :
 theorem clz_zero_imp_msb {val : Word} (h : (clzResult val).1 = 0) :
     val.toNat ≥ 2^63 := by
   rw [clzResult_fst_eq] at h
-  have hbnd := clzPipeline_fst_le val
+  have := clzPipeline_fst_le val
   split at h
   · -- Stage 5 passed: pipeline count = 0
     rename_i h5_pass
@@ -252,7 +252,7 @@ theorem clz_zero_imp_msb {val : Word} (h : (clzResult val).1 = 0) :
 theorem clz_zero_imp_snd {val : Word} (h : (clzResult val).1 = 0) :
     (clzResult val).2 = val := by
   rw [clzResult_fst_eq] at h
-  have hbnd := clzPipeline_fst_le val
+  have := clzPipeline_fst_le val
   split at h
   · rw [clzResult_snd_eq]; exact clzPipeline_zero h
   · exfalso
@@ -268,7 +268,7 @@ theorem clz_zero_imp_snd {val : Word} (h : (clzResult val).1 = 0) :
 theorem clzResult_fst_toNat_le (val : Word) :
     (clzResult val).1.toNat ≤ 63 := by
   rw [clzResult_fst_eq]
-  have hbnd := clzPipeline_fst_le val
+  have := clzPipeline_fst_le val
   split
   · omega
   · rw [BitVec.toNat_add, Nat.mod_eq_of_lt (by have := se_1; omega)]


### PR DESCRIPTION
## Summary
- Anonymize `have hbnd := clzPipeline_fst_le val` bindings in three theorems in `CLZLemmas.lean`. In each case the fact is consumed via context by `omega`, never referenced by name.
- Affected theorems: `clz_zero_imp_msb`, `clz_zero_imp_snd`, `clzResult_fst_toNat_le`.
- Part of #694.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.CLZLemmas`

🤖 Generated with [Claude Code](https://claude.com/claude-code)