### PR TITLE
chore(Rv64/InstructionSpecs): drop 5 imports covered by GenericSpecs

### DIFF
--- a/EvmAsm/Rv64/InstructionSpecs.lean
+++ b/EvmAsm/Rv64/InstructionSpecs.lean
@@ -14,11 +14,8 @@
   - LD/SD specs added using generic_ld_spec/generic_sd_spec
 -/
 
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Instructions
-import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.CPSSpec
+-- `GenericSpecs` transitively imports `Basic`, `Instructions`, `SepLogic`,
+-- `Execution`, and `CPSSpec`.
 import EvmAsm.Rv64.GenericSpecs
 
 namespace EvmAsm.Rv64


### PR DESCRIPTION
## Summary
- `EvmAsm.Rv64.GenericSpecs` transitively imports `Basic`, `Instructions`, `SepLogic`, `Execution`, and `CPSSpec`.
- So the five direct imports in `InstructionSpecs.lean` are redundant.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build EvmAsm.Rv64.InstructionSpecs` passes locally.
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)