### PR TITLE
refactor: anonymize 15 unused proof bindings in Shift compose files (#694)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -528,7 +528,7 @@ private theorem shr_bridge_merge (value : EvmWord) (s0 : Word)
     simp only [bs, signExtend12_63]
     rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
-  have hbs_lt : bs.toNat < 64 := by omega
+  have : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   rw [getLimb_ushiftRight, hL_div,
@@ -868,17 +868,17 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
         show value >>> shift.toNat = value >>> s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have hlt4 : limbShift.toNat < 4 := by
+        have : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-        have hn0 : limbShift.toNat ≠ 0 :=
+        have : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
-        have hn1 : limbShift.toNat ≠ 1 :=
+        have : limbShift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 1).toNat
             simp only [zero_add_se12_1_toNat]
             exact hc))
-        have hn2 : limbShift.toNat ≠ 2 :=
+        have : limbShift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 2).toNat
             simp only [zero_add_se12_2_toNat]

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -656,7 +656,7 @@ private theorem sar_bridge_merge (value : EvmWord) (s0 : Word)
     simp only [bs, signExtend12_63]
     rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
-  have hbs_lt : bs.toNat < 64 := by omega
+  have : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- sshiftRight agrees with ushiftRight for merge limbs
@@ -1026,17 +1026,17 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
         show BitVec.sshiftRight value shift.toNat = BitVec.sshiftRight value s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have hlt4 : limbShift.toNat < 4 := by
+        have : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-        have hn0 : limbShift.toNat ≠ 0 :=
+        have : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
-        have hn1 : limbShift.toNat ≠ 1 :=
+        have : limbShift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 1).toNat
             simp only [zero_add_se12_1_toNat]
             exact hc))
-        have hn2 : limbShift.toNat ≠ 2 :=
+        have : limbShift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 2).toNat
             simp only [zero_add_se12_2_toNat]

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -494,7 +494,7 @@ private theorem shl_bridge_merge (value : EvmWord) (s0 : Word)
     simp only [bs, signExtend12_63]
     rw [BitVec.toNat_and, bv64_toNat_63]
     exact Nat.and_two_pow_sub_one_eq_mod s0.toNat 6
-  have hbs_lt : bs.toNat < 64 := by omega
+  have : bs.toNat < 64 := by omega
   have hL_div : s0.toNat / 64 = L := by
     rw [← hL, bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
   -- Use getLimb_shiftLeft: i*64 >= s0.toNat since i >= L+1 and s0.toNat = L*64 + bs < (L+1)*64
@@ -844,17 +844,17 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
         show value <<< shift.toNat = value <<< s0.toNat; congr 1
       have hL : (s0 >>> (6 : BitVec 6).toNat).toNat = 3 := by
         obtain ⟨h0, h1, h2⟩ := hls
-        have hlt4 : limbShift.toNat < 4 := by
+        have : limbShift.toNat < 4 := by
           show (s0 >>> (6 : BitVec 6).toNat).toNat < 4
           rw [bv6_toNat_6]; simp [BitVec.toNat_ushiftRight]; omega
-        have hn0 : limbShift.toNat ≠ 0 :=
+        have : limbShift.toNat ≠ 0 :=
           fun hc => h0 (BitVec.eq_of_toNat_eq (by simpa using hc))
-        have hn1 : limbShift.toNat ≠ 1 :=
+        have : limbShift.toNat ≠ 1 :=
           fun hc => h1 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 1).toNat
             simp only [zero_add_se12_1_toNat]
             exact hc))
-        have hn2 : limbShift.toNat ≠ 2 :=
+        have : limbShift.toNat ≠ 2 :=
           fun hc => h2 (BitVec.eq_of_toNat_eq (by
             show limbShift.toNat = ((0 : Word) + signExtend12 2).toNat
             simp only [zero_add_se12_2_toNat]


### PR DESCRIPTION
## Summary
- Anonymize 15 unused proof bindings (`hbs_lt`, `hlt4`, `hn0`, `hn1`, `hn2`) across `Shift/Compose.lean`, `Shift/ShlCompose.lean`, and `Shift/SarCompose.lean` — the same pattern appears in all three shift-opcode compose theorems.
- Each fact is consumed by the subsequent `omega` via context; none are referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.Shift.Compose EvmAsm.Evm64.Shift.ShlCompose EvmAsm.Evm64.Shift.SarCompose\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)