### PR TITLE
chore(DivMod/Spec): narrow EvmWordArith to specific sub-modules (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -47,7 +47,13 @@ import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
-import EvmAsm.Evm64.EvmWordArith
+import EvmAsm.Evm64.EvmWordArith.Div
+import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
+import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
+import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+import EvmAsm.Evm64.EvmWordArith.CLZLemmas
+import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -18,6 +18,7 @@
 import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
+import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary
`DivMod/Spec.lean` was the last file importing the full `EvmWordArith` umbrella. It uses symbols from 7 sub-modules:

- `Div` (`div`, `mod`, zero variants, `getLimbN_zero`)
- `DivLimbBridge` (`ne_zero_iff_getLimbN_or`)
- `SkipBorrowExtract` (`c3_le_u_top_of_skip_borrow`)
- `ModBridgeAssemble` (`output_slot_to_evmWordIs_mod_n4_max_skip_denorm`)
- `DivN4DoubleAddback` (`n4_max_double_addback_div_mod_getLimbN`)
- `CLZLemmas` (`clzResult_fst_top_bound`)
- `MaxTrialVacuity` (`isMaxTrialN4_false_of_shift_nz`)

Replace the umbrella import with these sub-modules. `SpecCall.lean` also gains an explicit `Div128CallSkipClose` import that was previously coming through the umbrella transitively.

After this PR, no file under `EvmAsm/` imports `EvmAsm.Evm64.EvmWordArith` directly.

## Test plan
- [x] `lake build` succeeds full project (3690 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)