### PR TITLE
feat(rlp): scaffold Phase 3 single-byte exit (length = 1)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -7,7 +7,7 @@
   RV64IM execution:
     Phase 1 — Prefix classifier  (5-way cascade on the first byte)
     Phase 2 — Length extraction  (planned)
-    Phase 3 — Single-item decode (planned)
+    Phase 3 — Single-item decode (in progress: single-byte exit landed)
     Phase 4 — HINT_READ pipeline (planned)
     Phase 5 — Recursive list decode with explicit stack (planned)
     Phase 6 — Top-level pipeline (planned)
@@ -19,3 +19,4 @@ import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
 import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongLoopFive
+import EvmAsm.Rv64.RLP.Phase3SingleByte

--- a/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
+++ b/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
@@ -1,0 +1,87 @@
+/-
+  EvmAsm.Rv64.RLP.Phase3SingleByte
+
+  EL.3 Phase 3 (single-byte exit): the trivial flat-decode case.
+
+  When Phase 1's classifier reaches `e1` — i.e. the prefix byte `p < 0x80` —
+  the RLP item is a *single-byte string* whose data is the prefix byte
+  itself. The flat-decode output is therefore:
+
+      length   = 1
+      data_ptr = input_ptr   (unchanged: the prefix byte at `mem[ptr]`
+                              IS the entire data payload)
+
+  This file provides the one-instruction spec that materializes the
+  length in `x11`. The data pointer in `x13` is preserved as a frame.
+
+  Register usage:
+    x11 — output: payload length (= 1 after this step)
+    x0  — zero register (unchanged)
+
+  This is the smallest of the six Phase 3 exits; the other four
+  (short string, long string, short/long list error) follow in
+  separate files.
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- One-instruction "set length = 1" emitter for the single-byte exit:
+    `ADDI x11, x0, 1`. -/
+def rlp_phase3_single_byte_prog : Program :=
+  [.ADDI .x11 .x0 1]
+
+example : rlp_phase3_single_byte_prog.length = 1 := rfl
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- `cpsTriple` spec for the single-byte length emitter. After the one
+    instruction, `x11 = 1`. `x0` stays zero (RISC-V invariant); the caller
+    is expected to keep its data pointer (typically in `x13`) framed
+    through this step.
+
+    The triple does not name `x13` — the caller owns it as a frame
+    atom and threads it through unchanged via `cpsTriple_frameR`. -/
+theorem rlp_phase3_single_byte_spec (v11Old : Word) (base : Word) :
+    cpsTriple base (base + 4)
+      (CodeReq.ofProg base rlp_phase3_single_byte_prog)
+      ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x11 ↦ᵣ (1 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  -- The one-instruction `ofProg` reduces to a singleton CodeReq.
+  have hcr : CodeReq.ofProg base rlp_phase3_single_byte_prog =
+      CodeReq.singleton base (.ADDI .x11 .x0 1) := by
+    funext a
+    simp only [rlp_phase3_single_byte_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+      CodeReq.union, CodeReq.empty]
+    cases (CodeReq.singleton base (.ADDI .x11 .x0 1)) a <;> rfl
+  rw [hcr]
+  -- ADDI x11, x0, 1: x11 ← 0 + signExtend12 1 = 1.
+  have h := addi_spec_gen .x11 .x0 v11Old (0 : Word) 1 base (by nofun)
+  -- Normalize the post: 0 + signExtend12 1 = 1.
+  have hsig : (0 : Word) + signExtend12 (1 : BitVec 12) = (1 : Word) := by decide
+  rw [hsig] at h
+  -- `addi_spec_gen` produces `(rs1 ↦ᵣ ...) ** (rd ↦ᵣ ...)` (rs1 first);
+  -- the spec statement uses `(rd ↦ᵣ ...) ** (rs1 ↦ᵣ ...)`. Permute.
+  exact cpsTriple_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by xperm_hyp hp)
+    h
+
+/-! ## Concrete sanity check -/
+
+-- Confirms the one-instruction encoding matches the program definition.
+example : rlp_phase3_single_byte_prog =
+    [.ADDI .x11 .x0 1] := rfl
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -676,7 +676,15 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     (initial attempt hit Lean-level issues around
     `BitVec.ofNat 64 n` arithmetic and associativity normalization;
     unrolling is catching up in the meantime).
-- Phase 3: Single-item flat decode (byte strings only)
+- Phase 3: Single-item flat decode (byte strings only) — ⏳ scaffolding
+  - `rlp_phase3_single_byte_spec` (`EvmAsm/Rv64/RLP/Phase3SingleByte.lean`):
+    one-instruction `ADDI x11, x0, 1` that materializes `length = 1` for
+    Phase 1's `e1` exit (prefix byte `< 0x80`, single-byte string —
+    the prefix IS the data). The data pointer in `x13` rides through
+    as a frame atom; no pointer advance is needed.
+  - Remaining: short-string exit (`e2`: data_ptr += 1, length = p − 0x80),
+    long-string exit (`e3`: needs Phase 2 long output), short/long-list
+    error exits (`e4`/`e5`).
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (HINT_READ → decode → output)


### PR DESCRIPTION
## Summary

Starts EL.3 Phase 3 (single-item flat decode, #120). When Phase 1's classifier reaches `e1` — the prefix byte `p < 0x80` — the RLP item is a single-byte string whose data is the prefix byte itself. The flat-decode output is therefore:

- `length   = 1`
- `data_ptr = input_ptr` (unchanged: the prefix byte at `mem[ptr]` IS the entire data payload)

This PR ships the smallest of the six Phase 3 exits:

- `EvmAsm/Rv64/RLP/Phase3SingleByte.lean`:
  - `rlp_phase3_single_byte_prog := [ADDI x11 x0 1]` — one-instruction "set length = 1" emitter.
  - `rlp_phase3_single_byte_spec` — cpsTriple proving `x11` lands at `1` after the instruction.

The data pointer in `x13` is left to the caller as a frame atom (no pointer advance is needed for this exit).

## Remaining Phase 3 work

- Short-string exit (`e2`: data_ptr += 1, length = p − 0x80) — landable next.
- Long-string exit (`e3`: needs Phase 2 long-form general n-iteration closure, currently pending).
- Short / long-list error exits (`e4` / `e5`).

## Test plan
- [x] `lake build` (full) clean.
- [ ] CI green.

Part of #120 (EL.3 RLP decoder).

🤖 Generated with [Claude Code](https://claude.com/claude-code)