### PR TITLE
chore(Shift0AddbackMod): drop Div128Shift0 (covered by SpecCall)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Shift0AddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Shift0AddbackMod.lean
@@ -5,8 +5,8 @@
   Isolated to minimize whnf pressure.
 -/
 
+-- `SpecCall` transitively imports `EvmWordArith.Div128Shift0`.
 import EvmAsm.Evm64.DivMod.SpecCall
-import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary
- `SpecCall` already imports `EvmAsm.Evm64.EvmWordArith.Div128Shift0`, so `Shift0AddbackMod.lean`'s direct import is redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Shift0AddbackMod EvmAsm.Evm64.DivMod.Shift0Dispatcher` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)