### PR TITLE
chore(CallingConvention): drop unused XSimp import

### DIFF
--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -27,7 +27,6 @@
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
-import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
## Summary

`EvmAsm/Evm64/CallingConvention.lean` imports `Rv64.Tactics.XSimp` but never uses `xperm_hyp` / `xperm` / `xsimp` — verified by grep. Its proofs use `runBlock` (kept) and direct spec applications.

The only consumer is `EvmAsm.Evm64` (umbrella), which itself doesn't use `xperm_hyp` either, and nothing imports `EvmAsm.Evm64` directly, so this drop is safe.

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)