### PR TITLE
chore(DivMod/LoopBody{N2,N3}): drop redundant LoopDefs import (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN2.lean
@@ -17,7 +17,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.LoopDefs
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN3.lean
@@ -17,7 +17,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.LoopDefs
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary
`LoopBodyN2.lean` and `LoopBodyN3.lean` each import both `LoopBody` and `LoopDefs`. Since `LoopBody` itself imports `LoopDefs`, the explicit `LoopDefs` import in each is redundant.

## Test plan
- [x] `lake build` succeeds full project (3691 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)