### PR TITLE
refactor(SailEquiv): drop unneeded maxHeartbeats override on runSail_rX_bits_of_stateRel

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -268,7 +268,6 @@ private theorem runSail_rX_bits_x31 {s : SailState} {v : BitVec 64}
 -- Bridge lemma: rX_bits from StateRel
 -- ============================================================================
 
-set_option maxHeartbeats 800000 in
 /-- If StateRel holds, reading any Rv64 register from the SAIL state via rX_bits
     returns the same value as getReg, without modifying state. -/
 theorem runSail_rX_bits_of_stateRel {sRv : MachineState} {sSail : SailState}


### PR DESCRIPTION
## Summary
`runSail_rX_bits_of_stateRel`'s 32-arm dispatch carried a `set_option maxHeartbeats 800000` override from when the proof used a `<;> first | …` chain that needed to backtrack across many alternatives. It was rewritten to explicit `case xN => exact …` arms in #1205, which finishes well under the default 200k.

Drop the override; the proof builds in ~3s without it.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)
- [x] `lake build EvmAsm.Rv64.SailEquiv.MonadLemmas` runs in ~3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)