### PR TITLE
chore(SailEquiv): drop redundant StateRel/MonadLemmas imports (#1045)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -12,8 +12,6 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
 import LeanRV64D
 

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -11,8 +11,6 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs  -- for reg_ne_* and reg_agree_after_insert
 import LeanRV64D
 

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -8,8 +8,6 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
 import LeanRV64D
 

--- a/EvmAsm/Rv64/SailEquiv/MemProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemProofs.lean
@@ -17,8 +17,6 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
 import LeanRV64D
 

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -10,8 +10,6 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs
 import LeanRV64D
 


### PR DESCRIPTION
## Summary
5 SailEquiv proof files (`BranchProofs`, `ImmProofs`, `MExtProofs`, `MemProofs`, `ShiftProofs`) explicitly imported `StateRel` and `MonadLemmas` even though every one of them also imports `ALUProofs`, which transitively re-exports both via `MonadLemmas → StateRel`. Drop the redundant lines.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)