### PR TITLE
refactor(SailEquiv): drop unused hypotheses from Mem/MExt proofs

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -48,7 +48,7 @@ theorem int_ofNat_beq_zero {b : BitVec 64} :
   · intro h; subst h; simp
 
 /-- Unsigned division: SAIL's Int.tdiv on non-negative = BitVec udiv. -/
-theorem unsigned_div_equiv (a b : BitVec 64) (hb : b ≠ 0#64) :
+theorem unsigned_div_equiv (a b : BitVec 64) :
     to_bits_truncate (l := 64) ((↑a.toNat : Int).tdiv (↑b.toNat : Int)) = a / b := by
   rw [(Int.ofNat_tdiv a.toNat b.toNat).symm, to_bits_truncate_natCast]
   apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_udiv]
@@ -116,7 +116,7 @@ theorem divu_full_equiv {a b : BitVec 64} :
   by_cases hb : b = 0#64
   · subst hb; simp [to_bits_truncate_neg1]
   · simp only [show (b == 0#64) = false from by simp [hb], ite_false, Bool.false_eq_true]
-    exact unsigned_div_equiv a b hb
+    exact unsigned_div_equiv a b
 
 /-- REMU value equivalence: SAIL unsigned remainder computation = rv64_remu. -/
 theorem remu_full_equiv {a b : BitVec 64} :
@@ -151,7 +151,7 @@ private theorem to_bits_truncate_neg_pow63 :
 
 /-- For 64-bit signed values, Int.tdiv can only reach 2^63 in the overflow case,
     so the SAIL overflow guard (clamping to -(2^63)) produces the same to_bits_truncate. -/
-private theorem overflow_guard_div (a b : BitVec 64) (hb : b ≠ 0#64) :
+private theorem overflow_guard_div (a b : BitVec 64) :
     let q := a.toInt.tdiv b.toInt
     to_bits_truncate (l := 64)
       (if ((q ≥b ((2 : Int) ^ 63)) : Bool) then (-((2 : Int) ^ 63)) else q) =
@@ -185,7 +185,7 @@ theorem div_full_equiv_applied {a b : BitVec 64} :
     simp (config := { decide := true }) [to_bits_truncate_neg1]
   · simp only [show (b == 0#64) = false from by simp [hb], ite_false, Bool.false_eq_true]
     -- Apply overflow guard then signed_div_equiv
-    exact (overflow_guard_div a b hb).symm ▸ signed_div_equiv a b
+    exact (overflow_guard_div a b).symm ▸ signed_div_equiv a b
 
 -- ============================================================================
 -- Instruction proofs

--- a/EvmAsm/Rv64/SailEquiv/MemProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemProofs.lean
@@ -32,7 +32,7 @@ namespace EvmAsm.Rv64.SailEquiv
 -- ============================================================================
 
 theorem ld_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) false 8 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -45,7 +45,7 @@ theorem ld_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem sd_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rs1 rs2 : Reg) (offset : BitVec 12)
+    (rs1 rs2 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_STORE offset (regToRegidx rs2) (regToRegidx rs1) 8 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -62,7 +62,7 @@ theorem sd_sail_equiv (sRv : MachineState) (sSail : SailState)
 -- ============================================================================
 
 theorem lw_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) false 4 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -75,7 +75,7 @@ theorem lw_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem lwu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) true 4 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -88,7 +88,7 @@ theorem lwu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem sw_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rs1 rs2 : Reg) (offset : BitVec 12)
+    (rs1 rs2 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_STORE offset (regToRegidx rs2) (regToRegidx rs1) 4 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -105,7 +105,7 @@ theorem sw_sail_equiv (sRv : MachineState) (sSail : SailState)
 -- ============================================================================
 
 theorem lb_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) false 1 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -118,7 +118,7 @@ theorem lb_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem lbu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) true 1 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -131,7 +131,7 @@ theorem lbu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem sb_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rs1 rs2 : Reg) (offset : BitVec 12)
+    (rs1 rs2 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_STORE offset (regToRegidx rs2) (regToRegidx rs1) 1 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -148,7 +148,7 @@ theorem sb_sail_equiv (sRv : MachineState) (sSail : SailState)
 -- ============================================================================
 
 theorem lh_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) false 2 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -161,7 +161,7 @@ theorem lh_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem lhu_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rd rs1 : Reg) (offset : BitVec 12)
+    (rd rs1 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_LOAD offset (regToRegidx rs1) (regToRegidx rd) true 2 sSail =
         .ok RETIRE_SUCCESS sSail' ∧
@@ -174,7 +174,7 @@ theorem lhu_sail_equiv (sRv : MachineState) (sSail : SailState)
   exact ⟨s', by simp [runSail, h_ok], hrel'⟩
 
 theorem sh_sail_equiv (sRv : MachineState) (sSail : SailState)
-    (hrel : StateRel sRv sSail) (rs1 rs2 : Reg) (offset : BitVec 12)
+    (rs1 rs2 : Reg) (offset : BitVec 12)
     (h_exec : ∃ sSail',
       execute_STORE offset (regToRegidx rs2) (regToRegidx rs1) 2 sSail =
         .ok RETIRE_SUCCESS sSail' ∧


### PR DESCRIPTION
## Summary
- **MemProofs.lean**: All 11 memory-instruction theorems (`ld/sd/lw/lwu/sw/lb/lbu/sb/lh/lhu/sh_sail_equiv`) declared `hrel : StateRel sRv sSail` but discharge entirely via `h_exec`'s embedded post-state StateRel. Drop the unused parameter.
- **MExtProofs.lean**: `unsigned_div_equiv` and `overflow_guard_div` declared `hb : b ≠ 0#64` but neither proof uses it (the underlying Nat/Int division identities are total). Drop the parameter and the matching arg at the two call sites.

Silences 13 `unusedVariables` linter warnings.

## Test plan
- [x] `lake build EvmAsm.Rv64.SailEquiv.{MemProofs,MExtProofs}` succeeds (136 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)