### PR TITLE
chore(Shift0Dispatcher): drop SpecCall (covered by Shift0AddbackMod)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Shift0Dispatcher.lean
@@ -8,7 +8,7 @@
   is vacuously true and doesn't need to be supplied at this level.
 -/
 
-import EvmAsm.Evm64.DivMod.SpecCall
+-- `Shift0AddbackMod` transitively imports `SpecCall`.
 import EvmAsm.Evm64.DivMod.Shift0AddbackMod
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- `EvmAsm.Evm64.DivMod.Shift0AddbackMod` already imports `SpecCall`, so `Shift0Dispatcher.lean`'s direct import is redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Shift0Dispatcher` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)