### PR TITLE
feat(rlp): add readLength and empty-string decodeAux properties

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -33,6 +33,19 @@ theorem takeBytes_length_ge {bs : List Byte} {n : Nat} (h : n ≤ bs.length) :
     takeBytes bs n = some (bs.take n, bs.drop n) := by
   simp [takeBytes, h]
 
+/-! ## readLength properties -/
+
+/-- Reading zero length-bytes always succeeds with length 0 and the input
+    list unchanged. -/
+theorem readLength_zero (bs : List Byte) :
+    readLength bs 0 = some (0, bs) := by
+  simp [readLength, takeBytes]
+
+/-- Reading more length-bytes than the input contains returns `none`. -/
+theorem readLength_length_lt {bs : List Byte} {n : Nat} (h : bs.length < n) :
+    readLength bs n = none := by
+  simp [readLength, takeBytes, Nat.not_le_of_lt h]
+
 /-! ## decodeAux trivial cases -/
 
 /-- `decodeAux 0` always returns `none` (no fuel). -/
@@ -51,6 +64,12 @@ theorem decodeAux_single_byte (fuel : Nat) (pfx : Byte) (rest : List Byte)
     (h : pfx.toNat < 0x80) :
     decodeAux (fuel + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
   simp [decodeAux, h]
+
+/-- Empty short byte string (prefix `0x80`): `decodeAux` returns `(.bytes [], rest)`
+    consuming only the prefix byte. -/
+theorem decodeAux_empty_string (fuel : Nat) (rest : List Byte) :
+    decodeAux (fuel + 1) ((0x80 : Byte) :: rest) = some (.bytes [], rest) := by
+  simp [decodeAux, takeBytes]
 
 /-! ## Encoding produces non-empty output -/
 


### PR DESCRIPTION
## Summary

Three small additive lemmas in `EvmAsm/EL/RLP/Properties.lean`:

* `readLength_zero` — `readLength bs 0 = some (0, bs)` (no length bytes ⇒ length defaults to 0)
* `readLength_length_lt` — input shorter than `n` ⇒ `none`
* `decodeAux_empty_string` — prefix byte `0x80` decodes to `(.bytes [], rest)` consuming exactly one byte

Continues the trivial-case characterization line opened by #1342. Each is one or two lines of `simp` and gives downstream proofs cheap rewriters.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean
- [x] No `sorry`/`admit`; no `native_decide`

🤖 Generated with [Claude Code](https://claude.com/claude-code)