### PR TITLE
chore: relocate Mathlib tactic imports from EvmWordArith.Common to consumers

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -5,6 +5,9 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.Common
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Positivity
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
@@ -5,6 +5,10 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.Common
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.NormNum
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Positivity
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/Common.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Common.lean
@@ -6,9 +6,6 @@
 
 import EvmAsm.Evm64.Basic
 import Mathlib.Tactic.Linarith
-import Mathlib.Tactic.NormNum
-import Mathlib.Tactic.Ring
-import Mathlib.Tactic.Positivity
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -8,6 +8,9 @@
 
 import EvmAsm.Evm64.EvmWordArith.Common
 import EvmAsm.Rv64.Instructions
+import Mathlib.Tactic.Linarith
+import Mathlib.Tactic.Ring
+import Mathlib.Tactic.Positivity
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
## Summary

`EvmWordArith.Common` was importing four Mathlib tactic modules: `Linarith`, `NormNum`, `Ring`, `Positivity`. Of these, only `Linarith` is actually used by `Common` itself (`nlinarith` in `borrow_step_iff`). The other three were transitively re-exported to three downstream files that use them directly.

## Distribution

- **Drop from `Common.lean`**: `NormNum`, `Ring`, `Positivity` (not used by `Common` itself)
- **Add to `ByteOps.lean`** (uses `linarith`, `norm_num`, `ring`, `positivity`): all four
- **Add to `Arithmetic.lean`** (uses `norm_num`, `ring`, `positivity`): three
- **Add to `MultiLimb.lean`** (uses `linarith`, `ring`, `positivity`): three

Net +7 import lines across 4 files, but each file's imports now reflect actual direct usage.

`ByteOps.lean` adds `Linarith` directly even though `Common` still provides it transitively — preserves shake-cleanliness and the "import what you use" convention (same pattern as PR #1315 for `XSimp`).

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)