### PR TITLE
refactor: anonymize 7 more unused have bindings in DivMulSub* (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean
@@ -101,13 +101,13 @@ theorem mulsub_limb_carry_strict_lt {q v_i u_i carryIn : Word} :
   have h_ov : fullSub.toNat < carryIn.toNat := by
     simp only [h_ba_def] at h_ba_1; split at h_ba_1 <;> [assumption; omega]
   -- overflow: (q * v_i).toNat + carryIn.toNat ≥ 2^64
-  have h_overflow : (q * v_i).toNat + carryIn.toNat ≥ 2^64 := by
+  have : (q * v_i).toNat + carryIn.toNat ≥ 2^64 := by
     by_contra h_no; push Not at h_no
     rw [h_fs_val, Nat.mod_eq_of_lt h_no] at h_ov; omega
   -- (q * v_i).toNat = 1 and carryIn = 2^64 - 1
-  have h_plo_1 : (q * v_i).toNat = 1 := by omega
+  have : (q * v_i).toNat = 1 := by omega
   -- fullSub = 0
-  have h_fs_0 : fullSub.toNat = 0 := by rw [h_fs_val]; omega
+  have : fullSub.toNat = 0 := by rw [h_fs_val]; omega
   -- bs_n = 0 (nothing is < 0)
   have : bs_n = 0 := by
     simp only [h_bs_def, show ¬(u_i.toNat < fullSub.toNat) from by omega, ite_false]

--- a/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivMulSubLimb.lean
@@ -107,12 +107,12 @@ theorem mulsub_limb_nat_eq {q v_i u_i carryIn : Word} :
   -- div_add_mod for the add carry
   have hdm := Nat.div_add_mod (prodLo.toNat + carryIn.toNat) (2^64)
   -- Combine: normalize 2^64 to the literal everywhere
-  have hB : (2:Nat)^64 = 18446744073709551616 := by norm_num
+  have : (2:Nat)^64 = 18446744073709551616 := by norm_num
   -- Use B as shorthand for 2^64 literal
   set B := (18446744073709551616 : Nat)
   rw [show (2:Nat)^64 = B from by omega] at h_ba h_fs h_prod hdm hu hfs h_un ⊢
   -- Key: from hdm, (prodLo + carryIn) / B * B + fullSub = prodLo + carryIn
-  have hkey : (prodLo.toNat + carryIn.toNat) / B * B =
+  have : (prodLo.toNat + carryIn.toNat) / B * B =
       prodLo.toNat + carryIn.toNat - fullSub.toNat := by
     rw [h_fs]; omega
   -- Key: prodHi * B + prodLo = q * v_i
@@ -120,9 +120,9 @@ theorem mulsub_limb_nat_eq {q v_i u_i carryIn : Word} :
   have h_prod' : prodHi.toNat * B + prodLo.toNat = q.toNat * v_i.toNat := by
     show (rv64_mulhu q v_i).toNat * B + (q * v_i).toNat = _; linarith
   -- Expand the compound carry multiplication
-  have hfs_le : fullSub.toNat ≤ prodLo.toNat + carryIn.toNat := by
+  have : fullSub.toNat ≤ prodLo.toNat + carryIn.toNat := by
     rw [h_fs]; exact Nat.mod_le _ _
-  have hpl_le : prodLo.toNat ≤ prodHi.toNat * B + prodLo.toNat := Nat.le_add_left _ _
+  have : prodLo.toNat ≤ prodHi.toNat * B + prodLo.toNat := Nat.le_add_left _ _
   rw [h_ba, h_bs, h_un]
   -- Eliminate the nonlinear q*v_i term by replacing with prodHi*B + prodLo (linear!)
   rw [show q.toNat * v_i.toNat = prodHi.toNat * B + prodLo.toNat from h_prod'.symm]


### PR DESCRIPTION
## Summary
- Follow-up anonymization batch for `DivMulSubCarry.lean` (`h_overflow`, `h_plo_1`, `h_fs_0`) and `DivMulSubLimb.lean` (`hB`, `hkey`, `hfs_le`, `hpl_le`).
- Each fact is consumed by adjacent `omega`/`linarith` via context, never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.DivMulSubCarry EvmAsm.Evm64.EvmWordArith.DivMulSubLimb\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)