### PR TITLE
feat(rlp): add convenience variant of e3 full path with auto-derived disjointness

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1E3FullPath.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E3FullPath.lean
@@ -20,6 +20,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.Phase1CascadePrefixE3
+import EvmAsm.Rv64.RLP.Phase1Disjoint
 import EvmAsm.Rv64.RLP.Phase3LongString
 
 namespace EvmAsm.Rv64.RLP
@@ -109,5 +110,45 @@ theorem rlp_phase1_e3_full_path_spec
         (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12)))
         (by pcFree) ph3)
   exact cpsTriple_seq hd_phase3 prefix' ph3'
+
+/-- Convenience variant of `rlp_phase1_e3_full_path_spec` that
+    discharges the three pairwise cascade-step disjointness
+    obligations (`hd12`, `hd13`, `hd23`) internally via the
+    `rlp_phase1_step_code_disjoint_*` helpers. The caller still
+    supplies the Phase 1↔Phase 3 disjointness `hd_phase3` since
+    `e3_target` is not derivable from `base`. -/
+theorem rlp_phase1_e3_full_path_spec'
+    (v5 v10 v11Old v13 v14Old : Word)
+    (off1 off2 off3 : BitVec 13) (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (hv5_lo  : ¬ BitVec.ult v5 ((0 : Word) + signExtend12 (0x80 : BitVec 12)))
+    (hv5_mid : ¬ BitVec.ult v5 ((0 : Word) + signExtend12 (0xB8 : BitVec 12)))
+    (hv5_hi  : BitVec.ult v5 ((0 : Word) + signExtend12 (0xC0 : BitVec 12)))
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))).Disjoint
+        (CodeReq.ofProg e3_target rlp_phase3_long_string_prog)) :
+    cpsTriple base (e3_target + 12)
+      (((rlp_phase1_step_code 0x80 off1 base).union
+         ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+           (rlp_phase1_step_code 0xC0 off3 (base + 16)))).union
+         (CodeReq.ofProg e3_target rlp_phase3_long_string_prog))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14Old))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ (v5 + signExtend12 (-(0xB7 : BitVec 12))))) :=
+  rlp_phase1_e3_full_path_spec v5 v10 v11Old v13 v14Old off1 off2 off3 base
+    e3_target htarget hv5_lo hv5_mid hv5_hi
+    (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
+    (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
+    (by
+      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
+      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h
+      exact h)
+    hd_phase3
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Adds `rlp_phase1_e3_full_path_spec'` — wrapper around `rlp_phase1_e3_full_path_spec` (#1361) that internally discharges the three pairwise cascade-step disjointness obligations (`hd12`, `hd13`, `hd23`) via the `rlp_phase1_step_code_disjoint_*` helpers (#1364).

Mirrors the e2 convenience variant (#1366). The `hd23` case (between steps at `base + 8` and `base + 16`) needs a small `bv_omega` rewrite to align `(base + 8) + 8` with `base + 16`.

The user still supplies the Phase 1 ↔ Phase 3 disjointness `hd_phase3` since `e3_target` is not derivable from `base`.

## Test plan

- [x] `lake build EvmAsm.Rv64.RLP.Phase1E3FullPath` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)