### PR TITLE
chore(Evm64/DivMod): drop 4 more redundant umbrella imports (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -1,15 +1,14 @@
 import EvmAsm.Evm64.DivMod.NormDefs
 import EvmAsm.Evm64.DivMod.Program
 import EvmAsm.Evm64.DivMod.LimbSpec
-import EvmAsm.Evm64.DivMod.Compose
-import EvmAsm.Evm64.DivMod.Spec
-import EvmAsm.Evm64.DivMod.SpecCall
-import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
-import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
--- FullPathN1LoopUnified transitively imports FullPathN1Loop + FullPathN3Loop,
--- which in turn pull in LoopUnifiedN{1,2,3} + LoopComposeN3 + FullPathN{1,2,3}
+-- SpecCall covers Spec → Compose + FullPathN4 + FullPathN4Beq + ModFullPathN4
+-- + EvmWordArith + ModFullPathN4Shift0 + FullPathN4Shift0.
+-- LoopBody covers Compose + LoopDefs + EvmWordArith.DivN4Overestimate.
+-- FullPathN1LoopUnified transitively covers FullPathN1Loop + FullPathN3Loop,
+-- which pull in LoopUnifiedN{1,2,3} + LoopComposeN3 + FullPathN{1,2,3}
 -- + FullPathN4Loop. FullPathN2Full covers FullPathN2LoopUnified +
 -- FullPathN2Cases + FullPath.
+import EvmAsm.Evm64.DivMod.SpecCall
+import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full


### PR DESCRIPTION
## Summary
`SpecCall` transitively imports `Spec` + `FullPathN4Shift0` + `ModFullPathN4Shift0`. `Spec` imports `Compose` + `EvmWordArith`. `LoopBody` imports `Compose` + `EvmWordArith.DivN4Overestimate`.

So the DivMod umbrella's explicit `Compose`, `Spec`, `ModFullPathN4Shift0`, and `EvmWordArith.DivN4Overestimate` are all dead once `SpecCall` and `LoopBody` are present.

Drop the 4 redundant lines.

## Test plan
- [x] `lake build` succeeds full project (3693 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)