### PR TITLE
refactor(MulCorrect): drop omega aliases of stdlib mod/div lemmas

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulCorrect.lean
@@ -150,14 +150,6 @@ theorem mul_correct_limb2 (a b : EvmWord) :
 private theorem div_mod_eq (W : Nat) {x q r : Nat} (hq : q = x / W) (hr : r = x % W) :
     q * W + r = x := by subst hq; subst hr; rw [Nat.mul_comm]; exact Nat.div_add_mod x W
 
-/-- Mod-flattening: (a % W + b) % W = (a + b) % W for W = 2^64.
-    Extracted so omega runs in a clean context (no let-defs). -/
-private theorem mod_add_cancel_left (a b : Nat) :
-    (a % 2^64 + b) % 2^64 = (a + b) % 2^64 := by omega
-
-private theorem mod_add_cancel_right (a b : Nat) :
-    (a + b % 2^64) % 2^64 = (a + b) % 2^64 := by omega
-
 /-- 4×4 schoolbook product expansion into digit columns. Extracted so `ring`
     runs in its own heartbeat budget. -/
 private theorem product_expansion (a0 a1 a2 a3 b0 b1 b2 b3 W : Nat) :
@@ -269,10 +261,6 @@ private theorem schoolbook_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Nat) :
   rw [hDiv, show high = (D3 + C3) + (D4 + D5 * W + D6 * W^2) * W from by ring,
       Nat.add_mul_mod_self_right]
 
-/-- Generic algebraic identity: `(a*W + b)/W = a + b/W`. -/
-private theorem qC1_simp_helper (a b : ℕ) (hb : b < 2 ^ 64) :
-    (a * 2 ^ 64 + b) / 2 ^ 64 = a := by omega
-
 /-- Generic: `(a*W + b + (c*W + d) + e) / W = a + c + (b + d + e) / W`. -/
 private theorem qC2_simp_helper (a b c d e : ℕ) :
     (a * 2 ^ 64 + b + (c * 2 ^ 64 + d) + e) / 2 ^ 64 = a + c + (b + d + e) / 2 ^ 64 := by omega
@@ -318,7 +306,8 @@ private theorem carry_chain_mod_eq
         (mu01 * 2 ^ 64 + lo01 + (mu10 * 2 ^ 64 + lo10) +
           (mu00 * 2 ^ 64 + lo00) / 2 ^ 64) / 2 ^ 64) / 2 ^ 64) % 2 ^ 64 := by
   -- Simplify RHS via generic helpers (each omega runs in clean top-level context)
-  rw [qC1_simp_helper mu00 lo00 hb_lo00]
+  rw [Nat.add_comm (mu00 * 2^64) lo00, Nat.add_mul_div_right _ _ (by norm_num),
+      Nat.div_eq_of_lt hb_lo00, Nat.zero_add]
   rw [qC2_simp_helper mu01 lo01 mu10 lo10 mu00]
   rw [qC3_simp_helper mu02 lo02 mu11 lo11 mu20 lo20 mu01 mu10
         ((lo01 + lo10 + mu00) / 2 ^ 64)]
@@ -470,7 +459,7 @@ private theorem carry_chain_limb3 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
       h_c1_rc2, h_c0_r3p, h_sum20_c2, h_c1_cr1, h_c1_cr2, h_c2_c, h_c0_c2,
       h_c0_r2, h_c1_r2a, h_c1_r2, h_sum10_c1, h_c1_rc, h_c1_c1,
       h_c0_r1, h_c0_c1,
-      mod_add_cancel_left, mod_add_cancel_right,
+      Nat.mod_add_mod, Nat.add_mod_mod,
       hC3_def, hC2_def, hC1_def, hD3, hD2, hD1, hD0]
     -- Apply private theorem directly with .toNat values; bounds from BitVec.isLt
     -- Product bounds: each full product = a.toNat * b.toNat ≤ (2^64-1)*(2^64-1)


### PR DESCRIPTION
## Summary

Replace three private `omega`-aliases in `EvmWordArith/MulCorrect.lean` with the Lean core stdlib lemmas they alias:

- `mod_add_cancel_left`  → `Nat.mod_add_mod`        (`@[simp]`, `Init.Data.Nat.Lemmas`)
- `mod_add_cancel_right` → `Nat.add_mod_mod`        (`@[simp]`, `Init.Data.Nat.Lemmas`)
- `qC1_simp_helper`      → `Nat.add_mul_div_right` + `Nat.div_eq_of_lt`  (`Init.Data.Nat.Div.Basic`)

These helpers were written before the corresponding `@[simp]` lemmas were upstreamed and never cleaned up. Theorem statements unchanged; only proof internals.

## Notes

- All replacements are Lean core stdlib (not mathlib), so no new mathlib coupling.
- `qC2_simp_helper` and `qC3_simp_helper` are kept — bespoke shapes with no clean stdlib match; their `omega` proofs serve a real "clean context" role for the `carry_chain_mod_eq` proof.
- The `BitVec.toNat_add` simp-set collapse inside `carry_chain_limb3` (~50 more lines) was investigated and deferred — non-trivial interaction with `if-then-else` carry let-bindings.

## Test plan

- [x] `lake build` green (3697/3697 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)