### PR TITLE
feat(rlp): add encodeBytes pair characterization

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -134,6 +134,13 @@ theorem encodeBytes_single_large (b : Byte) (h : ¬ b.toNat < 0x80) :
     encodeBytes [b] = [BitVec.ofNat 8 0x81, b] := by
   simp [encodeBytes, h]
 
+/-- Two-byte short string: `encodeBytes [a, b] = [0x82, a, b]`.
+    No canonical-form branching applies; `data.length = 2 > 1` skips
+    the single-byte path, and `2 ≤ 55` selects the short-string form. -/
+theorem encodeBytes_pair (a b : Byte) :
+    encodeBytes [a, b] = [BitVec.ofNat 8 0x82, a, b] := by
+  simp [encodeBytes]
+
 /-! ## Encoding produces non-empty output -/
 
 theorem encodeBytes_nonempty (data : List Byte) :


### PR DESCRIPTION
## Summary

Adds `encodeBytes_pair`: `encodeBytes [a, b] = [0x82, a, b]` — the two-byte short-string encoding.

```lean
theorem encodeBytes_pair (a b : Byte) :
    encodeBytes [a, b] = [BitVec.ofNat 8 0x82, a, b] := by
  simp [encodeBytes]
```

No canonical-form branching applies because `data.length = 2 > 1` skips the single-byte path and `2 ≤ 55` selects the short-string form.

Companion to `decodeAux_two_byte_string` / `decode_two_byte_string` (#1351); the two together let the round-trip property be stated mechanically on this concrete pair: encode then decode recovers the original inputs.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)