### PR TITLE
chore(FullPathN2Full): drop FullPathN4Loop (covered by FullPathN2Cases)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Full.lean
@@ -7,7 +7,7 @@
   Starts with the all-max case (bltu_2 = bltu_1 = bltu_0 = false) as the foundation.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
+-- `FullPathN2Cases → FullPathN2LoopUnified → FullPathN2Loop → FullPathN4Loop`.
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Cases
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary
- Chain `FullPathN2Cases → FullPathN2LoopUnified → FullPathN2Loop → FullPathN4Loop` already covers `FullPathN4Loop`, so the direct import in `FullPathN2Full.lean` is redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.DivMod.Compose.FullPathN2Full` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)