### PR TITLE
chore: drop 9 four-hop redundant imports across 8 files

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -1,6 +1,5 @@
 import EvmAsm.Evm64.DivMod.NormDefs
--- LimbSpec transitively imports Program.
-import EvmAsm.Evm64.DivMod.LimbSpec
+-- `LoopBody` transitively imports `LimbSpec` (via `Compose → Base → LimbSpec`).
 -- SpecCall covers Spec → Compose + FullPathN4 + FullPathN4Beq + ModFullPathN4
 -- + EvmWordArith + ModFullPathN4Shift0 + FullPathN4Shift0.
 -- LoopBody covers Compose + LoopDefs + EvmWordArith.DivN4Overestimate.

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -6,7 +6,7 @@
   - Address normalization lemmas for j=0
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPath
+-- `LoopIterN4 → LoopBodyN4 → LoopBody → Compose → FullPath`.
 import EvmAsm.Evm64.DivMod.LoopIterN4
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/LoopSemantic.lean
+++ b/EvmAsm/Evm64/DivMod/LoopSemantic.lean
@@ -9,8 +9,8 @@
   loop body cpsTriple specs and the final EvmWord.div/mod correctness.
 -/
 
+-- `LoopDefs → LoopDefs.Post → LoopDefs.Iter → Compose.Base → DivMod.AddrNorm`.
 import EvmAsm.Evm64.DivMod.LoopDefs
-import EvmAsm.Evm64.DivMod.AddrNorm
 import EvmAsm.Evm64.EvmWordArith.DivMulSubCarry
 import EvmAsm.Evm64.EvmWordArith.DivAddbackCarry
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -20,10 +20,11 @@
   (which can occur under Phase 1b's check-fires branch).
 -/
 
+-- Both `Div128KnuthLower` and `Div128FinalAssembly` transitively reach
+-- `Div128QuotientBounds → KnuthTheoremB`, which imports `MaxTrialVacuity`
+-- (→ `Compose.FullPathN4`) and `DivN4Overestimate` (→ `DivMod.LoopSemantic`).
 import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
 import EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4
-import EvmAsm.Evm64.DivMod.LoopSemantic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -7,8 +7,8 @@
   - Body L (L=0..3, shift < 256): Phase A ntaken → B → C(exit L) → body_L → exit
 -/
 
+-- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.ComposeBase
-import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -9,9 +9,9 @@
   Mirrors ShlCompose.lean/Compose.lean with SAR body specs and bridge lemmas.
 -/
 
+-- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.SarSpec
 import EvmAsm.Evm64.Shift.ComposeBase
-import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -9,9 +9,9 @@
   Mirrors Compose.lean (SHR) with SHL body specs and bridge lemmas.
 -/
 
+-- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.ShlSpec
 import EvmAsm.Evm64.Shift.ComposeBase
-import EvmAsm.Evm64.SpAddr
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -6,8 +6,8 @@
   `EvmWord.signextend b x`.
 -/
 
+-- `SignExtend.Compose → SignExtend.LimbSpec → SignExtend.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.SignExtend.Compose
-import EvmAsm.Evm64.SpAddr
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
## Summary

Scanner extended to detect redundancies reachable through a four-hop chain starting at another direct import already in the file:

- `Evm64/DivMod.lean`: `DivMod.LimbSpec` (covered via the `LoopBody` chain).
- `Evm64/DivMod/Compose/FullPathN4Loop.lean`: `Compose.FullPath`.
- `Evm64/DivMod/LoopSemantic.lean`: `DivMod.AddrNorm`.
- `Evm64/EvmWordArith/Div128CallSkipClose.lean`: drop `Compose.FullPathN4` + `DivMod.LoopSemantic` (2 drops; both covered by `Div128KnuthLower`/`Div128FinalAssembly` through `KnuthTheoremB`).
- `Evm64/Shift/{Compose,SarCompose,ShlCompose}.lean`: `Evm64.SpAddr` (covered via `ComposeBase → LimbSpec → Program → Stack`).
- `Evm64/SignExtend/Spec.lean`: `Evm64.SpAddr` (same shape).

Total: 9 drops across 8 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)