### PR TITLE
refactor(DivN4Overestimate): anonymize val256_bound bindings

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -191,7 +191,7 @@ theorem n4_max_addback_correct {a0 a1 a2 a3 b0 b1 b2 b3 : Word}
     rw [word_toNat_1] at hmulsub_raw
     -- hmulsub_raw: val256 u + 1 * 2^256 = val256 un + qHat * val256 v
     -- So qHat * val256 v ≥ val256 u + 1 (since 2^256 > val256 un)
-    have hv_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+    have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
     have hv_pos := val256_pos_of_or_ne_zero hbnz
     have hq_mul_gt : (signExtend12 (4095 : BitVec 12) : Word).toNat * val256 b0 b1 b2 b3 >
         val256 a0 a1 a2 a3 := by nlinarith
@@ -223,9 +223,9 @@ theorem mulsubN4_c3_le_one {q v0 v1 v2 v3 u0 u1 u2 u3 : Word}
   have hmulsub := mulsubN4_val256_eq q v0 v1 v2 v3 u0 u1 u2 u3
   simp only [] at hmulsub
   -- Bounds
-  have hu_bound := val256_bound u0 u1 u2 u3
-  have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
-  have hv_bound := val256_bound v0 v1 v2 v3
+  have := val256_bound u0 u1 u2 u3
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound v0 v1 v2 v3
   have := val256_pos_of_or_ne_zero hbnz
   -- From hq_over: q * val256(v) ≤ (⌊u/v⌋ + 1) * val256(v)
   --            = ⌊u/v⌋ * val256(v) + val256(v) ≤ val256(u) + val256(v)
@@ -296,7 +296,7 @@ theorem mulsubN4_c3_le_one_v3_zero (q v0 v1 v2 u0 u1 u2 u3 : Word) :
   simp only [] at hmulsub
   let ms := mulsubN4 q v0 v1 v2 0 u0 u1 u2 u3
   let c3 := ms.2.2.2.2
-  have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have hv_bound := val256_lt_pow192 v0 v1 v2
   have := q.isLt
   have : q.toNat * val256 v0 v1 v2 0 < 2 ^ 256 := by nlinarith
@@ -362,7 +362,7 @@ theorem addbackN4_second_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   simp only [] at hab'
   -- Bounds
   have := val256_pos_of_or_ne_zero hbnz
-  have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
   have := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
   have hab'_result_bound := val256_bound
     (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 0 v0 v1 v2 v3).1
@@ -499,9 +499,9 @@ theorem addbackN4_first_carry_one (q v0 v1 v2 v3 u0 u1 u2 u3 : Word)
   set carry := (addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3).toNat
   set ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
   -- Bounds
-  have hun_bound := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
-  have hv_bound := val256_bound v0 v1 v2 v3
-  have hu_bound := val256_bound u0 u1 u2 u3
+  have := val256_bound ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+  have := val256_bound v0 v1 v2 v3
+  have := val256_bound u0 u1 u2 u3
   have := val256_bound ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1
   have hv_pos : 0 < val256 v0 v1 v2 v3 := val256_pos_of_or_ne_zero hbnz
   -- q * val256(v) > val256(u) (from c3 = 1, i.e., borrow)


### PR DESCRIPTION
## Summary
`hv_bound`, `hu_bound`, `hun_bound` in `DivN4Overestimate.lean` are all bound via `val256_bound …` but never referenced by name — consumed only implicitly by `nlinarith`'s context scan. Rename 9 bindings to anonymous `have := …`.

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith.DivN4Overestimate` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)