### PR TITLE
chore(Evm64): collapse Shift/SignExtend umbrellas (#1045)

### DIFF
--- a/EvmAsm/Evm64/Shift.lean
+++ b/EvmAsm/Evm64/Shift.lean
@@ -1,10 +1,5 @@
-import EvmAsm.Evm64.Shift.Program
-import EvmAsm.Evm64.Shift.LimbSpec
-import EvmAsm.Evm64.Shift.Compose
+-- The three Semantic leaves transitively cover Program / LimbSpec /
+-- {Shr,Shl,Sar}Spec / Compose / ComposeBase.
 import EvmAsm.Evm64.Shift.Semantic
-import EvmAsm.Evm64.Shift.ShlSpec
-import EvmAsm.Evm64.Shift.ShlCompose
 import EvmAsm.Evm64.Shift.ShlSemantic
-import EvmAsm.Evm64.Shift.SarSpec
-import EvmAsm.Evm64.Shift.SarCompose
 import EvmAsm.Evm64.Shift.SarSemantic

--- a/EvmAsm/Evm64/SignExtend.lean
+++ b/EvmAsm/Evm64/SignExtend.lean
@@ -1,4 +1,1 @@
-import EvmAsm.Evm64.SignExtend.Program
-import EvmAsm.Evm64.SignExtend.LimbSpec
-import EvmAsm.Evm64.SignExtend.Compose
 import EvmAsm.Evm64.SignExtend.Spec


### PR DESCRIPTION
## Summary
Extends the umbrella-collapse pattern from #1226 / #1229:

- **Shift.lean** (10 → 3 imports): Only the 3 `…Semantic` leaves are non-redundant. They transitively cover `Program` / `LimbSpec` / `{Shr,Shl,Sar}Spec` / `Compose` / `ComposeBase`.
- **SignExtend.lean** (4 → 1 import): `Spec` transitively covers `Compose → LimbSpec → Program`.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)