### PR TITLE
chore(RLP): relocate XSimp import from Phase2LongAcc to Phase2LongLoad

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -26,7 +26,6 @@
 
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.AddrNorm
-import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.RLP
 

--- a/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoad.lean
@@ -23,6 +23,7 @@
 
 -- `Phase2LongAcc → SyscallSpecs → ByteOps`.
 import EvmAsm.Rv64.RLP.Phase2LongAcc
+import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Rv64.RLP
 


### PR DESCRIPTION
## Summary

`Rv64/RLP/Phase2LongAcc.lean` imports `Rv64.Tactics.XSimp` but never uses `xperm_hyp` / `xperm` / `xsimp` directly. The downstream consumer `Phase2LongLoad.lean` does (4 uses of `xperm_hyp`) but was relying on the transitive import via `Phase2LongAcc`.

Move the dependency to where it's actually used:
- **Drop** `XSimp` from `Phase2LongAcc.lean` (not used)
- **Add** `XSimp` to `Phase2LongLoad.lean` (4 direct uses)

Same pattern as PR #1315 for the per-opcode `LimbSpec` → `Spec` move.

## Test plan
- [x] `lake build` (full) passes locally (3697 jobs).
- [ ] CI green.

Part of #1045 (import hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)