### PR TITLE
chore(Evm64): collapse opcode umbrellas to a single Spec import (#1045)

### DIFF
--- a/EvmAsm/Evm64/Add.lean
+++ b/EvmAsm/Evm64/Add.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Add.Program
-import EvmAsm.Evm64.Add.LimbSpec
 import EvmAsm.Evm64.Add.Spec

--- a/EvmAsm/Evm64/Byte.lean
+++ b/EvmAsm/Evm64/Byte.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Byte.Program
-import EvmAsm.Evm64.Byte.LimbSpec
 import EvmAsm.Evm64.Byte.Spec

--- a/EvmAsm/Evm64/Eq.lean
+++ b/EvmAsm/Evm64/Eq.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Eq.Program
-import EvmAsm.Evm64.Eq.LimbSpec
 import EvmAsm.Evm64.Eq.Spec

--- a/EvmAsm/Evm64/Gt.lean
+++ b/EvmAsm/Evm64/Gt.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Gt.Spec

--- a/EvmAsm/Evm64/IsZero.lean
+++ b/EvmAsm/Evm64/IsZero.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.IsZero.Program
-import EvmAsm.Evm64.IsZero.LimbSpec
 import EvmAsm.Evm64.IsZero.Spec

--- a/EvmAsm/Evm64/Lt.lean
+++ b/EvmAsm/Evm64/Lt.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Lt.Spec

--- a/EvmAsm/Evm64/Multiply.lean
+++ b/EvmAsm/Evm64/Multiply.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Multiply.Program
-import EvmAsm.Evm64.Multiply.LimbSpec
 import EvmAsm.Evm64.Multiply.Spec

--- a/EvmAsm/Evm64/Sgt.lean
+++ b/EvmAsm/Evm64/Sgt.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Sgt.Program
 import EvmAsm.Evm64.Sgt.Spec

--- a/EvmAsm/Evm64/Slt.lean
+++ b/EvmAsm/Evm64/Slt.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Slt.Program
 import EvmAsm.Evm64.Slt.Spec

--- a/EvmAsm/Evm64/Sub.lean
+++ b/EvmAsm/Evm64/Sub.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Sub.Program
-import EvmAsm.Evm64.Sub.LimbSpec
 import EvmAsm.Evm64.Sub.Spec


### PR DESCRIPTION
## Summary
For 9 single-opcode umbrellas (`Lt`, `Gt`, `Slt`, `Sgt`, `Eq`, `IsZero`, `Add`, `Sub`, `Multiply`, `Byte`), the umbrella imported `Program`, optionally `LimbSpec`, and `Spec`. Each `Spec` already imports its `LimbSpec` (when present), and each `LimbSpec` already imports its `Program`. So the only non-redundant line is `import …Spec`.

Collapse each umbrella to that one line.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)