### PR TITLE
chore(Evm64): narrow EvmWordArith imports to used sub-modules (#1045)

### DIFF
--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -6,7 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Add.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Arithmetic
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -6,7 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Eq.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Eq
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -8,7 +8,7 @@
 
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -6,7 +6,7 @@
 -/
 
 import EvmAsm.Evm64.IsZero.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.IsZero
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -7,7 +7,7 @@
 
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -11,7 +11,7 @@
 
 import EvmAsm.Evm64.Sgt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -10,7 +10,7 @@
 
 import EvmAsm.Evm64.Slt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -6,7 +6,7 @@
 -/
 
 import EvmAsm.Evm64.Sub.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Arithmetic
 import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
Seven opcode Spec files imported the full `EvmWordArith` umbrella but only use one sub-module's symbols each:

- `Add.Spec` → `EvmWordArith.Arithmetic` (`add_carry_chain_correct`)
- `Sub.Spec` → `EvmWordArith.Arithmetic` (`sub_borrow_chain_correct`)
- `Eq.Spec` → `EvmWordArith.Eq` (`eq_xor_or_reduce_correct`)
- `IsZero.Spec` → `EvmWordArith.IsZero` (`iszero_or_reduce_correct`)
- `Lt.Spec`, `Gt.Spec` → `EvmWordArith.Comparison` (`lt_borrow_chain_correct`)
- `Slt.Spec`, `Sgt.Spec` → `EvmWordArith.Comparison` (`slt_result_correct`)

Replace each umbrella import with the specific sub-module. Shrinks the transitive import surface of each Spec without changing behavior.

## Test plan
- [x] `lake build` succeeds full project (3693 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)