### PR TITLE
refactor(Val256ModBridge): inline hv/hge + anonymize unused hr_lt (#694)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean
@@ -48,9 +48,9 @@ theorem val256_ms_un_eq_val256_mod_max_skip
       (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 +
       val256 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 := by linarith
   -- Overestimate: val256(a)/val256(b) ≤ qHat.
-  have hge := max_trial_overestimate_n4 a0 a1 a2 a3 b0 b1 b2 b3 hb3nz
-  have hv := val256_pos_of_or_ne_zero hbnz
-  have ⟨hq, hr_lt⟩ := remainder_lt_of_ge_floor hv hmulsub hge
+  have ⟨hq, _⟩ := remainder_lt_of_ge_floor
+    (val256_pos_of_or_ne_zero hbnz) hmulsub
+    (max_trial_overestimate_n4 a0 a1 a2 a3 b0 b1 b2 b3 hb3nz)
   -- Substitute `qHat = val256(a)/val256(b)` into the mulsub equation, then
   -- compare with `Nat.div_add_mod` to conclude.
   rw [hq] at hmulsub


### PR DESCRIPTION
## Summary
In `val256_ms_un_eq_val256_mod_max_skip`:
- `hv := val256_pos_of_or_ne_zero hbnz` and `hge := max_trial_overestimate_n4 …` were each used exactly once, as arguments to `remainder_lt_of_ge_floor`. Inline both.
- `hr_lt` in the destructuring `have ⟨hq, hr_lt⟩ := …` is unused in the rest of the proof; rename to `_`.

Per #694 inline-rename scope: single-use applications.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.Val256ModBridge` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)