### PR TITLE
chore(SpecCall): drop FullPathN4Shift0 (covered by ModFullPathN4Shift0) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -16,7 +16,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
 import EvmAsm.Evm64.EvmWordArith.Div128Shift0


### PR DESCRIPTION
## Summary
`ModFullPathN4Shift0.lean` imports `FullPathN4Shift0.lean`, so the explicit `FullPathN4Shift0` import in `SpecCall.lean` is redundant once `ModFullPathN4Shift0` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.SpecCall` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)