### PR TITLE
refactor(DivMod): collapse LoopIterN2 per-j specs (#283)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopComposeN2.lean
@@ -89,7 +89,9 @@ theorem divK_loop_body_n2_max_unified_j2_spec
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
-    have J2 := divK_loop_body_n2_max_addback_j2_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n2_max_addback_jgt0_beq_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
       hcarry2_nz
     intro_lets at J2
@@ -101,7 +103,9 @@ theorem divK_loop_body_n2_max_unified_j2_spec
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
-    have J2 := divK_loop_body_n2_max_skip_j2_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n2_max_skip_jgt0_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
     intro_lets at J2
     exact cpsTriple_weaken
@@ -138,7 +142,9 @@ theorem divK_loop_body_n2_max_unified_j1_spec
   · -- addback path: use _beq spec
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) ≠ (0 : Word) := by rw [if_pos hb]; decide
-    have J1 := divK_loop_body_n2_max_addback_j1_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n2_max_addback_jgt0_beq_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu
       hcarry2_nz
     intro_lets at J1
@@ -150,7 +156,9 @@ theorem divK_loop_body_n2_max_unified_j1_spec
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : (if BitVec.ult uTop (mulsubN4_c3 (signExtend12 4095 : Word) v0 v1 v2 v3 u0 u1 u2 u3)
                     then (1 : Word) else 0) = (0 : Word) := if_neg hb
-    have J1 := divK_loop_body_n2_max_skip_j1_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n2_max_skip_jgt0_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
       hbltu
     intro_lets at J1
@@ -249,7 +257,9 @@ theorem divK_loop_body_n2_call_unified_j2_spec
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
-    have J2 := divK_loop_body_n2_call_addback_j2_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n2_call_addback_jgt0_beq_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -262,7 +272,9 @@ theorem divK_loop_body_n2_call_unified_j2_spec
       J2
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
-    have J2 := divK_loop_body_n2_call_skip_j2_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J2 := divK_loop_body_n2_call_skip_jgt0_spec (2 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_2
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -306,7 +318,9 @@ theorem divK_loop_body_n2_call_unified_j1_spec
   · -- addback path: use _beq spec
     have hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
       delta isAddbackBorrowN2Call; simp only []; rw [if_pos hb]; decide
-    have J1 := divK_loop_body_n2_call_addback_j1_beq_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n2_call_addback_jgt0_beq_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow
@@ -319,7 +333,9 @@ theorem divK_loop_body_n2_call_unified_j1_spec
       J1
   · -- skip path: use existing skip spec (unchanged)
     have hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop := if_neg hb
-    have J1 := divK_loop_body_n2_call_skip_j1_spec sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
+    have J1 := divK_loop_body_n2_call_skip_jgt0_spec (1 : Word)
+      EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
+      sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
       halign
       hbltu hborrow

--- a/EvmAsm/Evm64/DivMod/LoopIterN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopIterN2.lean
@@ -264,23 +264,24 @@ theorem divK_loop_body_n2_call_skip_j0_spec
     full
 
 -- ============================================================================
--- n=2, BLTU not-taken (max path) + BEQ skip, j=1 → cpsTriple to base+448
+-- n=2, BLTU not-taken (max path) + BEQ skip, j > 0 → cpsTriple to base+448
+-- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=2, max+skip, j=1.
-    Since j=1, the BGE loop-back is taken (j' = 0 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n2_max_skip_j1_spec
+/-- Loop body cpsTriple for n=2, max+skip, j > 0 (parametric on `j : Word`). -/
+theorem divK_loop_body_n2_max_skip_jgt0_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -291,7 +292,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN2SkipPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN2SkipPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
@@ -313,18 +314,18 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
+  have TF := divK_trial_max_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u1 vtopBase u2 v1 v2Old base
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u1 vtopBase u2 v1 v2Old base
 
   intro_lets at MCS
   have MCS0 := MCS hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j qHat u4_new (0 : Word) qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -336,7 +337,7 @@ theorem divK_loop_body_n2_max_skip_j1_spec
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
@@ -352,13 +353,14 @@ theorem divK_loop_body_n2_max_skip_j1_spec
     full
 
 -- ============================================================================
--- n=2, BLTU taken (call path) + BEQ skip, j=1 → cpsTriple to base+448
+-- n=2, BLTU taken (call path) + BEQ skip, j > 0 → cpsTriple to base+448
+-- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=2, call+skip, j=1.
-    Since j=1, the BGE loop-back is taken, giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n2_call_skip_j1_spec
+/-- Loop body cpsTriple for n=2, call+skip, j > 0 (parametric on `j : Word`). -/
+theorem divK_loop_body_n2_call_skip_jgt0_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -366,10 +368,10 @@ theorem divK_loop_body_n2_call_skip_j1_spec
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -384,7 +386,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallSkipPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN2CallSkipPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -414,7 +416,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   unfold isSkipBorrowN2Call div128Quot at hborrow
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+  have TF := divK_trial_call_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   unfold divKTrialCallFullPost at TF
@@ -422,7 +424,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCS := divK_mulsub_correction_skip_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCS
@@ -445,7 +447,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
   let un3 := u3 - fs3; let c3 := pc3 + bs3
   let u4_new := uTop - c3
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j qHat u4_new (0 : Word) qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -456,7 +458,7 @@ theorem divK_loop_body_n2_call_skip_j1_spec
   seqFrame TFf MCS0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
@@ -478,222 +480,6 @@ theorem divK_loop_body_n2_call_skip_j1_spec
       rw [sepConj_assoc'] at hp; xperm_hyp hp)
     full
 
-
--- ============================================================================
--- n=2, j=2 specs (first iteration, loop-back to base+448)
--- For j=2: j' = 2 + signExtend12 4095 = 1, BGE taken.
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=2, max+skip, j=2.
-    Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n2_max_skip_j2_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u2 v1) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN2SkipPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u2 u1 v1 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n2] at TF
-  rw [u_addr8_eq_n2] at TF
-  rw [vtop_eq_v1_n2] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u1 vtopBase u2 v1 v2Old base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (2 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=2, BLTU taken (call path) + BEQ skip, j=2 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-/-- Loop body cpsTriple for n=2, call+skip, j=2.
-    Since j=2, the BGE loop-back is taken (j' = 1 ≥ 0), giving a cpsTriple to base+448. -/
-theorem divK_loop_body_n2_call_skip_j2_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u2 v1)
-    (hborrow : isSkipBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallSkipPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v1 >>> (32 : BitVec 6).toNat
-  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u1 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isSkipBorrowN2Call div128Quot at hborrow
-  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u2 u1 v1 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n2] at TF
-  rw [u_addr8_eq_n2] at TF
-  rw [vtop_eq_v1_n2] at TF
-  have MCS := divK_mulsub_correction_skip_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCS
-  have MCS0 := MCS hborrow
-  let p0_lo := qHat * v0; let p0_hi := rv64_mulhu qHat v0
-  let fs0 := p0_lo + (signExtend12 0 : Word)
-  let ba0 := if BitVec.ult fs0 (signExtend12 0 : Word) then (1 : Word) else 0
-  let pc0 := ba0 + p0_hi; let bs0 := if BitVec.ult u0 fs0 then (1 : Word) else 0
-  let un0 := u0 - fs0; let c0 := pc0 + bs0
-  let p1_lo := qHat * v1; let p1_hi := rv64_mulhu qHat v1
-  let fs1 := p1_lo + c0; let ba1 := if BitVec.ult fs1 c0 then (1 : Word) else 0
-  let pc1 := ba1 + p1_hi; let bs1 := if BitVec.ult u1 fs1 then (1 : Word) else 0
-  let un1 := u1 - fs1; let c1 := pc1 + bs1
-  let p2_lo := qHat * v2; let p2_hi := rv64_mulhu qHat v2
-  let fs2 := p2_lo + c1; let ba2 := if BitVec.ult fs2 c1 then (1 : Word) else 0
-  let pc2 := ba2 + p2_hi; let bs2 := if BitVec.ult u2 fs2 then (1 : Word) else 0
-  let un2 := u2 - fs2; let c2 := pc2 + bs2
-  let p3_lo := qHat * v3; let p3_hi := rv64_mulhu qHat v3
-  let fs3 := p3_lo + c2; let ba3 := if BitVec.ult fs3 c2 then (1 : Word) else 0
-  let pc3 := ba3 + p3_hi; let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
-  let un3 := u3 - fs3; let c3 := pc3 + bs3
-  let u4_new := uTop - c3
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) qHat u4_new (0 : Word) qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCS0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_new) **
-     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCS0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN2CallSkipPostJ div128Quot div128DLo div128Un0
-            loopBodyN2SkipPost loopBodySkipPost mulsubN4 loopExitPostN2 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
 
 -- ============================================================================
 -- BEQ variants: double-addback handling (no sorry)
@@ -919,22 +705,24 @@ theorem divK_loop_body_n2_call_addback_j0_beq_spec
     full
 
 -- ============================================================================
--- n=2, BLTU not-taken (max path) + BEQ addback, j=1 → cpsTriple to base+448
+-- n=2, BLTU not-taken (max path) + BEQ addback, j > 0 → cpsTriple to base+448
+-- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-theorem divK_loop_body_n2_max_addback_j1_beq_spec
+theorem divK_loop_body_n2_max_addback_jgt0_beq_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (base : Word)
     (hbltu : ¬BitVec.ult u2 v1)
     (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
     let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -945,7 +733,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ uTop) **
        (qAddr ↦ₘ qOld))
-      (loopBodyN2AddbackBeqPost sp (1 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN2AddbackBeqPost sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qHat qAddr hborrow
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
@@ -963,19 +751,19 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
+  have TF := divK_trial_max_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
     u2 u1 v1 base hbltu
   dsimp only [] at TF
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (1 : Word) u1 vtopBase u2 v1 v2Old base
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    j u1 vtopBase u2 v1 v2Old base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     ((.x2 ↦ᵣ v2Old) **
@@ -987,7 +775,7 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
@@ -1003,11 +791,13 @@ theorem divK_loop_body_n2_max_addback_j1_beq_spec
     full
 
 -- ============================================================================
--- n=2, BLTU taken (call path) + BEQ addback, j=1 → cpsTriple to base+448
+-- n=2, BLTU taken (call path) + BEQ addback, j > 0 → cpsTriple to base+448
+-- Word-parametric: callers pass concrete j ∈ {1,2} + corresponding slt_jpos_k.
 -- ============================================================================
 
 set_option maxRecDepth 4096 in
-theorem divK_loop_body_n2_call_addback_j1_beq_spec
+theorem divK_loop_body_n2_call_addback_jgt0_beq_spec (j : Word)
+    (hpos : BitVec.slt (j + signExtend12 4095) 0 = false)
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -1016,10 +806,10 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
     (hbltu : BitVec.ult u2 v1)
     (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
     (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (1 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (1 : Word) <<< (3 : BitVec 6).toNat
+    let uBase := sp + signExtend12 4056 - j <<< (3 : BitVec 6).toNat
+    let qAddr := sp + signExtend12 4088 - j <<< (3 : BitVec 6).toNat
     cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (1 : Word)) **
+      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
        (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
@@ -1034,7 +824,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallAddbackBeqPostJ sp base (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
+      (loopBodyN2CallAddbackBeqPostJ sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
   intro uBase qAddr
   let dHi := v1 >>> (32 : BitVec 6).toNat
   let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -1079,7 +869,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
       addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
     else carry
   let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (1 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
+  have TF := divK_trial_call_full_spec sp j (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
     u2 u1 v1 retMem dMem dloMem scratch_un0 base
     halign hbltu
   unfold divKTrialCallFullPost at TF
@@ -1087,13 +877,13 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   rw [u_addr_eq_n2] at TF
   rw [u_addr8_eq_n2] at TF
   rw [vtop_eq_v1_n2] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (1 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
     x1Exit q0' dHi x7Exit q1' (base + 516) base
 
   intro_lets at MCA
   unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
   have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (1 : Word) q_out u4_out carryOut qOld base slt_jpos_1
+  have SL := divK_store_loop_jgt0_spec sp j q_out u4_out carryOut qOld base hpos
   intro_lets at SL
   have TFf := cpsTriple_frameR
     (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -1104,215 +894,7 @@ theorem divK_loop_body_n2_call_addback_j1_beq_spec
   seqFrame TFf MCA0
   have SLf := cpsTriple_frameR
     ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (1 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-     (sp + signExtend12 3968 ↦ₘ (base + 516)) **
-     (sp + signExtend12 3960 ↦ₘ v1) **
-     (sp + signExtend12 3952 ↦ₘ dLo) **
-     (sp + signExtend12 3944 ↦ₘ div_un0))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by
-      delta loopBodyN2CallAddbackBeqPostJ div128Quot div128DLo div128Un0
-            loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost
-      rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=2, BLTU not-taken (max path) + BEQ addback, j=2 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n2_max_addback_j2_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult u2 v1)
-    (hcarry2_nz : isAddbackCarry2NzN2Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN2AddbackBeqPost sp (2 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_max_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old
-    u2 u1 v1 base hbltu
-  dsimp only [] at TF
-  rw [u_addr_eq_n2] at TF
-  rw [u_addr8_eq_n2] at TF
-  rw [vtop_eq_v1_n2] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    (2 : Word) u1 vtopBase u2 v1 v2Old base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN2Max isAddbackCarry2Nz at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    ((.x2 ↦ᵣ v2Old) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
-     ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
-     ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ un3Out) **
-     ((uBase + signExtend12 4064) ↦ₘ u4_out) **
-     (sp + signExtend12 3984 ↦ₘ (2 : Word)))
-    (by pcFree) SL
-  have full := cpsTriple_seq_perm_same_cr
-    (fun h hp => by rw [sepConj_assoc'] at hp; xperm_hyp hp) TFfMCA0 SLf
-  exact cpsTriple_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hp => by delta loopBodyN2AddbackBeqPost loopBodyAddbackBeqPost loopExitPostN2 loopExitPost; rw [sepConj_assoc'] at hp; xperm_hyp hp)
-    full
-
--- ============================================================================
--- n=2, BLTU taken (call path) + BEQ addback, j=2 → cpsTriple to base+448
--- ============================================================================
-
-set_option maxRecDepth 4096 in
-theorem divK_loop_body_n2_call_addback_j2_beq_spec
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
-    (hbltu : BitVec.ult u2 v1)
-    (hborrow : isAddbackBorrowN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hcarry2_nz : isAddbackCarry2NzN2Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (2 : Word) <<< (3 : BitVec 6).toNat
-    let qAddr := sp + signExtend12 4088 - (2 : Word) <<< (3 : BitVec 6).toNat
-    cpsTriple (base + loopBodyOff) (base + loopBodyOff) (sharedDivModCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (2 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN2CallAddbackBeqPostJ sp base (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qAddr
-  let dHi := v1 >>> (32 : BitVec 6).toNat
-  let dLo := (v1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let div_un1 := u1 >>> (32 : BitVec 6).toNat
-  let div_un0 := (u1 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-  let q1 := rv64_divu u2 dHi; let rhat := u2 - q1 * dHi
-  let hi1 := q1 >>> (32 : BitVec 6).toNat
-  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-  let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  let qDlo := q1c * dLo
-  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let cu_q1_dlo := q1' * dLo
-  let un21 := cu_rhat_un1 - cu_q1_dlo
-  let q0 := rv64_divu un21 dHi; let rhat2 := un21 - q0 * dHi
-  let hi2 := q0 >>> (32 : BitVec 6).toNat
-  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-  let q0Dlo := q0c * dLo
-  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
-  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-  let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-  unfold isAddbackBorrowN2Call div128Quot at hborrow
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  let c3 := ms.2.2.2.2
-  let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
-  let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 (uTop - c3) v0 v1 v2 v3
-  let ab' := addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 v0 v1 v2 v3
-  let q_out := if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
-               else qHat + signExtend12 4095
-  let un0Out := if carry = 0 then ab'.1 else ab.1
-  let un1Out := if carry = 0 then ab'.2.1 else ab.2.1
-  let un2Out := if carry = 0 then ab'.2.2.1 else ab.2.2.1
-  let un3Out := if carry = 0 then ab'.2.2.2.1 else ab.2.2.2.1
-  let u4_out := if carry = 0 then ab'.2.2.2.2 else ab.2.2.2.2
-  let carryOut := if carry = 0 then
-      addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3
-    else carry
-  let vtopBase := sp + ((2 : Word) + signExtend12 4095) <<< (3 : BitVec 6).toNat
-  have TF := divK_trial_call_full_spec sp (2 : Word) (2 : Word) jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    u2 u1 v1 retMem dMem dloMem scratch_un0 base
-    halign hbltu
-  unfold divKTrialCallFullPost at TF
-  dsimp only [] at TF
-  rw [u_addr_eq_n2] at TF
-  rw [u_addr8_eq_n2] at TF
-  rw [vtop_eq_v1_n2] at TF
-  have MCA := divK_mulsub_correction_addback_beq_spec sp qHat (2 : Word) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    x1Exit q0' dHi x7Exit q1' (base + 516) base
-
-  intro_lets at MCA
-  unfold isAddbackCarry2NzN2Call isAddbackCarry2Nz div128Quot at hcarry2_nz
-  have MCA0 := MCA hcarry2_nz hborrow
-  have SL := divK_store_loop_jgt0_spec sp (2 : Word) q_out u4_out carryOut qOld base slt_jpos_2
-  intro_lets at SL
-  have TFf := cpsTriple_frameR
-    (((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-     ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-     ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4064) ↦ₘ uTop) **
-     (qAddr ↦ₘ qOld))
-    (by pcFree) TF
-  seqFrame TFf MCA0
-  have SLf := cpsTriple_frameR
-    ((.x6 ↦ᵣ uBase) ** (.x10 ↦ᵣ c3) ** (.x2 ↦ᵣ un3Out) **
-     (sp + signExtend12 3976 ↦ₘ (2 : Word)) **
+     (sp + signExtend12 3976 ↦ₘ j) **
      ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ un0Out) **
      ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ un1Out) **
      ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ un2Out) **


### PR DESCRIPTION
## Summary
Towards #283. Follow-up to the LoopIterN1 collapse. Applies the same `Word`-parametric `_jgt0_spec` pattern to `LoopIterN2.lean`: 8 per-j leaf specs (4 paths × {j=1, j=2}) collapse to 4 `_jgt0_spec` theorems, each invoked at the caller with `(k : Word) slt_jpos_k`.

## Files touched

| File | LOC change |
| --- | --- |
| [EvmAsm/Evm64/DivMod/LoopIterN2.lean](EvmAsm/Evm64/DivMod/LoopIterN2.lean) | +52 / −470 |
| [EvmAsm/Evm64/DivMod/LoopComposeN2.lean](EvmAsm/Evm64/DivMod/LoopComposeN2.lean) (4 caller-pair migrations) | +24 / −8 |

## Theorem layout

Before: 12 per-j leaf specs (4 paths × 3 j-values)
After: 4 `_j0_spec` (loop-exit) + 4 `_jgt0_spec` (loop-back, parametric)

| Path | Before | After |
| --- | --- | --- |
| max_skip | `_j0_spec`, `_j1_spec`, `_j2_spec` | `_j0_spec`, `_jgt0_spec (j : Word)` |
| call_skip | `_j0_spec`, `_j1_spec`, `_j2_spec` | `_j0_spec`, `_jgt0_spec (j : Word)` |
| max_addback_beq | `_j0_beq_spec`, `_j1_beq_spec`, `_j2_beq_spec` | `_j0_beq_spec`, `_jgt0_beq_spec (j : Word)` |
| call_addback_beq | `_j0_beq_spec`, `_j1_beq_spec`, `_j2_beq_spec` | `_j0_beq_spec`, `_jgt0_beq_spec (j : Word)` |

## Caller migration pattern

Each previously-written j=1 / j=2 call site:

```lean
have J1 := divK_loop_body_n2_max_skip_j1_spec sp jOld ... base halign hbltu hborrow
```

now reads:

```lean
have J1 := divK_loop_body_n2_max_skip_jgt0_spec (1 : Word)
  EvmAsm.Evm64.DivMod.AddrNorm.slt_jpos_1
  sp jOld ... base halign hbltu hborrow
```

(Fully-qualified `slt_jpos_k` because `LoopComposeN2.lean` does not `open EvmAsm.Evm64.DivMod.AddrNorm`.)


## Test plan
- [x] `lake build` green (3564/3564 jobs)
- [x] No downstream callers of deleted `_j{1,2}_spec` / `_j{1,2}_beq_spec` theorems remain (grep-verified across `EvmAsm/`)
- [x] All 4 caller pairs in [LoopComposeN2.lean](EvmAsm/Evm64/DivMod/LoopComposeN2.lean) (8 call sites: j=1 and j=2 per path) migrated to parametric `_jgt0_spec`
- [x] `_unified_j{1,2}_spec` wrapper API in LoopComposeN2.lean preserved unchanged (public consumers unaffected)