### PR TITLE
refactor: anonymize 6 unused have bindings across 3 files (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128KnuthLower.lean
@@ -125,7 +125,7 @@ theorem div128Quot_q1c_ge_q_true_1
   have h_q1_ge : (uHi.toNat * 2^32 + div_un1.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) ≤ q1.toNat :=
     div128Quot_q1_ge_q_true_1 uHi dHi dLo div_un1 hdHi_ne h_div_un1_lt
-  have h_q_true_lt : (uHi.toNat * 2^32 + div_un1.toNat) /
+  have : (uHi.toNat * 2^32 + div_un1.toNat) /
       (dHi.toNat * 2^32 + dLo.toNat) < 2^32 :=
     div128Quot_q_true_1_lt_pow32 uHi dHi dLo div_un1 h_div_un1_lt huHi_lt_vTop
   by_cases h_hi1 : hi1 = 0
@@ -133,7 +133,7 @@ theorem div128Quot_q1c_ge_q_true_1
     rw [if_pos h_hi1]
     exact h_q1_ge
   · -- hi1 ≠ 0 ⟹ q1 ≥ 2^32. q1c = q1 - 1 ≥ 2^32 - 1 ≥ q_true_1.
-    have hq1_ge : q1.toNat ≥ 2^32 := by
+    have : q1.toNat ≥ 2^32 := by
       by_contra h
       push Not at h
       apply h_hi1
@@ -169,7 +169,7 @@ theorem knuth_theorem_c_abstract
     uHi.toNat * 2^32 + div_un1.toNat <
     q1c.toNat * (dHi.toNat * 2^32 + dLo.toNat) := by
   -- Multiply Euclidean by 2^32: q1c * dHi * 2^32 + rhatc * 2^32 = uHi * 2^32.
-  have h_eucl_mul : q1c.toNat * dHi.toNat * 2^32 + rhatc.toNat * 2^32 =
+  have : q1c.toNat * dHi.toNat * 2^32 + rhatc.toNat * 2^32 =
       uHi.toNat * 2^32 := by
     have := congr_arg (· * 2^32) h_eucl
     simp only [Nat.add_mul] at this

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -410,7 +410,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   -- Lower bound: carry2 ≥ 1
   -- If carry2 = 0 then hab' gives val256(ab)+val256(v) = val256(ab'_result) < 2^256,
   -- contradicting h_ab1_v_ge.
-  have hc2_ge : carry2 ≥ 1 := by
+  have : carry2 ≥ 1 := by
     by_contra h; push Not at h
     have hc2_zero : carry2 = 0 := by omega
     rw [hc2_zero] at hab'

--- a/EvmAsm/Evm64/EvmWordArith/Normalization.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Normalization.lean
@@ -53,14 +53,14 @@ theorem norm_euclidean_bridge {a b q r s : Nat}
     have : r = a * 2^s - b * 2^s * q := by omega
     rw [this]; exact Nat.dvd_sub ⟨a, by ring⟩ ⟨b * q, by ring⟩
   obtain ⟨r', hr'⟩ := h_dvd; subst hr'
-  have ha : a = b * q + r' := by nlinarith [Nat.mul_comm (2^s) r']
+  have : a = b * q + r' := by nlinarith [Nat.mul_comm (2^s) r']
   have hr'_lt : r' < b := by nlinarith [Nat.mul_comm (2^s) r']
   constructor
   · have h4 : q * b ≤ a := by nlinarith
     have h5 : a < (q + 1) * b := by nlinarith
     exact (Nat.div_eq_of_lt_le h4 h5).symm
   · rw [Nat.mul_div_cancel_left _ hs]
-    have hq : q = a / b := by
+    have : q = a / b := by
       have h4 : q * b ≤ a := by nlinarith
       have h5 : a < (q + 1) * b := by nlinarith
       exact (Nat.div_eq_of_lt_le h4 h5).symm


### PR DESCRIPTION
## Summary
- Anonymize 6 unused local `have` bindings:
  - `Normalization.lean`: `ha`, `hq` in `div_of_normalize`
  - `DivN4Overestimate.lean`: `hc2_ge` in `addbackN4_second_carry_one`
  - `Div128KnuthLower.lean`: `h_q_true_lt`, `hq1_ge`, `h_eucl_mul`
- Each fact is consumed by adjacent `omega`/`linarith`/`nlinarith` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.Normalization EvmAsm.Evm64.EvmWordArith.DivN4Overestimate EvmAsm.Evm64.EvmWordArith.Div128KnuthLower\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)