### PR TITLE
fix: complete runSail_rX_bits handlers for all 32 Rv64 registers (#1195)

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -32,3 +32,4 @@ import EvmAsm.Rv64.AddrNormAttr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ByteAlgAttr
 import EvmAsm.Rv64.ByteAlg
+import EvmAsm.Rv64.SailEquiv.MonadLemmas

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -75,6 +75,20 @@ theorem runSail_rX_bits_x2 {s : SailState} {v : BitVec 64}
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
+theorem runSail_rX_bits_x3 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x3 = some v) :
+    runSail (rX_bits (regidx.Regidx 3)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x4 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x4 = some v) :
+    runSail (rX_bits (regidx.Regidx 4)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
 theorem runSail_rX_bits_x5 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x5 = some v) :
     runSail (rX_bits (regidx.Regidx 5)) s = some (v, s) := by
@@ -92,6 +106,20 @@ theorem runSail_rX_bits_x6 {s : SailState} {v : BitVec 64}
 theorem runSail_rX_bits_x7 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x7 = some v) :
     runSail (rX_bits (regidx.Regidx 7)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x8 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x8 = some v) :
+    runSail (rX_bits (regidx.Regidx 8)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x9 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x9 = some v) :
+    runSail (rX_bits (regidx.Regidx 9)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
@@ -117,27 +145,183 @@ theorem runSail_rX_bits_x12 {s : SailState} {v : BitVec 64}
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
+theorem runSail_rX_bits_x13 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x13 = some v) :
+    runSail (rX_bits (regidx.Regidx 13)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x14 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x14 = some v) :
+    runSail (rX_bits (regidx.Regidx 14)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x15 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x15 = some v) :
+    runSail (rX_bits (regidx.Regidx 15)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x16 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x16 = some v) :
+    runSail (rX_bits (regidx.Regidx 16)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x17 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x17 = some v) :
+    runSail (rX_bits (regidx.Regidx 17)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x18 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x18 = some v) :
+    runSail (rX_bits (regidx.Regidx 18)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x19 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x19 = some v) :
+    runSail (rX_bits (regidx.Regidx 19)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x20 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x20 = some v) :
+    runSail (rX_bits (regidx.Regidx 20)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x21 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x21 = some v) :
+    runSail (rX_bits (regidx.Regidx 21)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x22 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x22 = some v) :
+    runSail (rX_bits (regidx.Regidx 22)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x23 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x23 = some v) :
+    runSail (rX_bits (regidx.Regidx 23)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x24 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x24 = some v) :
+    runSail (rX_bits (regidx.Regidx 24)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x25 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x25 = some v) :
+    runSail (rX_bits (regidx.Regidx 25)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x26 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x26 = some v) :
+    runSail (rX_bits (regidx.Regidx 26)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x27 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x27 = some v) :
+    runSail (rX_bits (regidx.Regidx 27)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x28 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x28 = some v) :
+    runSail (rX_bits (regidx.Regidx 28)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x29 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x29 = some v) :
+    runSail (rX_bits (regidx.Regidx 29)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x30 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x30 = some v) :
+    runSail (rX_bits (regidx.Regidx 30)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
+theorem runSail_rX_bits_x31 {s : SailState} {v : BitVec 64}
+    (h : s.regs.get? Register.x31 = some v) :
+    runSail (rX_bits (regidx.Regidx 31)) s = some (v, s) := by
+  simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
+    PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
+    get, MonadState.get, getThe, MonadStateOf.get]
+
 -- ============================================================================
 -- Bridge lemma: rX_bits from StateRel
 -- ============================================================================
 
+set_option maxHeartbeats 800000 in
 /-- If StateRel holds, reading any Rv64 register from the SAIL state via rX_bits
     returns the same value as getReg, without modifying state. -/
 theorem runSail_rX_bits_of_stateRel {sRv : MachineState} {sSail : SailState}
     (hrel : StateRel sRv sSail) (r : Reg) :
     runSail (rX_bits (regToRegidx r)) sSail = some (sRv.getReg r, sSail) := by
   have ha := hrel.reg_agree r
-  cases r <;> simp [regToRegidx, sailRegVal, MachineState.getReg] at ha ⊢ <;>
-  · first
-      | exact runSail_rX_bits_x0 sSail
-      | exact runSail_rX_bits_x1 ha
-      | exact runSail_rX_bits_x2 ha
-      | exact runSail_rX_bits_x5 ha
-      | exact runSail_rX_bits_x6 ha
-      | exact runSail_rX_bits_x7 ha
-      | exact runSail_rX_bits_x10 ha
-      | exact runSail_rX_bits_x11 ha
-      | exact runSail_rX_bits_x12 ha
+  cases r <;> simp [regToRegidx, sailRegVal, MachineState.getReg] at ha ⊢
+  case x0 => exact runSail_rX_bits_x0
+  case x1 => exact runSail_rX_bits_x1 ha
+  case x2 => exact runSail_rX_bits_x2 ha
+  case x3 => exact runSail_rX_bits_x3 ha
+  case x4 => exact runSail_rX_bits_x4 ha
+  case x5 => exact runSail_rX_bits_x5 ha
+  case x6 => exact runSail_rX_bits_x6 ha
+  case x7 => exact runSail_rX_bits_x7 ha
+  case x8 => exact runSail_rX_bits_x8 ha
+  case x9 => exact runSail_rX_bits_x9 ha
+  case x10 => exact runSail_rX_bits_x10 ha
+  case x11 => exact runSail_rX_bits_x11 ha
+  case x12 => exact runSail_rX_bits_x12 ha
+  case x13 => exact runSail_rX_bits_x13 ha
+  case x14 => exact runSail_rX_bits_x14 ha
+  case x15 => exact runSail_rX_bits_x15 ha
+  case x16 => exact runSail_rX_bits_x16 ha
+  case x17 => exact runSail_rX_bits_x17 ha
+  case x18 => exact runSail_rX_bits_x18 ha
+  case x19 => exact runSail_rX_bits_x19 ha
+  case x20 => exact runSail_rX_bits_x20 ha
+  case x21 => exact runSail_rX_bits_x21 ha
+  case x22 => exact runSail_rX_bits_x22 ha
+  case x23 => exact runSail_rX_bits_x23 ha
+  case x24 => exact runSail_rX_bits_x24 ha
+  case x25 => exact runSail_rX_bits_x25 ha
+  case x26 => exact runSail_rX_bits_x26 ha
+  case x27 => exact runSail_rX_bits_x27 ha
+  case x28 => exact runSail_rX_bits_x28 ha
+  case x29 => exact runSail_rX_bits_x29 ha
+  case x30 => exact runSail_rX_bits_x30 ha
+  case x31 => exact runSail_rX_bits_x31 ha
 
 -- ============================================================================
 -- wX_bits — register write


### PR DESCRIPTION
## Summary
`EvmAsm.Rv64.SailEquiv.MonadLemmas` was previously excluded from the CI build (the umbrella module didn't import it) and `runSail_rX_bits_of_stateRel` was broken: it case-splits over `Reg` (32 cases) but only had per-register helpers for 9 of them (x0, x1, x2, x5, x6, x7, x10, x11, x12), so the other 23 cases had no handler.

## Fixes
- Add the 23 missing `runSail_rX_bits_xN` lemmas (x3, x4, x8, x9, x13..x31) following the same simp pattern as the existing ones.
- Restructure `runSail_rX_bits_of_stateRel` from a `<;> first | ...` chain to explicit `case xN => exact ...` handlers (the 32-alt `first` hit the heartbeat limit).
- Bump `maxHeartbeats` for that single theorem.
- Import `MonadLemmas` from the `Rv64` umbrella so CI covers it.

With this, `MonadLemmas.lean` joins `StateRel.lean` as the first SailEquiv files in the CI build. The downstream SailEquiv files (`ALUProofs`, `MExtProofs`, etc.) still have separate completeness gaps — they need similar register-coverage expansion for `reg_agree_after_insert` and related lemmas — and are left for a follow-up.

Addresses part of #1195.

## Test plan
- [x] \`lake build EvmAsm\` — full tree builds clean; `SailEquiv.MonadLemmas` now among the built oleans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)