### PR TITLE
refactor: anonymize unused hcancel binding in CodeRegion (#694)

### DIFF
--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -161,7 +161,7 @@ theorem evmCodeIs_split_at (base : Word) (bytes : List (BitVec 8)) (dw : Nat)
       have heq : (bytes.drop 8).length = bytes.length - 8 := by simp
       rw [heq]
       have h8 : 8 ≤ bytes.length := by omega
-      have hcancel : bytes.length - 8 + 8 = bytes.length := Nat.sub_add_cancel h8
+      have : bytes.length - 8 + 8 = bytes.length := Nat.sub_add_cancel h8
       omega
     rw [ih (base + 8) (bytes.drop 8) hdw']; clear hdw'
     -- Normalize addresses


### PR DESCRIPTION
## Summary
- Anonymize `have hcancel : bytes.length - 8 + 8 = bytes.length` in `CodeRegion.lean`. The fact is consumed by the subsequent `omega` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.CodeRegion\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)