### PR TITLE
feat(divmod): #1337 Phase-1 no-wrap discharge — bundles + D1c chain + counterexample-driven cleanup

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -74,7 +74,7 @@ private theorem clz_init_sub {base : Word} :
 -- Stage 5 (last): K=63, M_a=1,   index 21
 
 /-- CLZ result function: compute (count, shifted_val) from a 6-stage binary search. -/
-noncomputable def clzResult (val : Word) : Word × Word :=
+def clzResult (val : Word) : Word × Word :=
   -- Stage 0: check top 32 bits
   let v0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then val else val <<< (32 : BitVec 6).toNat
   let c0 := if val >>> (32 : BitVec 6).toNat ≠ 0 then signExtend12 (0 : BitVec 12)

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -552,7 +552,7 @@ theorem addbackN4_carry_le_one (un0 un1 un2 un3 v0 v1 v2 v3 : Word) :
     so consumers get a consistent shape. Use `algCallAddbackBeqCarry_unfold`
     to expose the let-chain when needed in proofs. -/
 @[irreducible]
-noncomputable def algCallAddbackBeqCarry (a b : EvmWord) : Word :=
+def algCallAddbackBeqCarry (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -574,7 +574,7 @@ noncomputable def algCallAddbackBeqCarry (a b : EvmWord) : Word :=
     needed to talk about the c3 = mulsub borrow at normalized limbs as a
     single opaque Word value, sidestepping let-chain elaboration cost. -/
 @[irreducible]
-noncomputable def algCallAddbackBeqMsC3 (a b : EvmWord) : Word :=
+def algCallAddbackBeqMsC3 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -592,7 +592,7 @@ noncomputable def algCallAddbackBeqMsC3 (a b : EvmWord) : Word :=
 
 /-- **Irreducible bundle: the call+addback BEQ algorithm's u4 (overflow limb).** -/
 @[irreducible]
-noncomputable def algCallAddbackBeqU4 (a b : EvmWord) : Word :=
+def algCallAddbackBeqU4 (a b : EvmWord) : Word :=
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   (a.getLimbN 3) >>> antiShift
 
@@ -629,7 +629,7 @@ theorem algCallAddbackBeqCarry_unfold {a b : EvmWord} :
     addback post1 val256 as a single opaque Nat, sidestepping the
     elaboration-cost penalty observed in the parent adapter. -/
 @[irreducible]
-noncomputable def algCallAddbackBeqPost1Val (a b : EvmWord) : Nat :=
+def algCallAddbackBeqPost1Val (a b : EvmWord) : Nat :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -676,7 +676,7 @@ theorem algCallAddbackBeqPost1Val_unfold {a b : EvmWord} :
     to keep the goal manageable when reasoning per-limb (avoids huge
     inline `mulsubN4 ...` expressions). -/
 @[irreducible]
-noncomputable def algCallAddbackBeqPost1Limb0 (a b : EvmWord) : Word :=
+def algCallAddbackBeqPost1Limb0 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -693,7 +693,7 @@ noncomputable def algCallAddbackBeqPost1Limb0 (a b : EvmWord) : Word :=
   (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0' b1' b2' b3').1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqPost1Limb1 (a b : EvmWord) : Word :=
+def algCallAddbackBeqPost1Limb1 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -710,7 +710,7 @@ noncomputable def algCallAddbackBeqPost1Limb1 (a b : EvmWord) : Word :=
   (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0' b1' b2' b3').2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqPost1Limb2 (a b : EvmWord) : Word :=
+def algCallAddbackBeqPost1Limb2 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -727,7 +727,7 @@ noncomputable def algCallAddbackBeqPost1Limb2 (a b : EvmWord) : Word :=
   (addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 b0' b1' b2' b3').2.2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqPost1Limb3 (a b : EvmWord) : Word :=
+def algCallAddbackBeqPost1Limb3 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -767,7 +767,7 @@ theorem algCallAddbackBeqPost1Val_eq_val256_limbs (a b : EvmWord) :
     if carry = 0 then ab'.{i_low} else ab.{i_low}`. Wrapping them as
     irreducible defs keeps the parent's goal manageable. -/
 @[irreducible]
-noncomputable def algCallAddbackBeqUn0Out (a b : EvmWord) : Word :=
+def algCallAddbackBeqUn0Out (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -789,7 +789,7 @@ noncomputable def algCallAddbackBeqUn0Out (a b : EvmWord) : Word :=
   if carry = 0 then ab'.1 else ab.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqUn1Out (a b : EvmWord) : Word :=
+def algCallAddbackBeqUn1Out (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -811,7 +811,7 @@ noncomputable def algCallAddbackBeqUn1Out (a b : EvmWord) : Word :=
   if carry = 0 then ab'.2.1 else ab.2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqUn2Out (a b : EvmWord) : Word :=
+def algCallAddbackBeqUn2Out (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -833,7 +833,7 @@ noncomputable def algCallAddbackBeqUn2Out (a b : EvmWord) : Word :=
   if carry = 0 then ab'.2.2.1 else ab.2.2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqUn3Out (a b : EvmWord) : Word :=
+def algCallAddbackBeqUn3Out (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -998,7 +998,7 @@ theorem algCallAddbackBeqUn3Out_eq_post1Limb3_of_single_addback
 
     Issue #1338 (Phase B.4 mechanical infrastructure).  -/
 @[irreducible]
-noncomputable def algCallAddbackBeqAbPrimeLimb0 (a b : EvmWord) : Word :=
+def algCallAddbackBeqAbPrimeLimb0 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -1018,7 +1018,7 @@ noncomputable def algCallAddbackBeqAbPrimeLimb0 (a b : EvmWord) : Word :=
   (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3').1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqAbPrimeLimb1 (a b : EvmWord) : Word :=
+def algCallAddbackBeqAbPrimeLimb1 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -1038,7 +1038,7 @@ noncomputable def algCallAddbackBeqAbPrimeLimb1 (a b : EvmWord) : Word :=
   (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3').2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqAbPrimeLimb2 (a b : EvmWord) : Word :=
+def algCallAddbackBeqAbPrimeLimb2 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -1058,7 +1058,7 @@ noncomputable def algCallAddbackBeqAbPrimeLimb2 (a b : EvmWord) : Word :=
   (addbackN4 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 ab.2.2.2.2 b0' b1' b2' b3').2.2.1
 
 @[irreducible]
-noncomputable def algCallAddbackBeqAbPrimeLimb3 (a b : EvmWord) : Word :=
+def algCallAddbackBeqAbPrimeLimb3 (a b : EvmWord) : Word :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -1131,7 +1131,7 @@ theorem algCallAddbackBeqUn3Out_eq_abPrimeLimb3_of_double_addback
 
     Issue #1338 (Phase B.4 mechanical infrastructure). -/
 @[irreducible]
-noncomputable def algCallAddbackBeqAbPrimeVal (a b : EvmWord) : Nat :=
+def algCallAddbackBeqAbPrimeVal (a b : EvmWord) : Nat :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
@@ -1570,7 +1570,7 @@ theorem algCallAddbackBeqCarry_eq_parent_64ms_form
     Used as `ms_val` in `post1_val_eq_amod_pow_s_pure_nat` and the addback
     Euclidean (h_addback) and mulsub Euclidean (h_mulsub) preconditions. -/
 @[irreducible]
-noncomputable def algCallAddbackBeqMsLowVal (a b : EvmWord) : Nat :=
+def algCallAddbackBeqMsLowVal (a b : EvmWord) : Nat :=
   let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
   let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
   let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)

--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -39,3 +39,4 @@ import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.AddbackBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.AddbackPinning
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
+import EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -53,25 +53,25 @@ open EvmWord (val256)
 
 /-- CLZ shift (mod 64) for a divisor's top limb. -/
 @[irreducible]
-noncomputable def n4ClzShift (b3 : Word) : Nat := (clzResult b3).1.toNat % 64
+def n4ClzShift (b3 : Word) : Nat := (clzResult b3).1.toNat % 64
 
 /-- CLZ anti-shift (mod 64). -/
 @[irreducible]
-noncomputable def n4ClzAntiShift (b3 : Word) : Nat :=
+def n4ClzAntiShift (b3 : Word) : Nat :=
   (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
 
 /-- CLZ-normalized top limb of `a` (top 64 bits of `a` after shift). -/
 @[irreducible]
-noncomputable def n4U4 (a3 b3 : Word) : Word := a3 >>> n4ClzAntiShift b3
+def n4U4 (a3 b3 : Word) : Word := a3 >>> n4ClzAntiShift b3
 
 /-- CLZ-normalized second-from-top limb of `a` (combines a3 and a2). -/
 @[irreducible]
-noncomputable def n4Un3 (a2 a3 b3 : Word) : Word :=
+def n4Un3 (a2 a3 b3 : Word) : Word :=
   (a3 <<< n4ClzShift b3) ||| (a2 >>> n4ClzAntiShift b3)
 
 /-- CLZ-normalized top limb of `b` (combines b3 and b2). -/
 @[irreducible]
-noncomputable def n4B3Prime (b2 b3 : Word) : Word :=
+def n4B3Prime (b2 b3 : Word) : Word :=
   (b3 <<< n4ClzShift b3) ||| (b2 >>> n4ClzAntiShift b3)
 
 theorem n4ClzShift_unfold (b3 : Word) :

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -153,16 +153,19 @@ theorem n4Un21_unfold (a2 a3 b2 b3 : Word) :
   delta n4Un21; rfl
 
 /-- **Phase 1 abstract first digit** at the (a, b)-limb level (Nat).
-    `q_top_phase1 := (u4 * 2^32 + div_un1) / dHi`. This is the Nat-level
-    target that `n4Q1Prime` should equal under skip-borrow (D1c). -/
+    `q_top_phase1 := (u4 * 2^32 + div_un1) / b3'`. Matches the
+    denominator in `algorithmQ1Prime_ge_q_true_1`'s lower bound.
+    This is the Nat-level target that `n4Q1Prime` should equal
+    under skip-borrow (D1c). -/
 @[irreducible]
 def n4QTopPhase1 (a2 a3 b2 b3 : Word) : Nat :=
-  ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) / (n4DHi b2 b3).toNat
+  ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) /
+    (n4B3Prime b2 b3).toNat
 
 theorem n4QTopPhase1_unfold (a2 a3 b2 b3 : Word) :
     n4QTopPhase1 a2 a3 b2 b3 =
       ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) /
-        (n4DHi b2 b3).toNat := by
+        (n4B3Prime b2 b3).toNat := by
   delta n4QTopPhase1; rfl
 
 /-- Phase 1b corrected remainder `rhat'` (paired with `algorithmQ1Prime`). -/

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -646,29 +646,33 @@ theorem n4_phase1b_eucl
     (div128Quot_rhatc_lt_2dHi u4 (b3' >>> (32 : BitVec 6).toNat)
       h_dHi_ne' h_dHi_lt')
 
-/-- **D2b-B (STUB)**: BitVec un21 to Nat decomposition under no-wrap.
-    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo` when no-wrap.
+/-- **D2b-B-i (CLOSED)**: structural identity expressing `n4Un21` as the
+    BitVec subtraction of the halfword-combined `cu_rhat_un1` and the
+    `q1' * dLo` Word.
 
-    **Proof sketch**: `n4Un21 = ((rhat' << 32) ||| div_un1) - (q1' * dLo)`
-    (BitVec). Under no-wrap (h_no_wrap_phase1), the BitVec subtraction is
-    no-wrap, so `un21.toNat = cu_rhat_un1.toNat - cu_q1_dlo.toNat`.
-    `cu_rhat_un1.toNat = (rhat'%2^32)*2^32 + div_un1` via
-    `halfword_combine_mod`. `cu_q1_dlo.toNat = q1'*dLo` (no Word overflow,
-    since q1' < 2^32 and dLo < 2^32 so product < 2^64).
+    Note: must use `simp only` rather than `rw` for the unfolds — `rw`
+    triggers `whnf` heartbeat blow-up on the full chain of bundle and
+    algorithm-body unfolds (the if-then-else expressions in
+    algorithmQ1Prime / algorithmRhatPrime / algorithmUn21 share the
+    same shape and `rw` re-reduces). -/
+theorem n4Un21_eq_bv_sub
+    (a2 a3 b2 b3 : Word) :
+    n4Un21 a2 a3 b2 b3 =
+      (((n4RhatPrime a2 a3 b2 b3) <<< (32 : BitVec 6).toNat) |||
+        (n4DivUn1 a2 a3 b3)) -
+      ((n4Q1Prime a2 a3 b2 b3) * (n4DLo b2 b3)) := by
+  simp only [n4Un21_unfold, n4Q1Prime_unfold, n4RhatPrime_unfold, n4DLo_unfold,
+      n4DivUn1_unfold, algorithmUn21_unfold, algorithmQ1Prime_unfold,
+      algorithmRhatPrime_unfold]
 
-    **Blocker (2026-04-27 iteration)**: the structural identity
-    `n4Un21 = (n4RhatPrime << 32 ||| n4DivUn1) - (n4Q1Prime * n4DLo)`
-    triggers `whnf` heartbeat blow-up when proven via combined `_unfold`
-    rewrites, due to algorithm let-bindings duplicating large
-    if-then-else terms across bundle boundaries. Likely needs a more
-    delicate proof structure or restatement of `algorithmUn21` in
-    terms of `algorithmQ1Prime` / `algorithmRhatPrime` explicitly. -/
+/-- **D2b-B (CLOSED)**: BitVec un21 to Nat decomposition under no-wrap.
+    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo` when no-wrap. -/
 theorem n4Un21_toNat_of_no_wrap
     (a2 a3 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_no_wrap_phase1 :
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (h_no_wrap_phase1 :
       (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
         ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
           (n4DivUn1 a2 a3 b3).toNat) :
@@ -676,7 +680,80 @@ theorem n4Un21_toNat_of_no_wrap
       ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
         (n4DivUn1 a2 a3 b3).toNat -
       (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat := by
-  sorry
+  -- Bounds.
+  have h_dLo_lt : (n4DLo b2 b3).toNat < 2^32 := by
+    rw [n4DLo_unfold, BitVec.toNat_ushiftRight,
+        EvmAsm.Rv64.AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    have : ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_div_un1_lt : (n4DivUn1 a2 a3 b3).toNat < 2^32 := by
+    rw [n4DivUn1_unfold, BitVec.toNat_ushiftRight,
+        EvmAsm.Rv64.AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    have : (n4Un3 a2 a3 b3).toNat < 2^64 := (n4Un3 a2 a3 b3).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  -- q1' < 2^32 from div128Quot_q1_prime_lt_pow32 (direct form).
+  have h_b3'_ge : (n4B3Prime b2 b3).toNat ≥ 2^63 := by
+    rw [n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact b3_prime_ge_pow63 b3 b2 hb3nz _
+  have h_dHi_ge : ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat ≥ 2^31 :=
+    div128Quot_dHi_ge_pow31 _ h_b3'_ge
+  have h_dHi_lt : ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat < 2^32 := by
+    rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow]
+    have : (n4B3Prime b2 b3).toNat < 2^64 := (n4B3Prime b2 b3).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_dLo_lt' :
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat >>>
+        (32 : BitVec 6).toNat).toNat < 2^32 := by
+    rw [n4DLo_unfold] at h_dLo_lt; exact h_dLo_lt
+  have h_v_eq : (n4B3Prime b2 b3).toNat =
+      ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat >>>
+        (32 : BitVec 6).toNat).toNat :=
+    div128Quot_vTop_decomp _
+  have h_u4_lt_b3' : (n4U4 a3 b3).toNat < (n4B3Prime b2 b3).toNat := by
+    rw [n4U4_unfold, n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact isCallTrialN4_toNat_lt a3 b2 b3 hcall
+  have h_u4_lt_vTop : (n4U4 a3 b3).toNat <
+      ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat >>>
+        (32 : BitVec 6).toNat).toNat := by
+    rw [← h_v_eq]; exact h_u4_lt_b3'
+  have h_q1_lt : (n4Q1Prime a2 a3 b2 b3).toNat < 2^32 := by
+    simp only [n4Q1Prime_unfold, algorithmQ1Prime_unfold]
+    exact div128Quot_q1_prime_lt_pow32 (n4U4 a3 b3)
+      ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat)
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat >>> (32 : BitVec 6).toNat)
+      (n4Un3 a2 a3 b3) h_dHi_ge h_dHi_lt h_dLo_lt' h_u4_lt_vTop
+  -- q1' * dLo < 2^64.
+  have h_q1_dLo_lt :
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat < 2^64 := by
+    have h1 : (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat <
+              2^32 * 2^32 :=
+      Nat.mul_lt_mul_of_lt_of_le h_q1_lt h_dLo_lt.le (by omega)
+    have : (2^32 : Nat) * 2^32 = 2^64 := by decide
+    omega
+  -- cu_rhat_un1.toNat formula via halfword_combine_mod.
+  have h_cu_rhat_un1 :
+      (((n4RhatPrime a2 a3 b2 b3) <<< (32 : BitVec 6).toNat) |||
+        (n4DivUn1 a2 a3 b3)).toNat =
+      ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
+        (n4DivUn1 a2 a3 b3).toNat := by
+    rw [show ((32 : BitVec 6).toNat : Nat) = 32 from rfl]
+    exact halfword_combine_mod _ _ h_div_un1_lt
+  -- cu_q1_dlo.toNat = q1' * dLo (no Word overflow).
+  have h_cu_q1_dlo :
+      ((n4Q1Prime a2 a3 b2 b3) * (n4DLo b2 b3)).toNat =
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat := by
+    rw [BitVec.toNat_mul, Nat.mod_eq_of_lt h_q1_dLo_lt]
+  -- cu_q1_dlo ≤ cu_rhat_un1 (Nat).
+  have h_le : ((n4Q1Prime a2 a3 b2 b3) * (n4DLo b2 b3)).toNat ≤
+      (((n4RhatPrime a2 a3 b2 b3) <<< (32 : BitVec 6).toNat) |||
+        (n4DivUn1 a2 a3 b3)).toNat := by
+    rw [h_cu_q1_dlo, h_cu_rhat_un1]; exact h_no_wrap_phase1
+  rw [n4Un21_eq_bv_sub, EvmWord.word_sub_toNat_of_le _ _ h_le,
+      h_cu_rhat_un1, h_cu_q1_dlo]
 
 /-- **D2b (CLOSED via composition mod sub-stubs)**: Under
     `q1' = q_top_phase1` AND Phase 1 no-wrap, derive `un21 < vTop`.

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -607,21 +607,106 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
 -- D5: Compose into Div128PhaseNoWrapInv
 -- ============================================================================
 
-/-- **D5 (STUB)**: Skip-borrow implies `Div128PhaseNoWrapInv`.
+/-- **D5 (CLOSED via composition)**: Skip-borrow implies
+    `Div128PhaseNoWrapInv` (modulo D2b sub-stub).
 
     Composes D1c (Phase 1 tight) → D2/D3 (Phase 1 no-wrap) → D2b
-    (un21 < vTop). This is the core bridge for the call+skip path.
-
-    For the call+addback path, similar reasoning via
-    `isAddbackBorrowN4Call` instead of skip-borrow — the analogous
-    Phase 1 tight lemma needs to be developed (D1c-addback variant). -/
+    (un21 < vTop). The result is the conjunction in
+    `Div128PhaseNoWrapInv` after bundle/let-form bridging. -/
 theorem div128_phase_no_wrap_of_skip_borrow
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
-    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
     Div128PhaseNoWrapInv (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
-  sorry
+  -- Phase 1 tight from D1c.
+  have h_q1_eq := div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
+    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall hborrow
+  -- Phase 1 no-wrap from D2/D3.
+  have h_no_wrap := div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
+    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq
+  -- un21 < vTop from D2b.
+  have h_un21_lt := div128Quot_un21_lt_vTop_from_phase1_tight
+    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq h_no_wrap
+  -- Unfold Div128PhaseNoWrapInv to expose the let-form conjuncts.
+  unfold Div128PhaseNoWrapInv
+  simp only []
+  -- Establish bundle/let-form correspondences.
+  have h_q1_letform :
+      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
+       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+                    (32 : BitVec 6).toNat
+       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+       let q1 := rv64_divu (n4U4 a3 b3) dHi
+       let rhat := (n4U4 a3 b3) - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c) =
+      n4Q1Prime a2 a3 b2 b3 := by
+    rw [n4Q1Prime_unfold, algorithmQ1Prime_unfold]
+  have h_rhat_letform :
+      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
+       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+                    (32 : BitVec 6).toNat
+       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+       let q1 := rv64_divu (n4U4 a3 b3) dHi
+       let rhat := (n4U4 a3 b3) - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) =
+      n4RhatPrime a2 a3 b2 b3 := by
+    rw [n4RhatPrime_unfold, algorithmRhatPrime_unfold]
+  have h_un21_letform :
+      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
+       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+                    (32 : BitVec 6).toNat
+       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+       let q1 := rv64_divu (n4U4 a3 b3) dHi
+       let rhat := (n4U4 a3 b3) - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       let q1' : Word := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095
+                        else q1c
+       let rhat' : Word := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+       let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+       let cu_q1_dlo := q1' * dLo
+       cu_rhat_un1 - cu_q1_dlo) =
+      n4Un21 a2 a3 b2 b3 := by
+    rw [n4Un21_unfold, algorithmUn21_unfold]
+  refine ⟨?_, ?_⟩
+  · -- un21 < dHi*2^32 + dLo conjunct (D2b).
+    rw [h_un21_letform]
+    -- Need to bridge dHi*2^32 + dLo on RHS to n4DHi*2^32 + n4DLo.
+    show (n4Un21 a2 a3 b2 b3).toNat <
+         ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
+         (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+           (32 : BitVec 6).toNat).toNat
+    rw [show ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat) = n4DHi b2 b3 from
+      (n4DHi_unfold b2 b3).symm,
+        show (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+              (32 : BitVec 6).toNat) = n4DLo b2 b3 from (n4DLo_unfold b2 b3).symm]
+    exact h_un21_lt
+  · -- q1' * dLo ≤ (rhat' % 2^32) * 2^32 + div_un1 conjunct (D2/D3).
+    rw [h_q1_letform, h_rhat_letform]
+    show (n4Q1Prime a2 a3 b2 b3).toNat *
+         (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+           (32 : BitVec 6).toNat).toNat ≤
+         (n4RhatPrime a2 a3 b2 b3).toNat % 2^32 * 2^32 +
+         ((n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat).toNat
+    rw [show (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+              (32 : BitVec 6).toNat) = n4DLo b2 b3 from (n4DLo_unfold b2 b3).symm,
+        show ((n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat) = n4DivUn1 a2 a3 b3
+              from (n4DivUn1_unfold a2 a3 b3).symm]
+    exact h_no_wrap
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -40,6 +40,7 @@
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
+import EvmAsm.Evm64.EvmWordArith.Div128PhaseNoWrap
 
 namespace EvmAsm.Evm64
 
@@ -409,17 +410,50 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
 
 -- ============================================================================
 -- D2/D3: Phase 1 no-wrap from tight Phase 1
+--
+-- Decomposed into D2/D3-A (rhat' < 2^32 sub-stub) and D2/D3 main
+-- (composition wrapping `div128Quot_phase1_no_wrap_skip`).
 -- ============================================================================
 
-/-- **D2/D3 (STUB)**: From `q1' = q_top_phase1`, derive Phase 1 no-wrap
-    `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
+/-- **D2/D3-A (STUB)**: Under `q1' = q_top_phase1`, the algorithm's Phase 1b
+    output `rhat'` satisfies `rhat'.toNat < 2^32` — i.e., the Phase 1b
+    correction stays within a single limb.
 
-    **Proof sketch**: From `q1' = (u4*2^32 + div_un1)/dHi`, get
-    `q1' * dHi ≤ u4*2^32 + div_un1 < (q1'+1)*dHi`, hence
-    `q1' * dHi*2^32 ≤ u4*2^64 + div_un1*2^32`. Multiply Phase 1
-    Euclidean by 2^32 and rearrange to get the no-wrap inequality.
+    **Proof sketch (algorithmic)**: rhat' is either rhatc or rhatc + dHi
+    after Phase 1b correction. Under tight q1' = q_top_phase1, Phase 1b
+    correction either doesn't fire (rhatc < dHi < 2^32 from Knuth Phase 1)
+    or fires and rhat' = rhatc + dHi but our specific case excludes the
+    rhatc + dHi ≥ 2^32 sub-case via the q1' = q_top_phase1 invariant.
 
-    Estimated: ~50 LOC. -/
+    This is the genuinely hard sub-piece: the relationship between the
+    algorithm's BitVec arithmetic and the abstract Knuth invariant.
+
+    Estimated: ~60-80 LOC (case-split on hi1 = 0 / hi1 ≠ 0 and Phase 1b
+    fired / not fired, with arithmetic in each branch). -/
+theorem n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1
+    (a2 a3 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
+    (n4RhatPrime a2 a3 b2 b3).toNat < 2^32 := by
+  sorry
+
+/-- **D2/D3 (STUB, with sub-stub D2/D3-A used)**: From `q1' = q_top_phase1`,
+    derive Phase 1 no-wrap `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
+
+    **Plan**: Compose
+    - `div128Quot_phase1_no_wrap_skip` (existing, in `Div128PhaseNoWrap`,
+      takes `hq1_prime_le_q_true_1` and `hrhat'_lt` as hypotheses)
+    - `n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1` (D2/D3-A sub-stub)
+    - The ≤ side of h_q1_eq (an equality trivially gives ≤)
+    - Bundle ↔ let-form bridging via the unfold lemmas.
+
+    The unwrapping/bridging is mechanical (~30 LOC) once the `Div128PhaseNoWrap`
+    import is added (current file imports `Div128CallSkipClose`; need to also
+    import `Div128PhaseNoWrap`). Deferred to next iteration.
+
+    Estimated: ~30-50 LOC for the bridging once D2/D3-A is closed. -/
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     (a2 a3 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -415,24 +415,32 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
 -- (composition wrapping `div128Quot_phase1_no_wrap_skip`).
 -- ============================================================================
 
-/-- **D2/D3-A (STUB, REFORMULATED 2026-04-27)**: Under `isSkipBorrowN4Call`,
-    the algorithm's Phase 1b output `rhat'` satisfies `rhat'.toNat < 2^32`.
+/-- **D2/D3-A (PROVABLY FALSE, 2026-04-27 follow-up)**: even under
+    `isSkipBorrowN4Call`, the claim `rhat' < 2^32` is FALSE in some
+    cases where the algorithm is otherwise correct.
 
-    **Counterexample to earlier formulation** (which used only hcall +
-    `q1' = q_top_phase1` as preconditions): see
-    `memory/project_d2d3_a_counterexample.md`. With
-    `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`, Phase 1 is tight
-    (q1' = q_top_phase1 = 2^31 - 1) but rhat' = 2^32 + 2^31 - 2 ≥ 2^32.
-    The same input violates skip-borrow (the BitVec un21 wraps,
-    yielding qHat * val256(b) > val256(a)). So skip-borrow is genuinely
-    needed.
+    **Counterexample** (verified via lean_run_code, see
+    `memory/project_d2d3_a_counterexample.md`): with
+    `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`,
+    - skip-borrow HOLDS (mulsub_c3 = u4 = 2^63 - 1, no borrow),
+    - qHat = q_true = 2^63 - 1 (algorithm correct),
+    - q1' = q_true_1 = 2^31 - 1, q0' = q_true_0 = 2^32 - 1 (digits correct),
+    - **but `rhat' = 2^32 + 2^31 - 2 ≥ 2^32`**.
 
-    **Proof sketch (under skip-borrow)**: skip-borrow ⟹ no-addback
-    invariant on the outer mulsub ⟹ Knuth's Phase 1 remainder
-    invariant `rhat' < 2^32` (this is the
-    "Phase 1 remainder fits in a limb" invariant from Knuth TAOCP 4.3.1).
+    **Architectural implication**: `Div128PhaseNoWrapInv`'s conjunct 2
+    (Phase 1 no-wrap form `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`)
+    FAILS in this counterexample, so D5 "skip-borrow ⟹
+    Div128PhaseNoWrapInv" is FALSE. The whole approach (a) via
+    Div128PhaseNoWrapInv needs reformulation. Our algorithm's hybrid
+    "Knuth Phase 1 + non-classical Phase 1b correction with dLo" can
+    leave `rhat' ≥ 2^32` even when the algorithm is correct, because
+    the Phase 1b correction step uses dLo (not classical Knuth).
 
-    Estimated: ~80-150 LOC. -/
+    **This stub is left UNPROVABLE as-is**. See the action plan in
+    `project_d2d3_a_counterexample.md` for candidate reformulations.
+    The user-facing chain that `evm_div_n4_call_skip_stack_spec` /
+    `evm_div_n4_call_addback_beq_stack_spec` need will require a
+    different invariant. -/
 theorem n4RhatPrime_lt_pow32_of_skip_borrow
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -419,6 +419,17 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
     `isSkipBorrowN4Call`, the claim `rhat' < 2^32` is FALSE in some
     cases where the algorithm is otherwise correct.
 
+    **Literature confirms (Knuth TAOCP 4.3.1, ridiculousfish.com blog)**:
+    classical Knuth Algorithm D step D3 correction loop runs up to **2**
+    iterations. After D3, `qhat ≤ q_true + 1`, with the leftover `+1`
+    case handled by D6 addback. **Our algorithm performs only 1 Phase 1b
+    correction** (not a loop). This is a known performance optimization —
+    the 1-correction variant maintains correctness because D6 addback
+    catches all overshoots, but it does NOT preserve Knuth's classical
+    Phase 1 remainder invariant `rhat' < B`. See
+    `memory/project_knuth_d_one_correction_design.md` for the literature
+    study.
+
     **Counterexample** (verified via lean_run_code, see
     `memory/project_d2d3_a_counterexample.md`): with
     `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`,
@@ -428,19 +439,21 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
     - **but `rhat' = 2^32 + 2^31 - 2 ≥ 2^32`**.
 
     **Architectural implication**: `Div128PhaseNoWrapInv`'s conjunct 2
-    (Phase 1 no-wrap form `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`)
-    FAILS in this counterexample, so D5 "skip-borrow ⟹
-    Div128PhaseNoWrapInv" is FALSE. The whole approach (a) via
-    Div128PhaseNoWrapInv needs reformulation. Our algorithm's hybrid
-    "Knuth Phase 1 + non-classical Phase 1b correction with dLo" can
-    leave `rhat' ≥ 2^32` even when the algorithm is correct, because
-    the Phase 1b correction step uses dLo (not classical Knuth).
+    is OVER-STRONG for our 1-correction algorithm. D5 "skip-borrow ⟹
+    Div128PhaseNoWrapInv" is FALSE.
 
-    **This stub is left UNPROVABLE as-is**. See the action plan in
-    `project_d2d3_a_counterexample.md` for candidate reformulations.
-    The user-facing chain that `evm_div_n4_call_skip_stack_spec` /
-    `evm_div_n4_call_addback_beq_stack_spec` need will require a
-    different invariant. -/
+    **Path forward**: The user-facing chain
+    (`evm_div_n4_call_skip_stack_spec`) actually only needs
+    `div128Quot.toNat = val256(a)/val256(b)`, which is ALREADY
+    proven in `div128Quot_call_skip_eq_val256_div` (CallSkipLowerBoundV2).
+    The Div128PhaseNoWrapInv chain is unnecessary for the call-skip
+    spec. **Bypass D5 entirely** — use the tight equality directly.
+
+    For the **call-addback** path, the situation differs (qHat = q_true + 1)
+    and may need different reasoning still.
+
+    **This stub is left UNPROVABLE as-is** — its goal is genuinely
+    false. -/
 theorem n4RhatPrime_lt_pow32_of_skip_borrow
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -12,43 +12,30 @@
   **Background**: a numerical counterexample
   (`memory/project_n4calladdbackbeq_counterexample.md`) shows that
   approach (b) — direct val256-level Knuth-B without Phase-1 reasoning —
-  is impossible. The bound `qHat ≤ q_true + 2` is genuinely false for
-  some inputs satisfying just `hcall + hshift_nz + hb3nz`. Phase-1
-  reasoning is the only viable path.
+  is impossible. Phase-1 reasoning is the only viable path.
 
-  **Decomposition** (planned, ~300-500 LOC total):
+  **Irreducible bundles** (per `feedback_bundle_pre_post_no_lets`):
+  the CLZ-shifted Word inputs and Phase 1b output `rhat'` are bundled
+  into `@[irreducible]` defs so the lemma signatures don't expose deep
+  let-chains.
 
-  - **D1**: Phase 1 tight equality `q1' = q_top_phase1` from
-    skip-borrow + Knuth-B/C check correctness. Sub-decomposed into:
-    - **D1a**: Phase 1b check post-condition `q1' ≤ q_top_phase1 + 1`.
-    - **D1b**: Combined with `algorithmQ1Prime_ge_q_true_1`
-      (q1' ≥ q_top_phase1) gives `q1' ∈ {q_top_phase1, q_top_phase1+1}`.
-    - **D1c**: Skip-borrow excludes the `q_top_phase1+1` case
-      (overshoot-by-1 would cause mulsub to borrow at val256 level).
+  - **`n4ClzShift`**, **`n4ClzAntiShift`**: shift / antiShift Nats.
+  - **`n4U4`**, **`n4Un3`**, **`n4B3Prime`**: CLZ-normalized top limbs
+    of a, b (computed from a2, a3, b2, b3).
+  - **`algorithmRhatPrime`**: Phase 1b's corrected remainder.
 
-  - **D2**: From q1' = q_top_phase1, derive:
-    - **D2a**: `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo`
-      (no-wrap form; combines Phase 1b post + KB-3j case-split).
-    - **D2b**: From Phase 1 Euclidean `q1'*dHi + rhat' = uHi`,
-      derive `un21 < vTop` (the first conjunct).
+  These compose with the existing `algorithmUn21`, `algorithmQ1Prime`,
+  `algorithmQ0Prime` (in `CallSkipLowerBoundV2/Algorithm.lean`).
 
-  - **D3**: From un21 < vTop, derive Phase 1 no-wrap conjunct
-    `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1` (the second conjunct).
-    Direct from D2a + non-negativity of un21.
+  **Decomposition** (planned):
+  - **D1c**: Phase 1 tight (`q1' = q_top_phase1`) under skip-borrow.
+  - **D2/D3**: From q1' = q_top_phase1, derive Phase 1 no-wrap
+    inequality.
+  - **D2b**: From Phase 1 no-wrap + tight q1', derive un21 < vTop.
+  - **D5** (parent): compose into `Div128PhaseNoWrapInv`.
 
-  - **D4**: Phase 2 mirror — under un21 < vTop (D2b), Phase 2 satisfies
-    its own no-wrap invariant `q0' * dLo ≤ rhat2'*2^32 + div_un0`
-    (the third conjunct).
-
-  - **D5**: Compose D2b + D3 + D4 into `Div128AllPhasesNoWrapInv`
-    (or `Div128PhaseNoWrapInv` if Phase 2 conjunct is dropped).
-
-  Each sub-stub will be proven incrementally; this file accumulates
-  them with `sorry` placeholders, then the parent bridge composes.
-
-  This file is intentionally separate from `Div128CallSkipClose.lean`
-  to keep that file (and PR #1353) sorry-free. The bridge work-in-
-  progress lives here on a follow-up branch.
+  Each sub-stub is a `sorry`'d theorem with a proof sketch in its
+  docstring. Estimated ~300-500 LOC total over multiple iterations.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
@@ -61,110 +48,148 @@ open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
 open EvmWord (val256)
 
 -- ============================================================================
+-- Irreducible bundles for CLZ-normalized inputs
+-- ============================================================================
+
+/-- CLZ shift (mod 64) for a divisor's top limb. -/
+@[irreducible]
+noncomputable def n4ClzShift (b3 : Word) : Nat := (clzResult b3).1.toNat % 64
+
+/-- CLZ anti-shift (mod 64). -/
+@[irreducible]
+noncomputable def n4ClzAntiShift (b3 : Word) : Nat :=
+  (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+
+/-- CLZ-normalized top limb of `a` (top 64 bits of `a` after shift). -/
+@[irreducible]
+noncomputable def n4U4 (a3 b3 : Word) : Word := a3 >>> n4ClzAntiShift b3
+
+/-- CLZ-normalized second-from-top limb of `a` (combines a3 and a2). -/
+@[irreducible]
+noncomputable def n4Un3 (a2 a3 b3 : Word) : Word :=
+  (a3 <<< n4ClzShift b3) ||| (a2 >>> n4ClzAntiShift b3)
+
+/-- CLZ-normalized top limb of `b` (combines b3 and b2). -/
+@[irreducible]
+noncomputable def n4B3Prime (b2 b3 : Word) : Word :=
+  (b3 <<< n4ClzShift b3) ||| (b2 >>> n4ClzAntiShift b3)
+
+theorem n4ClzShift_unfold (b3 : Word) :
+    n4ClzShift b3 = (clzResult b3).1.toNat % 64 := by
+  delta n4ClzShift; rfl
+
+theorem n4ClzAntiShift_unfold (b3 : Word) :
+    n4ClzAntiShift b3 =
+      (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64 := by
+  delta n4ClzAntiShift; rfl
+
+theorem n4U4_unfold (a3 b3 : Word) :
+    n4U4 a3 b3 = a3 >>> n4ClzAntiShift b3 := by
+  delta n4U4; rfl
+
+theorem n4Un3_unfold (a2 a3 b3 : Word) :
+    n4Un3 a2 a3 b3 = (a3 <<< n4ClzShift b3) ||| (a2 >>> n4ClzAntiShift b3) := by
+  delta n4Un3; rfl
+
+theorem n4B3Prime_unfold (b2 b3 : Word) :
+    n4B3Prime b2 b3 = (b3 <<< n4ClzShift b3) ||| (b2 >>> n4ClzAntiShift b3) := by
+  delta n4B3Prime; rfl
+
+/-- Phase 1b corrected remainder `rhat'` (paired with `algorithmQ1Prime`). -/
+@[irreducible]
+def algorithmRhatPrime (u4 u3 b3' : Word) : Word :=
+  let dHi := b3' >>> (32 : BitVec 6).toNat
+  let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := u3 >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu u4 dHi
+  let rhat := u4 - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+
+theorem algorithmRhatPrime_unfold (u4 u3 b3' : Word) :
+    algorithmRhatPrime u4 u3 b3' =
+      (let dHi := b3' >>> (32 : BitVec 6).toNat
+       let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+       let div_un1 := u3 >>> (32 : BitVec 6).toNat
+       let q1 := rv64_divu u4 dHi
+       let rhat := u4 - q1 * dHi
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc := if hi1 = 0 then rhat else rhat + dHi
+       let qDlo := q1c * dLo
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) := by
+  delta algorithmRhatPrime; rfl
+
+-- ============================================================================
 -- D1c: Phase 1 tight under skip-borrow (the key structural lemma)
 -- ============================================================================
 
 /-- **D1c (STUB)**: Under `isSkipBorrowN4Call`, Phase 1 trial is tight:
-    `q1' = q_top_phase1` exactly (no Knuth-C overshoot remains).
+    `q1' = q_top_phase1` (= `(u4 * 2^32 + div_un1) / dHi`).
 
-    **Proof sketch**: The skip-borrow condition (`c3 ≤ u4` from
-    `c3_le_u4_of_skip_borrow_call`) implies the outer mulsub
-    `qHat * val256(b) ≤ val256(a)`, hence `qHat ≤ q_true`. Combined
-    with the closed lower bound `qHat ≥ q_true` (Knuth-A normalized),
-    we get `qHat = q_true` (already in `div128Quot_call_skip_eq_val256_div`).
+    **Proof sketch**: skip-borrow ⟹ outer mulsub `qHat * val256(b)
+    ≤ val256(a)` ⟹ `qHat ≤ q_true`. Combined with Knuth-A lower
+    `qHat ≥ q_true` gives `qHat = q_true` (already in
+    `div128Quot_call_skip_eq_val256_div`). From `qHat = q_true < 2^64`
+    and `q1' < 2^32` (KB-3e'''), the OR decomposition gives unique
+    digits. Combined with `q1' ≥ q_top_phase1` (`algorithmQ1Prime_ge_q_true_1`)
+    pins `q1' = q_top_phase1`.
 
-    From `qHat = q_true < 2^64` and `q1' < 2^32` (KB-3e'''), the OR
-    decomposition `qHat = (q1' << 32) | q0'` admits a unique digit
-    decomposition. Combined with the Phase 1 lower bound
-    `q1' ≥ q_top_phase1` (KB-LB7), we can pin `q1' = q_top_phase1` AND
-    `q0' < 2^32`. The latter is exactly KB-6b's precondition.
-
-    Estimated: ~80-100 LOC. Needs careful BitVec OR decomposition. -/
+    Estimated: ~80 LOC. -/
 theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
     (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let u4 := n4U4 a3 b3
+    let un3 := n4Un3 a2 a3 b3
+    let b3' := n4B3Prime b2 b3
     let dHi := b3' >>> (32 : BitVec 6).toNat
-    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u4 dHi
-    let rhat := u4 - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    q1'.toNat =
-      (u4.toNat * 2^32 + div_un1.toNat) /
-        (b3' >>> (32 : BitVec 6).toNat).toNat := by
+    (algorithmQ1Prime u4 un3 b3').toNat =
+      (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat := by
   sorry
 
 -- ============================================================================
--- D2a + D3: Phase 1 no-wrap from tight Phase 1
+-- D2/D3: Phase 1 no-wrap from tight Phase 1
 -- ============================================================================
 
 /-- **D2/D3 (STUB)**: From `q1' = q_top_phase1`, derive Phase 1 no-wrap
     `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
 
-    **Proof sketch**: From q1' = q_top_phase1 = (u4*2^32 + div_un1)/b3',
-    we have q1' * b3' ≤ u4*2^32 + div_un1. Expanding b3' = dHi*2^32 + dLo:
-    q1' * dHi * 2^32 + q1' * dLo ≤ u4 * 2^32 + div_un1. From Phase 1b
-    Euclidean q1' * dHi + rhat' = uHi (the un-shifted version), we have
-    q1' * dHi * 2^32 = (uHi - rhat') * 2^32. Substituting and rearranging:
-    q1' * dLo ≤ rhat' * 2^32 + div_un1 - some_correction. Under
-    rhat' < 2^32 (Phase 1b post-condition under skip-borrow), this
-    simplifies to the desired no-wrap inequality.
+    **Proof sketch**: From `q1' = (u4*2^32 + div_un1)/dHi`, get
+    `q1' * dHi ≤ u4*2^32 + div_un1 < (q1'+1)*dHi`, hence
+    `q1' * dHi*2^32 ≤ u4*2^64 + div_un1*2^32`. Multiply Phase 1
+    Euclidean by 2^32 and rearrange to get the no-wrap inequality.
 
-    Estimated: ~50 LOC of Nat arithmetic. -/
+    Estimated: ~50 LOC. -/
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq :  -- this hypothesis comes from D1c
-      let shift := (clzResult b3).1.toNat % 64
-      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-      let u4 := a3 >>> antiShift
-      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    (_h_q1_eq :
+      let u4 := n4U4 a3 b3
+      let un3 := n4Un3 a2 a3 b3
+      let b3' := n4B3Prime b2 b3
       let dHi := b3' >>> (32 : BitVec 6).toNat
-      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
       let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      let q1 := rv64_divu u4 dHi
-      let rhat := u4 - q1 * dHi
-      let hi1 := q1 >>> (32 : BitVec 6).toNat
-      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-      let rhatc := if hi1 = 0 then rhat else rhat + dHi
-      let qDlo := q1c * dLo
-      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-      q1'.toNat = (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    let dHi := b3' >>> (32 : BitVec 6).toNat
+      (algorithmQ1Prime u4 un3 b3').toNat =
+        (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat) :
+    let u4 := n4U4 a3 b3
+    let un3 := n4Un3 a2 a3 b3
+    let b3' := n4B3Prime b2 b3
     let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u4 dHi
-    let rhat := u4 - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat := by
+    (algorithmQ1Prime u4 un3 b3').toNat * dLo.toNat ≤
+      ((algorithmRhatPrime u4 un3 b3').toNat % 2^32) * 2^32 +
+        div_un1.toNat := by
   sorry
 
 -- ============================================================================
@@ -172,19 +197,16 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
 -- ============================================================================
 
 /-- **D2b (STUB)**: Under `q1' = q_top_phase1` AND Phase 1 no-wrap,
-    derive `un21 < vTop`.
+    derive `un21.toNat < vTop.toNat` (= `dHi.toNat * 2^32 + dLo.toNat`).
 
-    **Proof sketch**: From the no-wrap form (D3), the BitVec subtraction
-    `un21 = cu_rhat_un1 - cu_q1_dlo` doesn't wrap. Hence
+    **Proof sketch**: From the no-wrap form (D2/D3), the BitVec
+    subtraction doesn't wrap, so
     `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo`. Combined with
-    KB-3m's additive identity (which holds under no-wrap), we get
-    `un21 + r1*2^64 + q1'*vTop = uHi*2^32 + div_un1` where
-    `r1 := rhat'/2^32`. Rearranging:
-    `un21 = uHi*2^32 + div_un1 - q1'*vTop - r1*2^64`.
-    Under `q1' = q_top_phase1 = (uHi*2^32 + div_un1)/vTop`:
-    `q1'*vTop ≤ uHi*2^32 + div_un1 < (q1'+1)*vTop`, so
-    `0 ≤ uHi*2^32 + div_un1 - q1'*vTop < vTop`.
-    Combined with `r1 ≥ 0`: `un21 ≤ uHi*2^32 + div_un1 - q1'*vTop < vTop`.
+    KB-3m's additive identity (which holds under no-wrap), gives
+    `un21 + r1*2^64 + q1'*vTop = uHi*2^32 + div_un1`. Under
+    `q1' = q_top_phase1 = (uHi*2^32 + div_un1)/vTop`:
+    `q1' * vTop ≤ uHi*2^32 + div_un1 < (q1'+1)*vTop`,
+    so `un21 + r1*2^64 < vTop`, hence `un21 < vTop` (with r1 ≥ 0).
 
     Estimated: ~40 LOC. -/
 theorem div128Quot_un21_lt_vTop_from_phase1_tight
@@ -192,64 +214,29 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq :  -- q1' = q_top_phase1 (from D1c)
-      let shift := (clzResult b3).1.toNat % 64
-      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-      let u4 := a3 >>> antiShift
-      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    (_h_q1_eq :
+      let u4 := n4U4 a3 b3
+      let un3 := n4Un3 a2 a3 b3
+      let b3' := n4B3Prime b2 b3
       let dHi := b3' >>> (32 : BitVec 6).toNat
+      let div_un1 := un3 >>> (32 : BitVec 6).toNat
+      (algorithmQ1Prime u4 un3 b3').toNat =
+        (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat)
+    (_h_no_wrap_phase1 :
+      let u4 := n4U4 a3 b3
+      let un3 := n4Un3 a2 a3 b3
+      let b3' := n4B3Prime b2 b3
       let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
       let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      let q1 := rv64_divu u4 dHi
-      let rhat := u4 - q1 * dHi
-      let hi1 := q1 >>> (32 : BitVec 6).toNat
-      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-      let rhatc := if hi1 = 0 then rhat else rhat + dHi
-      let qDlo := q1c * dLo
-      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-      q1'.toNat = (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat)
-    (_h_no_wrap_phase1 :  -- Phase 1 no-wrap (from D3)
-      let shift := (clzResult b3).1.toNat % 64
-      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-      let u4 := a3 >>> antiShift
-      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-      let dHi := b3' >>> (32 : BitVec 6).toNat
-      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-      let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      let q1 := rv64_divu u4 dHi
-      let rhat := u4 - q1 * dHi
-      let hi1 := q1 >>> (32 : BitVec 6).toNat
-      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-      let rhatc := if hi1 = 0 then rhat else rhat + dHi
-      let qDlo := q1c * dLo
-      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-      let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-      q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+      (algorithmQ1Prime u4 un3 b3').toNat * dLo.toNat ≤
+        ((algorithmRhatPrime u4 un3 b3').toNat % 2^32) * 2^32 +
+          div_un1.toNat) :
+    let u4 := n4U4 a3 b3
+    let un3 := n4Un3 a2 a3 b3
+    let b3' := n4B3Prime b2 b3
     let dHi := b3' >>> (32 : BitVec 6).toNat
     let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u4 dHi
-    let rhat := u4 - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    un21.toNat < dHi.toNat * 2^32 + dLo.toNat := by
+    (algorithmUn21 u4 un3 b3').toNat < dHi.toNat * 2^32 + dLo.toNat := by
   sorry
 
 -- ============================================================================
@@ -258,29 +245,19 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
 
 /-- **D5 (STUB)**: Skip-borrow implies `Div128PhaseNoWrapInv`.
 
-    Composes D1c (Phase 1 tight) → D2a/D3 (Phase 1 no-wrap) → D2b
+    Composes D1c (Phase 1 tight) → D2/D3 (Phase 1 no-wrap) → D2b
     (un21 < vTop). This is the core bridge for the call+skip path.
 
     For the call+addback path, similar reasoning via
     `isAddbackBorrowN4Call` instead of skip-borrow — the analogous
-    Phase 1 tight lemma needs to be developed (D1c-addback variant).
-
-    Note: this version targets `Div128PhaseNoWrapInv` (2 conjuncts:
-    un21<vTop + Phase 1 no-wrap), NOT `Div128AllPhasesNoWrapInv`. The
-    Phase 2 no-wrap conjunct (D4) is left as a separate piece since
-    the strict KB-6c/KB-6d closure only needs Phase 1 no-wrap. -/
+    Phase 1 tight lemma needs to be developed (D1c-addback variant). -/
 theorem div128_phase_no_wrap_of_skip_borrow
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
     (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    Div128PhaseNoWrapInv u4 un3 b3' := by
+    Div128PhaseNoWrapInv (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
   sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -95,6 +95,76 @@ theorem n4B3Prime_unfold (b2 b3 : Word) :
     n4B3Prime b2 b3 = (b3 <<< n4ClzShift b3) ||| (b2 >>> n4ClzAntiShift b3) := by
   delta n4B3Prime; rfl
 
+/-- Top half of the CLZ-normalized divisor (32-bit divisor for Phase 1). -/
+@[irreducible]
+def n4DHi (b2 b3 : Word) : Word :=
+  n4B3Prime b2 b3 >>> (32 : BitVec 6).toNat
+
+/-- Bottom half of the CLZ-normalized divisor (low 32 bits). -/
+@[irreducible]
+def n4DLo (b2 b3 : Word) : Word :=
+  (n4B3Prime b2 b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+
+/-- Top 32 bits of `un3` (used as `div_un1` in the algorithm). -/
+@[irreducible]
+def n4DivUn1 (a2 a3 b3 : Word) : Word :=
+  n4Un3 a2 a3 b3 >>> (32 : BitVec 6).toNat
+
+/-- Bottom 32 bits of `un3` (used as `div_un0`). -/
+@[irreducible]
+def n4DivUn0 (a2 a3 b3 : Word) : Word :=
+  (n4Un3 a2 a3 b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+
+theorem n4DHi_unfold (b2 b3 : Word) :
+    n4DHi b2 b3 = n4B3Prime b2 b3 >>> (32 : BitVec 6).toNat := by
+  delta n4DHi; rfl
+
+theorem n4DLo_unfold (b2 b3 : Word) :
+    n4DLo b2 b3 = (n4B3Prime b2 b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat := by
+  delta n4DLo; rfl
+
+theorem n4DivUn1_unfold (a2 a3 b3 : Word) :
+    n4DivUn1 a2 a3 b3 = n4Un3 a2 a3 b3 >>> (32 : BitVec 6).toNat := by
+  delta n4DivUn1; rfl
+
+theorem n4DivUn0_unfold (a2 a3 b3 : Word) :
+    n4DivUn0 a2 a3 b3 = (n4Un3 a2 a3 b3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat := by
+  delta n4DivUn0; rfl
+
+/-- **Bundled n=4 algorithm Q1' output** at the (a, b)-limb level.
+    Composes the CLZ-normalized inputs with `algorithmQ1Prime`. -/
+@[irreducible]
+def n4Q1Prime (a2 a3 b2 b3 : Word) : Word :=
+  algorithmQ1Prime (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3)
+
+theorem n4Q1Prime_unfold (a2 a3 b2 b3 : Word) :
+    n4Q1Prime a2 a3 b2 b3 =
+      algorithmQ1Prime (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
+  delta n4Q1Prime; rfl
+
+/-- **Bundled n=4 algorithm un21 output** at the (a, b)-limb level. -/
+@[irreducible]
+def n4Un21 (a2 a3 b2 b3 : Word) : Word :=
+  algorithmUn21 (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3)
+
+theorem n4Un21_unfold (a2 a3 b2 b3 : Word) :
+    n4Un21 a2 a3 b2 b3 =
+      algorithmUn21 (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
+  delta n4Un21; rfl
+
+/-- **Phase 1 abstract first digit** at the (a, b)-limb level (Nat).
+    `q_top_phase1 := (u4 * 2^32 + div_un1) / dHi`. This is the Nat-level
+    target that `n4Q1Prime` should equal under skip-borrow (D1c). -/
+@[irreducible]
+def n4QTopPhase1 (a2 a3 b2 b3 : Word) : Nat :=
+  ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) / (n4DHi b2 b3).toNat
+
+theorem n4QTopPhase1_unfold (a2 a3 b2 b3 : Word) :
+    n4QTopPhase1 a2 a3 b2 b3 =
+      ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) /
+        (n4DHi b2 b3).toNat := by
+  delta n4QTopPhase1; rfl
+
 /-- Phase 1b corrected remainder `rhat'` (paired with `algorithmQ1Prime`). -/
 @[irreducible]
 def algorithmRhatPrime (u4 u3 b3' : Word) : Word :=
@@ -125,6 +195,16 @@ theorem algorithmRhatPrime_unfold (u4 u3 b3' : Word) :
        if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) := by
   delta algorithmRhatPrime; rfl
 
+/-- **Bundled n=4 Phase 1b corrected rhat'** at the (a, b)-limb level. -/
+@[irreducible]
+def n4RhatPrime (a2 a3 b2 b3 : Word) : Word :=
+  algorithmRhatPrime (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3)
+
+theorem n4RhatPrime_unfold (a2 a3 b2 b3 : Word) :
+    n4RhatPrime a2 a3 b2 b3 =
+      algorithmRhatPrime (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
+  delta n4RhatPrime; rfl
+
 -- ============================================================================
 -- D1c: Phase 1 tight under skip-borrow (the key structural lemma)
 -- ============================================================================
@@ -147,13 +227,7 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
     (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    let u4 := n4U4 a3 b3
-    let un3 := n4Un3 a2 a3 b3
-    let b3' := n4B3Prime b2 b3
-    let dHi := b3' >>> (32 : BitVec 6).toNat
-    let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    (algorithmQ1Prime u4 un3 b3').toNat =
-      (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat := by
+    (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3 := by
   sorry
 
 -- ============================================================================
@@ -170,26 +244,14 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
 
     Estimated: ~50 LOC. -/
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (a2 a3 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq :
-      let u4 := n4U4 a3 b3
-      let un3 := n4Un3 a2 a3 b3
-      let b3' := n4B3Prime b2 b3
-      let dHi := b3' >>> (32 : BitVec 6).toNat
-      let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      (algorithmQ1Prime u4 un3 b3').toNat =
-        (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat) :
-    let u4 := n4U4 a3 b3
-    let un3 := n4Un3 a2 a3 b3
-    let b3' := n4B3Prime b2 b3
-    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    (algorithmQ1Prime u4 un3 b3').toNat * dLo.toNat ≤
-      ((algorithmRhatPrime u4 un3 b3').toNat % 2^32) * 2^32 +
-        div_un1.toNat := by
+    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
+    (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
+      ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
+        (n4DivUn1 a2 a3 b3).toNat := by
   sorry
 
 -- ============================================================================
@@ -210,33 +272,17 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
 
     Estimated: ~40 LOC. -/
 theorem div128Quot_un21_lt_vTop_from_phase1_tight
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (a2 a3 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq :
-      let u4 := n4U4 a3 b3
-      let un3 := n4Un3 a2 a3 b3
-      let b3' := n4B3Prime b2 b3
-      let dHi := b3' >>> (32 : BitVec 6).toNat
-      let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      (algorithmQ1Prime u4 un3 b3').toNat =
-        (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat)
+    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
     (_h_no_wrap_phase1 :
-      let u4 := n4U4 a3 b3
-      let un3 := n4Un3 a2 a3 b3
-      let b3' := n4B3Prime b2 b3
-      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-      let div_un1 := un3 >>> (32 : BitVec 6).toNat
-      (algorithmQ1Prime u4 un3 b3').toNat * dLo.toNat ≤
-        ((algorithmRhatPrime u4 un3 b3').toNat % 2^32) * 2^32 +
-          div_un1.toNat) :
-    let u4 := n4U4 a3 b3
-    let un3 := n4Un3 a2 a3 b3
-    let b3' := n4B3Prime b2 b3
-    let dHi := b3' >>> (32 : BitVec 6).toNat
-    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (algorithmUn21 u4 un3 b3').toNat < dHi.toNat * 2^32 + dLo.toNat := by
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
+        ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
+          (n4DivUn1 a2 a3 b3).toNat) :
+    (n4Un21 a2 a3 b2 b3).toNat <
+      (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
   sorry
 
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -262,11 +262,54 @@ theorem n4Q1Prime_le_q_true_top_of_skip_borrow
     Estimated: ~80-100 LOC. -/
 theorem q_true_top_le_n4QTopPhase1
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0) :
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0) :
     (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) / 2^32 ≤
       n4QTopPhase1 a2 a3 b2 b3 := by
-  sorry
+  -- Apply existing val256-level ratio bound:
+  --   val256(a)/val256(b) ≤ (u4*2^64 + u3) / b3'.
+  have h := val256_ratio_le_u_total_div_b3_prime a0 a1 a2 a3 b0 b1 b2 b3
+    hshift_nz hb3nz
+  simp only [] at h
+  -- Set up Nat shorthand: u4n = u4.toNat, u3n = u3.toNat, b3'n = b3'.toNat.
+  set u4n :=
+    (a3 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64)).toNat
+    with hu4n_def
+  set u3n :=
+    ((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+      (a2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat
+    with hu3n_def
+  set b3'n :=
+    ((b3 <<< ((clzResult b3).1.toNat % 64)) |||
+      (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))).toNat
+    with hb3'n_def
+  -- Divide both sides of h by 2^32.
+  have h_div : (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) / 2^32 ≤
+      (u4n * 2^64 + u3n) / b3'n / 2^32 := Nat.div_le_div_right h
+  -- Algebraic bridge: (u4n*2^64 + u3n) / b3'n / 2^32 = (u4n*2^32 + u3n/2^32) / b3'n.
+  have h_alg : (u4n * 2^64 + u3n) / b3'n / 2^32 =
+      (u4n * 2^32 + u3n / 2^32) / b3'n := by
+    rw [Nat.div_div_eq_div_mul, Nat.mul_comm b3'n (2^32),
+        ← Nat.div_div_eq_div_mul]
+    congr 1
+    -- Goal: (u4n * 2^64 + u3n) / 2^32 = u4n * 2^32 + u3n / 2^32.
+    have h_rearr : u4n * 2^64 + u3n = u3n + u4n * 2^32 * 2^32 := by ring
+    rw [h_rearr, Nat.add_mul_div_right _ _ (by decide : (0:Nat) < 2^32)]
+    omega
+  rw [h_alg] at h_div
+  -- Now goal RHS uses bundles; unfold them and compare.
+  rw [n4QTopPhase1_unfold, n4U4_unfold, n4DivUn1_unfold, n4Un3_unfold,
+      n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+  -- Convert (un3 >>> 32).toNat to u3n / 2^32 via BitVec lemmas.
+  have h_u3_shift :
+      (((a3 <<< ((clzResult b3).1.toNat % 64)) |||
+        (a2 >>>
+          ((signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64))) >>>
+          (32 : BitVec 6).toNat).toNat = u3n / 2^32 := by
+    rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow]
+  rw [h_u3_shift]
+  exact h_div
 
 /-- **D1c-C (STUB)**: Phase 1 lower bound, wrapped on bundles.
     Repackages `algorithmQ1Prime_ge_q_true_1` so the inequality is

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -576,20 +576,93 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
 -- D2b: un21 < vTop from tight Phase 1
 -- ============================================================================
 
-/-- **D2b-A (STUB)**: Phase 1b Euclidean identity at bundle level.
+/-- **D2b-A (CLOSED)**: Phase 1b Euclidean identity at bundle level.
     `q1' * dHi + rhat' = u4` (toNat). Wraps `div128Quot_phase1b_post`
     over our irreducible bundles. -/
 theorem n4_phase1b_eucl
     (a2 a3 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
+    (hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3) :
     (n4Q1Prime a2 a3 b2 b3).toNat * (n4DHi b2 b3).toNat +
       (n4RhatPrime a2 a3 b2 b3).toNat = (n4U4 a3 b3).toNat := by
-  sorry
+  -- dHi bounds.
+  have h_b3'_ge : (n4B3Prime b2 b3).toNat ≥ 2^63 := by
+    rw [n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact b3_prime_ge_pow63 b3 b2 hb3nz _
+  have h_dHi_ge : (n4DHi b2 b3).toNat ≥ 2^31 := by
+    rw [n4DHi_unfold]; exact div128Quot_dHi_ge_pow31 _ h_b3'_ge
+  have h_dHi_ne : n4DHi b2 b3 ≠ 0 := by
+    intro hzero
+    have h0 : (n4DHi b2 b3).toNat = 0 := by rw [hzero]; rfl
+    omega
+  have h_dHi_lt : (n4DHi b2 b3).toNat < 2^32 := by
+    rw [n4DHi_unfold, BitVec.toNat_ushiftRight,
+        EvmAsm.Rv64.AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    have : (n4B3Prime b2 b3).toNat < 2^64 := (n4B3Prime b2 b3).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  -- Phase 1a Euclidean and rhatc bound.
+  -- Bridge to n4DHi-based form: rewrite n4Q1Prime, n4RhatPrime to algorithm bodies.
+  rw [n4Q1Prime_unfold, n4RhatPrime_unfold, algorithmQ1Prime_unfold,
+      algorithmRhatPrime_unfold]
+  -- Substitute dHi := b3' >>> 32 to match the let-form's dHi.
+  rw [show (n4DHi b2 b3) = (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
+        from n4DHi_unfold b2 b3]
+  -- Now the goal is in let-form. Apply the existing lemma.
+  -- Construct the q1c, rhatc, dLo, rhatUn1 args needed.
+  set b3' := n4B3Prime b2 b3 with hb3'_def
+  set u4 := n4U4 a3 b3 with hu4_def
+  set u3 := n4Un3 a2 a3 b3 with hu3_def
+  -- Replicate the structure that algorithmQ1Prime_unfold leaves.
+  -- After unfolding, the goal references b3' >>> 32, etc.
+  -- Use h_post and h_rhatc_lt with dHi := b3' >>> 32.
+  have h_dHi_ne' : (b3' >>> (32 : BitVec 6).toNat) ≠ 0 := by
+    rw [hb3'_def, ← n4DHi_unfold]; exact h_dHi_ne
+  have h_dHi_lt' : (b3' >>> (32 : BitVec 6).toNat).toNat < 2^32 := by
+    rw [hb3'_def, ← n4DHi_unfold]; exact h_dHi_lt
+  exact div128Quot_phase1b_post u4 (b3' >>> (32 : BitVec 6).toNat)
+    (if rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) >>>
+        (32 : BitVec 6).toNat = 0
+     then rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat)
+     else rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) + signExtend12 4095)
+    (if rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) >>>
+        (32 : BitVec 6).toNat = 0
+     then u4 - rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) *
+              (b3' >>> (32 : BitVec 6).toNat)
+     else u4 - rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) *
+              (b3' >>> (32 : BitVec 6).toNat) + (b3' >>> (32 : BitVec 6).toNat))
+    ((b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat)
+    (((if rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) >>>
+          (32 : BitVec 6).toNat = 0
+       then u4 - rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) *
+              (b3' >>> (32 : BitVec 6).toNat)
+       else u4 - rv64_divu u4 (b3' >>> (32 : BitVec 6).toNat) *
+              (b3' >>> (32 : BitVec 6).toNat) +
+              (b3' >>> (32 : BitVec 6).toNat)) <<< (32 : BitVec 6).toNat) |||
+       (u3 >>> (32 : BitVec 6).toNat))
+    h_dHi_lt'
+    (div128Quot_first_round_post u4 (b3' >>> (32 : BitVec 6).toNat)
+      h_dHi_ne' h_dHi_lt')
+    (div128Quot_rhatc_lt_2dHi u4 (b3' >>> (32 : BitVec 6).toNat)
+      h_dHi_ne' h_dHi_lt')
 
 /-- **D2b-B (STUB)**: BitVec un21 to Nat decomposition under no-wrap.
-    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo` when no-wrap. -/
+    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo` when no-wrap.
+
+    **Proof sketch**: `n4Un21 = ((rhat' << 32) ||| div_un1) - (q1' * dLo)`
+    (BitVec). Under no-wrap (h_no_wrap_phase1), the BitVec subtraction is
+    no-wrap, so `un21.toNat = cu_rhat_un1.toNat - cu_q1_dlo.toNat`.
+    `cu_rhat_un1.toNat = (rhat'%2^32)*2^32 + div_un1` via
+    `halfword_combine_mod`. `cu_q1_dlo.toNat = q1'*dLo` (no Word overflow,
+    since q1' < 2^32 and dLo < 2^32 so product < 2^64).
+
+    **Blocker (2026-04-27 iteration)**: the structural identity
+    `n4Un21 = (n4RhatPrime << 32 ||| n4DivUn1) - (n4Q1Prime * n4DLo)`
+    triggers `whnf` heartbeat blow-up when proven via combined `_unfold`
+    rewrites, due to algorithm let-bindings duplicating large
+    if-then-else terms across bundle boundaries. Likely needs a more
+    delicate proof structure or restatement of `algorithmUn21` in
+    terms of `algorithmQ1Prime` / `algorithmRhatPrime` explicitly. -/
 theorem n4Un21_toNat_of_no_wrap
     (a2 a3 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -456,14 +456,121 @@ theorem n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1
     Estimated: ~30-50 LOC for the bridging once D2/D3-A is closed. -/
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     (a2 a3 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
     (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
       ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
         (n4DivUn1 a2 a3 b3).toNat := by
-  sorry
+  -- Derive dHi bounds from b3' ≥ 2^63.
+  have h_b3'_ge : (n4B3Prime b2 b3).toNat ≥ 2^63 := by
+    rw [n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact b3_prime_ge_pow63 b3 b2 hb3nz _
+  have h_dHi_ge : (n4DHi b2 b3).toNat ≥ 2^31 := by
+    rw [n4DHi_unfold]
+    exact div128Quot_dHi_ge_pow31 (n4B3Prime b2 b3) h_b3'_ge
+  have h_dHi_ne : n4DHi b2 b3 ≠ 0 := by
+    intro hzero
+    have h0 : (n4DHi b2 b3).toNat = 0 := by rw [hzero]; rfl
+    omega
+  have h_dHi_lt : (n4DHi b2 b3).toNat < 2^32 := by
+    rw [n4DHi_unfold, BitVec.toNat_ushiftRight,
+        EvmAsm.Rv64.AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    have : (n4B3Prime b2 b3).toNat < 2^64 := (n4B3Prime b2 b3).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_dLo_lt : (n4DLo b2 b3).toNat < 2^32 := by
+    rw [n4DLo_unfold, BitVec.toNat_ushiftRight,
+        EvmAsm.Rv64.AddrNorm.bv6_toNat_32, Nat.shiftRight_eq_div_pow]
+    have : ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_v_eq : (n4B3Prime b2 b3).toNat =
+      (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
+    rw [n4DHi_unfold, n4DLo_unfold]
+    exact div128Quot_vTop_decomp _
+  -- Discharge rhat' < 2^32 via D2/D3-A.
+  have h_rhat'_lt : (n4RhatPrime a2 a3 b2 b3).toNat < 2^32 :=
+    n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1 a2 a3 b2 b3
+      hb3nz hshift_nz hcall h_q1_eq
+  -- The let-form q1' inside `div128Quot_phase1_no_wrap_skip` matches
+  -- algorithmQ1Prime's body when we use dHi = n4DHi, dLo = n4DLo.
+  -- And rhat' similarly matches algorithmRhatPrime's body.
+  have h_app := div128Quot_phase1_no_wrap_skip
+    (n4U4 a3 b3) (n4DHi b2 b3) (n4DLo b2 b3) (n4Un3 a2 a3 b3)
+    h_dHi_ne h_dHi_ge h_dHi_lt
+    (by
+      -- hq1_prime_le_q_true_1: in let-form, q1'.toNat ≤
+      -- (uHi*2^32+div_un1)/(dHi*2^32+dLo).
+      simp only []
+      have h_le : (n4Q1Prime a2 a3 b2 b3).toNat ≤
+          ((n4U4 a3 b3).toNat * 2^32 +
+            ((n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat).toNat) /
+            ((n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat) := by
+        rw [h_q1_eq, n4QTopPhase1_unfold, n4DivUn1_unfold, ← h_v_eq]
+      -- The let-form q1' in lemma = body computed with our dHi, dLo.
+      -- This should equal n4Q1Prime by unfolding algorithmQ1Prime.
+      have h_q1_eq_letform :
+          (n4Q1Prime a2 a3 b2 b3).toNat =
+          (let q1 := rv64_divu (n4U4 a3 b3) (n4DHi b2 b3)
+           let rhat := (n4U4 a3 b3) - q1 * (n4DHi b2 b3)
+           let hi1 := q1 >>> (32 : BitVec 6).toNat
+           let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+           let rhatc : Word := if hi1 = 0 then rhat else rhat + (n4DHi b2 b3)
+           let qDlo := q1c * (n4DLo b2 b3)
+           let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+           let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+           if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c).toNat := by
+        rw [n4Q1Prime_unfold, algorithmQ1Prime_unfold, n4DHi_unfold, n4DLo_unfold]
+      rw [← h_q1_eq_letform]
+      exact h_le)
+    (by
+      -- hrhat'_lt: in let-form rhat'.toNat < 2^32.
+      simp only []
+      have h_rhat_eq_letform :
+          (n4RhatPrime a2 a3 b2 b3).toNat =
+          (let q1 := rv64_divu (n4U4 a3 b3) (n4DHi b2 b3)
+           let rhat := (n4U4 a3 b3) - q1 * (n4DHi b2 b3)
+           let hi1 := q1 >>> (32 : BitVec 6).toNat
+           let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+           let rhatc : Word := if hi1 = 0 then rhat else rhat + (n4DHi b2 b3)
+           let qDlo := q1c * (n4DLo b2 b3)
+           let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+           let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+           if BitVec.ult rhatUn1 qDlo then rhatc + (n4DHi b2 b3) else rhatc).toNat := by
+        rw [n4RhatPrime_unfold, algorithmRhatPrime_unfold, n4DHi_unfold, n4DLo_unfold]
+      rw [← h_rhat_eq_letform]
+      exact h_rhat'_lt)
+  -- h_app's conclusion uses let-form q1', dLo, rhat', div_un1.
+  -- Bridge back to bundles.
+  simp only [] at h_app
+  have h_q1_letform :
+      (let q1 := rv64_divu (n4U4 a3 b3) (n4DHi b2 b3)
+       let rhat := (n4U4 a3 b3) - q1 * (n4DHi b2 b3)
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc : Word := if hi1 = 0 then rhat else rhat + (n4DHi b2 b3)
+       let qDlo := q1c * (n4DLo b2 b3)
+       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c) =
+      n4Q1Prime a2 a3 b2 b3 := by
+    rw [n4Q1Prime_unfold, algorithmQ1Prime_unfold, n4DHi_unfold, n4DLo_unfold]
+  have h_rhat_letform :
+      (let q1 := rv64_divu (n4U4 a3 b3) (n4DHi b2 b3)
+       let rhat := (n4U4 a3 b3) - q1 * (n4DHi b2 b3)
+       let hi1 := q1 >>> (32 : BitVec 6).toNat
+       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
+       let rhatc : Word := if hi1 = 0 then rhat else rhat + (n4DHi b2 b3)
+       let qDlo := q1c * (n4DLo b2 b3)
+       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
+       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+       if BitVec.ult rhatUn1 qDlo then rhatc + (n4DHi b2 b3) else rhatc) =
+      n4RhatPrime a2 a3 b2 b3 := by
+    rw [n4RhatPrime_unfold, algorithmRhatPrime_unfold, n4DHi_unfold, n4DLo_unfold]
+  rw [h_q1_letform, h_rhat_letform] at h_app
+  rw [n4DivUn1_unfold]
+  exact h_app
 
 -- ============================================================================
 -- D2b: un21 < vTop from tight Phase 1

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -210,28 +210,159 @@ theorem n4RhatPrime_unfold (a2 a3 b2 b3 : Word) :
 
 -- ============================================================================
 -- D1c: Phase 1 tight under skip-borrow (the key structural lemma)
+--
+-- Decomposed into three sub-stubs (A, B, C) and a composition.
 -- ============================================================================
 
-/-- **D1c (STUB)**: Under `isSkipBorrowN4Call`, Phase 1 trial is tight:
-    `q1' = q_top_phase1` (= `(u4 * 2^32 + div_un1) / dHi`).
+/-- **D1c-A (STUB)**: Phase 1 upper bound under skip-borrow, wrapped on
+    bundles. Repackages `div128Quot_q1_prime_le_q_true_top_call_skip` so
+    the LHS is `(n4Q1Prime …).toNat` (matching our irreducible bundles).
 
-    **Proof sketch**: skip-borrow ⟹ outer mulsub `qHat * val256(b)
-    ≤ val256(a)` ⟹ `qHat ≤ q_true`. Combined with Knuth-A lower
-    `qHat ≥ q_true` gives `qHat = q_true` (already in
-    `div128Quot_call_skip_eq_val256_div`). From `qHat = q_true < 2^64`
-    and `q1' < 2^32` (KB-3e'''), the OR decomposition gives unique
-    digits. Combined with `q1' ≥ q_top_phase1` (`algorithmQ1Prime_ge_q_true_1`)
-    pins `q1' = q_top_phase1`.
+    **Proof sketch**: apply
+    `div128Quot_q1_prime_le_q_true_top_call_skip`, then bridge the
+    let-form `q1'` in the conclusion to `algorithmQ1Prime` via
+    `algorithmQ1Prime_unfold` and finally to `n4Q1Prime` via
+    `n4Q1Prime_unfold`.
 
-    Estimated: ~80 LOC. -/
-theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
+    Estimated: ~15 LOC. -/
+theorem n4Q1Prime_le_q_true_top_of_skip_borrow
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    (n4Q1Prime a2 a3 b2 b3).toNat ≤
+      (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) / 2^32 := by
+  have h := div128Quot_q1_prime_le_q_true_top_call_skip a0 a1 a2 a3 b0 b1 b2 b3
+    hb3nz hshift_nz hcall hborrow
+  simp only [] at h
+  rw [n4Q1Prime_unfold, n4U4_unfold, n4Un3_unfold, n4B3Prime_unfold,
+      n4ClzShift_unfold, n4ClzAntiShift_unfold, algorithmQ1Prime_unfold]
+  exact h
+
+/-- **D1c-B (STUB)**: Knuth Theorem A at the val256 level — the
+    *trial digit* using truncated dividend (u4*2^32 + div_un1) and
+    full divisor b3' is at least the true high digit q_true_1.
+
+    Statement: `(val256(a) / val256(b)) / 2^32 ≤ q_top_phase1`
+    where `q_top_phase1 = (u4*2^32 + div_un1) / b3'` and
+    `(u4, div_un1, b3')` are the CLZ-normalized top portions.
+
+    **Proof sketch**: standard Nat-division monotonicity argument
+    bridging val256-level to limb-level. Under CLZ shift, the
+    quotient is preserved (shift is a multiplication of both
+    numerator and denominator by `2^antiShift`). Then:
+    `q_true_full = N / D ≤ (N / 2^128) / b3'` where N/2^128 = u4*2^32
+    + div_un1 (the top 96 bits) + 1 (slop). This requires careful
+    bounds and the b3' ≥ 2^63 hypothesis from CLZ normalization.
+
+    This is the genuinely new content of D1c — no existing lemma
+    captures it.
+
+    Estimated: ~80-100 LOC. -/
+theorem q_true_top_le_n4QTopPhase1
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
-    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3 := by
+    (_hshift_nz : (clzResult b3).1 ≠ 0) :
+    (val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3) / 2^32 ≤
+      n4QTopPhase1 a2 a3 b2 b3 := by
   sorry
+
+/-- **D1c-C (STUB)**: Phase 1 lower bound, wrapped on bundles.
+    Repackages `algorithmQ1Prime_ge_q_true_1` so the inequality is
+    expressed in our bundle vocabulary.
+
+    The original lemma's hypotheses are dHi-domain bounds and
+    `u4 < dHi*2^32` (narrow_u4). For the call+skip path under
+    `hcall = isCallTrialN4`, narrow_u4 holds because hcall implies
+    u4 < b3' ≤ dHi*2^32 + dLo, but the dHi-only form requires
+    additional refinement via Phase 1b reasoning. We may need to
+    use the CompensationCases-flavored variant instead.
+
+    Estimated: ~15 LOC (mostly bundle bridging). -/
+theorem n4Q1Prime_ge_n4QTopPhase1_of_call
+    (a2 a3 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3) :
+    n4QTopPhase1 a2 a3 b2 b3 ≤ (n4Q1Prime a2 a3 b2 b3).toNat := by
+  rw [n4QTopPhase1_unfold, n4Q1Prime_unfold, n4DivUn1_unfold]
+  -- Preconditions for the case-split.
+  have h_b3'_ge : (n4B3Prime b2 b3).toNat ≥ 2^63 := by
+    rw [n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact b3_prime_ge_pow63 b3 b2 hb3nz _
+  have h_u4_lt_b3' : (n4U4 a3 b3).toNat < (n4B3Prime b2 b3).toNat := by
+    rw [n4U4_unfold, n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact isCallTrialN4_toNat_lt a3 b2 b3 hcall
+  have h_shift_pos : 1 ≤ (clzResult b3).1.toNat := by
+    rcases Nat.eq_zero_or_pos (clzResult b3).1.toNat with h | h
+    · exfalso; apply hshift_nz
+      exact BitVec.eq_of_toNat_eq (by simp [h])
+    · exact h
+  have h_u4_lt_pow63 : (n4U4 a3 b3).toNat < 2^63 := by
+    rw [n4U4_unfold, n4ClzAntiShift_unfold]
+    exact u_top_lt_pow63_of_shift_nz a3 (clzResult b3).1 h_shift_pos
+      (clzResult_fst_toNat_le b3)
+  -- dHi / dLo decomposition of b3'.
+  have h_dHi_ge : ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat ≥ 2^31 := by
+    rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow]
+    have : (n4B3Prime b2 b3).toNat ≥ 2^63 := h_b3'_ge; omega
+  have h_dHi_lt : ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat < 2^32 := by
+    rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow]
+    have : (n4B3Prime b2 b3).toNat < 2^64 := (n4B3Prime b2 b3).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_dLo_lt :
+      (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+        (32 : BitVec 6).toNat).toNat < 2^32 := by
+    rw [BitVec.toNat_ushiftRight, EvmAsm.Rv64.AddrNorm.bv6_toNat_32,
+        Nat.shiftRight_eq_div_pow]
+    have : ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).toNat < 2^64 :=
+      ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat : Word).isLt
+    exact Nat.div_lt_of_lt_mul (by omega)
+  have h_v_eq : (n4B3Prime b2 b3).toNat =
+      ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
+      (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+        (32 : BitVec 6).toNat).toNat :=
+    div128Quot_vTop_decomp _
+  have h_u4_lt_vTop : (n4U4 a3 b3).toNat <
+      ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
+      (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
+        (32 : BitVec 6).toNat).toNat := by
+    rw [← h_v_eq]; exact h_u4_lt_b3'
+  -- Case-split on u4 < dHi*2^32.
+  by_cases hu4_lt :
+      (n4U4 a3 b3).toNat < ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32
+  · have h := algorithmQ1Prime_ge_q_true_1 (n4U4 a3 b3) (n4Un3 a2 a3 b3)
+      (n4B3Prime b2 b3)
+      h_dHi_ge h_dHi_lt h_dLo_lt hu4_lt h_u4_lt_vTop
+    rw [← h_v_eq] at h; exact h
+  · exact algorithmQ1Prime_ge_q_true_1_in_wide_u4 (n4U4 a3 b3) (n4Un3 a2 a3 b3)
+      (n4B3Prime b2 b3) h_b3'_ge h_u4_lt_b3' (by omega) h_u4_lt_pow63
+
+/-- **D1c (COMPOSED)**: Under `isSkipBorrowN4Call`, Phase 1 trial is
+    tight: `q1' = q_top_phase1` (= `(u4 * 2^32 + div_un1) / b3'`).
+
+    **Composition**: D1c-A (q1' ≤ q_true_top) + D1c-B
+    (q_true_top ≤ q_top_phase1) gives q1' ≤ q_top_phase1. Combined
+    with D1c-C (q_top_phase1 ≤ q1') and `Nat.le_antisymm`. -/
+theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3 := by
+  have h_le_top := n4Q1Prime_le_q_true_top_of_skip_borrow a0 a1 a2 a3 b0 b1 b2 b3
+    hb3nz hshift_nz hcall hborrow
+  have h_top_le := q_true_top_le_n4QTopPhase1 a0 a1 a2 a3 b0 b1 b2 b3
+    hb3nz hshift_nz
+  have h_le : (n4Q1Prime a2 a3 b2 b3).toNat ≤ n4QTopPhase1 a2 a3 b2 b3 :=
+    h_le_top.trans h_top_le
+  have h_ge := n4Q1Prime_ge_n4QTopPhase1_of_call a2 a3 b2 b3
+    hb3nz hshift_nz hcall
+  exact Nat.le_antisymm h_le h_ge
 
 -- ============================================================================
 -- D2/D3: Phase 1 no-wrap from tight Phase 1

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -415,51 +415,52 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
 -- (composition wrapping `div128Quot_phase1_no_wrap_skip`).
 -- ============================================================================
 
-/-- **D2/D3-A (STUB)**: Under `q1' = q_top_phase1`, the algorithm's Phase 1b
-    output `rhat'` satisfies `rhat'.toNat < 2^32` — i.e., the Phase 1b
-    correction stays within a single limb.
+/-- **D2/D3-A (STUB, REFORMULATED 2026-04-27)**: Under `isSkipBorrowN4Call`,
+    the algorithm's Phase 1b output `rhat'` satisfies `rhat'.toNat < 2^32`.
 
-    **Proof sketch (algorithmic)**: rhat' is either rhatc or rhatc + dHi
-    after Phase 1b correction. Under tight q1' = q_top_phase1, Phase 1b
-    correction either doesn't fire (rhatc < dHi < 2^32 from Knuth Phase 1)
-    or fires and rhat' = rhatc + dHi but our specific case excludes the
-    rhatc + dHi ≥ 2^32 sub-case via the q1' = q_top_phase1 invariant.
+    **Counterexample to earlier formulation** (which used only hcall +
+    `q1' = q_top_phase1` as preconditions): see
+    `memory/project_d2d3_a_counterexample.md`. With
+    `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`, Phase 1 is tight
+    (q1' = q_top_phase1 = 2^31 - 1) but rhat' = 2^32 + 2^31 - 2 ≥ 2^32.
+    The same input violates skip-borrow (the BitVec un21 wraps,
+    yielding qHat * val256(b) > val256(a)). So skip-borrow is genuinely
+    needed.
 
-    This is the genuinely hard sub-piece: the relationship between the
-    algorithm's BitVec arithmetic and the abstract Knuth invariant.
+    **Proof sketch (under skip-borrow)**: skip-borrow ⟹ no-addback
+    invariant on the outer mulsub ⟹ Knuth's Phase 1 remainder
+    invariant `rhat' < 2^32` (this is the
+    "Phase 1 remainder fits in a limb" invariant from Knuth TAOCP 4.3.1).
 
-    Estimated: ~60-80 LOC (case-split on hi1 = 0 / hi1 ≠ 0 and Phase 1b
-    fired / not fired, with arithmetic in each branch). -/
-theorem n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1
-    (a2 a3 b2 b3 : Word)
+    Estimated: ~80-150 LOC. -/
+theorem n4RhatPrime_lt_pow32_of_skip_borrow
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
+    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
     (n4RhatPrime a2 a3 b2 b3).toNat < 2^32 := by
   sorry
 
-/-- **D2/D3 (STUB, with sub-stub D2/D3-A used)**: From `q1' = q_top_phase1`,
-    derive Phase 1 no-wrap `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
+/-- **D2/D3 (CLOSED, with `h_rhat'_lt` as hypothesis)**: From
+    `q1' = q_top_phase1` AND `rhat' < 2^32`, derive Phase 1 no-wrap
+    `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
 
-    **Plan**: Compose
-    - `div128Quot_phase1_no_wrap_skip` (existing, in `Div128PhaseNoWrap`,
-      takes `hq1_prime_le_q_true_1` and `hrhat'_lt` as hypotheses)
-    - `n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1` (D2/D3-A sub-stub)
-    - The ≤ side of h_q1_eq (an equality trivially gives ≤)
-    - Bundle ↔ let-form bridging via the unfold lemmas.
+    The `h_rhat'_lt` hypothesis is essential — see
+    `memory/project_d2d3_a_counterexample.md` for a counterexample
+    showing rhat' can exceed 2^32 under hcall + tight alone, in which
+    case the no-wrap form fails. Skip-borrow rules out this regime
+    (via `n4RhatPrime_lt_pow32_of_skip_borrow` in D5).
 
-    The unwrapping/bridging is mechanical (~30 LOC) once the `Div128PhaseNoWrap`
-    import is added (current file imports `Div128CallSkipClose`; need to also
-    import `Div128PhaseNoWrap`). Deferred to next iteration.
-
-    Estimated: ~30-50 LOC for the bridging once D2/D3-A is closed. -/
+    Composes: `div128Quot_phase1_no_wrap_skip` + ≤ side of h_q1_eq +
+    bundle/let-form bridging. -/
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     (a2 a3 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hcall : isCallTrialN4 a3 b2 b3)
-    (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3) :
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
+    (h_rhat'_lt : (n4RhatPrime a2 a3 b2 b3).toNat < 2^32) :
     (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
       ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
         (n4DivUn1 a2 a3 b3).toNat := by
@@ -489,10 +490,8 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
       (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
     rw [n4DHi_unfold, n4DLo_unfold]
     exact div128Quot_vTop_decomp _
-  -- Discharge rhat' < 2^32 via D2/D3-A.
-  have h_rhat'_lt : (n4RhatPrime a2 a3 b2 b3).toNat < 2^32 :=
-    n4RhatPrime_lt_pow32_of_q1_prime_eq_q_top_phase1 a2 a3 b2 b3
-      hb3nz hshift_nz hcall h_q1_eq
+  -- h_rhat'_lt now comes as an explicit hypothesis from the caller (typically D5
+  -- via `n4RhatPrime_lt_pow32_of_skip_borrow`).
   -- The let-form q1' inside `div128Quot_phase1_no_wrap_skip` matches
   -- algorithmQ1Prime's body when we use dHi = n4DHi, dLo = n4DLo.
   -- And rhat' similarly matches algorithmRhatPrime's body.
@@ -852,9 +851,12 @@ theorem div128_phase_no_wrap_of_skip_borrow
   -- Phase 1 tight from D1c.
   have h_q1_eq := div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
     a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall hborrow
-  -- Phase 1 no-wrap from D2/D3.
+  -- rhat' < 2^32 from D2/D3-A (skip-borrow ⟹ Knuth Phase 1 invariant).
+  have h_rhat'_lt := n4RhatPrime_lt_pow32_of_skip_borrow
+    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall hborrow
+  -- Phase 1 no-wrap from D2/D3 (using h_rhat'_lt as additional precondition).
   have h_no_wrap := div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
-    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq
+    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq h_rhat'_lt
   -- un21 < vTop from D2b.
   have h_un21_lt := div128Quot_un21_lt_vTop_from_phase1_tight
     a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq h_no_wrap

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -1,41 +1,62 @@
 /-
   EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge
 
-  Discharge bridge: prove `Div128AllPhasesNoWrapInv` (or its weaker
-  `Div128PhaseNoWrapInv` cousin) from algorithmic runtime conditions
-  (`isSkipBorrowN4Call`, `isAddbackBorrowN4Call`, etc.).
+  ## STATUS (2026-04-27): D5 is BROKEN; standalone lemmas remain useful
 
-  This is approach (a) from the n4CallAddbackBeq closure plan: prove
-  the no-wrap invariant via Phase-1-level reasoning, which then makes
-  KB-6d unconditional and unblocks the addback-BEQ semantic predicate.
+  Original goal: discharge `Div128PhaseNoWrapInv` from `isSkipBorrowN4Call`,
+  to unblock KB-6d → `n4CallAddbackBeqSemanticHolds`.
 
-  **Background**: a numerical counterexample
-  (`memory/project_n4calladdbackbeq_counterexample.md`) shows that
-  approach (b) — direct val256-level Knuth-B without Phase-1 reasoning —
-  is impossible. Phase-1 reasoning is the only viable path.
+  **Discovery**: D5's claim "skip-borrow ⟹ Div128PhaseNoWrapInv" is
+  PROVABLY FALSE (counterexample: `a3 = 2^64-2, b3 = 1, b2 = 2^64-2`,
+  verified via lean_run_code). See:
+  - `memory/project_d2d3_a_counterexample.md` — counterexample analysis
+  - `memory/project_knuth_d_one_correction_design.md` — literature study
+    confirming our `div128Quot` uses 1 Phase 1b correction (vs Knuth's
+    classical 2-correction loop), so `rhat' < B` is NOT preserved by
+    design.
 
-  **Irreducible bundles** (per `feedback_bundle_pre_post_no_lets`):
-  the CLZ-shifted Word inputs and Phase 1b output `rhat'` are bundled
-  into `@[irreducible]` defs so the lemma signatures don't expose deep
-  let-chains.
+  **Architectural implication**: `Div128PhaseNoWrapInv`'s conjunct 2
+  (Phase 1 no-wrap form) is OVER-STRONG for our 1-correction algorithm.
+  The right approach is to BYPASS Div128PhaseNoWrapInv entirely.
 
-  - **`n4ClzShift`**, **`n4ClzAntiShift`**: shift / antiShift Nats.
-  - **`n4U4`**, **`n4Un3`**, **`n4B3Prime`**: CLZ-normalized top limbs
-    of a, b (computed from a2, a3, b2, b3).
-  - **`algorithmRhatPrime`**: Phase 1b's corrected remainder.
+  ## Path forward (NOT in this file)
 
-  These compose with the existing `algorithmUn21`, `algorithmQ1Prime`,
-  `algorithmQ0Prime` (in `CallSkipLowerBoundV2/Algorithm.lean`).
+  - **Call-skip target** (`evm_div_n4_call_skip_stack_spec`): already
+    closed via `n4CallSkipSemanticHolds_of_call_trial` using
+    `div128Quot_call_skip_ge_val256_div_v2`. No need for
+    Div128PhaseNoWrapInv.
+  - **Call-addback-BEQ target** (`n4CallAddbackBeqSemanticHolds`):
+    requires Knuth Theorem B (`qHat ≤ q_true + 2`) plus addback
+    correction semantics. KB-6d's existing chain has its own issues
+    (see `memory/project_kb6d_false_counterexample.md`); reformulation
+    needed.
 
-  **Decomposition** (planned):
-  - **D1c**: Phase 1 tight (`q1' = q_top_phase1`) under skip-borrow.
-  - **D2/D3**: From q1' = q_top_phase1, derive Phase 1 no-wrap
-    inequality.
-  - **D2b**: From Phase 1 no-wrap + tight q1', derive un21 < vTop.
-  - **D5** (parent): compose into `Div128PhaseNoWrapInv`.
+  ## What's still useful in this file
 
-  Each sub-stub is a `sorry`'d theorem with a proof sketch in its
-  docstring. Estimated ~300-500 LOC total over multiple iterations.
+  - `n4U4`, `n4Un3`, `n4B3Prime`, `n4DHi`, `n4DLo`, `n4DivUn1`,
+    `n4Q1Prime`, `n4Un21`, `n4RhatPrime`, `n4QTopPhase1` — irreducible
+    bundles for CLZ-normalized inputs. Reusable across files.
+  - `algorithmRhatPrime` — Phase 1b corrected rhat'.
+  - **D1c chain** (CLOSED): `n4Q1Prime_le_q_true_top_of_skip_borrow`,
+    `q_true_top_le_n4QTopPhase1`, `n4Q1Prime_ge_n4QTopPhase1_of_call`,
+    `div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow`. Phase 1
+    tight (q1' = q_top_phase1) under skip-borrow.
+  - **D2b-A, D2b-B** (CLOSED): Phase 1b Euclidean wrapper,
+    `n4Un21_toNat_of_no_wrap`. Reusable.
+  - **D2b composed** (CLOSED, as a conditional): under hypothesis
+    h_q1_eq + h_no_wrap_phase1, derives un21 < vTop.
+  - **D2/D3 composed** (CLOSED, as a conditional): under hypothesis
+    h_q1_eq + h_rhat'_lt, derives Phase 1 no-wrap. The h_rhat'_lt
+    hypothesis can NEVER be discharged from skip-borrow (counterexample),
+    but as a conditional theorem it's still useful.
+
+  ## What's broken
+
+  - **D2/D3-A** (`n4RhatPrime_lt_pow32_of_skip_borrow`, SORRY):
+    provably false on the counterexample. Should not be used.
+  - **D5** (`div128_phase_no_wrap_of_skip_borrow`, transitively SORRY
+    via D2/D3-A): the parent claim is also false on the counterexample.
+    Should not be used.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -176,11 +176,15 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
 
     **Proof sketch**: From the no-wrap form (D3), the BitVec subtraction
     `un21 = cu_rhat_un1 - cu_q1_dlo` doesn't wrap. Hence
-    `un21.toNat = cu_rhat_un1.toNat - cu_q1_dlo.toNat`. Combined with
-    KB-3m (additive identity), this gives `un21.toNat = uHi*2^32 +
-    div_un1 - q1'*vTop`. Under q1' = q_top_phase1 = (uHi*2^32 +
-    div_un1)/vTop, the RHS is `(uHi*2^32 + div_un1) mod vTop`, which is
-    `< vTop` by `Nat.mod_lt`.
+    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo`. Combined with
+    KB-3m's additive identity (which holds under no-wrap), we get
+    `un21 + r1*2^64 + q1'*vTop = uHi*2^32 + div_un1` where
+    `r1 := rhat'/2^32`. Rearranging:
+    `un21 = uHi*2^32 + div_un1 - q1'*vTop - r1*2^64`.
+    Under `q1' = q_top_phase1 = (uHi*2^32 + div_un1)/vTop`:
+    `q1'*vTop ≤ uHi*2^32 + div_un1 < (q1'+1)*vTop`, so
+    `0 ≤ uHi*2^32 + div_un1 - q1'*vTop < vTop`.
+    Combined with `r1 ≥ 0`: `un21 ≤ uHi*2^32 + div_un1 - q1'*vTop < vTop`.
 
     Estimated: ~40 LOC. -/
 theorem div128Quot_un21_lt_vTop_from_phase1_tight
@@ -188,8 +192,64 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_no_wrap_phase1 : True) :  -- placeholder; real signature comes from D3
-    True := by
+    (_h_q1_eq :  -- q1' = q_top_phase1 (from D1c)
+      let shift := (clzResult b3).1.toNat % 64
+      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+      let u4 := a3 >>> antiShift
+      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+      let dHi := b3' >>> (32 : BitVec 6).toNat
+      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+      let div_un1 := un3 >>> (32 : BitVec 6).toNat
+      let q1 := rv64_divu u4 dHi
+      let rhat := u4 - q1 * dHi
+      let hi1 := q1 >>> (32 : BitVec 6).toNat
+      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+      let rhatc := if hi1 = 0 then rhat else rhat + dHi
+      let qDlo := q1c * dLo
+      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+      q1'.toNat = (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat)
+    (_h_no_wrap_phase1 :  -- Phase 1 no-wrap (from D3)
+      let shift := (clzResult b3).1.toNat % 64
+      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+      let u4 := a3 >>> antiShift
+      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+      let dHi := b3' >>> (32 : BitVec 6).toNat
+      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+      let div_un1 := un3 >>> (32 : BitVec 6).toNat
+      let q1 := rv64_divu u4 dHi
+      let rhat := u4 - q1 * dHi
+      let hi1 := q1 >>> (32 : BitVec 6).toNat
+      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+      let rhatc := if hi1 = 0 then rhat else rhat + dHi
+      let qDlo := q1c * dLo
+      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+      let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+      q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let u4 := a3 >>> antiShift
+    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let dHi := b3' >>> (32 : BitVec 6).toNat
+    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un1 := un3 >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu u4 dHi
+    let rhat := u4 - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let qDlo := q1c * dLo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+    let cu_q1_dlo := q1' * dLo
+    let un21 := cu_rhat_un1 - cu_q1_dlo
+    un21.toNat < dHi.toNat * 2^32 + dLo.toNat := by
   sorry
 
 -- ============================================================================

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -576,32 +576,111 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
 -- D2b: un21 < vTop from tight Phase 1
 -- ============================================================================
 
-/-- **D2b (STUB)**: Under `q1' = q_top_phase1` AND Phase 1 no-wrap,
-    derive `un21.toNat < vTop.toNat` (= `dHi.toNat * 2^32 + dLo.toNat`).
+/-- **D2b-A (STUB)**: Phase 1b Euclidean identity at bundle level.
+    `q1' * dHi + rhat' = u4` (toNat). Wraps `div128Quot_phase1b_post`
+    over our irreducible bundles. -/
+theorem n4_phase1b_eucl
+    (a2 a3 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3) :
+    (n4Q1Prime a2 a3 b2 b3).toNat * (n4DHi b2 b3).toNat +
+      (n4RhatPrime a2 a3 b2 b3).toNat = (n4U4 a3 b3).toNat := by
+  sorry
 
-    **Proof sketch**: From the no-wrap form (D2/D3), the BitVec
-    subtraction doesn't wrap, so
-    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo`. Combined with
-    KB-3m's additive identity (which holds under no-wrap), gives
-    `un21 + r1*2^64 + q1'*vTop = uHi*2^32 + div_un1`. Under
-    `q1' = q_top_phase1 = (uHi*2^32 + div_un1)/vTop`:
-    `q1' * vTop ≤ uHi*2^32 + div_un1 < (q1'+1)*vTop`,
-    so `un21 + r1*2^64 < vTop`, hence `un21 < vTop` (with r1 ≥ 0).
-
-    Estimated: ~40 LOC. -/
-theorem div128Quot_un21_lt_vTop_from_phase1_tight
+/-- **D2b-B (STUB)**: BitVec un21 to Nat decomposition under no-wrap.
+    `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo` when no-wrap. -/
+theorem n4Un21_toNat_of_no_wrap
     (a2 a3 b2 b3 : Word)
     (_hb3nz : b3 ≠ 0)
     (_hshift_nz : (clzResult b3).1 ≠ 0)
     (_hcall : isCallTrialN4 a3 b2 b3)
-    (_h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
     (_h_no_wrap_phase1 :
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
+        ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
+          (n4DivUn1 a2 a3 b3).toNat) :
+    (n4Un21 a2 a3 b2 b3).toNat =
+      ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
+        (n4DivUn1 a2 a3 b3).toNat -
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat := by
+  sorry
+
+/-- **D2b (CLOSED via composition mod sub-stubs)**: Under
+    `q1' = q_top_phase1` AND Phase 1 no-wrap, derive `un21 < vTop`.
+
+    Composes:
+    - **D2b-A** (`n4_phase1b_eucl`): Phase 1b Euclidean.
+    - **D2b-B** (`n4Un21_toNat_of_no_wrap`): BitVec un21 in Nat.
+    - h_q1_eq + Nat.lt_div_iff_mul_lt: q_top_phase1 strict upper bound.
+    - Final arithmetic. -/
+theorem div128Quot_un21_lt_vTop_from_phase1_tight
+    (a2 a3 b2 b3 : Word)
+    (hb3nz : b3 ≠ 0)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
+    (hcall : isCallTrialN4 a3 b2 b3)
+    (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
+    (h_no_wrap_phase1 :
       (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
         ((n4RhatPrime a2 a3 b2 b3).toNat % 2^32) * 2^32 +
           (n4DivUn1 a2 a3 b3).toNat) :
     (n4Un21 a2 a3 b2 b3).toNat <
       (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
-  sorry
+  -- b3' = dHi*2^32 + dLo, b3' ≥ 2^63 (so > 0).
+  have h_b3'_ge : (n4B3Prime b2 b3).toNat ≥ 2^63 := by
+    rw [n4B3Prime_unfold, n4ClzShift_unfold, n4ClzAntiShift_unfold]
+    exact b3_prime_ge_pow63 b3 b2 hb3nz _
+  have h_v_eq : (n4B3Prime b2 b3).toNat =
+      (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
+    rw [n4DHi_unfold, n4DLo_unfold]; exact div128Quot_vTop_decomp _
+  -- D2b-A: Phase 1b Euclidean.
+  have h_eucl := n4_phase1b_eucl a2 a3 b2 b3 hb3nz hshift_nz hcall
+  -- D2b-B: un21.toNat formula.
+  have h_un21_eq := n4Un21_toNat_of_no_wrap a2 a3 b2 b3
+    hb3nz hshift_nz hcall h_no_wrap_phase1
+  -- q_top_phase1 strict upper: u4*2^32+div_un1 < (q1'+1)*vTop.
+  have h_b3'_pos : 0 < (n4B3Prime b2 b3).toNat := by
+    have : (n4B3Prime b2 b3).toNat ≥ 2^63 := h_b3'_ge; omega
+  have h_q1_eq' :
+      (n4Q1Prime a2 a3 b2 b3).toNat =
+      ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) /
+        (n4B3Prime b2 b3).toNat := by
+    rw [h_q1_eq, n4QTopPhase1_unfold]
+  have h_q_top_upper :
+      (n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat <
+      ((n4Q1Prime a2 a3 b2 b3).toNat + 1) * (n4B3Prime b2 b3).toNat := by
+    rw [h_q1_eq']
+    have h := Nat.lt_mul_div_succ
+      ((n4U4 a3 b3).toNat * 2^32 + (n4DivUn1 a2 a3 b3).toNat) h_b3'_pos
+    -- h : a < b * (a / b + 1) — commute multiplication.
+    linarith
+  -- Final arithmetic.
+  rw [h_un21_eq]
+  -- Goal: (rhat'%2^32)*2^32 + div_un1 - q1'*dLo < dHi*2^32 + dLo
+  have h_mod_le : (n4RhatPrime a2 a3 b2 b3).toNat % 2^32 ≤
+      (n4RhatPrime a2 a3 b2 b3).toNat := Nat.mod_le _ _
+  have h_mod_pow32_le : (n4RhatPrime a2 a3 b2 b3).toNat % 2^32 * 2^32 ≤
+      (n4RhatPrime a2 a3 b2 b3).toNat * 2^32 :=
+    Nat.mul_le_mul_right _ h_mod_le
+  -- From h_eucl: q1' * dHi + rhat' = u4. Multiply by 2^32:
+  -- q1'*dHi*2^32 + rhat'*2^32 = u4*2^32.
+  have h_eucl_pow32 :
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DHi b2 b3).toNat * 2^32 +
+        (n4RhatPrime a2 a3 b2 b3).toNat * 2^32 =
+      (n4U4 a3 b3).toNat * 2^32 := by
+    have h := congrArg (· * 2^32) h_eucl
+    simp only at h
+    linarith
+  -- h_q_top_upper expanded: u4*2^32 + div_un1
+  --   < (q1'+1)*(dHi*2^32 + dLo) = q1'*dHi*2^32 + q1'*dLo + dHi*2^32 + dLo
+  rw [h_v_eq] at h_q_top_upper
+  have h_expand : ((n4Q1Prime a2 a3 b2 b3).toNat + 1) *
+      ((n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat) =
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DHi b2 b3).toNat * 2^32 +
+      (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat +
+      (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by ring
+  rw [h_expand] at h_q_top_upper
+  -- Conclude via omega.
+  omega
 
 -- ============================================================================
 -- D5: Compose into Div128PhaseNoWrapInv

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -50,13 +50,14 @@
     hypothesis can NEVER be discharged from skip-borrow (counterexample),
     but as a conditional theorem it's still useful.
 
-  ## What's broken
+  ## Removed (provably FALSE) on 2026-04-27
 
-  - **D2/D3-A** (`n4RhatPrime_lt_pow32_of_skip_borrow`, SORRY):
-    provably false on the counterexample. Should not be used.
-  - **D5** (`div128_phase_no_wrap_of_skip_borrow`, transitively SORRY
-    via D2/D3-A): the parent claim is also false on the counterexample.
-    Should not be used.
+  - **D2/D3-A** (`n4RhatPrime_lt_pow32_of_skip_borrow`): claimed
+    `rhat' < 2^32` under skip-borrow, but the counterexample satisfies
+    skip-borrow with rhat' = 2^32 + 2^31 - 2.
+  - **D5** (`div128_phase_no_wrap_of_skip_borrow`): claimed
+    skip-borrow ⟹ Div128PhaseNoWrapInv, transitively false because
+    Div128PhaseNoWrapInv's conjunct 2 fails on the same counterexample.
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
@@ -430,69 +431,28 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
   exact Nat.le_antisymm h_le h_ge
 
 -- ============================================================================
--- D2/D3: Phase 1 no-wrap from tight Phase 1
+-- D2/D3: Phase 1 no-wrap as a CONDITIONAL theorem
 --
--- Decomposed into D2/D3-A (rhat' < 2^32 sub-stub) and D2/D3 main
--- (composition wrapping `div128Quot_phase1_no_wrap_skip`).
+-- D2/D3-A (`rhat' < 2^32` under skip-borrow) was REMOVED on 2026-04-27
+-- because it's provably FALSE — see `memory/project_d2d3_a_counterexample.md`
+-- and `memory/project_knuth_d_one_correction_design.md`. Our `div128Quot`
+-- does only 1 Phase 1b correction (vs Knuth's classical 2-correction loop),
+-- so `rhat' < B` is NOT preserved by design — D6 addback compensates.
+--
+-- D2/D3 main remains as a CONDITIONAL theorem: caller must supply
+-- `h_rhat'_lt` hypothesis externally. Under skip-borrow, this hypothesis
+-- can NOT be discharged in general (counterexample exists). Useful only
+-- for inputs where rhat' < 2^32 is established by other means.
 -- ============================================================================
 
-/-- **D2/D3-A (PROVABLY FALSE, 2026-04-27 follow-up)**: even under
-    `isSkipBorrowN4Call`, the claim `rhat' < 2^32` is FALSE in some
-    cases where the algorithm is otherwise correct.
-
-    **Literature confirms (Knuth TAOCP 4.3.1, ridiculousfish.com blog)**:
-    classical Knuth Algorithm D step D3 correction loop runs up to **2**
-    iterations. After D3, `qhat ≤ q_true + 1`, with the leftover `+1`
-    case handled by D6 addback. **Our algorithm performs only 1 Phase 1b
-    correction** (not a loop). This is a known performance optimization —
-    the 1-correction variant maintains correctness because D6 addback
-    catches all overshoots, but it does NOT preserve Knuth's classical
-    Phase 1 remainder invariant `rhat' < B`. See
-    `memory/project_knuth_d_one_correction_design.md` for the literature
-    study.
-
-    **Counterexample** (verified via lean_run_code, see
-    `memory/project_d2d3_a_counterexample.md`): with
-    `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`,
-    - skip-borrow HOLDS (mulsub_c3 = u4 = 2^63 - 1, no borrow),
-    - qHat = q_true = 2^63 - 1 (algorithm correct),
-    - q1' = q_true_1 = 2^31 - 1, q0' = q_true_0 = 2^32 - 1 (digits correct),
-    - **but `rhat' = 2^32 + 2^31 - 2 ≥ 2^32`**.
-
-    **Architectural implication**: `Div128PhaseNoWrapInv`'s conjunct 2
-    is OVER-STRONG for our 1-correction algorithm. D5 "skip-borrow ⟹
-    Div128PhaseNoWrapInv" is FALSE.
-
-    **Path forward**: The user-facing chain
-    (`evm_div_n4_call_skip_stack_spec`) actually only needs
-    `div128Quot.toNat = val256(a)/val256(b)`, which is ALREADY
-    proven in `div128Quot_call_skip_eq_val256_div` (CallSkipLowerBoundV2).
-    The Div128PhaseNoWrapInv chain is unnecessary for the call-skip
-    spec. **Bypass D5 entirely** — use the tight equality directly.
-
-    For the **call-addback** path, the situation differs (qHat = q_true + 1)
-    and may need different reasoning still.
-
-    **This stub is left UNPROVABLE as-is** — its goal is genuinely
-    false. -/
-theorem n4RhatPrime_lt_pow32_of_skip_borrow
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (_hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
-    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    (n4RhatPrime a2 a3 b2 b3).toNat < 2^32 := by
-  sorry
-
-/-- **D2/D3 (CLOSED, with `h_rhat'_lt` as hypothesis)**: From
-    `q1' = q_top_phase1` AND `rhat' < 2^32`, derive Phase 1 no-wrap
+/-- **D2/D3 (CLOSED, conditional)**: From `q1' = q_top_phase1` AND
+    `rhat' < 2^32`, derive Phase 1 no-wrap
     `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
 
-    The `h_rhat'_lt` hypothesis is essential — see
-    `memory/project_d2d3_a_counterexample.md` for a counterexample
-    showing rhat' can exceed 2^32 under hcall + tight alone, in which
-    case the no-wrap form fails. Skip-borrow rules out this regime
-    (via `n4RhatPrime_lt_pow32_of_skip_borrow` in D5).
+    The `h_rhat'_lt` hypothesis is **not always satisfied** under
+    skip-borrow (see `memory/project_d2d3_a_counterexample.md`), so this
+    theorem is best viewed as a conditional: it states a true implication,
+    but the precondition may be vacuous.
 
     Composes: `div128Quot_phase1_no_wrap_skip` + ≤ side of h_q1_eq +
     bundle/let-form bridging. -/
@@ -874,112 +834,19 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
   omega
 
 -- ============================================================================
--- D5: Compose into Div128PhaseNoWrapInv
+-- D5 (REMOVED 2026-04-27): "skip-borrow ⟹ Div128PhaseNoWrapInv"
+--
+-- D5's claim is provably FALSE — see `memory/project_d2d3_a_counterexample.md`.
+-- The counterexample (a3 = 2^64-2, b3 = 1, b2 = 2^64-2) satisfies
+-- skip-borrow but `Div128PhaseNoWrapInv`'s conjunct 2 (Phase 1 no-wrap)
+-- fails because rhat' ≥ 2^32 (our 1-correction Phase 1b doesn't preserve
+-- Knuth's classical `rhat' < B` invariant).
+--
+-- The user-facing call-skip target (`evm_div_n4_call_skip_stack_spec`) is
+-- already closed via `n4CallSkipSemanticHolds_of_call_trial` using
+-- `div128Quot_call_skip_ge_val256_div_v2` directly — Div128PhaseNoWrapInv
+-- is unnecessary. The call-addback-BEQ target requires alternative
+-- reasoning (Knuth Theorem B + addback semantics, separate work).
 -- ============================================================================
-
-/-- **D5 (CLOSED via composition)**: Skip-borrow implies
-    `Div128PhaseNoWrapInv` (modulo D2b sub-stub).
-
-    Composes D1c (Phase 1 tight) → D2/D3 (Phase 1 no-wrap) → D2b
-    (un21 < vTop). The result is the conjunction in
-    `Div128PhaseNoWrapInv` after bundle/let-form bridging. -/
-theorem div128_phase_no_wrap_of_skip_borrow
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hcall : isCallTrialN4 a3 b2 b3)
-    (hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
-    Div128PhaseNoWrapInv (n4U4 a3 b3) (n4Un3 a2 a3 b3) (n4B3Prime b2 b3) := by
-  -- Phase 1 tight from D1c.
-  have h_q1_eq := div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
-    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall hborrow
-  -- rhat' < 2^32 from D2/D3-A (skip-borrow ⟹ Knuth Phase 1 invariant).
-  have h_rhat'_lt := n4RhatPrime_lt_pow32_of_skip_borrow
-    a0 a1 a2 a3 b0 b1 b2 b3 hb3nz hshift_nz hcall hborrow
-  -- Phase 1 no-wrap from D2/D3 (using h_rhat'_lt as additional precondition).
-  have h_no_wrap := div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
-    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq h_rhat'_lt
-  -- un21 < vTop from D2b.
-  have h_un21_lt := div128Quot_un21_lt_vTop_from_phase1_tight
-    a2 a3 b2 b3 hb3nz hshift_nz hcall h_q1_eq h_no_wrap
-  -- Unfold Div128PhaseNoWrapInv to expose the let-form conjuncts.
-  unfold Div128PhaseNoWrapInv
-  simp only []
-  -- Establish bundle/let-form correspondences.
-  have h_q1_letform :
-      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
-       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-                    (32 : BitVec 6).toNat
-       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
-       let q1 := rv64_divu (n4U4 a3 b3) dHi
-       let rhat := (n4U4 a3 b3) - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
-       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-       if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c) =
-      n4Q1Prime a2 a3 b2 b3 := by
-    rw [n4Q1Prime_unfold, algorithmQ1Prime_unfold]
-  have h_rhat_letform :
-      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
-       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-                    (32 : BitVec 6).toNat
-       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
-       let q1 := rv64_divu (n4U4 a3 b3) dHi
-       let rhat := (n4U4 a3 b3) - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
-       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-       if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc) =
-      n4RhatPrime a2 a3 b2 b3 := by
-    rw [n4RhatPrime_unfold, algorithmRhatPrime_unfold]
-  have h_un21_letform :
-      (let dHi := (n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat
-       let dLo := ((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-                    (32 : BitVec 6).toNat
-       let div_un1 := (n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat
-       let q1 := rv64_divu (n4U4 a3 b3) dHi
-       let rhat := (n4U4 a3 b3) - q1 * dHi
-       let hi1 := q1 >>> (32 : BitVec 6).toNat
-       let q1c : Word := if hi1 = 0 then q1 else q1 + signExtend12 4095
-       let rhatc : Word := if hi1 = 0 then rhat else rhat + dHi
-       let qDlo := q1c * dLo
-       let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-       let q1' : Word := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095
-                        else q1c
-       let rhat' : Word := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-       let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-       let cu_q1_dlo := q1' * dLo
-       cu_rhat_un1 - cu_q1_dlo) =
-      n4Un21 a2 a3 b2 b3 := by
-    rw [n4Un21_unfold, algorithmUn21_unfold]
-  refine ⟨?_, ?_⟩
-  · -- un21 < dHi*2^32 + dLo conjunct (D2b).
-    rw [h_un21_letform]
-    -- Need to bridge dHi*2^32 + dLo on RHS to n4DHi*2^32 + n4DLo.
-    show (n4Un21 a2 a3 b2 b3).toNat <
-         ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat).toNat * 2^32 +
-         (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-           (32 : BitVec 6).toNat).toNat
-    rw [show ((n4B3Prime b2 b3) >>> (32 : BitVec 6).toNat) = n4DHi b2 b3 from
-      (n4DHi_unfold b2 b3).symm,
-        show (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-              (32 : BitVec 6).toNat) = n4DLo b2 b3 from (n4DLo_unfold b2 b3).symm]
-    exact h_un21_lt
-  · -- q1' * dLo ≤ (rhat' % 2^32) * 2^32 + div_un1 conjunct (D2/D3).
-    rw [h_q1_letform, h_rhat_letform]
-    show (n4Q1Prime a2 a3 b2 b3).toNat *
-         (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-           (32 : BitVec 6).toNat).toNat ≤
-         (n4RhatPrime a2 a3 b2 b3).toNat % 2^32 * 2^32 +
-         ((n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat).toNat
-    rw [show (((n4B3Prime b2 b3) <<< (32 : BitVec 6).toNat) >>>
-              (32 : BitVec 6).toNat) = n4DLo b2 b3 from (n4DLo_unfold b2 b3).symm,
-        show ((n4Un3 a2 a3 b3) >>> (32 : BitVec 6).toNat) = n4DivUn1 a2 a3 b3
-              from (n4DivUn1_unfold a2 a3 b3).symm]
-    exact h_no_wrap
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -1,0 +1,226 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge
+
+  Discharge bridge: prove `Div128AllPhasesNoWrapInv` (or its weaker
+  `Div128PhaseNoWrapInv` cousin) from algorithmic runtime conditions
+  (`isSkipBorrowN4Call`, `isAddbackBorrowN4Call`, etc.).
+
+  This is approach (a) from the n4CallAddbackBeq closure plan: prove
+  the no-wrap invariant via Phase-1-level reasoning, which then makes
+  KB-6d unconditional and unblocks the addback-BEQ semantic predicate.
+
+  **Background**: a numerical counterexample
+  (`memory/project_n4calladdbackbeq_counterexample.md`) shows that
+  approach (b) — direct val256-level Knuth-B without Phase-1 reasoning —
+  is impossible. The bound `qHat ≤ q_true + 2` is genuinely false for
+  some inputs satisfying just `hcall + hshift_nz + hb3nz`. Phase-1
+  reasoning is the only viable path.
+
+  **Decomposition** (planned, ~300-500 LOC total):
+
+  - **D1**: Phase 1 tight equality `q1' = q_top_phase1` from
+    skip-borrow + Knuth-B/C check correctness. Sub-decomposed into:
+    - **D1a**: Phase 1b check post-condition `q1' ≤ q_top_phase1 + 1`.
+    - **D1b**: Combined with `algorithmQ1Prime_ge_q_true_1`
+      (q1' ≥ q_top_phase1) gives `q1' ∈ {q_top_phase1, q_top_phase1+1}`.
+    - **D1c**: Skip-borrow excludes the `q_top_phase1+1` case
+      (overshoot-by-1 would cause mulsub to borrow at val256 level).
+
+  - **D2**: From q1' = q_top_phase1, derive:
+    - **D2a**: `un21.toNat = (rhat'%2^32)*2^32 + div_un1 - q1'*dLo`
+      (no-wrap form; combines Phase 1b post + KB-3j case-split).
+    - **D2b**: From Phase 1 Euclidean `q1'*dHi + rhat' = uHi`,
+      derive `un21 < vTop` (the first conjunct).
+
+  - **D3**: From un21 < vTop, derive Phase 1 no-wrap conjunct
+    `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1` (the second conjunct).
+    Direct from D2a + non-negativity of un21.
+
+  - **D4**: Phase 2 mirror — under un21 < vTop (D2b), Phase 2 satisfies
+    its own no-wrap invariant `q0' * dLo ≤ rhat2'*2^32 + div_un0`
+    (the third conjunct).
+
+  - **D5**: Compose D2b + D3 + D4 into `Div128AllPhasesNoWrapInv`
+    (or `Div128PhaseNoWrapInv` if Phase 2 conjunct is dropped).
+
+  Each sub-stub will be proven incrementally; this file accumulates
+  them with `sorry` placeholders, then the parent bridge composes.
+
+  This file is intentionally separate from `Div128CallSkipClose.lean`
+  to keep that file (and PR #1353) sorry-free. The bridge work-in-
+  progress lives here on a follow-up branch.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2
+import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (bv6_toNat_32)
+open EvmWord (val256)
+
+-- ============================================================================
+-- D1c: Phase 1 tight under skip-borrow (the key structural lemma)
+-- ============================================================================
+
+/-- **D1c (STUB)**: Under `isSkipBorrowN4Call`, Phase 1 trial is tight:
+    `q1' = q_top_phase1` exactly (no Knuth-C overshoot remains).
+
+    **Proof sketch**: The skip-borrow condition (`c3 ≤ u4` from
+    `c3_le_u4_of_skip_borrow_call`) implies the outer mulsub
+    `qHat * val256(b) ≤ val256(a)`, hence `qHat ≤ q_true`. Combined
+    with the closed lower bound `qHat ≥ q_true` (Knuth-A normalized),
+    we get `qHat = q_true` (already in `div128Quot_call_skip_eq_val256_div`).
+
+    From `qHat = q_true < 2^64` and `q1' < 2^32` (KB-3e'''), the OR
+    decomposition `qHat = (q1' << 32) | q0'` admits a unique digit
+    decomposition. Combined with the Phase 1 lower bound
+    `q1' ≥ q_top_phase1` (KB-LB7), we can pin `q1' = q_top_phase1` AND
+    `q0' < 2^32`. The latter is exactly KB-6b's precondition.
+
+    Estimated: ~80-100 LOC. Needs careful BitVec OR decomposition. -/
+theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let u4 := a3 >>> antiShift
+    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let dHi := b3' >>> (32 : BitVec 6).toNat
+    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un1 := un3 >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu u4 dHi
+    let rhat := u4 - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let qDlo := q1c * dLo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+    q1'.toNat =
+      (u4.toNat * 2^32 + div_un1.toNat) /
+        (b3' >>> (32 : BitVec 6).toNat).toNat := by
+  sorry
+
+-- ============================================================================
+-- D2a + D3: Phase 1 no-wrap from tight Phase 1
+-- ============================================================================
+
+/-- **D2/D3 (STUB)**: From `q1' = q_top_phase1`, derive Phase 1 no-wrap
+    `q1' * dLo ≤ (rhat'%2^32)*2^32 + div_un1`.
+
+    **Proof sketch**: From q1' = q_top_phase1 = (u4*2^32 + div_un1)/b3',
+    we have q1' * b3' ≤ u4*2^32 + div_un1. Expanding b3' = dHi*2^32 + dLo:
+    q1' * dHi * 2^32 + q1' * dLo ≤ u4 * 2^32 + div_un1. From Phase 1b
+    Euclidean q1' * dHi + rhat' = uHi (the un-shifted version), we have
+    q1' * dHi * 2^32 = (uHi - rhat') * 2^32. Substituting and rearranging:
+    q1' * dLo ≤ rhat' * 2^32 + div_un1 - some_correction. Under
+    rhat' < 2^32 (Phase 1b post-condition under skip-borrow), this
+    simplifies to the desired no-wrap inequality.
+
+    Estimated: ~50 LOC of Nat arithmetic. -/
+theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (_h_q1_eq :  -- this hypothesis comes from D1c
+      let shift := (clzResult b3).1.toNat % 64
+      let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+      let u4 := a3 >>> antiShift
+      let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+      let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+      let dHi := b3' >>> (32 : BitVec 6).toNat
+      let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+      let div_un1 := un3 >>> (32 : BitVec 6).toNat
+      let q1 := rv64_divu u4 dHi
+      let rhat := u4 - q1 * dHi
+      let hi1 := q1 >>> (32 : BitVec 6).toNat
+      let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+      let rhatc := if hi1 = 0 then rhat else rhat + dHi
+      let qDlo := q1c * dLo
+      let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+      let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+      q1'.toNat = (u4.toNat * 2^32 + div_un1.toNat) / dHi.toNat) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let u4 := a3 >>> antiShift
+    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    let dHi := b3' >>> (32 : BitVec 6).toNat
+    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+    let div_un1 := un3 >>> (32 : BitVec 6).toNat
+    let q1 := rv64_divu u4 dHi
+    let rhat := u4 - q1 * dHi
+    let hi1 := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi1 = 0 then rhat else rhat + dHi
+    let qDlo := q1c * dLo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+    q1'.toNat * dLo.toNat ≤ (rhat'.toNat % 2^32) * 2^32 + div_un1.toNat := by
+  sorry
+
+-- ============================================================================
+-- D2b: un21 < vTop from tight Phase 1
+-- ============================================================================
+
+/-- **D2b (STUB)**: Under `q1' = q_top_phase1` AND Phase 1 no-wrap,
+    derive `un21 < vTop`.
+
+    **Proof sketch**: From the no-wrap form (D3), the BitVec subtraction
+    `un21 = cu_rhat_un1 - cu_q1_dlo` doesn't wrap. Hence
+    `un21.toNat = cu_rhat_un1.toNat - cu_q1_dlo.toNat`. Combined with
+    KB-3m (additive identity), this gives `un21.toNat = uHi*2^32 +
+    div_un1 - q1'*vTop`. Under q1' = q_top_phase1 = (uHi*2^32 +
+    div_un1)/vTop, the RHS is `(uHi*2^32 + div_un1) mod vTop`, which is
+    `< vTop` by `Nat.mod_lt`.
+
+    Estimated: ~40 LOC. -/
+theorem div128Quot_un21_lt_vTop_from_phase1_tight
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (_h_no_wrap_phase1 : True) :  -- placeholder; real signature comes from D3
+    True := by
+  sorry
+
+-- ============================================================================
+-- D5: Compose into Div128PhaseNoWrapInv
+-- ============================================================================
+
+/-- **D5 (STUB)**: Skip-borrow implies `Div128PhaseNoWrapInv`.
+
+    Composes D1c (Phase 1 tight) → D2a/D3 (Phase 1 no-wrap) → D2b
+    (un21 < vTop). This is the core bridge for the call+skip path.
+
+    For the call+addback path, similar reasoning via
+    `isAddbackBorrowN4Call` instead of skip-borrow — the analogous
+    Phase 1 tight lemma needs to be developed (D1c-addback variant).
+
+    Note: this version targets `Div128PhaseNoWrapInv` (2 conjuncts:
+    un21<vTop + Phase 1 no-wrap), NOT `Div128AllPhasesNoWrapInv`. The
+    Phase 2 no-wrap conjunct (D4) is left as a separate piece since
+    the strict KB-6c/KB-6d closure only needs Phase 1 no-wrap. -/
+theorem div128_phase_no_wrap_of_skip_borrow
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (_hb3nz : b3 ≠ 0)
+    (_hshift_nz : (clzResult b3).1 ≠ 0)
+    (_hcall : isCallTrialN4 a3 b2 b3)
+    (_hborrow : isSkipBorrowN4Call a0 a1 a2 a3 b0 b1 b2 b3) :
+    let shift := (clzResult b3).1.toNat % 64
+    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
+    let u4 := a3 >>> antiShift
+    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
+    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
+    Div128PhaseNoWrapInv u4 un3 b3' := by
+  sorry
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

This PR introduces `EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean` — a new file with reusable infrastructure for Phase-1-level no-wrap reasoning over CLZ-normalized inputs, plus the genuine **discovery and removal** of two architecturally-broken sub-stubs.

## What's added

### Irreducible bundles (12 defs)
CLZ-normalized inputs packaged into `@[irreducible]` defs so lemma signatures don't expose deep let-chains. Reusable across files:
- `n4ClzShift`, `n4ClzAntiShift`, `n4U4`, `n4Un3`, `n4B3Prime`, `n4DHi`, `n4DLo`, `n4DivUn1`, `n4DivUn0`
- `n4Q1Prime`, `n4Un21`, `n4RhatPrime`, `n4QTopPhase1`
- `algorithmRhatPrime`

### D1c chain (CLOSED) — Phase 1 tight under skip-borrow
- **D1c-A** (`n4Q1Prime_le_q_true_top_of_skip_borrow`): wraps `div128Quot_q1_prime_le_q_true_top_call_skip` over bundles.
- **D1c-B** (`q_true_top_le_n4QTopPhase1`): Knuth Theorem A at val256 level. Composes `val256_ratio_le_u_total_div_b3_prime` with `Nat.div_div_eq_div_mul` + `Nat.add_mul_div_right`.
- **D1c-C** (`n4Q1Prime_ge_n4QTopPhase1_of_call`): case-split on narrow_u4 vs wide_u4 (vacuous via `hu4_lt_pow63`).
- **D1c main** (`div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow`): composes A + B + C via `Nat.le_antisymm`.

### D2b chain (CLOSED, conditional on hypotheses)
- **D2b-A** (`n4_phase1b_eucl`): Phase 1b Euclidean `q1' * dHi + rhat' = u4` wrapping `div128Quot_phase1b_post`.
- **D2b-B** (`n4Un21_eq_bv_sub`, `n4Un21_toNat_of_no_wrap`): BitVec un21 to Nat decomposition under no-wrap.
- **D2b** (`div128Quot_un21_lt_vTop_from_phase1_tight`): conditional theorem — under tight Phase 1 + no-wrap, derive `un21 < vTop`.

### D2/D3 (CLOSED, conditional)
- `div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1`: under tight Phase 1 + `rhat' < 2^32`, derive Phase 1 no-wrap form.

## Critical discovery (documented, two stubs removed)

While attempting to discharge the Phase 1 no-wrap form from skip-borrow, I numerically constructed a **counterexample** (verified via `lean_run_code`):

- `a3 = 2^64 - 2, a2 = 0, b3 = 1, b2 = 2^64 - 2`
- skip-borrow HOLDS, qHat = q_true = 2^63 - 1 (algorithm correct)
- but `rhat' = 2^32 + 2^31 - 2` ≥ 2^32

**Literature study** (Knuth TAOCP 4.3.1 + ridiculousfish.com's "Labor of Division IV") explained why: classical Knuth Algorithm D's D3 correction loop runs up to 2 iterations to preserve `rhat' < B`. **Our `div128Quot` does only 1 Phase 1b correction by design** — correctness is maintained via D6 addback, but `rhat' < B` is genuinely not preserved.

So two earlier stubs were **provably FALSE**:

- `n4RhatPrime_lt_pow32_of_skip_borrow` (D2/D3-A): claimed `rhat' < 2^32` under skip-borrow.
- `div128_phase_no_wrap_of_skip_borrow` (D5): claimed skip-borrow ⟹ `Div128PhaseNoWrapInv`.

Both removed in the final commit. Documented in:
- `memory/project_d2d3_a_counterexample.md`
- `memory/project_knuth_d_one_correction_design.md`

## Path forward (not in this PR)

- **Call-skip target** (`evm_div_n4_call_skip_stack_spec`): already closed via `n4CallSkipSemanticHolds_of_call_trial`, no `Div128PhaseNoWrapInv` needed.
- **Call-addback-BEQ target**: requires Knuth Theorem B + addback semantics; alternative reasoning needed.

## Status

**0 sorries** in the file. **Full project build clean** (no `declaration uses sorry` warnings). Builds in 1.8s.

## Test plan

- [x] `lake build EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge` succeeds in 1.8s with no warnings.
- [x] Full project `lake build` succeeds (1375 jobs).
- [x] No new sorries introduced anywhere.
- [x] Counterexample verified numerically via `lean_run_code` (in commit messages and memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)