### PR TITLE
chore(DivMod): collapse SpecCall + Shift0AddbackMod into Shift0Dispatcher

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -8,8 +8,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec
 -- which pull in LoopUnifiedN{1,2,3} + LoopComposeN3 + FullPathN{1,2,3}
 -- + FullPathN4Loop. FullPathN2Full covers FullPathN2LoopUnified +
 -- FullPathN2Cases + FullPath.
-import EvmAsm.Evm64.DivMod.SpecCall
-import EvmAsm.Evm64.DivMod.Shift0AddbackMod
+-- Shift0Dispatcher → Shift0AddbackMod → SpecCall transitively.
 import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified


### PR DESCRIPTION
## Summary
- `Shift0Dispatcher` already imports `Shift0AddbackMod`, which already imports `SpecCall`.
- So the three direct imports in `EvmAsm/Evm64/DivMod.lean` collapse to a single `Shift0Dispatcher` import.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod` passes locally (3442 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)