### PR TITLE
chore(SignExtend/Compose): narrow EvmWordArith to SignExtend (#1045)

### DIFF
--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -9,7 +9,7 @@
 -/
 
 import EvmAsm.Evm64.SignExtend.LimbSpec
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.SignExtend
 import EvmAsm.Rv64.AddrNorm
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
`SignExtend/Compose.lean` uses only `signextLimb`, `signextFill`, and `EvmWord.signextend` — all from `EvmWordArith.SignExtend`. The full umbrella is overkill.

## Test plan
- [x] `lake build EvmAsm.Evm64.SignExtend.Compose` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)