### PR TITLE
chore: drop redundant EvmWordArith umbrella import in Multiply/Spec (#1045)

### DIFF
--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -15,7 +15,6 @@
 
 import EvmAsm.Evm64.Multiply.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
-import EvmAsm.Evm64.EvmWordArith
 import EvmAsm.Evm64.Stack
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
`Multiply/Spec.lean` imported both `EvmWordArith.MulCorrect` (where `mul_correct` lives) and the `EvmWordArith` umbrella. The umbrella is transitively redundant — every symbol used in this file resolves through `MulCorrect`. Drop the umbrella.

Found via `lake exe shake` (issue #1045 import-hygiene sweep).

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)