### PR TITLE
chore(LoopBody): remove file-size-exception now that file is under cap

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1,4 +1,3 @@
--- file-size-exception: tracked by issues #283/#266 (skip/addback unification + DIV/MOD loop factoring). Grandfathered pending consolidation.
 /-
   EvmAsm.Evm64.DivMod.LoopBody
 


### PR DESCRIPTION
## Summary

After PRs #1310, #1312, #1314, #1318, #1319, #1330 extracted Sections 9b/9c, 11, 10b, 6a, 8b, and 8a from `LoopBody.lean`, the file is now **964 lines** — well under the 1500-line cap enforced by `scripts/check-file-size.sh`. The grandfathered exception comment is no longer needed.

Drop the leading `-- file-size-exception: ...` line.

## Status of issues #283 / #266

This closes the **LoopBody.lean** half of those tracking issues. `SpecCall.lean` still has its own file-size-exception (1857 lines) pending its own consolidation work.

## Test plan
- [x] `lake build` (full) clean.
- [x] `LoopBody.lean` is 964 lines (well under the 1500 cap).
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)