### PR TITLE
feat(rlp): add singleton-list-of-empty-list decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -149,6 +149,14 @@ theorem decode_singleton_list_empty_string :
     decode [(0xC1 : Byte), (0x80 : Byte)] = some (.list [.bytes []], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems]
 
+/-- Singleton list containing the empty list:
+    `decode [0xC1, 0xC0] = some (.list [.list []], [])`. The
+    short-list branch fires with payload length 1, the inner `0xC0`
+    is recognized as the empty list, and the outer list closes. -/
+theorem decode_singleton_list_empty_list :
+    decode [(0xC1 : Byte), (0xC0 : Byte)] = some (.list [.list []], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_singleton_list_empty_list`:
```
decode [0xC1, 0xC0] = some (.list [.list []], [])
```

Companion to `decode_singleton_list_small_byte` (#1383) and `decode_singleton_list_empty_string` (#1385); the three together cover the singleton-list cases for the simplest inner items (small byte, empty string, empty list).

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)