### PR TITLE
refactor(SailEquiv): drop unused simp args in ALU/Branch/MExt proofs

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -117,7 +117,7 @@ theorem reg_agree_after_insert (sSail : SailState) (sRv : MachineState)
       | (cases r <;>
           simp only [sailRegVal, Std.ExtDHashMap.get?_insert_self,
             Std.ExtDHashMap.get?_insert, MachineState.getReg,
-            beq_self_eq_true, ite_true, decide_true, decide_false, ite_false,
+            beq_self_eq_true, ite_true,
             show (Register.x0 == Register.x0) = true from rfl] <;>
           (first
             | rfl
@@ -309,7 +309,7 @@ theorem sra_sail_equiv (sRv : MachineState) (sSail : SailState)
       StateRel (execInstrBr sRv (.SRA rd rs1 rs2)) sSail' := by
   unfold execute_RTYPE
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
-    shift_bits_right_arith, Sail.BitVec.extractLsb, BitVec.toNatInt, Int.toNat_emod]
+    shift_bits_right_arith, Sail.BitVec.extractLsb, BitVec.toNatInt]
   simp only [runSail_wX_bits_of_reg]
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC]
@@ -339,7 +339,7 @@ theorem lui_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.LUI rd imm)) sSail' := by
   unfold execute_UTYPE
-  simp only [runSail_bind, runSail_pure, lui_equiv]
+  simp only [runSail_bind, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]
@@ -366,8 +366,7 @@ theorem addiw_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.ADDIW rd rs1 imm)) sSail' := by
   unfold execute_ADDIW
-  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
-    addiw_equiv]
+  simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   simp only [runSail_wX_bits_of_reg]
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, signExtend12, ← addiw_equiv]
@@ -392,7 +391,7 @@ theorem auipc_sail_equiv (sRv : MachineState) (sSail : SailState)
         = some (RETIRE_SUCCESS, sSail') ∧
       StateRel (execInstrBr sRv (.AUIPC rd imm)) sSail' := by
   unfold execute_UTYPE
-  simp only [runSail_bind, runSail_pure, runSail_get_arch_pc h_pc, lui_equiv]
+  simp only [runSail_bind, runSail_pure, runSail_get_arch_pc h_pc]
   simp only [runSail_wX_bits_of_reg]
   exact ⟨_, rfl, ⟨
     fun r => by simpa [execInstrBr, MachineState.setPC, ← lui_equiv]

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -49,7 +49,7 @@ private theorem sge_equiv (a b : BitVec 64) : zopz0zKzJ_s a b = !zopz0zI_s a b :
     simp [h, show ¬(a.toInt < b.toInt) → a.toInt ≥ b.toInt from by omega]
 private theorem ult_equiv (a b : BitVec 64) : zopz0zI_u a b = BitVec.ult a b := by
   unfold zopz0zI_u BitVec.ult BitVec.toNatInt
-  simp [BEq.beq, decide_eq_decide, Int.ofNat_lt]
+  simp [Int.ofNat_lt]
 private theorem uge_equiv (a b : BitVec 64) : zopz0zKzJ_u a b = !zopz0zI_u a b := by
   unfold zopz0zKzJ_u zopz0zI_u BitVec.toNatInt
   by_cases h : (↑a.toNat : Int) < (↑b.toNat : Int) <;> (simp [h]; omega)
@@ -83,12 +83,12 @@ theorem beq_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 == sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
-  · simp only [h, ite_false]
+  · simp only [h]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
@@ -108,12 +108,12 @@ theorem bne_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure]
   by_cases h : sRv.getReg rs1 != sRv.getReg rs2
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
-  · simp only [h, ite_false]
+  · simp only [h]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
@@ -133,12 +133,12 @@ theorem blt_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, slt_equiv]
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
-  · simp only [h, ite_false]
+  · simp only [h]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
@@ -159,14 +159,14 @@ theorem bge_sail_equiv (sRv : MachineState) (sSail : SailState)
     sge_equiv, slt_equiv]
   by_cases h : BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2)
   · -- slt = true, so !slt = false → not taken
-    simp only [h, Bool.not_true, ite_false]
+    simp only [h, Bool.not_true]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, show ¬¬BitVec.slt _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩⟩
   · -- slt = false, so !slt = true → taken
     simp only [show BitVec.slt (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
@@ -187,12 +187,12 @@ theorem bltu_sail_equiv (sRv : MachineState) (sSail : SailState)
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure, ult_equiv]
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · simp only [h, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩ _⟩
-  · simp only [h, ite_false]
+  · simp only [h]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, h]; exact hrel.mem_agree a⟩⟩
@@ -213,14 +213,14 @@ theorem bgeu_sail_equiv (sRv : MachineState) (sSail : SailState)
     uge_equiv, ult_equiv]
   by_cases h : BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2)
   · -- ult = true, so !ult = false → not taken
-    simp only [h, Bool.not_true, ite_false]
+    simp only [h, Bool.not_true]
     exact ⟨_, rfl,
       ⟨fun r => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.reg_agree r,
        fun a => by simp [execInstrBr, show ¬¬BitVec.ult _ _ from fun h' => absurd h h']; exact hrel.mem_agree a⟩⟩
   · -- ult = false, so !ult = true → taken
     simp only [show BitVec.ult (sRv.getReg rs1) (sRv.getReg rs2) = false from by simp [h],
       Bool.not_false, ite_true, runSail_bind,
-      runSail_readReg_PC h_pc, runSail_pure, sign_extend_13_eq]
+      runSail_readReg_PC h_pc, sign_extend_13_eq]
     rw [runSail_jump_to misa_val h_align h_misa]
     exact ⟨_, rfl, stateRel_nextPC
       ⟨fun r => by simp [execInstrBr, h]; exact hrel.reg_agree r,

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -147,7 +147,7 @@ private theorem to_bits_truncate_neg_pow63 :
     to_bits_truncate (l := 64) (-(((2 : Int) ^ 63))) =
     to_bits_truncate (l := 64) (((2 : Int) ^ 63)) := by
   rw [to_bits_truncate_eq_ofInt, to_bits_truncate_eq_ofInt]
-  apply BitVec.eq_of_toNat_eq; simp [BitVec.toNat_ofInt]
+  apply BitVec.eq_of_toNat_eq; simp
 
 /-- For 64-bit signed values, Int.tdiv can only reach 2^63 in the overflow case,
     so the SAIL overflow guard (clamping to -(2^63)) produces the same to_bits_truncate. -/
@@ -324,7 +324,7 @@ theorem div_sail_equiv (sRv : MachineState) (sSail : SailState)
   unfold execute_DIV
   simp only [runSail_bind, runSail_rX_bits_of_stateRel hrel, runSail_pure,
     LeanRV64D.Functions.not,
-    Bool.not_false, Bool.true_and, ite_true, ite_false, Bool.false_eq_true]
+    Bool.not_false, Bool.true_and, ite_false, Bool.false_eq_true]
   conv in to_bits_truncate _ => rw [div_full_equiv_applied]
   simp only [runSail_wX_bits_of_reg]
   exact ⟨_, rfl, ⟨


### PR DESCRIPTION
## Summary
Drop simp arguments flagged by `linter.unusedSimpArgs`:

- **ALUProofs.lean**
  - `reg_agree_after_insert`: `decide_true, decide_false, ite_false`
  - `sra_sail_equiv`: `Int.toNat_emod`
  - `lui_sail_equiv`: `lui_equiv` (only the inverse `← lui_equiv` actually fires later)
  - `addiw_sail_equiv`: `addiw_equiv`
  - `auipc_sail_equiv`: `lui_equiv`
- **BranchProofs.lean**
  - `ult_equiv`: `BEq.beq, decide_eq_decide`
  - All 6 branch theorems: `runSail_pure` in the taken-path simp set
  - All 4 simply-converging branches: `ite_false` in not-taken simp
  - BGE / BGEU not-taken: `ite_false` after `Bool.not_true`
- **MExtProofs.lean**
  - `to_bits_truncate_neg_pow63`: `BitVec.toNat_ofInt`
  - `div_sail_equiv`: `ite_true`

No proof behavior changes.

## Test plan
- [x] `lake build EvmAsm.Rv64.SailEquiv.{ALUProofs,BranchProofs,MExtProofs,...}` succeeds with no `unusedSimpArgs` warnings on these files (134+ jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)