### PR TITLE
refactor: anonymize 7 unused have bindings across 5 files (#694)

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -536,7 +536,7 @@ theorem getLimb_sshiftRight_sign' {v : EvmWord} {n : Nat} {i : Fin 4}
   rw [BitVec.getLsbD_sshiftRight]
   have h1 : ¬(256 ≤ i.val * 64 + j) := by omega
   simp only [h1, decide_false, Bool.not_false, Bool.true_and]
-  have hnd : n / 64 * 64 ≤ n := Nat.div_mul_le_self n 64
+  have : n / 64 * 64 ≤ n := Nat.div_mul_le_self n 64
   have hge : ¬(n + (i.val * 64 + j) < 256) := by omega
   simp only [hge, ↓reduceIte]
   simp only [BitVec.getElem_sshiftRight, BitVec.getElem_extractLsb']

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -30,8 +30,8 @@ theorem ult_one_eq_zero {x : Word} : BitVec.ult x 1 ↔ x = 0 := by
     have h1 := of_decide_eq_true h
     change x.toNat < (1 : Word).toNat at h1
     apply BitVec.eq_of_toNat_eq
-    have h1eq : (1 : Word).toNat = 1 := by decide
-    have h0eq : (0 : Word).toNat = 0 := by decide
+    have : (1 : Word).toNat = 1 := by decide
+    have : (0 : Word).toNat = 0 := by decide
     omega
   · intro h; subst h; decide
 

--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -110,7 +110,7 @@ theorem bv_udiv_add_umod {n : Nat} {x y : BitVec n} :
   simp only [BitVec.toNat_add, BitVec.toNat_mul, BitVec.toNat_udiv, BitVec.toNat_umod]
   have hdiv := Nat.div_add_mod x.toNat y.toNat
   have hx := x.isLt
-  have hmul_le : y.toNat * (x.toNat / y.toNat) ≤ x.toNat := by omega
+  have : y.toNat * (x.toNat / y.toNat) ≤ x.toNat := by omega
   rw [Nat.mod_eq_of_lt (by omega : y.toNat * (x.toNat / y.toNat) < 2 ^ n),
       hdiv, Nat.mod_eq_of_lt hx]
 
@@ -121,7 +121,7 @@ theorem bv_udiv_umod_unique {n : Nat} {a b q r : BitVec n}
     (hno : b.toNat * q.toNat + r.toNat < 2 ^ n)
     (h : a = b * q + r) :
     q = a / b ∧ r = a % b := by
-  have hr_nat : r.toNat < b.toNat := BitVec.lt_def.mp hr
+  have : r.toNat < b.toNat := BitVec.lt_def.mp hr
   have h_eq := congrArg BitVec.toNat h
   simp only [BitVec.toNat_add, BitVec.toNat_mul] at h_eq
   rw [Nat.mod_eq_of_lt (by omega : b.toNat * q.toNat < 2 ^ n),

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean
@@ -93,7 +93,7 @@ private theorem addback_carries_exclusive (u_i v_i carryIn : Word)
   rw [h_ac1, h_ac2]
   -- Total: u_i + v_i + carryIn < 2 * 2^64 (since each < 2^64 and carryIn ≤ 1)
   have := u_i.isLt; have := v_i.isLt
-  have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
+  have : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
   -- c1 + c2 = (u_i + ci) / B + (upc + v) / B where upc = (u_i + ci) % B
   have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
     BitVec.toNat_add u_i carryIn

--- a/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean
@@ -57,7 +57,7 @@ theorem addback_limb_nat_eq (u_i v_i carryIn : Word) (hci : carryIn.toNat ≤ 1)
   -- Total: u_i + v_i + carryIn = (c1 + c2) * 2^64 + uNew
   -- But c1 + c2 ≤ 1 (the two carries are exclusive)
   have := u_i.isLt; have := v_i.isLt
-  have htot : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
+  have : u_i.toNat + v_i.toNat + carryIn.toNat < 2 * 2^64 := by omega
   have hupc : uPlusCarry.toNat = (u_i.toNat + carryIn.toNat) % 2^64 :=
     BitVec.toNat_add u_i carryIn
   -- If c1 = 1 then uPlusCarry is small, so c2 = 0


### PR DESCRIPTION
## Summary
- Anonymize 7 unused `have` bindings spanning `Basic.lean`, `EvmWordArith/Common.lean`, `EvmWordArith/Div.lean`, `EvmWordArith/DivAddbackCarry.lean`, and `EvmWordArith/DivAddbackLimb.lean`.
  - `hnd`, `h1eq`, `h0eq`, `hmul_le`, `hr_nat`, and two `htot` sites.
- Each fact is consumed by the adjacent `omega` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.Basic EvmAsm.Evm64.EvmWordArith.Common EvmAsm.Evm64.EvmWordArith.Div EvmAsm.Evm64.EvmWordArith.DivAddbackCarry EvmAsm.Evm64.EvmWordArith.DivAddbackLimb\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)