### PR TITLE
chore(Rv64): drop redundant SailEquiv imports from umbrella (#1045)

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -32,9 +32,7 @@ import EvmAsm.Rv64.AddrNormAttr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ByteAlgAttr
 import EvmAsm.Rv64.ByteAlg
-import EvmAsm.Rv64.SailEquiv.StateRel
-import EvmAsm.Rv64.SailEquiv.MonadLemmas
-import EvmAsm.Rv64.SailEquiv.ALUProofs
+-- SailEquiv leaves (each transitively imports ALUProofs → MonadLemmas → StateRel).
 import EvmAsm.Rv64.SailEquiv.ShiftProofs
 import EvmAsm.Rv64.SailEquiv.ImmProofs
 import EvmAsm.Rv64.SailEquiv.BranchProofs


### PR DESCRIPTION
## Summary
The `EvmAsm.Rv64` umbrella imported all 8 SailEquiv modules. The 5 leaves (`ShiftProofs`, `ImmProofs`, `BranchProofs`, `MemProofs`, `MExtProofs`) each transitively import `ALUProofs → MonadLemmas → StateRel`, so explicitly listing the 3 prefix modules is dead weight.

Drop the 3 redundant lines; add a one-line comment explaining the chain so the next reader understands why the umbrella is shorter than the directory listing.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)