### PR TITLE
chore(LoopBody): drop dead Section 8a after #1312

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -712,25 +712,6 @@ theorem divK_save_trial_load_spec
 theorem lb_bltu_taken {base : Word} : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
   rv64_addr
 theorem lb_bltu_ntaken {base : Word} : (base + 500 : Word) + 4 = base + 504 := by bv_addr
-private theorem lb_trial_max_end {base : Word} : (base + 504 : Word) + 12 = base + 516 := by bv_addr
-
--- ============================================================================
--- Section 8a: Trial quotient NOT-TAKEN path (uHi >= vTop)
--- Instrs [14]-[15] at base+504: ADDI x11 x0 4095 + JAL x0 8 → base+516.
--- ============================================================================
-
-/-- Trial quotient MAX path: qHat = MAX64, skip div128 call.
-    2 instructions at base+504. Entry: base+504, Exit: base+516. -/
-private theorem divK_trial_max_extended (v11Old : Word) (base : Word) :
-    cpsTriple (base + 504) (base + 516) (sharedDivModCode base)
-      ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ 0))
-      ((.x11 ↦ᵣ signExtend12 4095) ** (.x0 ↦ᵣ 0)) := by
-  have TM := divK_trial_max_spec v11Old (base + 504)
-  dsimp only [] at TM
-  rw [lb_trial_max_end] at TM
-  exact cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (lb_sub 14 _ _ (by decide) (by bv_addr) (by decide))
-      (lb_sub 15 _ _ (by decide) (by bv_addr) (by decide))) TM
 
 -- ============================================================================
 -- Section 9: Store q[j] + loop control


### PR DESCRIPTION
## Summary

After #1312 extracted Section 11 (`divK_trial_max_full_spec`) to `LoopBody/TrialMax.lean`, the Section 8a helpers in `LoopBody.lean` became dead code:

- `lb_trial_max_end` (private) — only used by `divK_trial_max_extended`
- `divK_trial_max_extended` (private) — only used by Section 11 (now in `TrialMax.lean`)

`LoopBody/TrialMax.lean` ships its own private copies of both, so removing the `LoopBody.lean` versions has no effect on any consumer (verified by `lake build`).

`LoopBody.lean`: 1152 → 1133 lines.

## Test plan
- [x] `lake build` (full) clean.
- [ ] CI green.

Part of #283/#266 file-size-exception cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)