### PR TITLE
chore(Rv64/SyscallSpecs): drop 6 imports covered by InstructionSpecs

### DIFF
--- a/EvmAsm/Rv64/SyscallSpecs.lean
+++ b/EvmAsm/Rv64/SyscallSpecs.lean
@@ -10,12 +10,9 @@
   Code is accessed via CodeReq.singleton side-condition (not instrAt in P/Q).
 -/
 
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Instructions
-import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.CPSSpec
-import EvmAsm.Rv64.GenericSpecs
+-- `InstructionSpecs → GenericSpecs → Basic, Instructions, SepLogic,
+-- Execution, CPSSpec`. `ByteOps`/`HalfwordOps`/`WordOps` are independent
+-- leaves and remain as direct imports.
 import EvmAsm.Rv64.InstructionSpecs
 import EvmAsm.Rv64.ByteOps
 import EvmAsm.Rv64.HalfwordOps


### PR DESCRIPTION
## Summary
- `InstructionSpecs → GenericSpecs → {Basic, Instructions, SepLogic, Execution, CPSSpec}`.
- So those six direct imports in `SyscallSpecs.lean` are redundant. `ByteOps`/`HalfwordOps`/`WordOps` are independent leaves and remain as direct imports.
- Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)