### PR TITLE
chore(Evm64/DivMod): drop FullPath{N1,N2,N3}Loop + N2LoopUnified + N2Cases (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -7,19 +7,17 @@ import EvmAsm.Evm64.DivMod.SpecCall
 import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+-- FullPathN1LoopUnified transitively covers FullPathN1Loop, FullPathN2Loop;
+-- FullPathN3LoopUnified covers FullPathN3Loop; FullPathN2Full covers
+-- FullPathN2LoopUnified + FullPathN2Cases.
 import EvmAsm.Evm64.DivMod.LoopUnifiedN3
 import EvmAsm.Evm64.DivMod.LoopUnifiedN2
-import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2Cases
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopFull
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Shift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Shift0
 import EvmAsm.Evm64.DivMod.LoopUnifiedN1
-import EvmAsm.Evm64.DivMod.Compose.FullPathN1Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Shift0
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Full


### PR DESCRIPTION
## Summary
Further DivMod umbrella reduction, continuing the pattern from #1231/#1234:

- `FullPathN1LoopUnified` transitively covers `FullPathN1Loop` and (via N1Loop → N2Loop) `FullPathN2Loop`.
- `FullPathN3LoopUnified` covers `FullPathN3Loop`.
- `FullPathN2Full` covers `FullPathN2LoopUnified` + `FullPathN2Cases`.

Drop the 5 now-redundant explicit imports.

## Test plan
- [x] `lake build` succeeds full project (3699 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)