### PR TITLE
refactor: anonymize h_B_lt in Div128FinalAssembly (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128FinalAssembly.lean
@@ -236,7 +236,7 @@ theorem div128Quot_un21_toNat_case (uHi dHi dLo uLo rhatUn1 : Word)
     have : rhat'.toNat % 2^32 < 2^32 := Nat.mod_lt _ (by decide)
     have : div_un1.toNat < 2^32 := Word_ushiftRight_32_lt_pow32
     nlinarith
-  have h_B_lt : B < 2^64 := by
+  have : B < 2^64 := by
     show q1'.toNat * dLo.toNat < 2^64
     have : cu_q1_dlo.toNat = q1'.toNat * dLo.toNat :=
       div128Quot_q1_prime_dLo_no_wrap uHi dHi dLo rhatUn1


### PR DESCRIPTION
## Summary
- Follow-up to #1198. Anonymize `h_B_lt` in `div128Quot_un21_toNat_case` — missed in that batch.
- The fact is consumed by the adjacent `omega` via context and never referenced by name.
- Part of #694.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)