### PR TITLE
refactor(DivAccumulate): inline 4 single-use hv bindings (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -155,8 +155,7 @@ theorem div_correct_n4_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero hbnz
-  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
+  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   -- val256(q0, 0, 0, 0) = q0.toNat
   have hq_val : val256 q0 0 0 0 = q0.toNat := val256_zero_upper_3
   have hmulsub' : val256 a0 a1 a2 a3 =
@@ -185,8 +184,7 @@ theorem div_correct_n3_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero hbnz
-  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
+  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 0 0 = q1.toNat * 2^64 + q0.toNat :=
     (accumulated_eq_val256_n3).symm
   have hmulsub' : val256 a0 a1 a2 a3 =
@@ -213,8 +211,7 @@ theorem div_correct_n2_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero hbnz
-  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
+  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 q2 0 = q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
     (accumulated_eq_val256_n2).symm
   have hmulsub' : val256 a0 a1 a2 a3 =
@@ -241,8 +238,7 @@ theorem div_correct_n1_no_shift
       match i with | 0 => r0 | 1 => r1 | 2 => r2 | 3 => r3
     q = EvmWord.div a b ∧ r = EvmWord.mod a b := by
   intro a b q r
-  have hv := val256_pos_of_or_ne_zero hbnz
-  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
+  have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 q2 q3 =
       q3.toNat * 2^192 + q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
     (accumulated_eq_val256_n1).symm


### PR DESCRIPTION
## Summary
Four theorems in `DivAccumulate.lean` each had:

\`\`\`lean
have hv := val256_pos_of_or_ne_zero hbnz
have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
\`\`\`

where \`hv\` is used exactly once, immediately on the next line. Inline the term to shave a name per theorem.

Per #694 inline-rename scope: single-use 1-arg application.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.DivAccumulate\` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)