### PR TITLE
refactor(SailEquiv): drop 4 unused hypotheses from jalr_sail_equiv

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -279,10 +279,6 @@ private theorem runSail_ok_bind (f : Unit → SailM β) (s s' : SailState)
   simp [runSail, bind, EStateM.bind, hm]
 
 theorem jalr_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail)
-    (h_pc : sSail.regs.get? Register.PC = some sRv.pc)
-    (h_nextpc : sSail.regs.get? Register.nextPC = some (sRv.pc + 4))
-    (h_misa : ∃ v, sSail.regs.get? Register.misa = some v)
     (rd rs1 : Reg) (offset : BitVec 12)
     -- update_elp_state succeeds and preserves StateRel + relevant state
     (h_elp : ∃ s_mid, update_elp_state (regToRegidx rs1) sSail = .ok () s_mid ∧


### PR DESCRIPTION
## Summary
- `jalr_sail_equiv` declared `hrel`, `h_pc`, `h_nextpc`, and `h_misa` as hypotheses about the *pre*-state `sSail`.
- The proof only uses the matching `_mid` versions extracted from `h_elp` (`hrel_mid`, `h_pc_mid`, `h_nextpc_mid`, `h_misa_mid`).
- The pre-state versions were unused (flagged by the `unusedVariables` linter). Drop them to shrink the call signature and silence the warning.
- No callers — only the definition itself references the theorem name.

## Test plan
- [x] `lake build EvmAsm.Rv64.SailEquiv.BranchProofs` succeeds (135 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)