### PR TITLE
feat(rlp): add convenience variant of e2 cascade prefix with auto-derived disjointness

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1CascadePrefixE2.lean
+++ b/EvmAsm/Rv64/RLP/Phase1CascadePrefixE2.lean
@@ -19,6 +19,7 @@
 -/
 
 import EvmAsm.Rv64.RLP.Phase1
+import EvmAsm.Rv64.RLP.Phase1Disjoint
 
 namespace EvmAsm.Rv64.RLP
 
@@ -58,5 +59,25 @@ theorem rlp_phase1_cascade_prefix_e2_spec (v5 v10 : Word)
     ((0 : Word) + signExtend12 (0x80 : BitVec 12)) 0xB8 off2
     (base + 8) e2_target htarget hv5_hi
   exact cpsTriple_seq hd step1 step2
+
+/-- Convenience variant of `rlp_phase1_cascade_prefix_e2_spec` that
+    discharges the cascade-step disjointness obligation internally
+    via `rlp_phase1_step_code_disjoint_8` (#1364). The user only
+    supplies the two dispatch hypotheses on `v5` and the `htarget`
+    PC equation. -/
+theorem rlp_phase1_cascade_prefix_e2_spec' (v5 v10 : Word)
+    (off1 off2 : BitVec 13) (base e2_target : Word)
+    (htarget : (base + 8 + 4) + signExtend13 off2 = e2_target)
+    (hv5_lo : ¬ BitVec.ult v5 ((0 : Word) + signExtend12 (0x80 : BitVec 12)))
+    (hv5_hi : BitVec.ult v5 ((0 : Word) + signExtend12 (0xB8 : BitVec 12))) :
+    let kVal2 := (0 : Word) + signExtend12 (0xB8 : BitVec 12)
+    cpsTriple base e2_target
+      ((rlp_phase1_step_code 0x80 off1 base).union
+         (rlp_phase1_step_code 0xB8 off2 (base + 8)))
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ v5) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ kVal2)) :=
+  rlp_phase1_cascade_prefix_e2_spec v5 v10 off1 off2 base e2_target
+    htarget hv5_lo hv5_hi
+    (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary

Adds `rlp_phase1_cascade_prefix_e2_spec'` — wrapper around `rlp_phase1_cascade_prefix_e2_spec` (#1358) that internally discharges the cascade-step disjointness obligation via `rlp_phase1_step_code_disjoint_8` (#1364).

Mirrors the e3 / e4 / e5 simplified variants (#1371 / #1369 / #1370). With this PR the simplified-variant rollout covers all four cascade prefixes (e2, e3, e4, e5) and both full paths (e2, e3).

## Test plan

- [x] `lake build EvmAsm.Rv64.RLP.Phase1CascadePrefixE2` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)