### PR TITLE
chore(Rv64): drop XPerm + XSimp (covered by RunBlock + LiftSpec)

### DIFF
--- a/EvmAsm/Rv64.lean
+++ b/EvmAsm/Rv64.lean
@@ -9,9 +9,8 @@
 -- WordOps, and Tactics.SpecDb. ControlFlow also covers Program directly.
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
--- RunBlock → SeqFrame → {XCancel, PerfTrace, InstructionSpecs} + SpecDb.
-import EvmAsm.Rv64.Tactics.XPerm
-import EvmAsm.Rv64.Tactics.XSimp
+-- RunBlock → SeqFrame → {XCancel → XPerm, PerfTrace, InstructionSpecs} + SpecDb.
+-- LiftSpec → XSimp → XPerm.
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.LiftSpec
 import EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary
- `LiftSpec → XSimp → XPerm`, and `RunBlock → SeqFrame → XCancel → XPerm`.
- So the direct `Tactics.XPerm` and `Tactics.XSimp` imports in `Rv64.lean` are redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)