### PR TITLE
chore(Evm64): drop Basic and Stack imports from umbrella (#1045)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -4,9 +4,8 @@
   Root import file for the 64-bit EVM opcode implementations (RV64IM).
 -/
 
--- Foundations
-import EvmAsm.Evm64.Basic
-import EvmAsm.Evm64.Stack
+-- Foundations (Basic and Stack are transitively imported by every
+-- opcode Program file via Stack → Basic).
 import EvmAsm.Evm64.CodeRegion
 
 -- Stack operations


### PR DESCRIPTION
## Summary
Every opcode `Program.lean` file (And, Or, Xor, Not, Pop, Push0, Dup, Swap, Add, Sub, Lt, Gt, Eq, IsZero, Slt, Sgt, Shift, Byte, SignExtend, Multiply, DivMod) imports `EvmAsm.Evm64.Stack`, which itself imports `EvmAsm.Evm64.Basic`. So listing `Basic` and `Stack` explicitly in the `EvmAsm.Evm64` umbrella is dead weight once any opcode is imported.

Per #1045 import-hygiene sweep.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)