### PR TITLE
chore: drop 8 five-hop redundant imports across 8 files

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -1,14 +1,12 @@
 import EvmAsm.Evm64.DivMod.NormDefs
--- `LoopBody` transitively imports `LimbSpec` (via `Compose → Base → LimbSpec`).
 -- SpecCall covers Spec → Compose + FullPathN4 + FullPathN4Beq + ModFullPathN4
 -- + EvmWordArith + ModFullPathN4Shift0 + FullPathN4Shift0.
--- LoopBody covers Compose + LoopDefs + EvmWordArith.DivN4Overestimate.
+-- Shift0Dispatcher → Shift0AddbackMod → SpecCall transitively.
 -- FullPathN1LoopUnified transitively covers FullPathN1Loop + FullPathN3Loop,
 -- which pull in LoopUnifiedN{1,2,3} + LoopComposeN3 + FullPathN{1,2,3}
--- + FullPathN4Loop. FullPathN2Full covers FullPathN2LoopUnified +
--- FullPathN2Cases + FullPath.
--- Shift0Dispatcher → Shift0AddbackMod → SpecCall transitively.
+-- + FullPathN4Loop → LoopIterN4 → LoopBodyN4 → LoopBody → Compose +
+-- LoopDefs + EvmWordArith.DivN4Overestimate. FullPathN2Full covers
+-- FullPathN2LoopUnified + FullPathN2Cases + FullPath.
 import EvmAsm.Evm64.DivMod.Shift0Dispatcher
-import EvmAsm.Evm64.DivMod.LoopBody
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Loop.lean
@@ -9,7 +9,8 @@
   Follows the pattern of FullPathN3Loop.lean but for n=2.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2
+-- `FullPathN4Loop` (5-hop) transitively reaches `FullPathN2` via
+-- `LoopIterN4 → LoopBodyN4 → LoopBody → Compose → FullPathN2`.
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
 import EvmAsm.Evm64.DivMod.LoopUnifiedN2
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3Loop.lean
@@ -7,8 +7,9 @@
 -/
 
 -- `LoopUnifiedN3` transitively imports `LoopComposeN3`.
+-- `FullPathN4Loop` (5-hop) transitively reaches `FullPathN3` via
+-- `LoopIterN4 → LoopBodyN4 → LoopBody → Compose → FullPathN3`.
 import EvmAsm.Evm64.DivMod.LoopUnifiedN3
-import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -45,7 +45,9 @@
 
 import EvmAsm.Evm64.DivMod.Compose
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
-import EvmAsm.Evm64.EvmWordArith.DivLimbBridge
+-- `DivLimbBridge` reached transitively via `DivN4DoubleAddback →
+-- DivN4Overestimate → DivAccumulate → DivRemainderBound →
+-- DivAddbackLimb → DivMulSubLimb → DivLimbBridge`.
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback

--- a/EvmAsm/Evm64/Dup/Program.lean
+++ b/EvmAsm/Evm64/Dup/Program.lean
@@ -6,7 +6,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Pop/Program.lean
+++ b/EvmAsm/Evm64/Pop/Program.lean
@@ -6,7 +6,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Push0/Program.lean
+++ b/EvmAsm/Evm64/Push0/Program.lean
@@ -6,7 +6,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Swap/Program.lean
+++ b/EvmAsm/Evm64/Swap/Program.lean
@@ -6,7 +6,6 @@
 -/
 
 import EvmAsm.Evm64.Stack
-import EvmAsm.Rv64.CPSSpec
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary

Scanner extended to detect redundancies reachable through a five-hop chain starting at another direct import already in the file:

- `Evm64/DivMod.lean`: drop `DivMod.LoopBody`.
- `Evm64/DivMod/Compose/FullPathN2Loop.lean`: drop `Compose.FullPathN2`.
- `Evm64/DivMod/Compose/FullPathN3Loop.lean`: drop `Compose.FullPathN3`.
- `Evm64/DivMod/Spec.lean`: drop `EvmWordArith.DivLimbBridge`.
- `Evm64/{Dup,Pop,Push0,Swap}/Program.lean`: drop `Rv64.CPSSpec` (these files use `cps*` APIs but reach them via `Evm64.Stack`'s chain).

Total: 8 drops across 8 files.

Part of #1045 (import hygiene).

## Test plan
- [x] `lake build` (full) passes locally (3693 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)