### PR TITLE
chore(Shift/SarSpec): drop AddrNorm (covered by Shift.LimbSpec)

### DIFF
--- a/EvmAsm/Evm64/Shift/SarSpec.lean
+++ b/EvmAsm/Evm64/Shift/SarSpec.lean
@@ -10,8 +10,8 @@
   - Reuses SHR phase A/B/C specs from ShiftSpec.lean (with different offsets)
 -/
 
+-- `Shift.LimbSpec` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.Shift.LimbSpec
-import EvmAsm.Rv64.AddrNorm
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary
- `EvmAsm.Evm64.Shift.LimbSpec` already imports `EvmAsm.Rv64.AddrNorm`, so the direct import in `SarSpec.lean` is redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Evm64.Shift.SarSpec` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)