### PR TITLE
feat(rlp): add five-byte and six-byte encodeBytes characterizations

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -214,6 +214,19 @@ theorem encodeBytes_quad (a b c d : Byte) :
     encodeBytes [a, b, c, d] = [BitVec.ofNat 8 0x84, a, b, c, d] := by
   simp [encodeBytes]
 
+/-- Five-byte short string:
+    `encodeBytes [a, b, c, d, e] = [0x85, a, b, c, d, e]`. -/
+theorem encodeBytes_quint (a b c d e : Byte) :
+    encodeBytes [a, b, c, d, e] = [BitVec.ofNat 8 0x85, a, b, c, d, e] := by
+  simp [encodeBytes]
+
+/-- Six-byte short string:
+    `encodeBytes [a, b, c, d, e, f] = [0x86, a, b, c, d, e, f]`. -/
+theorem encodeBytes_sext (a b c d e f : Byte) :
+    encodeBytes [a, b, c, d, e, f] =
+      [BitVec.ofNat 8 0x86, a, b, c, d, e, f] := by
+  simp [encodeBytes]
+
 /-! ## Encoding produces non-empty output -/
 
 theorem encodeBytes_nonempty (data : List Byte) :


### PR DESCRIPTION
## Summary

Two trivial-case lemmas extending the `encodeBytes` characterization chain (#1356, #1365, #1374):

* `encodeBytes_quint` — `encodeBytes [a, b, c, d, e] = [0x85, a..e]`
* `encodeBytes_sext` — `encodeBytes [a, b, c, d, e, f] = [0x86, a..f]`

Companions to the merged `decodeAux_five_byte_string` (#1378) and `decodeAux_six_byte_string` (#1379) on the encode side.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)