### PR TITLE
chore: drop unused Mathlib.Tactic from EL/RLP/Properties.lean

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -5,7 +5,6 @@
 -/
 -- `Decode` transitively imports `Basic`.
 import EvmAsm.EL.RLP.Decode
-import Mathlib.Tactic
 
 namespace EvmAsm.EL.RLP
 


### PR DESCRIPTION
## Summary

`EvmAsm/EL/RLP/Properties.lean` imports `Mathlib.Tactic` but only uses `decide` / `rfl` / `simp` (all in Lean core). None of the Mathlib tactics (`interval_cases`, `fin_cases`, `ring`, `omega`, etc.) are referenced — verified by `grep "by " ...`.

The import is vestigial. Drop it: cuts a transitive dependency on hundreds of mathlib files for any downstream consumer.

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)