### PR TITLE
chore(SignExtend/Spec): drop EvmWordArith (covered by Compose) (#1045)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -7,7 +7,6 @@
 -/
 
 import EvmAsm.Evm64.SignExtend.Compose
-import EvmAsm.Evm64.EvmWordArith
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
`SignExtend/Compose.lean` imports `EvmWordArith`, so the explicit import in `SignExtend/Spec.lean` is dead weight once `Compose` is imported.

## Test plan
- [x] `lake build EvmAsm.Evm64.SignExtend.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)