### PR TITLE
refactor(DivMod): inline _max/_call_iter_spec wrappers into _iter_spec (#283)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -559,90 +559,12 @@ theorem divK_loop_body_n1_call_unified_j0_spec
       J0
 
 -- ============================================================================
--- Fin-parametric iter specs for n=1
--- ============================================================================
-
-/-- Fin-parametric unified max-path iter spec for n=1. -/
-theorem divK_loop_body_n1_max_iter_spec (j : Fin 4)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old))
-      (loopIterPostN1Max sp (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · exact divK_loop_body_n1_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · exact divK_loop_body_n1_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · exact divK_loop_body_n1_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · exact divK_loop_body_n1_max_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-
-/-- Fin-parametric unified call-path iter spec for n=1. -/
-theorem divK_loop_body_n1_call_iter_spec (j : Fin 4)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN1Call sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · exact divK_loop_body_n1_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n1_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n1_call_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-
--- ============================================================================
 -- Single `(j : Fin 4) (bltu : Bool)` iter spec for n=1
 -- ============================================================================
 
 /-- Unified iter spec for n=1: one theorem covering all 16 original path combinations.
-    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
-    need vacuous dischargers — they pass the reduced hypothesis directly. -/
+    Dispatches directly to per-j `_unified_j{k}_spec` specs via `fin_cases j` +
+    Fin-residue cleanup from `AddrNorm.fin_id_*` helpers. -/
 theorem divK_loop_body_n1_iter_spec (j : Fin 4) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
@@ -664,25 +586,32 @@ theorem divK_loop_body_n1_iter_spec (j : Fin 4) (bltu : Bool)
                     v5_old v6_old v7_old v10_old v11_old v2_old
                     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old)
       (loopIterPostN1 bltu sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro exit_addr
   cases bltu
-  · -- false (max): halign reduces to True, hbltu to ¬ult, hcarry to max variant
+  · -- false (max)
     rw [if_neg (by decide)] at hbltu hcarry
-    have H := divK_loop_body_n1_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN1; simp only []; rw [sepConj_emp_right']; exact hp)
-      H
-  · -- true (call): halign, hbltu, hcarry reduce to call-path types
+    delta loopBodyPre
+    simp only [loopIterPostN1, sepConj_emp_right']
+    fin_cases j
+    · exact divK_loop_body_n1_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n1_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n1_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n1_max_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+  · -- true (call)
     rw [if_pos rfl] at halign hbltu hcarry
-    have H := divK_loop_body_n1_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN1; simp only []; exact hp)
-      H
+    delta loopBodyPreWithScratch loopBodyPre
+    simp only [loopIterPostN1, sepConj_assoc']
+    fin_cases j
+    · exact divK_loop_body_n1_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n1_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n1_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n1_call_unified_j3_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -723,81 +723,6 @@ theorem divK_loop_n2_call_max_spec
 -- Unifies j ∈ {0, 1, 2} into one theorem via Fin 3 + fin_cases dispatch.
 -- ============================================================================
 
-/-- Fin-parametric unified max-path iter spec for n=2.
-    Dispatches over `j : Fin 3` via `fin_cases` to the existing per-j unified specs.
-    Exit address depends on j: j=0 exits loop (base+denormOff), j>0 loops back (base+loopBodyOff). -/
-theorem divK_loop_body_n2_max_iter_spec (j : Fin 3)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old))
-      (loopIterPostN2Max sp (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · -- j = 0: exit_addr reduces to base + denormOff
-    exact divK_loop_body_n2_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · -- j = 1: exit_addr reduces to base + loopBodyOff
-    exact divK_loop_body_n2_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · -- j = 2: exit_addr reduces to base + loopBodyOff
-    exact divK_loop_body_n2_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-
-/-- Fin-parametric unified call-path iter spec for n=2 (intermediate, to be absorbed into _iter_spec). -/
-theorem divK_loop_body_n2_call_iter_spec (j : Fin 3)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN2Call sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · exact divK_loop_body_n2_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n2_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-
 -- ============================================================================
 -- Single `(j : Fin 3) (bltu : Bool)` iter spec for n=2
 -- Combines Fin-parametric j with Bool-parametric bltu → one theorem per n.
@@ -805,8 +730,8 @@ theorem divK_loop_body_n2_call_iter_spec (j : Fin 3)
 -- ============================================================================
 
 /-- Unified iter spec for n=2: one theorem covering all 12 original path combinations.
-    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
-    need vacuous dischargers — they pass the reduced hypothesis directly. -/
+    Dispatches directly to per-j `_unified_j{k}_spec` specs via `fin_cases j` after
+    unfolding `loopBodyPre` / `loopBodyPreWithScratch` / `loopIterPostN2`. -/
 theorem divK_loop_body_n2_iter_spec (j : Fin 3) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
@@ -828,25 +753,28 @@ theorem divK_loop_body_n2_iter_spec (j : Fin 3) (bltu : Bool)
                     v5_old v6_old v7_old v10_old v11_old v2_old
                     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old)
       (loopIterPostN2 bltu sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro exit_addr
   cases bltu
   · -- false (max)
     rw [if_neg (by decide)] at hbltu hcarry
-    have H := divK_loop_body_n2_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN2; simp only []; rw [sepConj_emp_right']; exact hp)
-      H
+    delta loopBodyPre
+    simp only [loopIterPostN2, sepConj_emp_right']
+    fin_cases j
+    · exact divK_loop_body_n2_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n2_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n2_max_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
   · -- true (call)
     rw [if_pos rfl] at halign hbltu hcarry
-    have H := divK_loop_body_n2_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN2; simp only []; exact hp)
-      H
+    delta loopBodyPreWithScratch loopBodyPre
+    simp only [loopIterPostN2, sepConj_assoc']
+    fin_cases j
+    · exact divK_loop_body_n2_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n2_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n2_call_unified_j2_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN3.lean
@@ -685,82 +685,12 @@ theorem divK_loop_n3_call_max_spec
     full
 
 -- ============================================================================
--- Fin-parametric iter specs for n=3
--- ============================================================================
-
-/-- Fin-parametric unified max-path iter spec for n=3. -/
-theorem divK_loop_body_n3_max_iter_spec (j : Fin 2)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Max v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old))
-      (loopIterPostN3Max sp (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · exact divK_loop_body_n3_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-  · exact divK_loop_body_n3_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry2_nz
-
-/-- Fin-parametric unified call-path iter spec for n=3. -/
-theorem divK_loop_body_n3_call_iter_spec (j : Fin 2)
-    (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
-    (ret_mem d_mem dlo_mem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u3 v2)
-    (hcarry2_nz : isAddbackCarry2NzN3Call v0 v1 v2 v3 u0 u1 u2 u3 u_top) :
-    let u_base := sp + signExtend12 4056 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let q_addr := sp + signExtend12 4088 - (j.val : Word) <<< (3 : BitVec 6).toNat
-    let exit_addr := if j.val = 0 then base + denormOff else base + loopBodyOff
-    cpsTriple (base + loopBodyOff) exit_addr (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (j.val : Word)) **
-       (.x5 ↦ᵣ v5_old) ** (.x6 ↦ᵣ v6_old) **
-       (.x7 ↦ᵣ v7_old) ** (.x10 ↦ᵣ v10_old) ** (.x11 ↦ᵣ v11_old) **
-       (.x2 ↦ᵣ v2_old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ j_old) ** (sp + signExtend12 3984 ↦ₘ (3 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((u_base + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((u_base + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((u_base + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((u_base + signExtend12 4072) ↦ₘ u3) **
-       ((u_base + signExtend12 4064) ↦ₘ u_top) **
-       (q_addr ↦ₘ q_old) **
-       (sp + signExtend12 3968 ↦ₘ ret_mem) **
-       (sp + signExtend12 3960 ↦ₘ d_mem) **
-       (sp + signExtend12 3952 ↦ₘ dlo_mem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopIterPostN3Call sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro u_base q_addr exit_addr
-  fin_cases j
-  · exact divK_loop_body_n3_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-  · exact divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry2_nz
-
--- ============================================================================
 -- Single `(j : Fin 2) (bltu : Bool)` iter spec for n=3
 -- ============================================================================
 
 /-- Unified iter spec for n=3: one theorem covering all 8 original path combinations.
-    Uses `if bltu then ... else ...` hypothesis API so concrete-bltu call sites don't
-    need vacuous dischargers — they pass the reduced hypothesis directly. -/
+    Dispatches directly to per-j `_unified_j{k}_spec` specs via `fin_cases j` after
+    unfolding `loopBodyPre` / `loopBodyPreWithScratch` / `loopIterPostN3`. -/
 theorem divK_loop_body_n3_iter_spec (j : Fin 2) (bltu : Bool)
     (sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old : Word)
@@ -782,23 +712,24 @@ theorem divK_loop_body_n3_iter_spec (j : Fin 2) (bltu : Bool)
                     v5_old v6_old v7_old v10_old v11_old v2_old
                     v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old)
       (loopIterPostN3 bltu sp base (j.val : Word) v0 v1 v2 v3 u0 u1 u2 u3 u_top) := by
-  intro exit_addr
   cases bltu
-  · rw [if_neg (by decide)] at hbltu hcarry
-    have H := divK_loop_body_n3_max_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN3; simp only []; rw [sepConj_emp_right']; exact hp)
-      H
-  · rw [if_pos rfl] at halign hbltu hcarry
-    have H := divK_loop_body_n3_call_iter_spec j sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
-      v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
-    intro_lets at H
-    exact cpsTriple_weaken
-      (fun _ hp => by delta loopBodyPreWithScratch loopBodyPre at hp; xperm_hyp hp)
-      (fun _ hp => by unfold loopIterPostN3; simp only []; exact hp)
-      H
+  · -- false (max)
+    rw [if_neg (by decide)] at hbltu hcarry
+    delta loopBodyPre
+    simp only [loopIterPostN3, sepConj_emp_right']
+    fin_cases j
+    · exact divK_loop_body_n3_max_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+    · exact divK_loop_body_n3_max_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old base hbltu hcarry
+  · -- true (call)
+    rw [if_pos rfl] at halign hbltu hcarry
+    delta loopBodyPreWithScratch loopBodyPre
+    simp only [loopIterPostN3, sepConj_assoc']
+    fin_cases j
+    · exact divK_loop_body_n3_call_unified_j0_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
+    · exact divK_loop_body_n3_call_unified_j1_spec sp j_old v5_old v6_old v7_old v10_old v11_old v2_old
+        v0 v1 v2 v3 u0 u1 u2 u3 u_top q_old ret_mem d_mem dlo_mem scratch_un0 base halign hbltu hcarry
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- Delete 6 intermediate Fin-dispatch wrappers (`_max_iter_spec` + `_call_iter_spec` in `LoopComposeN{1,2,3}.lean`)
- Inline their `fin_cases j` dispatch directly into each file's `_iter_spec` using `delta` + `sepConj_assoc'` normalization
- Net: **−190 LOC** (278 deletions, 88 insertions); one `_iter_spec` per n remains as the sole entry point, matching #283's API target

## Pattern
```lean
cases bltu
· rw [if_neg (by decide)] at hbltu hcarry
  delta loopBodyPre
  simp only [loopIterPostN{k}, sepConj_emp_right']
  fin_cases j
  · exact _max_unified_j0_spec ...
  ...
· rw [if_pos rfl] at halign hbltu hcarry
  delta loopBodyPreWithScratch loopBodyPre
  simp only [loopIterPostN{k}, sepConj_assoc']
  fin_cases j
  · exact _call_unified_j0_spec ...
```

## Files touched
EvmAsm/Evm64/DivMod/LoopComposeN1.lean (−71 LOC)
EvmAsm/Evm64/DivMod/LoopComposeN2.lean (−67 LOC)
EvmAsm/Evm64/DivMod/LoopComposeN3.lean (−59 LOC)

## Test plan
 - [x] lake build green (3564/3564 jobs)
 - [x] No downstream callers of deleted wrappers (grep-verified: only self-references inside each file)

