### PR TITLE
chore(DivMod/Spec): drop Div import (covered via DivLimbBridge chain) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -45,7 +45,6 @@
 
 import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
-import EvmAsm.Evm64.EvmWordArith.Div
 import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble


### PR DESCRIPTION
## Summary
`DivLimbBridge → DivBridge → Normalization → Div`, so the explicit `EvmWordArith.Div` import in `DivMod/Spec.lean` is redundant once `DivLimbBridge` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Spec` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)