### PR TITLE
feat(rlp): add convenience variant of e3 cascade prefix with auto-derived disjointness

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1CascadePrefixE3.lean
+++ b/EvmAsm/Rv64/RLP/Phase1CascadePrefixE3.lean
@@ -21,6 +21,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.Phase1
+import EvmAsm.Rv64.RLP.Phase1Disjoint
 
 namespace EvmAsm.Rv64.RLP
 
@@ -76,5 +77,31 @@ theorem rlp_phase1_cascade_prefix_e3_spec (v5 v10 : Word)
         (rlp_phase1_step_code 0xC0 off3 (base + 16))) :=
     CodeReq.Disjoint.union_right hd12 hd13
   exact cpsTriple_seq hd1_23 step1 step23
+
+/-- Convenience variant of `rlp_phase1_cascade_prefix_e3_spec` that
+    discharges all three pairwise cascade-step disjointness obligations
+    internally via the `rlp_phase1_step_code_disjoint_*` helpers
+    (#1364). The user only supplies the dispatch hypotheses on `v5`
+    and the `htarget` PC equation. -/
+theorem rlp_phase1_cascade_prefix_e3_spec' (v5 v10 : Word)
+    (off1 off2 off3 : BitVec 13) (base e3_target : Word)
+    (htarget : (base + 16 + 4) + signExtend13 off3 = e3_target)
+    (hv5_lo  : ¬ BitVec.ult v5 ((0 : Word) + signExtend12 (0x80 : BitVec 12)))
+    (hv5_mid : ¬ BitVec.ult v5 ((0 : Word) + signExtend12 (0xB8 : BitVec 12)))
+    (hv5_hi  : BitVec.ult v5 ((0 : Word) + signExtend12 (0xC0 : BitVec 12))) :
+    let kVal3 := (0 : Word) + signExtend12 (0xC0 : BitVec 12)
+    cpsTriple base e3_target
+      ((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          (rlp_phase1_step_code 0xC0 off3 (base + 16))))
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal3)) :=
+  rlp_phase1_cascade_prefix_e3_spec v5 v10 off1 off2 off3 base e3_target
+    htarget hv5_lo hv5_mid hv5_hi
+    (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
+    (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
+    (by
+      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
+      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h; exact h)
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Adds `rlp_phase1_cascade_prefix_e3_spec'` — wrapper around `rlp_phase1_cascade_prefix_e3_spec` (#1359) that internally discharges all three pairwise cascade-step disjointness obligations via the `rlp_phase1_step_code_disjoint_*` helpers (#1364).

Mirrors the e4 / e5 simplified variants (#1369 / #1370). The user only supplies the three dispatch hypotheses on `v5` and the `htarget` PC equation.

## Test plan

- [x] `lake build EvmAsm.Rv64.RLP.Phase1CascadePrefixE3` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)