### PR TITLE
refactor(DivN4Overestimate): inline hdiv into final calc step (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -108,10 +108,10 @@ theorem bv_udiv_add_umod {n : Nat} {x y : BitVec n} :
     y * (x / y) + x % y = x := by
   apply BitVec.eq_of_toNat_eq
   simp only [BitVec.toNat_add, BitVec.toNat_mul, BitVec.toNat_udiv, BitVec.toNat_umod]
-  have hdiv := Nat.div_add_mod x.toNat y.toNat
+  have := Nat.div_add_mod x.toNat y.toNat
   have : y.toNat * (x.toNat / y.toNat) ≤ x.toNat := by omega
   rw [Nat.mod_eq_of_lt (by omega : y.toNat * (x.toNat / y.toNat) < 2 ^ n),
-      hdiv, Nat.mod_eq_of_lt x.isLt]
+      Nat.div_add_mod, Nat.mod_eq_of_lt x.isLt]
 
 /-- Uniqueness of BitVec unsigned division: if `a = b * q + r` with `r < b`
     and no overflow in `b * q + r`, then `q = a / b` and `r = a % b`. -/

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -512,12 +512,12 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
     have : q.toNat = 0 := by omega
     simp [this] at hqv_gt_u
   -- (q-1) * val256(v) ≤ val256(u) (from hq_over: q ≤ ⌊u/v⌋ + 1)
-  have hqm1_le : (q.toNat - 1) * val256 v0 v1 v2 v3 ≤ val256 u0 u1 u2 u3 := by
-    have hdiv := Nat.div_mul_le_self (val256 u0 u1 u2 u3) (val256 v0 v1 v2 v3)
+  have hqm1_le : (q.toNat - 1) * val256 v0 v1 v2 v3 ≤ val256 u0 u1 u2 u3 :=
     calc (q.toNat - 1) * val256 v0 v1 v2 v3
         ≤ (val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3) * val256 v0 v1 v2 v3 := by
           apply Nat.mul_le_mul_right; omega
-      _ ≤ val256 u0 u1 u2 u3 := hdiv
+      _ ≤ val256 u0 u1 u2 u3 :=
+          Nat.div_mul_le_self (val256 u0 u1 u2 u3) (val256 v0 v1 v2 v3)
   -- q * val256(v) ≤ val256(u) + val256(v) (from hqm1_le)
   have hqv_le : q.toNat * val256 v0 v1 v2 v3 ≤
       val256 u0 u1 u2 u3 + val256 v0 v1 v2 v3 := by


### PR DESCRIPTION
## Summary
`hdiv := Nat.div_mul_le_self …` inside `hqm1_le` was only used once — as the proof term for the last calc step. Inline it there and drop the surrounding `by` block.

Per #694 inline-rename scope: single-use bare lemma reference.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.DivN4Overestimate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)