### PR TITLE
feat(rlp): add empty-bytes round-trip lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -173,6 +173,20 @@ theorem encode_nonempty (item : RLPItem) : (encode item).length > 0 := by
     simp [encode]
     split <;> simp [List.length_append]
 
+/-! ## Round-trip correctness (parametric cases)
+
+These lemmas prove `decode (encode (.bytes [b])) = some (.bytes [b], [])`
+mechanically (not via `decide`) by chaining the existing `encodeBytes_*`
+and `decode_*` characterizations. -/
+
+/-- Empty byte string round-trip:
+    `decode (encode (.bytes [])) = some (.bytes [], [])`. Chains
+    `encodeBytes_nil` with `decode_empty_string`. -/
+theorem decode_encode_bytes_empty :
+    decode (encode (.bytes [])) = some (.bytes [], []) := by
+  simp only [encode, encodeBytes_nil]
+  exact decode_empty_string
+
 /-! ## Round-trip correctness (concrete cases)
 
 The round-trip property `decode (encode item) = some (item, [])` is verified


### PR DESCRIPTION
## Summary

Adds `decode_encode_bytes_empty`:
```
decode (encode (.bytes [])) = some (.bytes [], [])
```

Proved mechanically by chaining `encodeBytes_nil` (#1356) with `decode_empty_string` (#1348). Companion to `decode_encode_bytes_single_small` (#1375 in flight). Together these cover the empty-bytes and small-single-byte cases of an eventual fully parametric round-trip theorem.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)