### PR TITLE
feat(rlp): scaffold Phase 3 short-string exit

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -19,3 +19,4 @@ import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
 import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongLoopFive
+import EvmAsm.Rv64.RLP.Phase3ShortString

--- a/EvmAsm/Rv64/RLP/Phase3ShortString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3ShortString.lean
@@ -1,0 +1,126 @@
+/-
+  EvmAsm.Rv64.RLP.Phase3ShortString
+
+  EL.3 Phase 3 (short-string exit): flat decode for the short byte-string
+  category.
+
+  When Phase 1's classifier reaches `e2` — i.e. the prefix byte
+  `p ∈ [0x80, 0xB8)` — the RLP item is a *short byte string* whose payload
+  occupies the next `(p − 0x80)` bytes after the prefix. The flat-decode
+  output is therefore:
+
+      length   = p − 0x80   (range [0, 55])
+      data_ptr = input_ptr + 1   (skip past the prefix byte)
+
+  Two instructions:
+
+      ADDI x11, x5, -0x80     ; length = prefix - 0x80
+      ADDI x13, x13, 1        ; data_ptr += 1
+
+  Register usage:
+    x5  — input: the RLP prefix byte (preserved)
+    x11 — output: payload length
+    x13 — input/output: byte pointer (advances by 1 to point at the
+                         first payload byte)
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- Two-instruction short-string flat-decode emitter:
+    `ADDI x11, x5, -0x80 ; ADDI x13, x13, 1`. -/
+def rlp_phase3_short_string_prog : Program :=
+  [.ADDI .x11 .x5 (-0x80), .ADDI .x13 .x13 1]
+
+example : rlp_phase3_short_string_prog.length = 2 := rfl
+
+/-! ## Concrete sanity checks -/
+
+-- Short byte string with prefix 0x85 (5-byte payload): length = 5.
+example : ((0x85 : Word) + signExtend12 (-(0x80 : BitVec 12))) = (5 : Word) := by decide
+
+-- Short byte string with prefix 0xB7 (55-byte payload): length = 55.
+example : ((0xB7 : Word) + signExtend12 (-(0x80 : BitVec 12))) = (55 : Word) := by decide
+
+-- Empty short byte string (prefix = 0x80): length = 0.
+example : ((0x80 : Word) + signExtend12 (-(0x80 : BitVec 12))) = (0 : Word) := by decide
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- `cpsTriple` spec for the short-string flat-decode. After two
+    instructions, `x11` holds `prefix − 0x80` (the payload length) and
+    `x13` has advanced by 1 to point at the first payload byte. `x5`
+    is preserved.
+
+    The spec places no range constraint on `v5`; if the caller reaches
+    this program outside the short-string category the result is still
+    well-defined (just not interpretable as a payload length). Downstream
+    consumers typically compose this with a preceding Phase 1 exit post
+    so that `v5 ∈ [0x80, 0xB8)` is available and the subtraction lands
+    in `[0, 55]`. -/
+theorem rlp_phase3_short_string_spec (v5 v11Old v13 : Word) (base : Word) :
+    cpsTriple base (base + 8)
+      (CodeReq.ofProg base rlp_phase3_short_string_prog)
+      ((.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13))
+      ((.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12)))) := by
+  -- Reshape the two-instruction `ofProg` into a singleton-union pair.
+  have hcr_eq : CodeReq.ofProg base rlp_phase3_short_string_prog =
+      (CodeReq.singleton base (.ADDI .x11 .x5 (-0x80))).union
+      (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) := by
+    funext a
+    simp only [rlp_phase3_short_string_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
+      CodeReq.union, CodeReq.empty]
+    cases (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) a <;> rfl
+  rw [hcr_eq]
+  -- Disjointness of the two singletons (distinct PCs).
+  have hd : CodeReq.Disjoint
+      (CodeReq.singleton base (.ADDI .x11 .x5 (-0x80)))
+      (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) :=
+    CodeReq.Disjoint.singleton (by bv_omega)
+  -- Step 1: ADDI x11, x5, -0x80 at base. Frame with `x13`.
+  have s1Base := addi_spec_gen .x11 .x5 v11Old v5 (-0x80) base (by nofun)
+  have s1 : cpsTriple base (base + 4)
+      (CodeReq.singleton base (.ADDI .x11 .x5 (-0x80)))
+      ((.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13))
+      ((.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))) **
+       (.x13 ↦ᵣ v13)) := by
+    have framed := cpsTriple_frameR (.x13 ↦ᵣ v13) (by pcFree) s1Base
+    exact cpsTriple_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  -- Step 2: ADDI x13, x13, 1 at base + 4. Frame with `x5` and `x11`.
+  have s2Base := addi_spec_gen_same .x13 v13 1 (base + 4) (by nofun)
+  have s2 : cpsTriple (base + 4) (base + 8)
+      (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1))
+      ((.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))) **
+       (.x13 ↦ᵣ v13))
+      ((.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12)))) := by
+    have framed := cpsTriple_frameR
+      ((.x5 ↦ᵣ v5) ** (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))))
+      (by pcFree) s2Base
+    rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at framed
+    exact cpsTriple_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  exact cpsTriple_seq hd s1 s2
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Continues EL.3 Phase 3 (#120). When Phase 1's classifier reaches `e2` — the prefix byte `p ∈ [0x80, 0xB8)` — the RLP item is a short byte string whose payload occupies the next `(p − 0x80)` bytes after the prefix. Flat-decode output:

```
length   = p − 0x80     (range [0, 55])
data_ptr = input_ptr + 1
```

Add `EvmAsm/Rv64/RLP/Phase3ShortString.lean` with:
- `rlp_phase3_short_string_prog := [ADDI x11 x5 (-0x80), ADDI x13 x13 1]`
- `rlp_phase3_short_string_spec` — cpsTriple proving `x11` lands at `v5 + signExtend12 (-0x80)` and `x13` at `v13 + signExtend12 1` after the two-instruction sequence.

The spec places no range constraint on `v5`; downstream consumers compose this with Phase 1's `e2` exit post (carrying `v5 ∈ [0x80, 0xB8)`) so the subtraction lands in `[0, 55]`.

## Concrete sanity

`example`s in the file confirm prefix `0x85` → 5, `0xB7` → 55, `0x80` → 0 via `decide`.

## Companion to #1340

#1340 ships the simpler `e1` (single-byte) exit. This PR is the next exit (`e2`); both are independent and can land in either order.

## Test plan
- [x] `lake build` (full) clean (1355 jobs).
- [ ] CI green.

Part of #120 (EL.3 RLP decoder, Phase 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)