### PR TITLE
chore(noshake): suppress IntervalCases/FinCases/Fintype false positives in HalfwordOps/WordOps

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -1,1 +1,6 @@
-{"ignoreImport": ["Init", "Lean"]}
+{"ignoreImport": ["Init", "Lean"],
+ "ignore":
+ {"EvmAsm.Rv64.HalfwordOps":
+  ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
+  "EvmAsm.Rv64.WordOps":
+  ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"]}}


### PR DESCRIPTION
## Summary

Per issue #1045 (and the PR #1044 fix), both `Rv64.HalfwordOps` and `Rv64.WordOps` genuinely use `interval_cases` (from `Mathlib.Tactic.IntervalCases`) and `fin_cases` (from `Mathlib.Tactic.FinCases` + `Mathlib.Data.Fintype.Basic`) in their byte-algebra macros. Shake doesn't track tactic-elaboration dependencies and keeps suggesting these be removed, masking real findings.

Add per-file ignore entries to `scripts/noshake.json` for the three modules in both files.

Reduces shake output from 208 → 206 file entries.

## Schema

Format follows mathlib's `noshake.json` schema:
- `ignore` is a map from module name to list of imports that shake should keep silent about for that module.
- Same pattern used by Batteries' `noshake.json` (e.g. `"Batteries.Data.Range.Lemmas": ["Batteries.Tactic.Alias", "Batteries.Tactic.SeqFocus"]`).

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [x] `lake exe shake EvmAsm` shows 206 entries (was 208), with HalfwordOps and WordOps no longer flagged for IntervalCases/FinCases/Fintype removal.
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)