### PR TITLE
chore(SailEquiv): drop redundant imports in ALUProofs (#1045)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
+++ b/EvmAsm/Rv64/SailEquiv/ALUProofs.lean
@@ -25,9 +25,7 @@
 -/
 
 import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SailEquiv.StateRel
 import EvmAsm.Rv64.SailEquiv.MonadLemmas
-import LeanRV64D
 
 open LeanRV64D.Functions
 open Sail


### PR DESCRIPTION
## Summary
`ALUProofs.lean` imported both `StateRel` and `LeanRV64D` directly even though it also imports `MonadLemmas`, which itself imports `StateRel` (which in turn imports `LeanRV64D`). Both lines are silent dead weight.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)