### PR TITLE
chore(noshake): suppress Init/Lean false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -1,1 +1,1 @@
-{}
+{"ignoreImport": ["Init", "Lean"]}


### PR DESCRIPTION
## Summary

Configure `scripts/noshake.json` to globally ignore `Init` and `Lean` imports across all `lake exe shake EvmAsm` analyses. Both modules are auto-imported by core Lean — flagging them as removable is noise that buries genuine import-hygiene findings.

Reduces shake output from 752 → 734 lines (−16 false-positive `remove #[Init, ...]` / `remove #[Lean, ...]` entries cleared).

## Schema

`ignoreImport` is a top-level list of module names that shake should never suggest removing. Pattern lifted from Batteries' `noshake.json` (which uses the same `ignoreImport: ["Init", "Lean"]` entry).

## Test plan
- [x] `lake build` (full) passes locally (3695 jobs).
- [x] `lake exe shake EvmAsm` no longer flags Init/Lean (verified locally).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)