### PR TITLE
feat(rlp): add canonical-form rejection lemma for single-byte string

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -123,6 +123,15 @@ theorem decodeAux_six_byte_string
       some (.bytes [b1, b2, b3, b4, b5, b6], rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
+    with `b.toNat < 0x80` is non-canonical (the byte should have
+    been encoded as itself, not under prefix `0x81`), so `decodeAux`
+    returns `none`. -/
+theorem decodeAux_canonical_rejection_single
+    (fuel : Nat) (b : Byte) (rest : List Byte) (h : b.toNat < 0x80) :
+    decodeAux (fuel + 1) ((0x81 : Byte) :: b :: rest) = none := by
+  simp [decodeAux, takeBytes, h]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decodeAux_canonical_rejection_single`: when the prefix is `0x81` followed by a byte `b` with `b.toNat < 0x80`, `decodeAux` returns `none`. The encoding is non-canonical because such a byte should have been emitted as itself rather than under the `0x81` length prefix.

```lean
theorem decodeAux_canonical_rejection_single
    (fuel : Nat) (b : Byte) (rest : List Byte) (h : b.toNat < 0x80) :
    decodeAux (fuel + 1) ((0x81 : Byte) :: b :: rest) = none := by
  simp [decodeAux, takeBytes, h]
```

Companion to the affirmative single-large-byte round-trip (`decode_encode_bytes_single_large`, #1377): together the two lemmas show the canonical-form check correctly accepts/rejects the boundary cases at `b = 0x7F` and `b = 0x80`.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)