### PR TITLE
feat(rlp): add three-byte and four-byte encodeBytes characterizations

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -157,6 +157,16 @@ theorem encodeBytes_pair (a b : Byte) :
     encodeBytes [a, b] = [BitVec.ofNat 8 0x82, a, b] := by
   simp [encodeBytes]
 
+/-- Three-byte short string: `encodeBytes [a, b, c] = [0x83, a, b, c]`. -/
+theorem encodeBytes_triple (a b c : Byte) :
+    encodeBytes [a, b, c] = [BitVec.ofNat 8 0x83, a, b, c] := by
+  simp [encodeBytes]
+
+/-- Four-byte short string: `encodeBytes [a, b, c, d] = [0x84, a, b, c, d]`. -/
+theorem encodeBytes_quad (a b c d : Byte) :
+    encodeBytes [a, b, c, d] = [BitVec.ofNat 8 0x84, a, b, c, d] := by
+  simp [encodeBytes]
+
 /-! ## Encoding produces non-empty output -/
 
 theorem encodeBytes_nonempty (data : List Byte) :


### PR DESCRIPTION
## Summary

Two trivial-case lemmas extending the `encodeBytes` characterization chain (#1356, #1365):

* `encodeBytes_triple` — `encodeBytes [a, b, c] = [0x83, a, b, c]`
* `encodeBytes_quad` — `encodeBytes [a, b, c, d] = [0x84, a, b, c, d]`

Companions to `decodeAux_three_byte_string` / `decode_three_byte_string` (#1368) on the encode side.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)