### PR TITLE
discovery(divmod): #1337 formalize n4CallAddbackBeq counterexample + algorithm bug analysis

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -162,10 +162,36 @@ def div128Un0 (uLo : Word) : Word :=
 
 -- ============================================================================
 -- Double-addback iter variants (model the FIXED algorithm with double addback)
+--
+-- 🚨 Correctness note (2026-04-27): This iter assumes that `qHat` overshoots
+-- the true quotient by AT MOST 2 (Knuth Theorem B). That assumption holds
+-- when the trial digit is computed by Knuth's classical Phase 1b
+-- (2-iteration D3 correction loop). Our `div128Quot` (in the same file)
+-- does only 1 Phase 1b correction, which under hshift_nz allows val256-level
+-- qHat overshoot up to ~2^33 (combining per-digit Knuth-B applied to q1' and
+-- q0' independently). On such inputs `iterWithDoubleAddback` exits with the
+-- wrong q_out (off by ~2^32 from q_true), making
+-- `n4CallAddbackBeqSemanticHolds` provably FALSE.
+--
+-- See `memory/project_n4callbeq_addback_overshoot_2pow32.md` for the
+-- counterexample (a3 = 2^63+2^33, b3 = 1, b2 = 2^33-1) and
+-- `memory/project_knuth_d_one_correction_design.md` for the literature
+-- analysis.
+--
+-- Remediation: either modify `div128Quot` to do 2 Phase 1b corrections
+-- (matches Knuth classical, simplest fix) or harden the loop's exit
+-- condition. The actual RISC-V program at `Program.lean:386` has a
+-- BEQ-based addback loop matching this Lean abstraction's at-most-2
+-- iterations — so the bug is in the algorithm itself, not in the
+-- abstraction.
 -- ============================================================================
 
 /-- Helper: single iteration with double addback, parameterized by qHat.
-    Used by all iter* variants. -/
+    Used by all iter* variants.
+
+    **Correctness assumption**: qHat overshoots q_true by ≤ 2. Holds for
+    Knuth-classical 2-correction Phase 1b; FAILS for our 1-correction
+    `div128Quot` on certain inputs. -/
 def iterWithDoubleAddback (qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     Word × Word × Word × Word × Word × Word :=
   let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -112,6 +112,41 @@ def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
     val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
       val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
+/-- **Formal counterexample to `n4CallAddbackBeqSemanticHolds`** (2026-04-27).
+
+    Concrete (a, b) satisfying all runtime preconditions of
+    `evm_div_n4_full_call_addback_beq_stack_pre_spec` but for which the
+    predicate is FALSE — algorithm overshoots true quotient by 2^32-2.
+
+    Witness:
+    - `a = (2^63 + 2^33) * 2^192` (a3 = 2^63 + 2^33, lower limbs zero)
+    - `b = 2^192 + (2^33 - 1) * 2^128` (b3 = 1, b2 = 2^33 - 1, lower zero)
+    - q_true = `val256(a) / val256(b) = 2^63 + 2^32 - 2`
+    - qHat = `div128Quot(...) = 2^63 + 2^33 - 3`
+    - Algorithm's q_out = qHat - 1 = 2^63 + 2^33 - 4 ≠ q_true.
+
+    See `memory/project_n4callbeq_addback_overshoot_2pow32.md` for the
+    full analysis. The proof is by `decide` after unfolding the
+    predicate — Lean evaluates the Prop directly on the concrete
+    Word inputs.
+
+    **Implication**: this theorem proves that
+    `n4CallAddbackBeqSemanticHolds_of_*` (any closure from runtime
+    conditions) cannot exist — the predicate is genuinely false on
+    runtime-reachable inputs. The user-facing
+    `evm_div_n4_full_call_addback_beq_stack_pre_spec` and its
+    relatives have a vacuous semantic correctness bridge for this
+    input class, until the algorithm is fixed (see
+    `memory/project_knuth_d_one_correction_design.md`). -/
+theorem n4CallAddbackBeqSemanticHolds_counterexample :
+    ¬ (n4CallAddbackBeqSemanticHolds
+        (EvmWord.fromLimbs (fun i => match i with
+          | 0 => 0 | 1 => 0 | 2 => 0 | 3 => BitVec.ofNat 64 (2^63 + 2^33)))
+        (EvmWord.fromLimbs (fun i => match i with
+          | 0 => 0 | 1 => 0 | 2 => BitVec.ofNat 64 (2^33 - 1) | 3 => 1))) := by
+  unfold n4CallAddbackBeqSemanticHolds
+  decide
+
 theorem n4CallAddbackBeqSemanticHolds_def {a b : EvmWord} :
     n4CallAddbackBeqSemanticHolds a b =
     (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -43,10 +43,23 @@ open EvmAsm.Rv64.Tactics
     Unlike `n4CallSkipSemanticHolds` which states a lower-bound on the raw
     `div128Quot`, this predicate directly states that the post-addback
     corrected quotient is the true quotient. Proving it from first
-    principles requires the Knuth TAOCP Theorem A overestimate bound
+    principles requires the Knuth TAOCP Theorem B overestimate bound
     (`q̂ ≤ q_true + 2`) plus the algorithm's addback-correction semantics,
     which combine to ensure q_out is exactly correct. Deferred to a future
     task; the stack spec delegates the proof to callers.
+
+    **Status (2026-04-27, post PR #1384)**: the original closure approach
+    via `Div128PhaseNoWrapInv` is broken — the predicate's conjunct 2
+    (Phase 1 no-wrap) is provably FALSE under skip-borrow because our
+    `div128Quot` does only 1 Phase 1b correction (vs Knuth classical 2),
+    so `rhat' < B` is not preserved by design. See
+    `memory/project_d2d3_a_counterexample.md` and
+    `memory/project_knuth_d_one_correction_design.md`. The revised
+    closure plan is in `memory/project_addback_beq_closure_plan_v2.md`:
+    direct val256-level Knuth-B + carry-driven case-split. KB-6d
+    (Knuth-B at Word level) has its own Word-level counterexample
+    (`memory/project_kb6d_false_counterexample.md`); needs
+    re-investigation at val256 level under hshift_nz constraints.
 
     Mirror of `n4CallSkipSemanticHolds` for the call+addback branch. -/
 def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -48,18 +48,30 @@ open EvmAsm.Rv64.Tactics
     which combine to ensure q_out is exactly correct. Deferred to a future
     task; the stack spec delegates the proof to callers.
 
-    **Status (2026-04-27, post PR #1384)**: the original closure approach
-    via `Div128PhaseNoWrapInv` is broken — the predicate's conjunct 2
-    (Phase 1 no-wrap) is provably FALSE under skip-borrow because our
-    `div128Quot` does only 1 Phase 1b correction (vs Knuth classical 2),
-    so `rhat' < B` is not preserved by design. See
-    `memory/project_d2d3_a_counterexample.md` and
-    `memory/project_knuth_d_one_correction_design.md`. The revised
-    closure plan is in `memory/project_addback_beq_closure_plan_v2.md`:
-    direct val256-level Knuth-B + carry-driven case-split. KB-6d
-    (Knuth-B at Word level) has its own Word-level counterexample
-    (`memory/project_kb6d_false_counterexample.md`); needs
-    re-investigation at val256 level under hshift_nz constraints.
+    **🚨 STATUS (2026-04-27): counterexample to predicate found**.
+
+    Verified via `lean_run_code`: with
+    `a3 = 2^63 + 2^33, a2 = a1 = a0 = 0, b3 = 1, b2 = 2^33 - 1,
+    b1 = b0 = 0`, the input satisfies ALL runtime preconditions for
+    the call-addback-BEQ branch (hbnz, hb3nz, hshift_nz, hbltu,
+    hborrow, hcarry2_nz), but the algorithm computes
+    `q_out = qHat - 1 = 2^63 + 2^33 - 4 = 9223372045444710396` while
+    `q_true = val256(a) / val256(b) = 2^63 + 2^32 - 2 = 9223372041149743102`.
+    The discrepancy is `2^32 - 2` ≈ 4.3 × 10⁹.
+
+    **Root cause (per `memory/project_knuth_d_one_correction_design.md`
+    + `memory/project_n4callbeq_addback_overshoot_2pow32.md`)**: our
+    `div128Quot` does only 1 Phase 1b correction (vs Knuth classical
+    2-correction loop). Per-digit Knuth Theorem B gives overshoot ≤ 2,
+    which combined at val256 level gives qHat overshoot up to ~2^33.
+    The BEQ branch's at-most-2 outer addbacks can only correct
+    overshoots of 0/1/2 — not 2^32-scale.
+
+    **Implication**: either (a) the Lean abstraction
+    `fullDivN4CallAddbackBeqPost` doesn't match the actual RISC-V
+    program (the program may have additional correction logic), or (b)
+    the actual algorithm is genuinely buggy on this input class. Cross-
+    reference urgently needed before any closure attempt.
 
     Mirror of `n4CallSkipSemanticHolds` for the call+addback branch. -/
 def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -180,7 +180,15 @@ theorem n4CallAddbackBeqSemanticHolds_def {a b : EvmWord} :
     Simpler than the call-skip bridge: hsem directly gives the tight equality
     `q_out.toNat = val256(a)/val256(b)`, so we don't need to combine with T3.
     From that, `(EvmWord.div a b).toNat = q_out.toNat` via `BitVec.toNat_udiv`,
-    and `q_out : Word` bounds pin the limbs. -/
+    and `q_out : Word` bounds pin the limbs.
+
+    **VACUITY note (2026-04-27)**: per
+    `n4CallAddbackBeqSemanticHolds_counterexample` (below), the `hsem`
+    hypothesis is FALSE on a class of runtime-reachable inputs — the
+    algorithm overshoots q_true by ~2^32 in those cases. So this bridge
+    cannot be applied to derive correctness on the full input space;
+    callers must restrict to inputs where `hsem` is independently
+    discharged (currently impossible without algorithm fix). -/
 theorem n4_call_addback_beq_div_mod_getLimbN (a b : EvmWord)
     (hbnz : b ≠ 0)
     (hsem : n4CallAddbackBeqSemanticHolds a b) :

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -48,7 +48,7 @@ open EvmAsm.Rv64.Tactics
     which combine to ensure q_out is exactly correct. Deferred to a future
     task; the stack spec delegates the proof to callers.
 
-    **🚨 STATUS (2026-04-27): counterexample to predicate found**.
+    **🚨 STATUS (2026-04-27, updated): real correctness bug in algorithm**.
 
     Verified via `lean_run_code`: with
     `a3 = 2^63 + 2^33, a2 = a1 = a0 = 0, b3 = 1, b2 = 2^33 - 1,
@@ -59,19 +59,35 @@ open EvmAsm.Rv64.Tactics
     `q_true = val256(a) / val256(b) = 2^63 + 2^32 - 2 = 9223372041149743102`.
     The discrepancy is `2^32 - 2` ≈ 4.3 × 10⁹.
 
-    **Root cause (per `memory/project_knuth_d_one_correction_design.md`
-    + `memory/project_n4callbeq_addback_overshoot_2pow32.md`)**: our
-    `div128Quot` does only 1 Phase 1b correction (vs Knuth classical
-    2-correction loop). Per-digit Knuth Theorem B gives overshoot ≤ 2,
-    which combined at val256 level gives qHat overshoot up to ~2^33.
-    The BEQ branch's at-most-2 outer addbacks can only correct
-    overshoots of 0/1/2 — not 2^32-scale.
+    **Root cause**: our `div128Quot` does only 1 Phase 1b correction
+    (vs Knuth classical 2-correction loop), so qHat can overshoot at
+    val256 level by up to ~2^33. The actual RISC-V program at
+    `Program.lean:386` has an addback LOOP (`BEQ x7 x0` jumps back if
+    x7 = 0), but the loop-exit heuristic "limb-3 carry of addback ≠ 0"
+    fires after 1 addback in this case — leaving q_out = qHat - 1,
+    still ~2^32 too large.
 
-    **Implication**: either (a) the Lean abstraction
-    `fullDivN4CallAddbackBeqPost` doesn't match the actual RISC-V
-    program (the program may have additional correction logic), or (b)
-    the actual algorithm is genuinely buggy on this input class. Cross-
-    reference urgently needed before any closure attempt.
+    **Implication**: the algorithm is genuinely buggy on this input
+    class. The `n4CallAddbackBeqSemanticHolds` predicate is provably
+    FALSE on runtime-reachable inputs. Closure
+    (`n4CallAddbackBeqSemanticHolds_of_*`) cannot be proven; the
+    user-facing `evm_div_n4_full_call_addback_beq_stack_pre_spec` and
+    its relatives are vacuous on this input class.
+
+    See `memory/project_n4callbeq_addback_overshoot_2pow32.md` and
+    `memory/project_knuth_d_one_correction_design.md` for the full
+    analysis.
+
+    **Remediation options**:
+    1. Modify `div128Quot` to do 2 Phase 1b corrections (matching Knuth
+       classical D3 loop). Restores Knuth Theorem B's per-digit ≤ 2
+       overshoot bound. Requires changing both Lean abstraction and
+       RISC-V code.
+    2. Modify the addback loop's exit condition to detect 2^32-scale
+       overshoots (e.g., bound iteration count by some explicit limit
+       and re-check). Non-trivial.
+    3. Document the input class as out-of-scope and gate it externally.
+       Pragmatically blocks complete EVM-level verification.
 
     Mirror of `n4CallSkipSemanticHolds` for the call+addback branch. -/
 def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=

--- a/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128NoWrapDischarge.lean
@@ -459,8 +459,6 @@ theorem div128Quot_q1_prime_eq_q_top_phase1_of_skip_borrow
 theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     (a2 a3 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3)
     (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
     (h_rhat'_lt : (n4RhatPrime a2 a3 b2 b3).toNat < 2^32) :
     (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
@@ -582,9 +580,7 @@ theorem div128Quot_phase1_no_wrap_of_q1_prime_eq_q_top_phase1
     over our irreducible bundles. -/
 theorem n4_phase1b_eucl
     (a2 a3 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (_hcall : isCallTrialN4 a3 b2 b3) :
+    (hb3nz : b3 ≠ 0) :
     (n4Q1Prime a2 a3 b2 b3).toNat * (n4DHi b2 b3).toNat +
       (n4RhatPrime a2 a3 b2 b3).toNat = (n4U4 a3 b3).toNat := by
   -- dHi bounds.
@@ -671,7 +667,6 @@ theorem n4Un21_eq_bv_sub
 theorem n4Un21_toNat_of_no_wrap
     (a2 a3 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
     (hcall : isCallTrialN4 a3 b2 b3)
     (h_no_wrap_phase1 :
       (n4Q1Prime a2 a3 b2 b3).toNat * (n4DLo b2 b3).toNat ≤
@@ -767,7 +762,6 @@ theorem n4Un21_toNat_of_no_wrap
 theorem div128Quot_un21_lt_vTop_from_phase1_tight
     (a2 a3 b2 b3 : Word)
     (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
     (hcall : isCallTrialN4 a3 b2 b3)
     (h_q1_eq : (n4Q1Prime a2 a3 b2 b3).toNat = n4QTopPhase1 a2 a3 b2 b3)
     (h_no_wrap_phase1 :
@@ -784,10 +778,10 @@ theorem div128Quot_un21_lt_vTop_from_phase1_tight
       (n4DHi b2 b3).toNat * 2^32 + (n4DLo b2 b3).toNat := by
     rw [n4DHi_unfold, n4DLo_unfold]; exact div128Quot_vTop_decomp _
   -- D2b-A: Phase 1b Euclidean.
-  have h_eucl := n4_phase1b_eucl a2 a3 b2 b3 hb3nz hshift_nz hcall
+  have h_eucl := n4_phase1b_eucl a2 a3 b2 b3 hb3nz
   -- D2b-B: un21.toNat formula.
   have h_un21_eq := n4Un21_toNat_of_no_wrap a2 a3 b2 b3
-    hb3nz hshift_nz hcall h_no_wrap_phase1
+    hb3nz hcall h_no_wrap_phase1
   -- q_top_phase1 strict upper: u4*2^32+div_un1 < (q1'+1)*vTop.
   have h_b3'_pos : 0 < (n4B3Prime b2 b3).toNat := by
     have : (n4B3Prime b2 b3).toNat ≥ 2^63 := h_b3'_ge; omega


### PR DESCRIPTION
## Summary

This PR formalizes the **algorithm correctness bug** in the call-addback-BEQ branch of EVM-level DIV/MOD (n=4, shift ≠ 0), discovered while exploring closure of `n4CallAddbackBeqSemanticHolds`. The bug is a real defect — provably reachable from runtime conditions — and is now a kernel-checked theorem.

## Key contribution: machine-checkable counterexample

```lean
theorem n4CallAddbackBeqSemanticHolds_counterexample :
    ¬ (n4CallAddbackBeqSemanticHolds
        (EvmWord.fromLimbs (fun i => match i with
          | 0 => 0 | 1 => 0 | 2 => 0 | 3 => BitVec.ofNat 64 (2^63 + 2^33)))
        (EvmWord.fromLimbs (fun i => match i with
          | 0 => 0 | 1 => 0 | 2 => BitVec.ofNat 64 (2^33 - 1) | 3 => 1))) := by
  unfold n4CallAddbackBeqSemanticHolds
  decide
```

**Verified via lean_verify**: uses only `propext` + `Quot.sound`. **No `sorry`, no `native_decide`**. Pure kernel-checkable proof.

## Bug analysis

- **Input**: `a3 = 2^63 + 2^33`, `b3 = 1`, `b2 = 2^33 - 1`. Satisfies all runtime preconditions (`hbnz`, `hb3nz`, `hshift_nz`, `hbltu`, `hborrow`, `hcarry2_nz`).
- **Algorithm output**: `q_out = qHat - 1 = 9223372045444710396`.
- **True quotient**: `q_true = val256(a) / val256(b) = 9223372041149743102`.
- **Discrepancy**: `2^32 - 2 ≈ 4.3 × 10⁹`.

## Root cause

Per Knuth TAOCP 4.3.1 + literature study (linked in memory), classical Knuth Algorithm D's D3 step runs up to **2** correction iterations. Our `div128Quot` (in `LoopDefs/Iter.lean`) does only **1** Phase 1b correction, allowing val256-level qHat overshoot up to ~2^33. The actual RISC-V program at `Program.lean:386` has a BEQ-based addback loop, but its exit heuristic (limb-3 carry of addback ≠ 0) assumes per-digit overshoot ≤ 2 — which fails for our 1-correction design on certain inputs.

## What's added

### Source-level annotations
- **`SpecCallAddbackBeq.lean:115`**: the counterexample theorem.
- **`SpecCallAddbackBeq.lean:175`**: vacuity note on the bridge `n4_call_addback_beq_div_mod_getLimbN`.
- **`SpecCallAddbackBeq.lean:39-78`**: predicate docstring with full status.
- **`Iter.lean:163`**: comment on `iterWithDoubleAddback` documenting the correctness assumption.

### Memory documentation (4 files)
- `project_d2d3_a_counterexample.md` — initial counterexample analysis.
- `project_n4callbeq_addback_overshoot_2pow32.md` — val256-level + loop semantics analysis.
- `project_knuth_d_one_correction_design.md` — literature study (Knuth TAOCP, ridiculousfish blog).
- `project_addback_beq_closure_plan_v2.md` — revised closure plan post-discovery.

### Cleanup
- Removed unused parameters per `feedback_unused_vars`.

## Implication

The **EVM-level DIV/MOD stack spec** (issue #61) is **correct on most inputs but vacuous on the bug class**. The user-facing `evm_div_n4_full_call_addback_beq_stack_pre_spec` and its MOD/bundled relatives take `n4CallAddbackBeqSemanticHolds` as a hypothesis; the counterexample shows this hypothesis cannot be discharged for all runtime-reachable inputs.

## Remediation paths (documented in source)

1. **Modify `div128Quot`** to do 2 Phase 1b corrections (matches Knuth classical). Cleanest fix; restores Knuth-B per-digit ≤ 2 invariant.
2. **Modify the addback loop** to detect 2^32-scale overshoots. Non-trivial.
3. **Document and gate** the bug class externally. Pragmatic but blocks complete verification.

User decision required before further closure work.

## Test plan

- [x] `lean_verify` confirms counterexample uses only standard axioms (`propext`, `Quot.sound`).
- [x] Full project `lake build` succeeds with no sorries.
- [x] Counterexample reproducible via `lean_run_code` (documented in memory files).
- [x] No code changes that affect other paths (call-skip path, max-skip, max-addback all unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)