### PR TITLE
chore(Rv64): collapse 7 redundant imports in root umbrella

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -4,25 +4,20 @@
   Root import file for the 64-bit RISC-V machine model (RV64IM).
 -/
 
--- SyscallSpecs transitively imports Basic, Instructions, SepLogic, Execution,
--- CPSSpec, GenericSpecs, InstructionSpecs, ByteOps, HalfwordOps, WordOps,
--- and Tactics.SpecDb.
+-- SyscallSpecs transitively imports Basic, Instructions, Program, SepLogic,
+-- Execution, CPSSpec, GenericSpecs, InstructionSpecs, ByteOps, HalfwordOps,
+-- WordOps, and Tactics.SpecDb. ControlFlow also covers Program directly.
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.ControlFlow
-import EvmAsm.Rv64.Tactics.PerfTrace
+-- RunBlock → SeqFrame → {XCancel, PerfTrace, InstructionSpecs} + SpecDb.
 import EvmAsm.Rv64.Tactics.XPerm
 import EvmAsm.Rv64.Tactics.XSimp
-import EvmAsm.Rv64.Tactics.XCancel
-import EvmAsm.Rv64.Tactics.SeqFrame
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.LiftSpec
 import EvmAsm.Rv64.RLP
-import EvmAsm.Rv64.RegOpsAttr
+-- The `*Attr` files are imported by their non-Attr counterparts.
 import EvmAsm.Rv64.RegOps
-import EvmAsm.Rv64.AddrNormAttr
 import EvmAsm.Rv64.AddrNorm
-import EvmAsm.Rv64.ByteAlgAttr
 import EvmAsm.Rv64.ByteAlg
 -- SailEquiv leaves (each transitively imports ALUProofs → MonadLemmas → StateRel).
 import EvmAsm.Rv64.SailEquiv.ShiftProofs


### PR DESCRIPTION
## Summary
Remove 7 redundant imports from `EvmAsm/Rv64.lean`, each transitively covered by another umbrella import:

- `Program` — `ControlFlow → Program`; also `SyscallSpecs → Execution → Program`.
- `Tactics.PerfTrace`, `Tactics.SeqFrame`, `Tactics.XCancel` — all covered via `Tactics.RunBlock → Tactics.SeqFrame → {XCancel, PerfTrace, InstructionSpecs}`.
- `RegOpsAttr`, `AddrNormAttr`, `ByteAlgAttr` — each imported by its non-Attr counterpart (`RegOps`, `AddrNorm`, `ByteAlg`).

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Rv64` passes locally.
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)