### PR TITLE
chore(DivMod/Spec): drop FullPathN4Beq (covered by ModFullPathN4) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -44,7 +44,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
 import EvmAsm.Evm64.EvmWordArith.Div
 import EvmAsm.Evm64.EvmWordArith.DivLimbBridge


### PR DESCRIPTION
## Summary
`ModFullPathN4.lean` imports `FullPathN4Beq.lean`, so explicitly listing `FullPathN4Beq` in `DivMod/Spec.lean` is redundant once `ModFullPathN4` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)