### PR TITLE
chore: drop vestigial Rv64.CPSSpec from 16 opcode Program files

### DIFF
--- a/EvmAsm/Evm64/Add/Program.lean
+++ b/EvmAsm/Evm64/Add/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/And/Program.lean
+++ b/EvmAsm/Evm64/And/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Byte/Program.lean
+++ b/EvmAsm/Evm64/Byte/Program.lean
@@ -37,7 +37,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -39,7 +39,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Eq/Program.lean
+++ b/EvmAsm/Evm64/Eq/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Gt/Program.lean
+++ b/EvmAsm/Evm64/Gt/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/IsZero/Program.lean
+++ b/EvmAsm/Evm64/IsZero/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Lt/Program.lean
+++ b/EvmAsm/Evm64/Lt/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -40,7 +40,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Not/Program.lean
+++ b/EvmAsm/Evm64/Not/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Or/Program.lean
+++ b/EvmAsm/Evm64/Or/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sgt/Program.lean
+++ b/EvmAsm/Evm64/Sgt/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/Program.lean
+++ b/EvmAsm/Evm64/Shift/Program.lean
@@ -33,7 +33,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/SignExtend/Program.lean
+++ b/EvmAsm/Evm64/SignExtend/Program.lean
@@ -35,7 +35,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sub/Program.lean
+++ b/EvmAsm/Evm64/Sub/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Xor/Program.lean
+++ b/EvmAsm/Evm64/Xor/Program.lean
@@ -5,7 +5,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary

Each of these 16 opcode `Program.lean` files only defines instruction-list `Program` constants; none actually uses any `cps*` / `CodeReq` / `cpsTriple` / `cpsBranch` API. Their `import EvmAsm.Rv64.CPSSpec` lines are vestigial and are already covered transitively via `Evm64.Stack → Evm64.SpAddr → Rv64.Tactics.SeqFrame → Rv64.InstructionSpecs → GenericSpecs → CPSSpec` (five hops) anyway.

Files affected: Add, And, Byte, DivMod, Eq, Gt, IsZero, Lt, Multiply, Not, Or, Sgt, Shift, SignExtend, Sub, Xor.

`Dup`, `Pop`, `Push0`, and `Swap` are intentionally left untouched — their `Program.lean` files use `cps*` APIs directly (they define stack-shape specs inline).

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)