### PR TITLE
feat(rlp): add singleton-list-of-small-byte decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -132,6 +132,14 @@ theorem decodeAux_canonical_rejection_single
     decodeAux (fuel + 1) ((0x81 : Byte) :: b :: rest) = none := by
   simp [decodeAux, takeBytes, h]
 
+/-- Singleton list containing one small byte: top-level `decode` of
+    `[0xC1, b]` with `b < 0x80` returns `.list [.bytes [b]]`. The
+    short-list branch fires with payload length 1, the inner byte is
+    recognized as a single-byte item, and the list closes cleanly. -/
+theorem decode_singleton_list_small_byte (b : Byte) (h : b.toNat < 0x80) :
+    decode [(0xC1 : Byte), b] = some (.list [.bytes [b]], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems, h]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_singleton_list_small_byte`: for any byte `b < 0x80`,
```
decode [0xC1, b] = some (.list [.bytes [b]], [])
```

This is the **first parametric (non-`decide`) characterization of a list form** in the file — the existing concrete examples like `decode (encode (.list [.bytes [0x01], .bytes [0x02]])) = ...` are all `decide`-based spot checks.

Trace: short-list branch fires (`p = 0xC1`, payload length 1), inner byte recognized as single-byte item via the canonical-form check (passes since `b < 0x80`), and `decodeItems` closes the list with empty leftover.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)