### PR TITLE
chore(FullPathN4Shift0): drop FullPathN4 (covered by FullPathN4Beq)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Shift0.lean
@@ -10,7 +10,7 @@
   Two sub-cases: skip (borrow=0) and addback (borrow≠0).
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4
+-- `FullPathN4Beq` transitively imports `FullPathN4`.
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
- `Compose/FullPathN4Beq.lean` already imports `FullPathN4`, so the direct import in `FullPathN4Shift0.lean` is redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)