### PR TITLE
chore(SpecCall): drop Div128CallSkipClose (covered by Div128Shift0) (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecCall.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCall.lean
@@ -18,7 +18,6 @@
 import EvmAsm.Evm64.DivMod.Spec
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
-import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
 import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
`Div128Shift0.lean` imports `Div128CallSkipClose.lean`, so the explicit `Div128CallSkipClose` import in `SpecCall.lean` is redundant once `Div128Shift0` is present.

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.SpecCall` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)