### PR TITLE
chore: drop 10 two-hop redundant imports across 10 files

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -5,9 +5,10 @@
   program length lemmas, and the skipBlock tactic macro.
 -/
 
+-- `LimbSpec` re-exports several sub-files that import `DivMod.AddrNorm`
+-- (CLZ, TrialQuotient, TrialStoreComposed, SubCarryStoreQj), which in
+-- turn imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.DivMod.LimbSpec
--- `Evm64.DivMod.AddrNorm` transitively imports `Rv64.AddrNorm`.
-import EvmAsm.Evm64.DivMod.AddrNorm
 import EvmAsm.Evm64.DivMod.Compose.Offsets
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -9,8 +9,8 @@
   Issue #87: DIV/MOD loop body composition.
 -/
 
+-- `DivN4Overestimate → LoopSemantic → LoopDefs`.
 import EvmAsm.Evm64.DivMod.Compose
-import EvmAsm.Evm64.DivMod.LoopDefs
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -19,10 +19,11 @@ import EvmAsm.Evm64.EvmWordArith.SignExtend
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 
--- DivAccumulate covers DivRemainderBound → DivAddbackLimb →
--- DivMulSubLimb → DivLimbBridge → DivBridge → Normalization →
--- MulSubChain → Div128Lemmas → MultiLimb → Div → Common.
-import EvmAsm.Evm64.EvmWordArith.DivAccumulate
+-- `DivN4DoubleAddback` and `AddbackPinning` both transitively bring
+-- `DivAccumulate` (via `DivN4Overestimate`), which in turn covers
+-- DivRemainderBound → DivAddbackLimb → DivMulSubLimb → DivLimbBridge →
+-- DivBridge → Normalization → MulSubChain → Div128Lemmas → MultiLimb →
+-- Div → Common.
 
 -- Carry extensions of the Limb variants.
 import EvmAsm.Evm64.EvmWordArith.DivMulSubCarry

--- a/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ModBridgeUtop.lean
@@ -17,9 +17,9 @@
   - `hsem`    : un-normalized mulsub carry is 0 (semantic skip).
 -/
 
+-- `Val256ModBridge → DivN4Overestimate → LoopSemantic`.
 import EvmAsm.Evm64.EvmWordArith.DenormLemmas
 import EvmAsm.Evm64.EvmWordArith.Val256ModBridge
-import EvmAsm.Evm64.DivMod.LoopSemantic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -6,10 +6,10 @@
   26 instructions total (3 + 3×6 + 5 store).
 -/
 
+-- `Gt.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -5,10 +5,10 @@
   26 instructions total (3 + 3×6 + 5 store).
 -/
 
+-- `Lt.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -13,9 +13,9 @@
   the consumer-facing contract.
 -/
 
+-- `Multiply.LimbSpec → Multiply.Program → Stack`.
 import EvmAsm.Evm64.Multiply.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
-import EvmAsm.Evm64.Stack
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -9,10 +9,10 @@
   If MSB limbs equal, use unsigned borrow chain on lower 3 limbs (b - a).
 -/
 
+-- `Sgt.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Sgt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
-import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow
 

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -8,10 +8,10 @@
   If MSB limbs equal, use unsigned borrow chain on limbs 0-2.
 -/
 
+-- `Slt.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Slt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
-import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow
 

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -21,7 +21,7 @@
     x13 — byte pointer (preserved; the caller advances it separately)
 -/
 
-import EvmAsm.Rv64.ByteOps
+-- `Phase2LongAcc → SyscallSpecs → ByteOps`.
 import EvmAsm.Rv64.RLP.Phase2LongAcc
 
 namespace EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Each direct import is covered transitively through a two-hop chain starting at another direct import already in the same file:

- `Evm64/DivMod/Compose/Base.lean`: `DivMod.AddrNorm` via `LimbSpec → LimbSpec.CLZ → DivMod.AddrNorm`.
- `Evm64/DivMod/LoopBody.lean`: `DivMod.LoopDefs` via `DivN4Overestimate → LoopSemantic → LoopDefs`.
- `Evm64/EvmWordArith.lean`: `DivAccumulate` via `{DivN4DoubleAddback, AddbackPinning} → DivN4Overestimate → DivAccumulate`.
- `Evm64/EvmWordArith/ModBridgeUtop.lean`: `DivMod.LoopSemantic` via `Val256ModBridge → DivN4Overestimate → LoopSemantic`.
- `Evm64/{Gt,Lt,Sgt,Slt}/Spec.lean`: `Evm64.SpAddr` via `{Gt,Lt,Sgt,Slt}.Program → Evm64.Stack → SpAddr` (4 files).
- `Evm64/Multiply/Spec.lean`: `Evm64.Stack` via `Multiply.LimbSpec → Multiply.Program → Stack`.
- `Rv64/RLP/Phase2LongLoad.lean`: `Rv64.ByteOps` via `Phase2LongAcc → SyscallSpecs → ByteOps`.

Total: 10 drops across 10 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)