### PR TITLE
refactor: anonymize hshift_toNat bindings in Shift compose files (#694)

### DIFF
--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -799,7 +799,7 @@ theorem evm_shr_body_evmWord_spec (sp base : Word)
   have hbody3_w := cpsTriple_weaken
     (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
-  have hshift_toNat : shift.toNat = s0.toNat :=
+  have : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   -- from Phase C postcondition into body postcondition conversion.

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -955,7 +955,7 @@ theorem evm_sar_body_evmWord_spec (sp base : Word)
   have hbody3_w := cpsTriple_weaken
     (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
-  have hshift_toNat : shift.toNat = s0.toNat :=
+  have : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   let resultPost :=

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -773,7 +773,7 @@ theorem evm_shl_body_evmWord_spec (sp base : Word)
   have hbody3_w := cpsTriple_weaken
     (fun h hp => hp) (fun h hq => body_post_weaken h (by xperm_hyp hq)) hbody3_f
   -- Bitvector bridge: common facts
-  have hshift_toNat : shift.toNat = s0.toNat :=
+  have : shift.toNat = s0.toNat :=
     EvmWord.toNat_eq_getLimb0_of_high_zero hhigh_zero
   -- Body bridge specs: use cpsTriple_strip_pure_and_convert to thread pure dispatch fact
   let resultPost :=


### PR DESCRIPTION
## Summary
- Anonymize `have hshift_toNat : shift.toNat = s0.toNat` in `Shift/Compose.lean`, `Shift/ShlCompose.lean`, and `Shift/SarCompose.lean`.
- The fact is picked up via context by the `congr 1` step inside each body-dispatch lambda's `have hresult` proof and never referenced by name.
- Part of #694. Companion to #1170 which anonymized the other unused bindings in the same files.

## Test plan
- [x] \`lake build EvmAsm.Evm64.Shift.Compose EvmAsm.Evm64.Shift.ShlCompose EvmAsm.Evm64.Shift.SarCompose\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)