### PR TITLE
chore(Rv64/RLP): collapse umbrella to 4 leaves (#1045)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -13,14 +13,9 @@
     Phase 6 — Top-level pipeline (planned)
 -/
 
+-- Phase2LongLoopFive transitively covers Four → Three → Two → One →
+-- Body → Iter. Phase2LongLoad covers Phase2LongAcc.
 import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
-import EvmAsm.Rv64.RLP.Phase2LongAcc
 import EvmAsm.Rv64.RLP.Phase2LongLoad
-import EvmAsm.Rv64.RLP.Phase2LongIter
-import EvmAsm.Rv64.RLP.Phase2LongLoopBody
-import EvmAsm.Rv64.RLP.Phase2LongLoopOne
-import EvmAsm.Rv64.RLP.Phase2LongLoopTwo
-import EvmAsm.Rv64.RLP.Phase2LongLoopThree
-import EvmAsm.Rv64.RLP.Phase2LongLoopFour
 import EvmAsm.Rv64.RLP.Phase2LongLoopFive


### PR DESCRIPTION
## Summary
`EvmAsm.Rv64.RLP.lean` listed all 11 phase modules. The `Phase2LongLoop*` chain is strictly linear: `Five → Four → Three → Two → One → Body → Iter`. And `Phase2LongLoad` imports `Phase2LongAcc`.

So importing `Phase2LongLoopFive` transitively covers 6 others, and `Phase2LongLoad` covers `Phase2LongAcc`. With `Phase1` and `Phase2Short` as standalone leaves, the umbrella reduces to 4 lines (down from 11).

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)