### PR TITLE
chore(Evm64/DivMod): drop imports redundant via LoopUnified chain (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -5,13 +5,8 @@ import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.SpecCall
 import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
-import EvmAsm.Evm64.DivMod.LoopIterN3
-import EvmAsm.Evm64.DivMod.LoopIterN2
-import EvmAsm.Evm64.DivMod.LoopComposeN3
-import EvmAsm.Evm64.DivMod.LoopComposeN2
 import EvmAsm.Evm64.DivMod.LoopUnifiedN3
 import EvmAsm.Evm64.DivMod.LoopUnifiedN2
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
@@ -23,8 +18,6 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2Cases
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopFull
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Shift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Shift0
-import EvmAsm.Evm64.DivMod.LoopIterN1
-import EvmAsm.Evm64.DivMod.LoopComposeN1
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified


### PR DESCRIPTION
## Summary
The `LoopUnifiedN{1,2,3}` modules each transitively pull in their `LoopCompose` (which pulls in `LoopIter`). Additionally, `LoopUnifiedN2 → LoopComposeN2 → LoopComposeN3`, so listing `LoopComposeN3` separately is redundant.

`FullPathN4Shift0` is pulled in by `ModFullPathN4Shift0` in the same umbrella, so its explicit import is also redundant.

Net: drop 6 redundant lines from the `EvmAsm.Evm64.DivMod` umbrella.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)