### PR TITLE
fix: import DivMod/NormDefs in DivMod umbrella (#1195)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -1,3 +1,4 @@
+import EvmAsm.Evm64.DivMod.NormDefs
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LimbSpec
 import EvmAsm.Evm64.DivMod.Compose


### PR DESCRIPTION
## Summary
- `EvmAsm/Evm64/DivMod/NormDefs.lean` (8 `def`s for Knuth Algorithm D normalization limbs) is not transitively imported from the `EvmAsm` root module, so it was silently excluded from the CI build.
- Add it to the `DivMod` umbrella so every file in the tree is covered.

## Detection method
- `find EvmAsm -name '*.lean'` → 286 source files; `find .lake/build/lib/lean/EvmAsm -name '*.olean'` → 278 built. The 8-file gap matched one orphan + 7 files in the SailEquiv tree (which has a pre-existing build error; untouched here).

Addresses #1195.

## Test plan
- [x] \`lake build EvmAsm.Evm64.DivMod\` — 3455 targets clean, including `DivMod.NormDefs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)