### PR TITLE
chore(DivMod/Spec): drop CLZLemmas (covered by MaxTrialVacuity) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -50,7 +50,6 @@ import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
-import EvmAsm.Evm64.EvmWordArith.CLZLemmas
 import EvmAsm.Evm64.EvmWordArith.MaxTrialVacuity
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
`MaxTrialVacuity.lean` imports `CLZLemmas.lean`, so the explicit `CLZLemmas` import in `DivMod/Spec.lean` is redundant once `MaxTrialVacuity` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)