### PR TITLE
chore(Evm64): collapse 8 more opcode umbrellas to a single Spec import (#1045)

### DIFF
--- a/EvmAsm/Evm64/And.lean
+++ b/EvmAsm/Evm64/And.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.And.Program
-import EvmAsm.Evm64.And.LimbSpec
 import EvmAsm.Evm64.And.Spec

--- a/EvmAsm/Evm64/Dup.lean
+++ b/EvmAsm/Evm64/Dup.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Dup.Program
 import EvmAsm.Evm64.Dup.Spec

--- a/EvmAsm/Evm64/Not.lean
+++ b/EvmAsm/Evm64/Not.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Not.Program
-import EvmAsm.Evm64.Not.LimbSpec
 import EvmAsm.Evm64.Not.Spec

--- a/EvmAsm/Evm64/Or.lean
+++ b/EvmAsm/Evm64/Or.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Or.Program
-import EvmAsm.Evm64.Or.LimbSpec
 import EvmAsm.Evm64.Or.Spec

--- a/EvmAsm/Evm64/Pop.lean
+++ b/EvmAsm/Evm64/Pop.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Pop.Program
 import EvmAsm.Evm64.Pop.Spec

--- a/EvmAsm/Evm64/Push0.lean
+++ b/EvmAsm/Evm64/Push0.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Push0.Program
 import EvmAsm.Evm64.Push0.Spec

--- a/EvmAsm/Evm64/Swap.lean
+++ b/EvmAsm/Evm64/Swap.lean
@@ -1,2 +1,1 @@
-import EvmAsm.Evm64.Swap.Program
 import EvmAsm.Evm64.Swap.Spec

--- a/EvmAsm/Evm64/Xor.lean
+++ b/EvmAsm/Evm64/Xor.lean
@@ -1,3 +1,1 @@
-import EvmAsm.Evm64.Xor.Program
-import EvmAsm.Evm64.Xor.LimbSpec
 import EvmAsm.Evm64.Xor.Spec


### PR DESCRIPTION
## Summary
Same pattern as #1226: 8 more single-opcode umbrellas where the explicit `Program` (and `LimbSpec`) imports were redundant.

- `Pop`, `Push0`, `Dup`, `Swap`: `Spec` already imports `Program`
- `And`, `Or`, `Xor`, `Not`: `Spec` imports `LimbSpec` which imports `Program`

Each umbrella now has just `import …Spec`.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)