### PR TITLE
refactor(SignExtend/Compose): inline hdecomp into the rw (#694)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -659,9 +659,8 @@ theorem signext_body_spec (sp base : Word)
   have hb3_zero : b3 = 0 := hb12_b3.2
   -- b.toNat = b0.toNat (since high limbs are zero)
   have hb0_eq_b : b0.toNat = b.toNat := by
-    have hdecomp := EvmWord.toNat_eq_limb_sum b
     change b0.toNat = b.toNat
-    rw [hdecomp]
+    rw [EvmWord.toNat_eq_limb_sum b]
     simp only [b1, b2, b3] at hb1_zero hb2_zero hb3_zero
     simp [b0, hb1_zero, hb2_zero, hb3_zero]
   have hnotge : ¬ b.toNat ≥ 31 := by omega


### PR DESCRIPTION
## Summary
`hdecomp := EvmWord.toNat_eq_limb_sum b` is bound only to be used once in the very next `rw`. Inline the term directly.

Per #694 inline-rename scope: bare 1-arg lemma reference, single use.

## Test plan
- [x] `lake build EvmAsm.Evm64.SignExtend.Compose` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)