### PR TITLE
chore(Rv64): collapse foundation-triangle imports to minimal chain

### DIFF
--- a/EvmAsm/Rv64/CPSSpec.lean
+++ b/EvmAsm/Rv64/CPSSpec.lean
@@ -25,9 +25,8 @@
   MachineState via `holdsFor`.
 -/
 
-import EvmAsm.Rv64.Basic
+-- `SepLogic` transitively imports `Basic` and `Execution`.
 import EvmAsm.Rv64.SepLogic
-import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Rv64
 

--- a/EvmAsm/Rv64/Execution.lean
+++ b/EvmAsm/Rv64/Execution.lean
@@ -15,8 +15,7 @@
   - step / stepN: single-step and multi-step execution over code memory
 -/
 
-import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.Instructions
+-- `Program` transitively imports `Instructions` and (via `Instructions`) `Basic`.
 import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Rv64

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -12,7 +12,7 @@
   machine state when there exists a compatible partial state satisfying it.
 -/
 
-import EvmAsm.Rv64.Basic
+-- `Execution` transitively imports `Basic`.
 import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Rv64


### PR DESCRIPTION
## Summary
The foundation chain is `SepLogic → Execution → Program → Instructions → Basic`. The three foundational files each duplicate imports already covered by their own top-level import:

- `CPSSpec.lean`: drop `Basic`, `Execution` — `SepLogic` covers both.
- `Execution.lean`: drop `Basic`, `Instructions` — `Program` covers both.
- `SepLogic.lean`: drop `Basic` — `Execution` covers it.

Total: 5 drops across 3 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)