### PR TITLE
feat(rlp): add large-single-byte round-trip lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -173,6 +173,20 @@ theorem encode_nonempty (item : RLPItem) : (encode item).length > 0 := by
     simp [encode]
     split <;> simp [List.length_append]
 
+/-! ## Round-trip correctness (parametric — large single byte)
+
+Mechanically-proved (not via `decide`) round-trip for the
+single-large-byte case (`b ≥ 0x80`): the byte is encoded as the
+two-byte sequence `[0x81, b]`, then the decoder reads the prefix as
+a one-byte short string, applies the canonical-form check (which
+passes because `b ≥ 0x80`), and returns `.bytes [b]`. -/
+
+theorem decode_encode_bytes_single_large (b : Byte) (h : ¬ b.toNat < 0x80) :
+    decode (encode (.bytes [b])) = some (.bytes [b], []) := by
+  rw [show encode (.bytes [b]) = [BitVec.ofNat 8 0x81, b] from
+    encodeBytes_single_large b h]
+  simp [decode, decodeAux, takeBytes, h]
+
 /-! ## Round-trip correctness (concrete cases)
 
 The round-trip property `decode (encode item) = some (item, [])` is verified


### PR DESCRIPTION
## Summary

Adds `decode_encode_bytes_single_large`: for any `b : Byte` with `b.toNat ≥ 0x80`,
```
decode (encode (.bytes [b])) = some (.bytes [b], [])
```

Mechanically proved (not via `decide`) by rewriting the encoding via `encodeBytes_single_large` (#1356) to `[0x81, b]`, then unfolding the decoder. The canonical-form check passes because `b ≥ 0x80`.

Companion to the empty-bytes (#1376 in flight) and small-single-byte (#1375 in flight) round-trip lemmas — the three together cover the entire single-byte case.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)