### PR TITLE
chore(ModFullPathN4): drop FullPathN4 (covered by FullPathN4Beq) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -7,7 +7,6 @@
   For n=4, the loop runs exactly 1 iteration (j=0 only).
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 import EvmAsm.Evm64.DivMod.Compose.ModFullPath
 


### PR DESCRIPTION
## Summary
`FullPathN4Beq.lean` imports `FullPathN4.lean`, so the explicit import of `FullPathN4` in `ModFullPathN4.lean` is redundant once `FullPathN4Beq` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN4` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)