### PR TITLE
feat(rlp): add public Phase 1 cascade-step disjointness helpers

### DIFF
--- a/EvmAsm/Rv64/RLP.lean
+++ b/EvmAsm/Rv64/RLP.lean
@@ -25,6 +25,7 @@ import EvmAsm.Rv64.RLP.Phase2LongLoopSix
 import EvmAsm.Rv64.RLP.Phase3LongString
 import EvmAsm.Rv64.RLP.Phase3ShortString
 import EvmAsm.Rv64.RLP.Phase3SingleByte
+import EvmAsm.Rv64.RLP.Phase1Disjoint
 import EvmAsm.Rv64.RLP.Phase1CascadePrefixE2
 import EvmAsm.Rv64.RLP.Phase1CascadePrefixE3
 import EvmAsm.Rv64.RLP.Phase1E2FullPath

--- a/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
+++ b/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
@@ -1,0 +1,69 @@
+/-
+  EvmAsm.Rv64.RLP.Phase1Disjoint
+
+  Public disjointness helpers for Phase 1 cascade-step `CodeReq`s.
+
+  The Phase 1 classifier program is a chain of four cascade steps,
+  each occupying eight bytes. Composing them requires disjointness
+  between the various pairs. The proof obligations fall into three
+  shapes (8 / 16 / 24 byte gaps), each of which holds for any
+  threshold/offset by `bv_omega` on the addresses.
+
+  These public helpers give downstream consumers (cascade-prefix
+  specs, full-path specs) a single re-exported entry point so they
+  do not need to either:
+    * reach into `Phase1.lean`'s `private` `step_code_Disjoint_{8,16,24}`
+      helpers, or
+    * re-prove the same `bv_omega` shape inline at every call site.
+-/
+
+import EvmAsm.Rv64.RLP.Phase1
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Pairwise step-code disjointness (8 / 16 / 24 byte gaps)
+-- ============================================================================
+
+/-- Two cascade-step `CodeReq`s at bases 8 bytes apart are disjoint. -/
+theorem rlp_phase1_step_code_disjoint_8
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 base).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 8)) :=
+  CodeReq.Disjoint.union_left
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+
+/-- Two cascade-step `CodeReq`s at bases 16 bytes apart are disjoint. -/
+theorem rlp_phase1_step_code_disjoint_16
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 base).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 16)) :=
+  CodeReq.Disjoint.union_left
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+
+/-- Two cascade-step `CodeReq`s at bases 24 bytes apart are disjoint. -/
+theorem rlp_phase1_step_code_disjoint_24
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 base).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 24)) :=
+  CodeReq.Disjoint.union_left
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+    (CodeReq.Disjoint.union_right
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.singleton (by bv_omega)))
+
+end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Adds three public theorems in a new `EvmAsm.Rv64.RLP.Phase1Disjoint` module:

* `rlp_phase1_step_code_disjoint_8`
* `rlp_phase1_step_code_disjoint_16`
* `rlp_phase1_step_code_disjoint_24`

Each witnesses that two cascade-step `CodeReq`s at bases 8 / 16 / 24 bytes apart are disjoint. The proof shape is the same as the existing `private` helpers in `Phase1.lean` (a fixed 4-fold `CodeReq.Disjoint.union_*` chain over `bv_omega`-discharged singleton disjointness facts), but exposed in their own file so cascade-prefix and full-path consumers can call them directly without re-proving the same `bv_omega` shape inline.

The cascade-prefix specs (#1358 / #1359 / #1362 / #1363) and full-path specs (#1360 / #1361) currently take their pairwise disjointness as explicit hypotheses; future iterations can replace those obligations with calls to these helpers.

## Files

- `EvmAsm/Rv64/RLP/Phase1Disjoint.lean` — new (~70 lines)
- `EvmAsm/Rv64/RLP.lean` — wire the new module in

## Test plan

- [x] `lake build EvmAsm.Rv64.RLP.Phase1Disjoint` — clean
- [x] `lake build` (full repo, 1366 jobs) — clean
- [x] No `sorry`/`admit`; no `native_decide`

Refs #120.

🤖 Generated with [Claude Code](https://claude.com/claude-code)