### PR TITLE
chore: replace Mathlib.Tactic with specific submodules in ByteOps

### DIFF
--- a/EvmAsm/Evm64/CodeRegion.lean
+++ b/EvmAsm/Evm64/CodeRegion.lean
@@ -13,6 +13,7 @@
 import EvmAsm.Evm64.Basic
 -- `ByteOps` transitively imports `Rv64.SepLogic`.
 import EvmAsm.Rv64.ByteOps
+import Mathlib.Tactic.Ring
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -6,7 +6,9 @@
 -/
 -- `CPSSpec` transitively imports `Basic`, `SepLogic`, and `Execution`.
 import EvmAsm.Rv64.CPSSpec
-import Mathlib.Tactic
+import Mathlib.Tactic.IntervalCases
+import Mathlib.Tactic.FinCases
+import Mathlib.Data.Fintype.Basic
 
 namespace EvmAsm.Rv64
 


### PR DESCRIPTION
## Summary

Mirrors the fix from PR #1044 (`HalfwordOps`, `WordOps`): replace the catch-all `import Mathlib.Tactic` in `Rv64/ByteOps.lean` with the three specific submodules actually used:

- `Mathlib.Tactic.IntervalCases` (for `interval_cases`)
- `Mathlib.Tactic.FinCases` (for `fin_cases`)
- `Mathlib.Data.Fintype.Basic`

Cuts a transitive dependency on hundreds of mathlib files for any build downstream of `Rv64.ByteOps`, which is essentially every opcode using LBU or the byte algebra layer.

## CodeRegion fallout

`CodeRegion` (downstream of ByteOps) incidentally relied on transitive `ring` from `Mathlib.Tactic` — used in two `(n+1)*8 = ...` arith helpers inside `evmCodeIs_split_at`. Added a direct `import Mathlib.Tactic.Ring` there so it stays self-sufficient.

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)