### PR TITLE
refactor(EvmWordArith): inline single-use isLt have bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -109,10 +109,9 @@ theorem bv_udiv_add_umod {n : Nat} {x y : BitVec n} :
   apply BitVec.eq_of_toNat_eq
   simp only [BitVec.toNat_add, BitVec.toNat_mul, BitVec.toNat_udiv, BitVec.toNat_umod]
   have hdiv := Nat.div_add_mod x.toNat y.toNat
-  have hx := x.isLt
   have : y.toNat * (x.toNat / y.toNat) ≤ x.toNat := by omega
   rw [Nat.mod_eq_of_lt (by omega : y.toNat * (x.toNat / y.toNat) < 2 ^ n),
-      hdiv, Nat.mod_eq_of_lt hx]
+      hdiv, Nat.mod_eq_of_lt x.isLt]
 
 /-- Uniqueness of BitVec unsigned division: if `a = b * q + r` with `r < b`
     and no overflow in `b * q + r`, then `q = a / b` and `r = a % b`. -/

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -95,14 +95,11 @@ theorem val256_lt_of_b3_bound (b0 b1 b2 b3 : Word) {s : Nat} (hs : s ≤ 64)
     (hb3_bound : b3.toNat < 2 ^ (64 - s)) :
     val256 b0 b1 b2 b3 < 2 ^ (256 - s) := by
   unfold val256
-  have h0 := b0.isLt
-  have h1 := b1.isLt
-  have h2 := b2.isLt
   -- val256 b ≤ (2^64 - 1)(1 + 2^64 + 2^128) + (2^(64-s) - 1) * 2^192 = 2^(256-s) - 1.
   have hpow : (2 : Nat) ^ (256 - s) = 2 ^ (64 - s) * 2 ^ 192 := by
     rw [← pow_add, show (64 - s) + 192 = 256 - s from by omega]
   rw [hpow]
-  nlinarith [h0, h1, h2, hb3_bound,
+  nlinarith [b0.isLt, b1.isLt, b2.isLt, hb3_bound,
              (show 0 < 2 ^ (64 - s) from by positivity)]
 
 /-- Fully abstract Nat-level `uTop = c3_n` lemma. Takes all relevant


### PR DESCRIPTION
## Summary
- `Div.lean` and `ModBridgeUtop.lean` had `have hX := y.isLt` bindings whose only use was as a single argument to the next tactic. Inline them.
- `val256_lt_of_b3_bound` had three `have h0/h1/h2 := b{0,1,2}.isLt` lines consumed only by `nlinarith [h0, h1, h2, ...]`'s seed list — pass `b0.isLt, b1.isLt, b2.isLt` directly to `nlinarith`.

Per #694 inline-rename scope: bare `have x := bareTerm` with single consumption.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.{Div,ModBridgeUtop}` succeeds (3369 jobs total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)