### PR TITLE
chore(FullPathN2{Cases,Full}): drop redundant imports (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -15,7 +15,6 @@
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPath
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2Loop
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -7,8 +7,6 @@
   Starts with the all-max case (bltu_2 = bltu_1 = bltu_0 = false) as the foundation.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Cases
 


### PR DESCRIPTION
## Summary
- `FullPathN2Cases.lean` imports both `FullPathN2LoopUnified` and `FullPathN2Loop`; the former transitively imports the latter. Drop the explicit `FullPathN2Loop` import.
- `FullPathN2Full.lean` imports `FullPathN2LoopUnified`, `FullPath`, `FullPathN4Loop`, and `FullPathN2Cases`. `FullPathN2Cases` itself imports `FullPathN2LoopUnified` and `FullPath`, so those two are redundant.

## Test plan
- [x] `lake build` succeeds full project (3691 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)