### PR TITLE
chore: relocate XSimp import from per-opcode LimbSpec to Spec

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Add.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -8,6 +8,7 @@
 -- `Add.LimbSpec → Add.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Add.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/And/LimbSpec.lean
+++ b/EvmAsm/Evm64/And/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.And.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `And.LimbSpec → And.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.And.LimbSpec
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -9,7 +9,6 @@
 
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Eq.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -8,6 +8,7 @@
 -- `Eq.LimbSpec → Eq.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Eq.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Eq
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -10,6 +10,7 @@
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/IsZero/LimbSpec.lean
+++ b/EvmAsm/Evm64/IsZero/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.IsZero.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.IsZero
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -9,6 +9,7 @@
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Multiply/LimbSpec.lean
+++ b/EvmAsm/Evm64/Multiply/LimbSpec.lean
@@ -14,7 +14,6 @@
 
 import EvmAsm.Evm64.Multiply.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -16,6 +16,7 @@
 -- `Multiply.LimbSpec → Multiply.Program → Stack`.
 import EvmAsm.Evm64.Multiply.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Not/LimbSpec.lean
+++ b/EvmAsm/Evm64/Not/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Not.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Not.LimbSpec
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Or/LimbSpec.lean
+++ b/EvmAsm/Evm64/Or/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Or.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Or.LimbSpec → Or.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Or.LimbSpec
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -14,6 +14,7 @@ import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Sub.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -8,6 +8,7 @@
 -- `Sub.LimbSpec → Sub.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Sub.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 

--- a/EvmAsm/Evm64/Xor/LimbSpec.lean
+++ b/EvmAsm/Evm64/Xor/LimbSpec.lean
@@ -6,7 +6,6 @@
 
 import EvmAsm.Evm64.Xor.Program
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Xor.LimbSpec → Xor.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Xor.LimbSpec
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary

Per shake's analysis (issue #1045), 10 opcode `LimbSpec.lean` files import `Rv64.Tactics.XSimp` but never reference `xperm_hyp` / `xperm` / `xsimp`. The 13 corresponding `Spec.lean` files do use `xperm_hyp` but were relying on the transitive import via `LimbSpec`.

Move the dependency to where it's actually used:

- **Drop `XSimp` from 10 LimbSpec files**: Add, And, Compare, Eq, IsZero, Multiply, Not, Or, Sub, Xor
- **Add `XSimp` to 13 Spec files**: Add, And, Eq, Gt, IsZero, Lt, Multiply, Not, Or, Sgt, Slt, Sub, Xor

Net +3 import lines, but each file's import list now reflects what it actually uses.

## Test plan
- [x] `lake build` (full) passes locally (3695 jobs).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)