### PR TITLE
chore(DivMod/Spec): drop FullPathN4 (covered by FullPathN4Beq) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -44,7 +44,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
 import EvmAsm.Evm64.EvmWordArith.Div


### PR DESCRIPTION
## Summary
`FullPathN4Beq.lean` imports `FullPathN4.lean`, so explicitly listing `FullPathN4` in `DivMod/Spec.lean`'s imports is redundant once `FullPathN4Beq` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)