### PR TITLE
refactor(SailEquiv): simplify stateRel_nextPC proof with simpa+decide

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -37,16 +37,7 @@ theorem stateRel_nextPC {sRv : MachineState} {sSail : SailState}
     StateRel sRv { sSail with regs := sSail.regs.insert Register.nextPC v } :=
   ⟨fun r => by
     have ha := hrel.reg_agree r
-    cases r <;> simp only [sailRegVal, Std.ExtDHashMap.get?_insert,
-      show (Register.nextPC == Register.x1) = false from by decide,
-      show (Register.nextPC == Register.x2) = false from by decide,
-      show (Register.nextPC == Register.x5) = false from by decide,
-      show (Register.nextPC == Register.x6) = false from by decide,
-      show (Register.nextPC == Register.x7) = false from by decide,
-      show (Register.nextPC == Register.x10) = false from by decide,
-      show (Register.nextPC == Register.x11) = false from by decide,
-      show (Register.nextPC == Register.x12) = false from by decide,
-      ite_false] at ha ⊢ <;> exact ha,
+    cases r <;> simpa [sailRegVal, Std.ExtDHashMap.get?_insert] using ha,
    fun a => hrel.mem_agree a⟩
 
 -- Comparison operator equivalences (definitional: SAIL and Lean use the same operations)


### PR DESCRIPTION
## Summary
- The `stateRel_nextPC` proof in `BranchProofs.lean` enumerated 8 `show (Register.nextPC == Register.xN) = false from by decide` simp lemmas — a hardcoded subset of the 31 non-x0 non-nextPC registers.
- That subset worked because the downstream proofs only touched x1/x2/x5/x6/x7/x10/x11/x12, but with the SailEquiv build now covering all 32 registers the enumeration is incomplete and brittle.
- Replace the enumerated show-list with `simpa` so simp's built-in decide-based reduction handles `Register.nextPC == Register.xN` uniformly for all 32 concrete register pairs after `cases r`.

## Test plan
- [x] `lake build EvmAsm.Rv64.SailEquiv.BranchProofs` succeeds (135 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)