### PR TITLE
chore(Byte/Spec): narrow EvmWordArith import to ByteOps (#1045)

### DIFF
--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -14,7 +14,7 @@
 -/
 
 import EvmAsm.Evm64.Byte.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.ByteOps
 import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import Mathlib.Tactic.Set


### PR DESCRIPTION
## Summary
`Byte/Spec.lean` uses `byte_correct` (from `EvmWordArith.ByteOps`) and `EvmWord.toNat_eq_getLimb0_of_high_zero` (from `EvmAsm.Evm64.Basic`, transitively imported). The full `EvmWordArith` umbrella is overkill. Narrow to `EvmWordArith.ByteOps`.

## Test plan
- [x] `lake build EvmAsm.Evm64.Byte.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)