### PR TITLE
refactor(SailEquiv): mark per-register rX_bits/wX_bits xN as private

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -47,217 +47,217 @@ theorem runSail_rX_bits_x0 {s : SailState} :
   simp [runSail, rX_bits, rX, BitVec.toNatInt, zero_reg, zeros, regval_from_reg,
     pure, EStateM.pure, bind, EStateM.bind]
 
-theorem runSail_rX_bits_x1 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x1 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x1 = some v) :
     runSail (rX_bits (regidx.Regidx 1)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get, EStateM.modifyGet]
 
-theorem runSail_rX_bits_x2 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x2 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x2 = some v) :
     runSail (rX_bits (regidx.Regidx 2)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x3 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x3 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x3 = some v) :
     runSail (rX_bits (regidx.Regidx 3)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x4 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x4 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x4 = some v) :
     runSail (rX_bits (regidx.Regidx 4)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x5 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x5 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x5 = some v) :
     runSail (rX_bits (regidx.Regidx 5)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x6 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x6 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x6 = some v) :
     runSail (rX_bits (regidx.Regidx 6)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x7 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x7 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x7 = some v) :
     runSail (rX_bits (regidx.Regidx 7)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x8 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x8 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x8 = some v) :
     runSail (rX_bits (regidx.Regidx 8)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x9 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x9 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x9 = some v) :
     runSail (rX_bits (regidx.Regidx 9)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x10 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x10 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x10 = some v) :
     runSail (rX_bits (regidx.Regidx 10)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x11 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x11 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x11 = some v) :
     runSail (rX_bits (regidx.Regidx 11)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x12 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x12 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x12 = some v) :
     runSail (rX_bits (regidx.Regidx 12)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x13 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x13 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x13 = some v) :
     runSail (rX_bits (regidx.Regidx 13)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x14 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x14 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x14 = some v) :
     runSail (rX_bits (regidx.Regidx 14)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x15 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x15 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x15 = some v) :
     runSail (rX_bits (regidx.Regidx 15)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x16 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x16 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x16 = some v) :
     runSail (rX_bits (regidx.Regidx 16)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x17 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x17 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x17 = some v) :
     runSail (rX_bits (regidx.Regidx 17)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x18 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x18 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x18 = some v) :
     runSail (rX_bits (regidx.Regidx 18)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x19 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x19 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x19 = some v) :
     runSail (rX_bits (regidx.Regidx 19)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x20 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x20 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x20 = some v) :
     runSail (rX_bits (regidx.Regidx 20)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x21 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x21 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x21 = some v) :
     runSail (rX_bits (regidx.Regidx 21)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x22 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x22 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x22 = some v) :
     runSail (rX_bits (regidx.Regidx 22)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x23 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x23 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x23 = some v) :
     runSail (rX_bits (regidx.Regidx 23)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x24 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x24 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x24 = some v) :
     runSail (rX_bits (regidx.Regidx 24)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x25 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x25 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x25 = some v) :
     runSail (rX_bits (regidx.Regidx 25)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x26 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x26 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x26 = some v) :
     runSail (rX_bits (regidx.Regidx 26)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x27 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x27 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x27 = some v) :
     runSail (rX_bits (regidx.Regidx 27)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x28 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x28 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x28 = some v) :
     runSail (rX_bits (regidx.Regidx 28)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x29 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x29 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x29 = some v) :
     runSail (rX_bits (regidx.Regidx 29)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x30 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x30 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x30 = some v) :
     runSail (rX_bits (regidx.Regidx 30)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
     PreSail.readReg, h, pure, EStateM.pure, bind, EStateM.bind, EStateM.get,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_rX_bits_x31 {s : SailState} {v : BitVec 64}
+private theorem runSail_rX_bits_x31 {s : SailState} {v : BitVec 64}
     (h : s.regs.get? Register.x31 = some v) :
     runSail (rX_bits (regidx.Regidx 31)) s = some (v, s) := by
   simp [runSail, rX_bits, rX, BitVec.toNatInt, regval_from_reg,
@@ -320,7 +320,7 @@ theorem runSail_wX_bits_x0 {v : BitVec 64} {s : SailState} :
 
 /-- wX_bits on a non-x0 register: writes the value and calls the (no-op) callback.
     The final state has the register updated and everything else unchanged. -/
-theorem runSail_wX_bits_x1 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x1 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 1) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x1 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -332,7 +332,7 @@ theorem runSail_wX_bits_x1 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x2 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x2 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 2) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x2 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -344,7 +344,7 @@ theorem runSail_wX_bits_x2 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x3 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x3 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 3) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x3 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -356,7 +356,7 @@ theorem runSail_wX_bits_x3 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x4 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x4 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 4) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x4 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -368,7 +368,7 @@ theorem runSail_wX_bits_x4 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x5 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x5 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 5) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x5 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -380,7 +380,7 @@ theorem runSail_wX_bits_x5 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x6 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x6 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 6) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x6 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -392,7 +392,7 @@ theorem runSail_wX_bits_x6 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x7 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x7 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 7) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x7 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -404,7 +404,7 @@ theorem runSail_wX_bits_x7 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x8 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x8 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 8) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x8 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -416,7 +416,7 @@ theorem runSail_wX_bits_x8 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x9 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x9 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 9) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x9 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -428,7 +428,7 @@ theorem runSail_wX_bits_x9 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x10 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x10 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 10) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x10 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -440,7 +440,7 @@ theorem runSail_wX_bits_x10 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x11 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x11 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 11) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x11 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -452,7 +452,7 @@ theorem runSail_wX_bits_x11 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x12 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x12 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 12) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x12 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -464,7 +464,7 @@ theorem runSail_wX_bits_x12 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x13 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x13 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 13) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x13 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -476,7 +476,7 @@ theorem runSail_wX_bits_x13 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x14 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x14 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 14) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x14 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -488,7 +488,7 @@ theorem runSail_wX_bits_x14 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x15 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x15 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 15) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x15 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -500,7 +500,7 @@ theorem runSail_wX_bits_x15 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x16 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x16 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 16) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x16 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -512,7 +512,7 @@ theorem runSail_wX_bits_x16 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x17 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x17 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 17) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x17 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -524,7 +524,7 @@ theorem runSail_wX_bits_x17 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x18 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x18 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 18) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x18 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -536,7 +536,7 @@ theorem runSail_wX_bits_x18 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x19 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x19 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 19) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x19 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -548,7 +548,7 @@ theorem runSail_wX_bits_x19 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x20 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x20 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 20) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x20 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -560,7 +560,7 @@ theorem runSail_wX_bits_x20 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x21 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x21 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 21) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x21 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -572,7 +572,7 @@ theorem runSail_wX_bits_x21 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x22 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x22 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 22) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x22 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -584,7 +584,7 @@ theorem runSail_wX_bits_x22 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x23 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x23 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 23) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x23 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -596,7 +596,7 @@ theorem runSail_wX_bits_x23 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x24 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x24 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 24) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x24 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -608,7 +608,7 @@ theorem runSail_wX_bits_x24 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x25 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x25 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 25) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x25 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -620,7 +620,7 @@ theorem runSail_wX_bits_x25 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x26 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x26 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 26) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x26 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -632,7 +632,7 @@ theorem runSail_wX_bits_x26 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x27 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x27 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 27) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x27 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -644,7 +644,7 @@ theorem runSail_wX_bits_x27 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x28 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x28 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 28) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x28 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -656,7 +656,7 @@ theorem runSail_wX_bits_x28 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x29 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x29 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 29) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x29 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -668,7 +668,7 @@ theorem runSail_wX_bits_x29 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x30 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x30 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 30) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x30 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,
@@ -680,7 +680,7 @@ theorem runSail_wX_bits_x30 {v : BitVec 64} {s : SailState} :
     bind, EStateM.bind, pure, EStateM.pure,
     get, MonadState.get, getThe, MonadStateOf.get]
 
-theorem runSail_wX_bits_x31 {v : BitVec 64} {s : SailState} :
+private theorem runSail_wX_bits_x31 {v : BitVec 64} {s : SailState} :
     runSail (wX_bits (regidx.Regidx 31) v) s =
       some (⟨⟩, { s with regs := s.regs.insert Register.x31 v }) := by
   simp [runSail, wX_bits, wX, BitVec.toNatInt, regval_into_reg,


### PR DESCRIPTION
## Summary
- The 31 `runSail_rX_bits_xN` and 31 `runSail_wX_bits_xN` lemmas (N=1..31) in MonadLemmas.lean are scaffolding for the generic `runSail_rX_bits_of_stateRel` / `runSail_wX_bits_of_reg` dispatchers and have no callers outside MonadLemmas.lean.
- Mark them `private` to shrink the public API by 62 names. The dispatchers keep working — `private` only restricts cross-module visibility.
- `runSail_rX_bits_x0` and `runSail_wX_bits_x0` stay public because `nop_sail_equiv` in ImmProofs.lean uses them directly (the `regidx 0` in the NOP body is not routed through `regToRegidx`, so the generic dispatchers don't apply there).

## Test plan
- [x] `lake build EvmAsm.Rv64.SailEquiv.{MonadLemmas,ALUProofs,BranchProofs,ImmProofs,MExtProofs,ShiftProofs}` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)