### PR TITLE
chore(ModDiv128): drop redundant Base import (covered by Div128) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -1,4 +1,3 @@
-import EvmAsm.Evm64.DivMod.Compose.Base
 import EvmAsm.Evm64.DivMod.Compose.Div128
 
 /-!


### PR DESCRIPTION
## Summary
`Div128.lean` imports `Base.lean`, so the explicit `Base` import in `ModDiv128.lean` is redundant once `Div128` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.ModDiv128` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)