### PR TITLE
refactor: anonymize 8 unused have bindings in Div128CallSkipClose (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -77,14 +77,14 @@ theorem knuth_compose_qHat_vTop_le_nat_v2
         (rhat' % 2^32) * 2^64 + div_un1 * 2^32 := by ring
     linarith
   -- uHi * 2^64 = q1' * dHi * 2^64 + rhat' * 2^64 (Phase 1b Euclidean ×2^64).
-  have h_uHi_mul : uHi * 2^64 = q1' * dHi * 2^64 + rhat' * 2^64 := by
+  have : uHi * 2^64 = q1' * dHi * 2^64 + rhat' * 2^64 := by
     have h_expand : (q1' * dHi + rhat') * 2^64 =
         q1' * dHi * 2^64 + rhat' * 2^64 := by ring
     have := congr_arg (· * 2^64) h_ph1_eucl
     simp only at this
     linarith
   -- Decompose rhat' * 2^64 = (rhat'/2^32)*2^96 + (rhat' % 2^32)*2^64.
-  have h_rhat_split : rhat' * 2^64 =
+  have : rhat' * 2^64 =
       (rhat' / 2^32) * 2^96 + (rhat' % 2^32) * 2^64 := by
     have h_div_mod : (rhat' / 2^32) * 2^32 + rhat' % 2^32 = rhat' := by
       have := Nat.div_add_mod rhat' (2^32)
@@ -112,7 +112,7 @@ theorem knuth_compose_qHat_vTop_le_nat_v2
     linarith
   -- (3) q0' * dLo ≤ rhat2' * 2^32 + div_un0 (given).
   -- (4) (rhat' / 2^32) * 2^96 ≥ 0 (Nat).
-  have h_high_ge : 0 ≤ (rhat' / 2^32) * 2^96 := Nat.zero_le _
+  have : 0 ≤ (rhat' / 2^32) * 2^96 := Nat.zero_le _
   -- Combine.
   linarith
 
@@ -417,17 +417,17 @@ theorem div128Quot_call_skip_mul_val256_b_le_val256_a
       val256 a0 a1 a2 a3 * 2^(clzResult b3).1.toNat := by
     -- h_mulsub: val256 u0..u3 + ms.2.2.2.2.toNat * 2^256 = val256 un + qHat * val256 v'
     -- So qHat * val256 v' = val256 u + c3 * 2^256 - val256 un.
-    have hv_bound : val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 < 2^256 := h_un_bound
+    have : val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 < 2^256 := h_un_bound
     -- Combine: qHat * val256 v' ≤ val256 u + c3 * 2^256.
-    have h1 : qHat.toNat * val256 b0' b1' b2' b3' ≤
+    have : qHat.toNat * val256 b0' b1' b2' b3' ≤
         val256 u0 u1 u2 u3 + ms.2.2.2.2.toNat * 2^256 := by omega
     -- Use c3 ≤ u4.
-    have h2 : val256 u0 u1 u2 u3 + ms.2.2.2.2.toNat * 2^256 ≤
+    have : val256 u0 u1 u2 u3 + ms.2.2.2.2.toNat * 2^256 ≤
         val256 u0 u1 u2 u3 + u4.toNat * 2^256 := by
       apply Nat.add_le_add_left
       exact Nat.mul_le_mul_right _ h_c3_le
     -- Use h_norm_u.
-    have h3 : val256 u0 u1 u2 u3 + u4.toNat * 2^256 =
+    have : val256 u0 u1 u2 u3 + u4.toNat * 2^256 =
         val256 a0 a1 a2 a3 * 2^(clzResult b3).1.toNat := h_norm_u
     omega
   -- Now use h_norm_v to rewrite val256(v') = val256(b) * 2^shift.
@@ -553,7 +553,7 @@ theorem q_true_full_lt_q_true_1_succ_mul_pow32_nat
   have h_num_lt : uHi * 2^64 + div_un1 * 2^32 + div_un0 <
       vTop_nat * (q_true_1 + 1) * 2^32 := by
     have h_plus_one : uHi * 2^32 + div_un1 + 1 ≤ vTop_nat * (q_true_1 + 1) := h_lt
-    have h_mul_1 : (uHi * 2^32 + div_un1 + 1) * 2^32 ≤
+    have : (uHi * 2^32 + div_un1 + 1) * 2^32 ≤
         vTop_nat * (q_true_1 + 1) * 2^32 :=
       Nat.mul_le_mul_right _ h_plus_one
     have h_expand_lhs : (uHi * 2^32 + div_un1 + 1) * 2^32 =


### PR DESCRIPTION
## Summary
- Anonymize 8 unused local `have hX : ...` bindings in `Div128CallSkipClose.lean`:
  - `h_uHi_mul`, `h_rhat_split`, `h_high_ge` in `knuth_compose_qHat_vTop_le_nat_v2`
  - `hv_bound`, `h1`, `h2`, `h3` in the skip-borrow upper-bound chain
  - `h_mul_1` in `q_true_full_lt_q_true_1_succ_mul_pow32_nat`
- Each fact is consumed by the adjacent `linarith`/`omega` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)