### PR TITLE
chore(SailEquiv): drop redundant Execution imports (#1045)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/BranchProofs.lean
@@ -11,7 +11,6 @@
   JAL/JALR additionally write a link register (rd := next_pc).
 -/
 
-import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs

--- a/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ImmProofs.lean
@@ -10,7 +10,6 @@
   equivalence lemmas are needed.
 -/
 
-import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs  -- for reg_ne_* and reg_agree_after_insert

--- a/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MExtProofs.lean
@@ -7,7 +7,6 @@
   MUL (low 64 bits) is already proved in ALUProofs.lean.
 -/
 
-import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs

--- a/EvmAsm/Rv64/SailEquiv/MemProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/MemProofs.lean
@@ -16,7 +16,6 @@
   - The byte-level SAIL memory agrees with Rv64's doubleword memory (StateRel.mem_agree)
 -/
 
-import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs

--- a/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ShiftProofs.lean
@@ -9,7 +9,6 @@
   the intermediate `% 64` form that simp introduces.
 -/
 
-import EvmAsm.Rv64.Execution
 import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
 import EvmAsm.Rv64.SailEquiv.ALUProofs


### PR DESCRIPTION
## Summary
5 SailEquiv proof files (`BranchProofs`, `ImmProofs`, `MExtProofs`, `MemProofs`, `ShiftProofs`) imported `EvmAsm.Rv64.Execution` directly even though all 5 also import `ALUProofs`, which itself imports `Execution`. The duplicate is silent dead weight.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)