### PR TITLE
chore(Rv64): collapse foundational imports covered by CPSSpec

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -4,9 +4,7 @@
   Byte-level infrastructure: extractByte/replaceByte algebra and
   generic CPS specs for LBU (load byte unsigned) and SB (store byte).
 -/
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SepLogic
+-- `CPSSpec` transitively imports `Basic`, `SepLogic`, and `Execution`.
 import EvmAsm.Rv64.CPSSpec
 import Mathlib.Tactic
 

--- a/EvmAsm/Rv64/GenericSpecs.lean
+++ b/EvmAsm/Rv64/GenericSpecs.lean
@@ -14,10 +14,8 @@
   are one-line applications of these generic lemmas.
 -/
 
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Instructions
-import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Execution
+-- `CPSSpec` transitively imports `Basic`, `SepLogic`, `Execution`, and
+-- (via `Execution`) `Instructions`.
 import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Rv64

--- a/EvmAsm/Rv64/HalfwordOps.lean
+++ b/EvmAsm/Rv64/HalfwordOps.lean
@@ -5,9 +5,7 @@
   generic CPS specs for LH (load halfword signed), LHU (load halfword unsigned),
   and SH (store halfword).
 -/
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SepLogic
+-- `CPSSpec` transitively imports `Basic`, `SepLogic`, and `Execution`.
 import EvmAsm.Rv64.CPSSpec
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Tactic.FinCases

--- a/EvmAsm/Rv64/WordOps.lean
+++ b/EvmAsm/Rv64/WordOps.lean
@@ -5,9 +5,7 @@
   generic CPS specs for LW (load word signed), LWU (load word unsigned),
   and SW (store word).
 -/
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Execution
-import EvmAsm.Rv64.SepLogic
+-- `CPSSpec` transitively imports `Basic`, `SepLogic`, and `Execution`.
 import EvmAsm.Rv64.CPSSpec
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Tactic.FinCases


### PR DESCRIPTION
## Summary
`EvmAsm.Rv64.CPSSpec` transitively imports `Basic`, `SepLogic`, `Execution`, and (via `Execution`) `Instructions`. So direct imports of those modules are redundant alongside `CPSSpec`:

- `GenericSpecs.lean`: drop `Basic`, `Instructions`, `SepLogic`, `Execution` (4).
- `ByteOps.lean`: drop `Basic`, `Execution`, `SepLogic` (3).
- `HalfwordOps.lean`: drop `Basic`, `Execution`, `SepLogic` (3).
- `WordOps.lean`: drop `Basic`, `Execution`, `SepLogic` (3).

Total: 13 drops across 4 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)