### PR TITLE
chore(Slt/Program): drop redundant Stack import (#1045)

### DIFF
--- a/EvmAsm/Evm64/Slt/Program.lean
+++ b/EvmAsm/Evm64/Slt/Program.lean
@@ -4,7 +4,6 @@
   256-bit EVM SLT program definition.
 -/
 
-import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
## Summary
`Slt/Program.lean` imports `EvmAsm.Evm64.Stack`, but nothing in the file uses anything from `Stack.lean` — the opcode is pure `Program`/`Instr` construction, and `Program`/`Instr` are pulled in transitively through `Rv64.CPSSpec → Execution → Program`.

Downstream (`Slt/Spec.lean`) imports `Stack` directly where needed, so removing it from `Slt/Program.lean` doesn't break the chain.

(I verified this: dropping `Stack` from the other opcode `Program.lean` files causes their `Spec.lean` files to lose access to `Stack` symbols, so this cleanup is only safe for `Slt/Program.lean`.)

## Test plan
- [x] `lake build` succeeds full project (3694 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)