### PR TITLE
refactor: drop dead 'have hresult_limb0' in evm_byte_body_evmWord_spec

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -599,7 +599,6 @@ theorem evm_byte_body_evmWord_spec (sp base : Word)
     byte_getLimb_high idx value (2 : Fin 4) (by decide)
   have hresult_high3 : getLimb result 3 = 0 :=
     byte_getLimb_high idx value (3 : Fin 4) (by decide)
-  have hresult_limb0 := byte_correct idx value hlt
   have hlimb_val : limbFromMsb.toNat = i0.toNat / 8 := by
     show (i0 >>> (3 : BitVec 6).toNat).toNat = i0.toNat / 8
     rw [bv6_toNat_3]; simp [BitVec.toNat_ushiftRight]; omega


### PR DESCRIPTION
## Summary
- Drop dead `have hresult_limb0 := byte_correct idx value hlt` in `evm_byte_body_evmWord_spec` (`Byte/Spec.lean`). The binding is never referenced by name and removing it leaves the proof building successfully — the `bridge` helper below uses `rw [byte_correct idx value hlt]` directly.

## Test plan
- [x] \`lake build EvmAsm.Evm64.Byte.Spec\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)