### PR TITLE
chore: drop 13 scattered redundant imports across 13 files

### DIFF
--- a/EvmAsm/EL/RLP.lean
+++ b/EvmAsm/EL/RLP.lean
@@ -3,6 +3,5 @@
 
   Root import file for the RLP (Recursive Length Prefix) module.
 -/
-import EvmAsm.EL.RLP.Basic
-import EvmAsm.EL.RLP.Decode
+-- `Properties` transitively imports `Decode`, which transitively imports `Basic`.
 import EvmAsm.EL.RLP.Properties

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -3,7 +3,7 @@
 
   Round-trip correctness: `decode (encode item) = some (item, [])`.
 -/
-import EvmAsm.EL.RLP.Basic
+-- `Decode` transitively imports `Basic`.
 import EvmAsm.EL.RLP.Decode
 import Mathlib.Tactic
 

--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -11,7 +11,7 @@
 -/
 
 import EvmAsm.Evm64.Basic
-import EvmAsm.Rv64.SepLogic
+-- `ByteOps` transitively imports `Rv64.SepLogic`.
 import EvmAsm.Rv64.ByteOps
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -6,9 +6,9 @@
 -/
 
 import EvmAsm.Evm64.DivMod.LimbSpec
+-- `Evm64.DivMod.AddrNorm` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.DivMod.AddrNorm
 import EvmAsm.Evm64.DivMod.Compose.Offsets
-import EvmAsm.Rv64.AddrNorm
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -6,7 +6,7 @@
   preloop+loop specs (base → base+904).
 -/
 
-import EvmAsm.Evm64.DivMod.LoopComposeN3
+-- `LoopUnifiedN3` transitively imports `LoopComposeN3`.
 import EvmAsm.Evm64.DivMod.LoopUnifiedN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop

--- a/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/CLZ.lean
@@ -21,8 +21,8 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+-- `Evm64.DivMod.AddrNorm` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.DivMod.AddrNorm
-import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/TrialQuotient.lean
@@ -19,8 +19,8 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Program
+-- `Evm64.DivMod.AddrNorm` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.DivMod.AddrNorm
-import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/DivMod/LoopDefs.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs.lean
@@ -11,6 +11,6 @@
   editor responsiveness (issue #312).
 -/
 
-import EvmAsm.Evm64.DivMod.LoopDefs.Iter
+-- `Post` transitively imports `Iter`.
 import EvmAsm.Evm64.DivMod.LoopDefs.Post
 import EvmAsm.Evm64.DivMod.LoopDefs.Bundle

--- a/EvmAsm/Evm64/Shift/ComposeBase.lean
+++ b/EvmAsm/Evm64/Shift/ComposeBase.lean
@@ -15,8 +15,8 @@
     keeps its bridges locally.
 -/
 
+-- `Shift.LimbSpec` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.Shift.LimbSpec
-import EvmAsm.Rv64.AddrNorm
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/SarSemantic.lean
+++ b/EvmAsm/Evm64/Shift/SarSemantic.lean
@@ -9,8 +9,8 @@
    else sshiftRight value shift.toNat`.
 -/
 
+-- `Shift.SarCompose` transitively imports `Evm64.SpAddr`.
 import EvmAsm.Evm64.Shift.SarCompose
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Shift/Semantic.lean
+++ b/EvmAsm/Evm64/Shift/Semantic.lean
@@ -8,8 +8,8 @@
   `if shift.toNat ≥ 256 then 0 else value >>> shift.toNat`.
 -/
 
+-- `Shift.Compose` transitively imports `Evm64.SpAddr`.
 import EvmAsm.Evm64.Shift.Compose
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Shift/ShlSemantic.lean
+++ b/EvmAsm/Evm64/Shift/ShlSemantic.lean
@@ -8,8 +8,8 @@
   `if shift.toNat ≥ 256 then 0 else value <<< shift.toNat`.
 -/
 
+-- `Shift.ShlCompose` transitively imports `Evm64.SpAddr`.
 import EvmAsm.Evm64.Shift.ShlCompose
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -8,9 +8,9 @@
   - Body L (L=0..3, b < 31): Phase A ntaken → B → C(exit L) → body_L → done → exit
 -/
 
+-- `SignExtend.LimbSpec` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.SignExtend.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.SignExtend
-import EvmAsm.Rv64.AddrNorm
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary

Each direct import below is covered transitively by another import already in the file:

- `EL/RLP.lean`: `Basic` + `Decode` covered by `Properties`.
- `EL/RLP/Properties.lean`: `Basic` covered by `Decode`.
- `Evm64/CodeRegion.lean`: `Rv64.SepLogic` covered by `Rv64.ByteOps`.
- `Evm64/DivMod/Compose/Base.lean`: `Rv64.AddrNorm` covered by `Evm64.DivMod.AddrNorm`.
- `Evm64/DivMod/Compose/FullPathN3Loop.lean`: `LoopComposeN3` covered by `LoopUnifiedN3`.
- `Evm64/DivMod/LimbSpec/CLZ.lean`: `Rv64.AddrNorm` covered by `Evm64.DivMod.AddrNorm`.
- `Evm64/DivMod/LimbSpec/TrialQuotient.lean`: `Rv64.AddrNorm` covered by `Evm64.DivMod.AddrNorm`.
- `Evm64/DivMod/LoopDefs.lean`: `LoopDefs.Iter` covered by `LoopDefs.Post`.
- `Evm64/Shift/ComposeBase.lean`: `Rv64.AddrNorm` covered by `Shift.LimbSpec`.
- `Evm64/Shift/{Sar,Shl,}Semantic.lean`: `Evm64.SpAddr` covered by the corresponding `{Sar,Shl,}Compose` import (3 files).
- `Evm64/SignExtend/Compose.lean`: `Rv64.AddrNorm` covered by `SignExtend.LimbSpec`.

Total: 13 drops across 13 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)