### PR TITLE
feat(rlp): add five-byte short-string decode characterization

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -98,6 +98,14 @@ theorem decodeAux_three_byte_string
       some (.bytes [b1, b2, b3], rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Five-byte short string (prefix `0x85`). Multi-byte payload
+    bypasses the canonical-form check. -/
+theorem decodeAux_five_byte_string
+    (fuel : Nat) (b1 b2 b3 b4 b5 : Byte) (rest : List Byte) :
+    decodeAux (fuel + 1) ((0x85 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: rest) =
+      some (.bytes [b1, b2, b3, b4, b5], rest) := by
+  simp [decodeAux, takeBytes]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/
@@ -132,6 +140,13 @@ theorem decode_two_byte_string (b1 b2 : Byte) :
     `decodeAux_three_byte_string` at the top-level fuel. -/
 theorem decode_three_byte_string (b1 b2 b3 : Byte) :
     decode [(0x83 : Byte), b1, b2, b3] = some (.bytes [b1, b2, b3], []) := by
+  simp [decode, decodeAux, takeBytes]
+
+/-- `decode [0x85, b1, b2, b3, b4, b5] = some (.bytes [b1..b5], [])`
+    — the canonical five-byte short-string encoding. -/
+theorem decode_five_byte_string (b1 b2 b3 b4 b5 : Byte) :
+    decode [(0x85 : Byte), b1, b2, b3, b4, b5] =
+      some (.bytes [b1, b2, b3, b4, b5], []) := by
   simp [decode, decodeAux, takeBytes]
 
 /-! ## encodeBytes characterizations -/


### PR DESCRIPTION
## Summary

Two trivial-case lemmas extending the trivial-case characterization chain (#1342, #1346, #1348, #1351, #1368, #1373):

* `decodeAux_five_byte_string` — prefix `0x85` followed by five payload bytes decodes to `.bytes [b1..b5]`, consuming six bytes
* `decode_five_byte_string` — top-level wrapper specialization

Multi-byte payload bypasses the canonical-form check.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)