### PR TITLE
chore(EvmWordArith): drop Div128CallSkipClose (covered by Div128Shift0)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -28,10 +28,11 @@ import EvmAsm.Evm64.EvmWordArith.DivAccumulate
 import EvmAsm.Evm64.EvmWordArith.DivMulSubCarry
 import EvmAsm.Evm64.EvmWordArith.DivAddbackCarry
 
--- Div128CallSkipClose covers Div128FinalAssembly + Div128KnuthLower +
--- Div128QuotientBounds → KnuthTheoremB → {DivN4Overestimate,
--- MaxTrialVacuity → CLZLemmas → DivN4Lemmas, DenormLemmas}.
-import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
+-- Div128Shift0 → Div128CallSkipClose → Div128FinalAssembly +
+-- Div128KnuthLower + Div128QuotientBounds → KnuthTheoremB →
+-- {DivN4Overestimate, MaxTrialVacuity → CLZLemmas → DivN4Lemmas,
+-- DenormLemmas}.
+import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 
 -- ModBridgeAssemble covers ModBridgeUtop → Val256ModBridge.
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
@@ -41,4 +42,3 @@ import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.AddbackBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.AddbackPinning
-import EvmAsm.Evm64.EvmWordArith.Div128Shift0


### PR DESCRIPTION
## Summary
- `Div128Shift0` already imports `Div128CallSkipClose`, so the direct import in the `EvmWordArith.lean` umbrella is redundant.
- Folded the existing transitive-coverage comment into the `Div128Shift0` line and moved `Div128Shift0` up so the chain stays documented.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.EvmWordArith` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)