### PR TITLE
chore: drop imports covered by Rv64.SyscallSpecs in 5 files

### DIFF
--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -8,7 +8,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -32,8 +32,6 @@
 -/
 
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -25,8 +25,6 @@
 -/
 
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Rv64/RLP/Phase2LongIter.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongIter.lean
@@ -23,10 +23,7 @@
     x14 — iteration counter (mutated: decrements by 1)
 -/
 
-import EvmAsm.Rv64.ByteOps
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.Program
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Rv64/RLP/Phase2Short.lean
+++ b/EvmAsm/Rv64/RLP/Phase2Short.lean
@@ -20,8 +20,6 @@
 -/
 
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Rv64.RLP
 


### PR DESCRIPTION
## Summary
`Rv64.SyscallSpecs` transitively imports `CPSSpec`, `Program` (via `Execution → Program`), and `ByteOps`, so direct imports of those modules in files that already import `SyscallSpecs` are redundant.

- `Rv64/RLP/Phase1.lean`: drop `CPSSpec`, `Program`.
- `Rv64/RLP/Phase2Short.lean`: drop `CPSSpec`, `Program`.
- `Rv64/RLP/Phase2LongAcc.lean`: drop `CPSSpec`, `Program`.
- `Rv64/RLP/Phase2LongIter.lean`: drop `ByteOps`, `CPSSpec`, `Program`.
- `Evm64/Compare/LimbSpec.lean`: drop `CPSSpec`.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)