### PR TITLE
chore: drop 10 three-hop redundant imports across 9 files

### DIFF
--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -5,9 +5,9 @@
   30 instructions total (5 + 3×8 + 1 ADDI).
 -/
 
+-- `Add.LimbSpec → Add.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Add.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -4,8 +4,8 @@
   Full 256-bit EVM AND spec.
 -/
 
+-- `And.LimbSpec → And.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.And.LimbSpec
-import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -13,9 +13,9 @@
   6. body_0: idx ∈ [0,7], extract from limb 3 at sp+56
 -/
 
+-- `Byte.LimbSpec → Byte.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Byte.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.ByteOps
-import EvmAsm.Evm64.SpAddr
 import EvmAsm.Rv64.AddrNorm
 import Mathlib.Tactic.Set
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Cases.lean
@@ -13,8 +13,8 @@
   `evm_div_n2_full_all_max_spec`.
 -/
 
+-- `FullPathN2LoopUnified → FullPathN2Loop → FullPathN4Loop → FullPath`.
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.FullPath
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -5,9 +5,9 @@
   21 instructions total (3 + 3×4 + 6 store).
 -/
 
+-- `Eq.LimbSpec → Eq.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Eq.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Eq
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -19,19 +19,15 @@ import EvmAsm.Evm64.EvmWordArith.SignExtend
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 
--- DivAccumulate covers DivRemainderBound → DivAddbackLimb →
--- DivMulSubLimb → DivLimbBridge → DivBridge → Normalization →
--- MulSubChain → Div128Lemmas → MultiLimb → Div → Common.
-import EvmAsm.Evm64.EvmWordArith.DivAccumulate
-
--- Carry extensions of the Limb variants.
-import EvmAsm.Evm64.EvmWordArith.DivMulSubCarry
-import EvmAsm.Evm64.EvmWordArith.DivAddbackCarry
-
--- Div128Shift0 → Div128CallSkipClose → Div128FinalAssembly +
+-- Div128Shift0 → Div128CallSkipClose → {Div128FinalAssembly +
 -- Div128KnuthLower + Div128QuotientBounds → KnuthTheoremB →
 -- {DivN4Overestimate, MaxTrialVacuity → CLZLemmas → DivN4Lemmas,
--- DenormLemmas}.
+-- DenormLemmas}, DivMod.LoopSemantic → {DivMulSubCarry, DivAddbackCarry}}.
+-- `AddbackPinning` and `DivN4DoubleAddback` both import
+-- `DivN4Overestimate`, which in turn imports `DivAccumulate`, covering
+-- DivRemainderBound → DivAddbackLimb → DivMulSubLimb → DivLimbBridge →
+-- DivBridge → Normalization → MulSubChain → Div128Lemmas → MultiLimb →
+-- Div → Common.
 import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 
 -- ModBridgeAssemble covers ModBridgeUtop → Val256ModBridge.

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -4,8 +4,8 @@
   Full 256-bit EVM OR spec.
 -/
 
+-- `Or.LimbSpec → Or.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Or.LimbSpec
-import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -5,9 +5,9 @@
   30 instructions total (5 + 3×8 + 1 ADDI).
 -/
 
+-- `Sub.LimbSpec → Sub.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Sub.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -4,8 +4,8 @@
   Full 256-bit EVM XOR spec.
 -/
 
+-- `Xor.LimbSpec → Xor.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Xor.LimbSpec
-import EvmAsm.Evm64.SpAddr
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary

Scanner extended to detect redundancies reachable through a three-hop chain starting at another direct import already in the file:

- `Evm64/{Add,And,Byte,Eq,Or,Sub,Xor}/Spec.lean`: `Evm64.SpAddr` via `<Op>.LimbSpec → <Op>.Program → Evm64.Stack → SpAddr` (7 files).
- `Evm64/DivMod/Compose/FullPathN2Cases.lean`: `Compose.FullPath` via `FullPathN2LoopUnified → FullPathN2Loop → FullPathN4Loop → FullPath`.
- `Evm64/EvmWordArith.lean`: `DivMulSubCarry` + `DivAddbackCarry` (via `Div128Shift0 → Div128CallSkipClose → DivMod.LoopSemantic → {DivMulSubCarry, DivAddbackCarry}`).

Total: 10 drops across 9 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)