### PR TITLE
chore(Rv64): collapse umbrella imports redundant via SyscallSpecs (#1045)

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -4,27 +4,19 @@
   Root import file for the 64-bit RISC-V machine model (RV64IM).
 -/
 
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Instructions
-import EvmAsm.Rv64.Program
-import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.GenericSpecs
-import EvmAsm.Rv64.InstructionSpecs
+-- SyscallSpecs transitively imports Basic, Instructions, SepLogic, Execution,
+-- CPSSpec, GenericSpecs, InstructionSpecs, ByteOps, HalfwordOps, WordOps,
+-- and Tactics.SpecDb.
 import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.PerfTrace
 import EvmAsm.Rv64.Tactics.XPerm
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.XCancel
 import EvmAsm.Rv64.Tactics.SeqFrame
-import EvmAsm.Rv64.Tactics.SpecDb
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.LiftSpec
-import EvmAsm.Rv64.ByteOps
-import EvmAsm.Rv64.HalfwordOps
-import EvmAsm.Rv64.WordOps
 import EvmAsm.Rv64.RLP
 import EvmAsm.Rv64.RegOpsAttr
 import EvmAsm.Rv64.RegOps


### PR DESCRIPTION
## Summary
`EvmAsm/Rv64/SyscallSpecs.lean` already imports `Basic`, `Instructions`, `SepLogic`, `Execution`, `CPSSpec`, `GenericSpecs`, `InstructionSpecs`, `ByteOps`, `HalfwordOps`, `WordOps`, and `Tactics.SpecDb`. The `EvmAsm.Rv64` umbrella was listing every one of those explicitly.

Drop the 11 redundant lines and add a one-line comment so the next reader knows why the umbrella is shorter than the directory listing.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)