### PR TITLE
feat(rlp): scaffold Phase 3 long-string entry (lenLen seed)

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -19,4 +19,5 @@ import EvmAsm.Rv64.RLP.Phase1
 import EvmAsm.Rv64.RLP.Phase2Short
 import EvmAsm.Rv64.RLP.Phase2LongLoad
 import EvmAsm.Rv64.RLP.Phase2LongLoopFive
+import EvmAsm.Rv64.RLP.Phase3LongString
 import EvmAsm.Rv64.RLP.Phase3SingleByte

--- a/EvmAsm/Rv64/RLP/Phase3LongString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3LongString.lean
@@ -1,0 +1,182 @@
+/-
+  EvmAsm.Rv64.RLP.Phase3LongString
+
+  EL.3 Phase 3 (long-string entry): seed the long-form length-of-length
+  loop for the long byte-string category.
+
+  When Phase 1's classifier reaches `e3` — i.e. the prefix byte
+  `p ∈ [0xB8, 0xC0)` — the RLP item is a *long byte string* whose total
+  payload length is encoded in the next `(p − 0xB7)` bytes after the
+  prefix. The Phase 3 entry leaves the machine in the canonical pre-loop
+  state expected by the Phase 2 long-form loop:
+
+      x14 = lenLen   = p − 0xB7   (number of length bytes; range [1, 8])
+      x11 = len_acc  = 0          (initial accumulator)
+      x13 = data_ptr = old_ptr+1  (advance past the prefix byte; the next
+                                   `lenLen` bytes are the encoded length)
+
+  Three instructions:
+
+      ADDI x14, x5, -0xB7     ; lenLen = prefix - 0xB7
+      ADDI x11, x0, 0         ; len_acc := 0
+      ADDI x13, x13, 1        ; data_ptr += 1
+
+  After this entry block, the caller dispatches to the matching
+  `rlp_phase2_long_loop_*_byte_spec` (or the planned `n`-iteration
+  closure) on `x14` to fold the length bytes into `x11`.
+
+  Register usage:
+    x0  — zero register (unchanged)
+    x5  — input: the RLP prefix byte (preserved)
+    x11 — output: cleared length accumulator (= 0)
+    x13 — input/output: byte pointer (advances by 1)
+    x14 — output: length-of-length counter (= prefix − 0xB7)
+-/
+
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+-- ============================================================================
+-- Program definition
+-- ============================================================================
+
+/-- Three-instruction long-string entry emitter:
+    `ADDI x14, x5, -0xB7 ; ADDI x11, x0, 0 ; ADDI x13, x13, 1`. -/
+def rlp_phase3_long_string_prog : Program :=
+  [.ADDI .x14 .x5 (-0xB7), .ADDI .x11 .x0 0, .ADDI .x13 .x13 1]
+
+example : rlp_phase3_long_string_prog.length = 3 := rfl
+
+/-! ## Concrete sanity checks -/
+
+-- Long byte string with prefix 0xB8 (1-byte length): lenLen = 1.
+example : ((0xB8 : Word) + signExtend12 (-(0xB7 : BitVec 12))) = (1 : Word) := by decide
+
+-- Long byte string with prefix 0xBF (8-byte length): lenLen = 8.
+example : ((0xBF : Word) + signExtend12 (-(0xB7 : BitVec 12))) = (8 : Word) := by decide
+
+-- ADDI x11, x0, 0 with x0 = 0: x11 := 0.
+example : ((0 : Word) + signExtend12 (0 : BitVec 12)) = (0 : Word) := by decide
+
+-- ============================================================================
+-- Spec
+-- ============================================================================
+
+/-- `cpsTriple` spec for the long-string entry. After three instructions:
+    * `x14` holds `prefix − 0xB7` (length-of-length counter),
+    * `x11` is cleared to 0 (initial length accumulator),
+    * `x13` has advanced by 1 (skips past the prefix byte),
+    * `x5` and `x0` are preserved.
+
+    The spec places no range constraint on `v5`; if the caller reaches
+    this program outside the long-string category, the subtraction
+    `v5 + signExtend12 (-0xB7)` still has a well-defined value but does
+    not interpret as a length-of-length. Downstream consumers compose
+    this with the preceding Phase 1 `e3` exit so that `v5 ∈ [0xB8, 0xC0)`
+    and the result lands in `[1, 8]`. -/
+theorem rlp_phase3_long_string_spec
+    (v5 v11Old v13 v14Old : Word) (base : Word) :
+    cpsTriple base (base + 12)
+      (CodeReq.ofProg base rlp_phase3_long_string_prog)
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14Old))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (0 : Word)) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12))))) := by
+  -- Decompose the 3-instruction `ofProg` as singleton ∪ ofProg-of-tail.
+  have hcr_eq : CodeReq.ofProg base rlp_phase3_long_string_prog =
+      (CodeReq.singleton base (.ADDI .x14 .x5 (-0xB7))).union
+      (CodeReq.ofProg (base + 4) [.ADDI .x11 .x0 0, .ADDI .x13 .x13 1]) := by
+    simp only [rlp_phase3_long_string_prog, CodeReq.ofProg_cons]
+  rw [hcr_eq]
+  -- Sub-decompose the tail similarly: singleton ∪ singleton.
+  have hcr_tail : CodeReq.ofProg (base + 4) [.ADDI .x11 .x0 0, .ADDI .x13 .x13 1] =
+      (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0)).union
+      (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) := by
+    funext a
+    simp only [CodeReq.ofProg_cons, CodeReq.ofProg_nil, CodeReq.union, CodeReq.empty]
+    cases (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) a <;> rfl
+  -- Step 1: ADDI x14, x5, -0xB7 at base.
+  have s1Base := addi_spec_gen .x14 .x5 v14Old v5 (-0xB7) base (by nofun)
+  have s1 : cpsTriple base (base + 4)
+      (CodeReq.singleton base (.ADDI .x14 .x5 (-0xB7)))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14Old))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12))))) := by
+    have framed := cpsTriple_frameR
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13))
+      (by pcFree) s1Base
+    exact cpsTriple_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  -- Step 2: ADDI x11, x0, 0 at base + 4.
+  have s2Base := addi_spec_gen .x11 .x0 v11Old (0 : Word) 0 (base + 4) (by nofun)
+  have hsig0 : (0 : Word) + signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  rw [hsig0] at s2Base
+  have s2 : cpsTriple (base + 4) ((base + 4) + 4)
+      (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12)))))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12))))) := by
+    have framed := cpsTriple_frameR
+      ((.x5 ↦ᵣ v5) ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12)))))
+      (by pcFree) s2Base
+    exact cpsTriple_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  -- Step 3: ADDI x13, x13, 1 at (base + 4) + 4.
+  have s3Base := addi_spec_gen_same .x13 v13 1 ((base + 4) + 4) (by nofun)
+  have s3 : cpsTriple ((base + 4) + 4) (((base + 4) + 4) + 4)
+      (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (0 : Word)) ** (.x13 ↦ᵣ v13) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12)))))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (0 : Word)) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12))))) := by
+    have framed := cpsTriple_frameR
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+       (.x11 ↦ᵣ (0 : Word)) **
+       (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12)))))
+      (by pcFree) s3Base
+    exact cpsTriple_weaken
+      (fun _ hp => by xperm_hyp hp)
+      (fun _ hp => by xperm_hyp hp)
+      framed
+  -- Compose s2 ; s3 over the tail.
+  have hd23 : CodeReq.Disjoint
+      (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0))
+      (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) :=
+    CodeReq.Disjoint.singleton (by bv_omega)
+  have s23_raw := cpsTriple_seq hd23 s2 s3
+  -- Re-express the composed code as `ofProg (base + 4) tail` and adjust
+  -- the exit PC from `((base + 4) + 4) + 4` to `base + 12`.
+  have hexit : (((base + 4) + 4) + 4 : Word) = base + 12 := by bv_omega
+  rw [← hcr_tail, hexit] at s23_raw
+  -- Compose s1 ; s23.
+  have hd1_23 : CodeReq.Disjoint
+      (CodeReq.singleton base (.ADDI .x14 .x5 (-0xB7)))
+      (CodeReq.ofProg (base + 4) [.ADDI .x11 .x0 0, .ADDI .x13 .x13 1]) := by
+    apply CodeReq.Disjoint.ofProg_cons_right
+    · exact CodeReq.Disjoint.singleton (by bv_omega)
+    apply CodeReq.Disjoint.ofProg_cons_right
+    · exact CodeReq.Disjoint.singleton (by bv_omega)
+    exact CodeReq.Disjoint.ofProg_nil_right _ _
+  exact cpsTriple_seq hd1_23 s1 s23_raw
+
+end EvmAsm.Rv64.RLP

--- a/PLAN.md
+++ b/PLAN.md
@@ -682,9 +682,17 @@ prerequisites provide the pure spec and RISC-V infrastructure for that.
     Phase 1's `e1` exit (prefix byte `< 0x80`, single-byte string —
     the prefix IS the data). The data pointer in `x13` rides through
     as a frame atom; no pointer advance is needed.
+  - `rlp_phase3_long_string_spec` (`EvmAsm/Rv64/RLP/Phase3LongString.lean`):
+    three-instruction entry block for Phase 1's `e3` exit
+    (`p ∈ [0xB8, 0xC0)`). Sets `x14 = p − 0xB7` (length-of-length;
+    range [1, 8]), clears the length accumulator `x11 := 0`, and
+    advances the data pointer `x13 += 1` to the first length byte —
+    leaving the machine in the canonical pre-loop state expected by
+    the `rlp_phase2_long_loop_*_byte_spec` family.
   - Remaining: short-string exit (`e2`: data_ptr += 1, length = p − 0x80),
-    long-string exit (`e3`: needs Phase 2 long output), short/long-list
-    error exits (`e4`/`e5`).
+    long-string composition with Phase 2 (`e3` continuation: thread the
+    Phase 2 loop output into a final `data_ptr += lenLen` step),
+    short/long-list error exits (`e4`/`e5`).
 - Phase 4: HINT_READ integration (load RLP input into memory buffer)
 - Phase 5: Recursive list decode (iterative with explicit stack)
 - Phase 6: Top-level pipeline (HINT_READ → decode → output)


### PR DESCRIPTION
## Summary

Three-instruction `cpsTriple` for Phase 1's `e3` exit (long-string prefix `p ∈ [0xB8, 0xC0)`):

```
ADDI x14, x5, -0xB7    ; lenLen = p - 0xB7   (range [1, 8])
ADDI x11, x0, 0        ; len_acc := 0
ADDI x13, x13, 1       ; data_ptr += 1       (skip prefix byte)
```

After this entry block the machine is in the canonical pre-loop state for the Phase 2 long-form length-of-length loop (`rlp_phase2_long_loop_*_byte_spec` family). The next step on the `e3` path is composing this with the matching Phase 2 closure on `x14`.

## Files

- `EvmAsm/Rv64/RLP/Phase3LongString.lean` — new (~190 lines): program + spec
- `EvmAsm/Rv64/RLP.lean` — wired the new module in
- `PLAN.md` — Phase 3 status note

Pattern mirrors `Phase3SingleByte` / `Phase3ShortString`: a CodeReq decomposition into singleton ∪ ofProg-tail, three framed `addi_spec_gen` steps, and a final `cpsTriple_seq` chain. Sanity `decide` examples confirm the boundary cases (`0xB8 → 1`, `0xBF → 8`).

## Test plan

- [x] `lake build EvmAsm.Rv64.RLP.Phase3LongString` — clean (1.2s)
- [x] `lake build` (full repo, 1355 jobs) — clean
- [x] No `sorry`/`admit`; no `native_decide` (kernel-checkable)

Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)