### PR TITLE
feat(rlp): add six-byte short-string decode characterization

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -114,6 +114,15 @@ theorem decodeAux_five_byte_string
       some (.bytes [b1, b2, b3, b4, b5], rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Six-byte short string (prefix `0x86`). Multi-byte payload
+    bypasses the canonical-form check. -/
+theorem decodeAux_six_byte_string
+    (fuel : Nat) (b1 b2 b3 b4 b5 b6 : Byte) (rest : List Byte) :
+    decodeAux (fuel + 1)
+        ((0x86 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: rest) =
+      some (.bytes [b1, b2, b3, b4, b5, b6], rest) := by
+  simp [decodeAux, takeBytes]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/
@@ -163,6 +172,13 @@ theorem decode_four_byte_string (b1 b2 b3 b4 : Byte) :
 theorem decode_five_byte_string (b1 b2 b3 b4 b5 : Byte) :
     decode [(0x85 : Byte), b1, b2, b3, b4, b5] =
       some (.bytes [b1, b2, b3, b4, b5], []) := by
+  simp [decode, decodeAux, takeBytes]
+
+/-- `decode [0x86, b1..b6] = some (.bytes [b1..b6], [])` — the
+    canonical six-byte short-string encoding. -/
+theorem decode_six_byte_string (b1 b2 b3 b4 b5 b6 : Byte) :
+    decode [(0x86 : Byte), b1, b2, b3, b4, b5, b6] =
+      some (.bytes [b1, b2, b3, b4, b5, b6], []) := by
   simp [decode, decodeAux, takeBytes]
 
 /-! ## encodeBytes characterizations -/


### PR DESCRIPTION
## Summary

Two trivial-case lemmas extending the trivial-case characterization chain:

* `decodeAux_six_byte_string` — prefix `0x86` followed by six payload bytes decodes to `.bytes [b1..b6]`, consuming seven bytes
* `decode_six_byte_string` — top-level wrapper specialization

Multi-byte payload bypasses the canonical-form check.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)