### PR TITLE
refactor: anonymize 2 unused hlen bindings in DivMod LimbSpec (#694)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/LoopSetup.lean
@@ -96,7 +96,7 @@ theorem divK_loopSetup_spec (sp n v1 v5 : Word)
       rw [beq_iff_eq] at heq; subst heq
       simp only [Option.some.injEq] at h; subst h
       show divK_loopSetup_code bltOff base (base + 12) = _
-      have hlen : (divK_loopSetup bltOff).length = 4 := by
+      have : (divK_loopSetup bltOff).length = 4 := by
         unfold divK_loopSetup LD ADDI single seq; rfl
       exact CodeReq.ofProg_lookup base (divK_loopSetup bltOff) 3
         (by omega) (by omega)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/PhaseC2.lean
@@ -99,7 +99,7 @@ theorem divK_phaseC2_spec (sp shift v2 shiftMem : Word)
       rw [beq_iff_eq] at heq; subst heq
       simp only [Option.some.injEq] at h; subst h
       show divK_phaseC2_code shift0_off base (base + 12) = _
-      have hlen : (divK_phaseC2 shift0_off).length = 4 := by
+      have : (divK_phaseC2 shift0_off).length = 4 := by
         unfold divK_phaseC2 SD ADDI single seq; rfl
       exact CodeReq.ofProg_lookup base (divK_phaseC2 shift0_off) 3
         (by omega) (by omega)


### PR DESCRIPTION
## Summary
- Anonymize \`have hlen : (divK_phaseC2 _).length = 4\` in \`DivMod/LimbSpec/PhaseC2.lean\` and the analogous binding for \`divK_loopSetup\` in \`DivMod/LimbSpec/LoopSetup.lean\`.
- Each length fact is consumed by the adjacent \`by omega\` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2 EvmAsm.Evm64.DivMod.LimbSpec.LoopSetup\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)