### PR TITLE
chore(*Attr): use Lean core RegisterCommand instead of Mathlib wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/DivMod/AddrNormAttr.lean
@@ -8,7 +8,7 @@
   import `AddrNorm.lean` (which imports this file) — not this file directly.
 -/
 
-import Mathlib.Tactic.Attr.Register
+import Lean.Meta.Tactic.Simp.RegisterCommand
 
 /-- Simp set for DivMod address arithmetic. Collects atomic evaluations of
     `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that appear

--- a/EvmAsm/Rv64/AddrNormAttr.lean
+++ b/EvmAsm/Rv64/AddrNormAttr.lean
@@ -8,7 +8,7 @@
   import `AddrNorm.lean` (which imports this file) — not this file directly.
 -/
 
-import Mathlib.Tactic.Attr.Register
+import Lean.Meta.Tactic.Simp.RegisterCommand
 
 /-- Simp/grind set for Rv64 address arithmetic. Collects `BitVec.add_assoc`
     rewrites plus atomic `signExtend13` / `signExtend21` evaluations on the

--- a/EvmAsm/Rv64/ByteAlgAttr.lean
+++ b/EvmAsm/Rv64/ByteAlgAttr.lean
@@ -8,7 +8,7 @@
   import `ByteAlg.lean` (which imports this file) — not this file directly.
 -/
 
-import Mathlib.Tactic.Attr.Register
+import Lean.Meta.Tactic.Simp.RegisterCommand
 
 /-- Simp/grind set for `extractByte` / `replaceByte` algebra on 64-bit words.
     Collects the commute / cancel identities (`extractByte (replaceByte w p b) p

--- a/EvmAsm/Rv64/RegOpsAttr.lean
+++ b/EvmAsm/Rv64/RegOpsAttr.lean
@@ -8,7 +8,7 @@
   import `RegOps.lean` (which imports this file) — not this file directly.
 -/
 
-import Mathlib.Tactic.Attr.Register
+import Lean.Meta.Tactic.Simp.RegisterCommand
 
 /-- Simp/grind set for `MachineState` register, PC, memory, code, committed,
     publicValues, and privateInput projection lemmas. Collects the shape


### PR DESCRIPTION
## Summary

Each `*Attr.lean` file in EvmAsm (`Rv64.AddrNormAttr`, `Rv64.RegOpsAttr`, `Rv64.ByteAlgAttr`, `Evm64.DivMod.AddrNormAttr`) only uses the `register_simp_attr` syntax to register a simp set. That syntax is defined in Lean core (`Lean.Meta.Tactic.Simp.RegisterCommand`); the `Mathlib.Tactic.Attr.Register` wrapper just re-exports it alongside a fixed list of mathlib simp sets we don't use.

Switch the import in all four files: `Mathlib.Tactic.Attr.Register` → `Lean.Meta.Tactic.Simp.RegisterCommand`.

## Why this helps

Negligible per-file gain individually, but `Rv64.AddrNormAttr` sits below `Rv64.AddrNorm` which is in the import chain of essentially every EvmAsm proof. Each Mathlib import drag adds compiled-module weight and cold-build time across the dependency cone.

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)