### PR TITLE
refactor(DivMod): collapse LoopIterN1/* per-j specs (#283)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN1.lean
@@ -155,7 +155,9 @@ theorem divK_loop_body_n1_max_unified_j3_spec
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
-    have J3 := divK_loop_body_n1_max_addback_j3_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J3 := divK_loop_body_n1_max_addback_jgt0_beq_spec (3 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_3
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
       hcarry2_nz
     intro_lets at J3
@@ -167,7 +169,9 @@ theorem divK_loop_body_n1_max_unified_j3_spec
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
-    have J3 := divK_loop_body_n1_max_skip_j3_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J3 := divK_loop_body_n1_max_skip_jgt0_spec (3 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_3
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
     intro_lets at J3
     exact cpsTriple_weaken
@@ -203,7 +207,9 @@ theorem divK_loop_body_n1_max_unified_j2_spec
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
-    have J2 := divK_loop_body_n1_max_addback_j2_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n1_max_addback_jgt0_beq_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
       hcarry2_nz
     intro_lets at J2
@@ -215,7 +221,9 @@ theorem divK_loop_body_n1_max_unified_j2_spec
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
-    have J2 := divK_loop_body_n1_max_skip_j2_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n1_max_skip_jgt0_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
     intro_lets at J2
     exact cpsTriple_weaken
@@ -251,7 +259,9 @@ theorem divK_loop_body_n1_max_unified_j1_spec
   · -- addback path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
-    have J1 := divK_loop_body_n1_max_addback_j1_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n1_max_addback_jgt0_beq_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
       hbltu
       hcarry2_nz
@@ -264,7 +274,9 @@ theorem divK_loop_body_n1_max_unified_j1_spec
   · -- skip path
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
-    have J1 := divK_loop_body_n1_max_skip_j1_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n1_max_skip_jgt0_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
       hbltu
     intro_lets at J1
@@ -362,7 +374,9 @@ theorem divK_loop_body_n1_call_unified_j3_spec
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
-    have J3 := divK_loop_body_n1_call_addback_j3_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J3 := divK_loop_body_n1_call_addback_jgt0_beq_spec (3 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_3
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -375,7 +389,9 @@ theorem divK_loop_body_n1_call_unified_j3_spec
       J3
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
-    have J3 := divK_loop_body_n1_call_skip_j3_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J3 := divK_loop_body_n1_call_skip_jgt0_spec (3 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_3
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -419,7 +435,9 @@ theorem divK_loop_body_n1_call_unified_j2_spec
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
-    have J2 := divK_loop_body_n1_call_addback_j2_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n1_call_addback_jgt0_beq_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -432,7 +450,9 @@ theorem divK_loop_body_n1_call_unified_j2_spec
       J2
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
-    have J2 := divK_loop_body_n1_call_skip_j2_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n1_call_skip_jgt0_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -476,7 +496,9 @@ theorem divK_loop_body_n1_call_unified_j1_spec
   · -- addback path
     have hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN1Call; simp only []; rw [if_pos hb]; decide
-    have J1 := divK_loop_body_n1_call_addback_j1_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n1_call_addback_jgt0_beq_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -489,7 +511,9 @@ theorem divK_loop_body_n1_call_unified_j1_spec
       J1
   · -- skip path
     have hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
-    have J1 := divK_loop_body_n1_call_skip_j1_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n1_call_skip_jgt0_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -142,13 +142,16 @@ theorem divK_loop_body_n1_call_skip_j0_spec
     full
 
 -- ============================================================================
--- n=1, BLTU taken (call path) + BEQ skip, j=1 → cpsTriple to base+448
+-- n=1, BLTU taken (call path) + BEQ skip, j > 0 → cpsTriple to base+448
+-- Single Word-parametric theorem: callers pass concrete j ∈ {1,2,3} and the
+-- corresponding `slt_jpos_k` fact to discharge BLT-not-taken.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, call+skip, j=1.
-    Since j=1, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_call_skip_j1_spec
+/-- Loop body cpsTriple for n=1, call+skip, j > 0 (parametric on `j : Word`).
+    `hpos` discharges BGE loop-back via caller's `slt_jpos_k` for k ∈ {1,2,3}. -/
+theorem divK_loop_body_n1_call_skip_jgt0_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -156,10 +159,10 @@ theorem divK_loop_body_n1_call_skip_j1_spec
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -174,7 +177,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN1CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -204,7 +207,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+  have TF := divK_trial_call_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   unfold divKTrialCallFullPost at TF
@@ -212,7 +215,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
@@ -235,7 +238,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j qHat u4_new (0 : Word) qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -246,261 +249,7 @@ theorem divK_loop_body_n1_call_skip_j1_spec
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
-            loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=1, BLTU taken (call path) + BEQ skip, j=2 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, call+skip, j=2.
-    Since j=2, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_call_skip_j2_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v0 >>> (32 : BitVec 6).toNat
-  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u0 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u1 u0 v0 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN1CallSkipPostJ div128Quot div128DLo div128Un0
-            loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=1, BLTU taken (call path) + BEQ skip, j=3 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, call+skip, j=3.
-    Since j=3, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_call_skip_j3_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u1 v0)
-    (hborrow : isSkipBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallSkipPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v0 >>> (32 : BitVec 6).toNat
-  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u0 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isSkipBorrowN1Call div128Quot at hborrow
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u1 u0 v0 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_3
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean
@@ -12,7 +12,6 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- n=1, BLTU taken (call path) + BEQ skip, j=0 → cpsTriple to base+904

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -140,10 +140,13 @@ theorem divK_loop_body_n1_call_addback_j0_beq_spec
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
--- n=1, call+addback BEQ, j=1
+-- n=1, call+addback BEQ, j > 0 (Word-parametric)
 
 set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_call_addback_j1_beq_spec
+/-- Loop body cpsTriple for n=1, call+addback BEQ, j > 0 (parametric on `j : Word`).
+    Callers pass `(k : Word)` + `slt_jpos_k` for k ∈ {1,2,3}. -/
+theorem divK_loop_body_n1_call_addback_jgt0_beq_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -152,10 +155,10 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
     (hbltu : BitVec.ult u1 v0)
     (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -170,7 +173,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN1CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v0 >>> (32 : BitVec 6).toNat
   let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -200,7 +203,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isAddbackBorrowN1Call div128Quot at hborrow
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+  have TF := divK_trial_call_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u1 u0 v0 retMem dMem dloMem scratch_un0 base
     halign hbltu
   unfold divKTrialCallFullPost at TF
@@ -223,13 +226,13 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   let carryOut := if carry = 0 then
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
@@ -240,7 +243,7 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
@@ -261,250 +264,5 @@ theorem divK_loop_body_n1_call_addback_j1_beq_spec
             loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
-
--- n=1, call+addback BEQ, j=2
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_call_addback_j2_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v0 >>> (32 : BitVec 6).toNat
-  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u0 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u1 u0 v0 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
-            loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- n=1, call+addback BEQ, j=3
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_call_addback_j3_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u1 v0)
-    (hborrow : isAddbackBorrowN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : isAddbackCarry2NzN1Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN1CallAddbackBeqPostJ sp base (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v0 >>> (32 : BitVec 6).toNat
-  let dLo := (v0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u0 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u0 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u1 dHi; let rhat := u1 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isAddbackBorrowN1Call div128Quot at hborrow
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u1 u0 v0 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN1Call isAddbackCarry2Nz div128Quot at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base slt_jpos_3
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v0) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN1CallAddbackBeqPostJ div128Quot div128DLo div128Un0
-            loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean
@@ -12,7 +12,6 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- BEQ variants: call path addback with double-addback handling (no sorry)

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -12,7 +12,6 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- n=1, BLTU not-taken (max path) + BEQ skip, j=0 → cpsTriple to base+904

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean
@@ -118,23 +118,27 @@ theorem divK_loop_body_n1_max_skip_j0_spec
     full
 
 -- ============================================================================
--- n=1, BLTU not-taken (max path) + BEQ skip, j=3 → cpsTriple to base+448
+-- n=1, BLTU not-taken (max path) + BEQ skip, j > 0 → cpsTriple to base+448
+-- Single Word-parametric theorem: callers pass concrete j ∈ {1,2,3} and the
+-- corresponding `slt_jpos_k` fact to discharge BLT-not-taken.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, max+skip, j=3.
-    Since j=3, the BGE loop-back is taken (j' = 2 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_max_skip_j3_spec
+/-- Loop body cpsTriple for n=1, max+skip, j > 0 (parametric on `j : Word`).
+    `hpos` discharges the BGE loop-back (j - 1 ≥ 0) via the caller's concrete j.
+    Callers pass `(k : Word)` with `slt_jpos_k` for k ∈ {1,2,3}; exits to base+448. -/
+theorem divK_loop_body_n1_max_skip_jgt0_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0) :
-    let uBase := sp + signExtend12 4056 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -145,7 +149,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN1SkipPost sp (3 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN1SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -167,18 +171,18 @@ theorem divK_loop_body_n1_max_skip_j3_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
+  have TF := divK_trial_max_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (3 : Word) u0 vtopBase u1 v0 v2Old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u0 vtopBase u1 v0 v2Old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_3
+  have SL := divK_store_loop_jgt0_spec sp j qHat u4_new (0 : Word) qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -190,183 +194,7 @@ theorem divK_loop_body_n1_max_skip_j3_spec
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=1, BLTU not-taken (max path) + BEQ skip, j=1 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, max+skip, j=1.
-    Since j=1, the BGE loop-back is taken (j' = 0 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_max_skip_j1_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u1 v0) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN1SkipPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u1 u0 v0 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u0 vtopBase u1 v0 v2Old base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN1SkipPost loopBodySkipPost mulsubN4 loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=1, BLTU not-taken (max path) + BEQ skip, j=2 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=1, max+skip, j=2.
-    Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n1_max_skip_j2_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u1 v0) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN1SkipPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u1 u0 v0 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u0 vtopBase u1 v0 v2Old base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -100,21 +100,26 @@ theorem divK_loop_body_n1_max_addback_j0_beq_spec
     (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
--- n=1, max+addback BEQ, j=3
+-- n=1, max+addback BEQ, j > 0 → cpsTriple to base+448
+-- Single Word-parametric theorem: callers pass concrete j ∈ {1,2,3} and the
+-- corresponding `slt_jpos_k` fact to discharge BLT-not-taken.
 
 set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_max_addback_j3_beq_spec
+/-- Loop body cpsTriple for n=1, max+addback BEQ, j > 0 (parametric on `j : Word`).
+    `hpos` discharges BGE loop-back via caller's `slt_jpos_k` for k ∈ {1,2,3}. -/
+theorem divK_loop_body_n1_max_addback_jgt0_beq_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u1 v0)
     (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 -(3 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (3 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (3 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -125,7 +130,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN1AddbackBeqPost sp (3 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN1AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -143,19 +148,19 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (3 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
+  have TF := divK_trial_max_full_spec sp j (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u1 u0 v0 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n1] at TF
   rw [u_addr8_eq_n1] at TF
   rw [vtop_eq_v0_n1] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (3 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (3 : Word) u0 vtopBase u1 v0 v2Old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u0 vtopBase u1 v0 v2Old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (3 : Word) q_out u4_out carryOut qOld base slt_jpos_3
+  have SL := divK_store_loop_jgt0_spec sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -167,171 +172,7 @@ theorem divK_loop_body_n1_max_addback_j3_beq_spec
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (3 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- n=1, max+addback BEQ, j=1
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_max_addback_j1_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 -(1 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN1AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (1 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u1 u0 v0 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u0 vtopBase u1 v0 v2Old base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (1 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN1AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN1 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- n=1, max+addback BEQ, j=2
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n1_max_addback_j2_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u1 v0)
-    (hcarry2_nz : isAddbackCarry2NzN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 -(2 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (1 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN1AddbackBeqPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  let vtopBase := sp + ((1 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (2 : Word) (1 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u1 u0 v0 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n1] at TF
-  rw [u_addr8_eq_n1] at TF
-  rw [vtop_eq_v0_n1] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u0 vtopBase u1 v0 v2Old base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN1Max isAddbackCarry2Nz at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **

--- a/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean
@@ -12,7 +12,6 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
-open EvmAsm.Evm64.DivMod.AddrNorm (slt_jpos_1 slt_jpos_2 slt_jpos_3)
 
 -- ============================================================================
 -- BEQ variants: max path addback with double-addback handling (no sorry)


### PR DESCRIPTION
## Summary
Completes the substrate layer of #283 Axis 2 (per-j iter specs) for `LoopIterN1/*`.
Earlier PRs #704 + #728 shipped the API layer (1 `_iter_spec` entry point per n);
this PR deletes the redundant per-j duplicates that sit below it.

- 12 per-j theorems (j=1,2,3 × 4 paths) → 4 Word-parametric `_jgt0` theorems
- Per-path: `_j1_spec + _j2_spec + _j3_spec` → single `_jgt0_spec (j : Word) (hpos)`
- `_j0_spec` unchanged (distinct structure — exits loop via `divK_store_loop_j0_spec`)
- Callers in `LoopComposeN1.lean` migrated to pass concrete `(k : Word)` + `slt_jpos_k`

## Pattern
Before — 3 near-identical theorems per path:
```lean
theorem _max_skip_j1_spec ... := by  -- (1 : Word) everywhere
theorem _max_skip_j2_spec ... := by  -- (2 : Word) everywhere
theorem _max_skip_j3_spec ... := by  -- (3 : Word) everywhere
```

After — 1 parametric theorem per path:
```lean
theorem _max_skip_jgt0_spec (j : Word)
    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false) ... := by
  -- body with `j` symbolic; `divK_store_loop_jgt0_spec ... hpos`
Caller migration (LoopComposeN1.lean):
```

## Files touched
| File | LOC change |
| --- | --- |
| [EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean](EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean) | −194 |
| [EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean](EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean) | −185 |
| [EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean](EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean) | −273 |
| [EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean](EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean) | −262 |
| [EvmAsm/Evm64/DivMod/LoopComposeN1.lean](EvmAsm/Evm64/DivMod/LoopComposeN1.lean) (12 caller updates) | +34 |


## Test plan
- [x] `lake build` green (3564/3564 jobs)
- [x] No downstream callers of deleted `_j{1,2,3}_spec` theorems remain (grep-verified)
- [x] All 12 call sites in [LoopComposeN1.lean](EvmAsm/Evm64/DivMod/LoopComposeN1.lean) migrated to parametric `_jgt0_spec`
