### PR TITLE
chore(Evm64): drop EvmWordArith and Compare.LimbSpec redundancies (#1045)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -21,15 +21,11 @@ import EvmAsm.Evm64.Or
 import EvmAsm.Evm64.Xor
 import EvmAsm.Evm64.Not
 
--- EvmWord arithmetic correctness lemmas
-import EvmAsm.Evm64.EvmWordArith
-
--- Arithmetic
+-- Arithmetic (Add.Spec transitively imports EvmWordArith)
 import EvmAsm.Evm64.Add
 import EvmAsm.Evm64.Sub
 
--- Comparisons
-import EvmAsm.Evm64.Compare.LimbSpec
+-- Comparisons (Lt.Spec transitively imports Compare.LimbSpec)
 import EvmAsm.Evm64.Lt
 import EvmAsm.Evm64.Gt
 import EvmAsm.Evm64.Eq


### PR DESCRIPTION
## Summary
- `EvmWordArith` is imported by `Add.Spec` (and every other arithmetic / comparison / shift / byte / multiply / divmod opcode Spec). So the explicit `import EvmAsm.Evm64.EvmWordArith` in the umbrella is dead weight once any of those opcodes is present.
- `Compare.LimbSpec` is imported by the four comparator Specs (`Lt.Spec`, `Gt.Spec`, `Slt.Spec`, `Sgt.Spec`). The explicit umbrella import is redundant once `Lt` (or any of the other three) is present.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)