### PR TITLE
chore(DivMod/LoopBody{N1,N4}): drop redundant LoopDefs import (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN1.lean
@@ -17,7 +17,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.LoopDefs
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBodyN4.lean
@@ -17,7 +17,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LoopBody
-import EvmAsm.Evm64.DivMod.LoopDefs
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary
Same pattern as #1269: `LoopBodyN1.lean` and `LoopBodyN4.lean` each import both `LoopBody` and `LoopDefs`. Since `LoopBody` itself imports `LoopDefs`, the explicit import is redundant.

## Test plan
- [x] `lake build` succeeds full project (3691 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)