### PR TITLE
chore(SailEquiv): drop redundant LeanRV64D imports (#1045)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -27,7 +27,6 @@
 import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -15,7 +15,6 @@ import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -14,7 +14,6 @@ import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs  -- for reg_ne_* and reg_agree_after_insert
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -11,7 +11,6 @@ import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/MemProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemProofs.lean
@@ -20,7 +20,6 @@ import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -6,7 +6,6 @@
 -/
 
 import EvmAsm.Rv64.SailEquiv.StateRel
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -13,7 +13,6 @@ import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail


### PR DESCRIPTION
## Summary
7 SailEquiv files (`ALUProofs`, `BranchProofs`, `ImmProofs`, `MExtProofs`, `MemProofs`, `MonadLemmas`, `ShiftProofs`) import `LeanRV64D` directly even though they all also import `EvmAsm.Rv64.SailEquiv.StateRel` (or transitively a sibling that does), and `StateRel.lean` already imports `LeanRV64D`. The duplicate import is a no-op for the build but adds noise to file headers.

Per `lake exe shake` (issue #1045 import-hygiene sweep).

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)