### PR TITLE
refactor: anonymize 5 unused have bindings in KnuthTheoremB + Arithmetic (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -89,7 +89,7 @@ theorem add_carry_chain_correct (a b : EvmWord) :
     have := a1.isLt; have := b1.isLt; rw [hc1]; omega
   have hc2 : carry2.toNat = (a2.toNat + b2.toNat + carry1.toNat) / 2^64 :=
     combined_carry_toNat hc1_le
-  have hc2_le : carry2.toNat ≤ 1 := by
+  have : carry2.toNat ≤ 1 := by
     have := a2.isLt; have := b2.isLt; rw [hc2]; omega
   -- toNat decomposition using local def names (a0, a1, ... not a.getLimb i)
   have hab : (a + b).toNat = (a.toNat + b.toNat) % 2^256 := BitVec.toNat_add a b
@@ -322,7 +322,7 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
   have ha_sum := toNat_eq_limb_sum a
   have hb_sum := toNat_eq_limb_sum b
   have := b.isLt
-  have hab_le : b.toNat ≤ a.toNat + 2^256 := by omega
+  have : b.toNat ≤ a.toNat + 2^256 := by omega
   -- diff0 toNat
   have hdiff0_nat : diff0.toNat = (a0.toNat + 2^64 - b0.toNat) % 2^64 := by
     simp only [diff0, BitVec.toNat_sub]; congr 1; omega

--- a/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
+++ b/EvmAsm/Evm64/EvmWordArith/KnuthTheoremB.lean
@@ -198,9 +198,9 @@ theorem knuth_core_ineq (x y z : Nat) (hz : 0 < z)
   by_contra hgt
   push Not at hgt
   have h3 : y / z + 3 ≤ x := hgt
-  have h4 : (y / z + 3) * z ≤ x * z := Nat.mul_le_mul_right z h3
-  have hd : z * (y / z) + y % z = y := Nat.div_add_mod y z
-  have hm : y % z < z := Nat.mod_lt y hz
+  have : (y / z + 3) * z ≤ x * z := Nat.mul_le_mul_right z h3
+  have : z * (y / z) + y % z = y := Nat.div_add_mod y z
+  have : y % z < z := Nat.mod_lt y hz
   nlinarith
 
 /-- Knuth B — trial-remainder bookkeeping (Nat-abstract call-trial bound).


### PR DESCRIPTION
## Summary
- Anonymize unused local `have` bindings:
  - `KnuthTheoremB.lean`: `h4`, `hd`, `hm` in `knuth_core_ineq`
  - `Arithmetic.lean`: `hc2_le` in the add correctness proof and `hab_le` in the sub correctness proof
- Each fact is consumed by adjacent `nlinarith`/`omega` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.KnuthTheoremB EvmAsm.Evm64.EvmWordArith.Arithmetic\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)