### PR TITLE
fix(divmod): #1337 algorithm correctness — add div128Quot_v2 + divK_div128_v2 (Knuth classical D3)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -152,23 +152,25 @@ def div128Quot (uHi uLo vTop : Word) : Word :=
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   (q1' <<< (32 : BitVec 6).toNat) ||| q0'
 
-/-- **FIXED** trial quotient: `div128Quot` with the bug fix
-    (2 D3 correction iterations matching Knuth TAOCP 4.3.1 D3 loop).
+/-- **FIXED** trial quotient: `div128Quot` with Knuth's classical 2-iteration
+    D3 correction loop (TAOCP 4.3.1).
 
-    Differs from `div128Quot` (the current/buggy abstraction) by adding
-    a 2nd D3 correction iteration. The 2nd fires only when `rhat' < 2^32`
-    (Knuth's loop exit condition) AND the product test still holds.
+    Differs from `div128Quot` only in Phase 1b: the 2nd D3 correction is
+    delegated to the existing `div128Quot_phase2b_q0'` helper, which already
+    encodes Knuth's classical D3 single iteration (with the `rhat' < B`
+    guard). Calling it for Phase 1b reuses the well-tested classical
+    construction.
 
-    With both iterations, q1' overshoots q_true_1 by ≤ 0 (Knuth-classical
-    invariant); combined with at-most-2 outer addbacks, qHat overshoot ≤ 2
-    and the addback path correctly recovers q_true.
+    With 2 D3 iterations, q1' satisfies Knuth's per-digit overshoot ≤ 0
+    invariant; combined with the at-most-2 outer addbacks, qHat overshoot
+    stays ≤ 2 and the BEQ branch recovers q_true correctly.
 
     **Migration plan**: this is the target abstraction post-fix. The
     actual RISC-V program at `Program.lean:divK_div128` needs the
     corresponding 2nd D3 correction inserted (~6 instructions after
-    the existing one at lines 80-87 of Program.lean). Once the program
-    is updated, all references to `div128Quot` should migrate to
-    `div128Quot_v2`, and the buggy `div128Quot` removed. See
+    the existing one at lines 80-87). Once the program is updated, all
+    references to `div128Quot` should migrate to `div128Quot_v2`, and
+    the buggy `div128Quot` removed. See
     `memory/project_n4callbeq_addback_overshoot_2pow32.md` for the
     counterexample that motivates this fix. -/
 def div128Quot_v2 (uHi uLo vTop : Word) : Word :=
@@ -181,20 +183,22 @@ def div128Quot_v2 (uHi uLo vTop : Word) : Word :=
   let hi1 := q1 >>> (32 : BitVec 6).toNat
   let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
   let rhatc := if hi1 = 0 then rhat else rhat + dHi
-  -- Phase 1b: 1st D3 correction
+  -- Phase 1b: 1st D3 correction (unchanged).
   let qDlo := q1c * dLo
   let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
   let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
   let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-  -- Phase 1b: 2nd D3 correction (Knuth classical full loop) — THE FIX
-  -- Fire only if rhat' < 2^32 (Knuth's loop exit condition) AND test still holds.
-  let rhat'_lt_pow32 : Bool := (rhat' >>> (32 : BitVec 6).toNat) = (0 : Word)
-  let qDlo2 := q1' * dLo
-  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-  let fire2 : Bool := rhat'_lt_pow32 && BitVec.ult rhatUn1' qDlo2
-  let q1'' := if fire2 then q1' + signExtend12 4095 else q1'
-  let rhat'' := if fire2 then rhat' + dHi else rhat'
-  -- Phase 2 setup with q1''/rhat''
+  -- Phase 1b: 2nd D3 correction — reuse Knuth's classical step from
+  -- `div128Quot_phase2b_q0'` (which has the `rhat' < B` guard built-in).
+  let q1'' := div128Quot_phase2b_q0' q1' rhat' dLo div_un1
+  -- rhat'' tracking: only changes if the 2nd D3 correction fires.
+  let rhat'' :=
+    if rhat' >>> (32 : BitVec 6).toNat = 0 then
+      let qDlo2 := q1' * dLo
+      let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+      if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+    else rhat'
+  -- Phase 2 setup with q1''/rhat''.
   let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| div_un1
   let cu_q1_dlo := q1'' * dLo
   let un21 := cu_rhat_un1 - cu_q1_dlo

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -152,6 +152,60 @@ def div128Quot (uHi uLo vTop : Word) : Word :=
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
   (q1' <<< (32 : BitVec 6).toNat) ||| q0'
 
+/-- **FIXED** trial quotient: `div128Quot` with the bug fix
+    (2 D3 correction iterations matching Knuth TAOCP 4.3.1 D3 loop).
+
+    Differs from `div128Quot` (the current/buggy abstraction) by adding
+    a 2nd D3 correction iteration. The 2nd fires only when `rhat' < 2^32`
+    (Knuth's loop exit condition) AND the product test still holds.
+
+    With both iterations, q1' overshoots q_true_1 by ≤ 0 (Knuth-classical
+    invariant); combined with at-most-2 outer addbacks, qHat overshoot ≤ 2
+    and the addback path correctly recovers q_true.
+
+    **Migration plan**: this is the target abstraction post-fix. The
+    actual RISC-V program at `Program.lean:divK_div128` needs the
+    corresponding 2nd D3 correction inserted (~6 instructions after
+    the existing one at lines 80-87 of Program.lean). Once the program
+    is updated, all references to `div128Quot` should migrate to
+    `div128Quot_v2`, and the buggy `div128Quot` removed. See
+    `memory/project_n4callbeq_addback_overshoot_2pow32.md` for the
+    counterexample that motivates this fix. -/
+def div128Quot_v2 (uHi uLo vTop : Word) : Word :=
+  let dHi := vTop >>> (32 : BitVec 6).toNat
+  let dLo := (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let div_un1 := uLo >>> (32 : BitVec 6).toNat
+  let div_un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  -- Phase 1b: 1st D3 correction
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- Phase 1b: 2nd D3 correction (Knuth classical full loop) — THE FIX
+  -- Fire only if rhat' < 2^32 (Knuth's loop exit condition) AND test still holds.
+  let rhat'_lt_pow32 : Bool := (rhat' >>> (32 : BitVec 6).toNat) = (0 : Word)
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let fire2 : Bool := rhat'_lt_pow32 && BitVec.ult rhatUn1' qDlo2
+  let q1'' := if fire2 then q1' + signExtend12 4095 else q1'
+  let rhat'' := if fire2 then rhat' + dHi else rhat'
+  -- Phase 2 setup with q1''/rhat''
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| div_un1
+  let cu_q1_dlo := q1'' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
+  (q1'' <<< (32 : BitVec 6).toNat) ||| q0'
+
 /-- Low 32 bits of vTop, stored to scratch during div128 call path. -/
 def div128DLo (vTop : Word) : Word :=
   (vTop <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -123,6 +123,108 @@ def divK_div128 : Program :=
   JALR .x0 .x2 0                              -- [50] return
   -- Total: 51 instructions
 
+/-- **FIXED** 128/64-bit unsigned division subroutine — same as `divK_div128`
+    but with Knuth's classical 2nd D3 correction iteration added (TAOCP
+    4.3.1). The 2nd correction has the `rhat < B` guard, mirroring the
+    existing Phase 2b guard at lines 107-108.
+
+    This fixes the algorithm correctness bug — see
+    `n4CallAddbackBeqSemanticHolds_counterexample` (in
+    `EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean`) and the matching
+    Lean abstraction `div128Quot_v2` (in `LoopDefs/Iter.lean`).
+
+    **Layout**:
+    - [0..24]: same as `divK_div128` (initial split + Phase 1a + 1st D3).
+    - **[25..34]: NEW — Phase 1b 2nd D3 correction (10 instructions)**.
+      Mirrors Phase 2b's guarded D3 at [37..46] in `divK_div128`.
+    - [35..60]: original [25..50] shifted by 10 (Phase 2 + finish).
+
+    Total: 61 instructions (vs 51 in the buggy version).
+
+    **Migration**: callers of `divK_div128` should be updated to call
+    `divK_div128_v2` (this requires updating offsets in the main loop
+    at `divK_loopBody`, since the subroutine moved). Once all use-sites
+    migrate, the buggy `divK_div128` should be removed. -/
+def divK_div128_v2 : Program :=
+  -- Save return addr and d
+  SD .x12 .x2 3968 ;;                         -- [0]  save return addr
+  SD .x12 .x10 3960 ;;                        -- [1]  save d
+  -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
+  SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
+  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
+  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
+  -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
+  SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
+  SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
+  SD .x12 .x5 3944 ;;                         -- [9]  save un0
+  -- Step 1: q1 = DIVU(uHi, dHi), rhat = uHi - q1*dHi
+  single (.DIVU .x10 .x7 .x6) ;;             -- [10] x10 = q1
+  single (.MUL .x5 .x10 .x6) ;;              -- [11] x5 = q1 * dHi
+  single (.SUB .x7 .x7 .x5) ;;               -- [12] x7 = rhat
+  -- Refine q1: clamp to < 2^32
+  SRLI .x5 .x10 32 ;;                         -- [13] test q1 >= 2^32
+  single (.BEQ .x5 .x0 12) ;;                -- [14] skip if q1 < 2^32 → [17]
+  ADDI .x10 .x10 4095 ;;                      -- [15] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
+  -- [17] Phase 1b 1st D3 correction: q1*dLo > rhat*2^32 + un1?
+  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
+  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
+  SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
+  single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
+  single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
+  JAL .x0 12 ;;                                -- [22] skip → [25]
+  ADDI .x10 .x10 4095 ;;                      -- [23] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
+  -- [25] Phase 1b 2nd D3 correction (Knuth TAOCP §4.3.1 D3 loop, full).
+  --      Guard: skip mul-check when rhat ≥ 2^32 (matches Phase 2b's guard
+  --      at [47..48] below). Without this, BLTU would false-positive fire
+  --      due to `<< 32` truncation. Mirrors Phase 2b structure.
+  SRLI .x1 .x7 32 ;;                          -- [25] x1 = rhat >> 32
+  single (.BNE .x1 .x0 36) ;;                -- [26] if nonzero → skip to [35]
+  -- [27] 2nd D3 product check (only when rhat < 2^32)
+  LD .x1 .x12 3952 ;;                         -- [27] dLo
+  single (.MUL .x5 .x10 .x1) ;;              -- [28] x5 = q1 * dLo
+  SLLI .x1 .x7 32 ;;                          -- [29] x1 = rhat << 32
+  single (.OR .x1 .x1 .x11) ;;               -- [30] x1 = rhat*2^32 + un1
+  single (.BLTU .x1 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
+  JAL .x0 12 ;;                                -- [32] skip → [35]
+  ADDI .x10 .x10 4095 ;;                      -- [33] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [34] rhat += dHi
+  -- [35] Compute un21 = rhat*2^32 + un1 - q1*dLo
+  LD .x1 .x12 3952 ;;                         -- [35] dLo
+  SLLI .x5 .x7 32 ;;                          -- [36] rhat << 32
+  single (.OR .x5 .x5 .x11) ;;               -- [37] x5 = rhat*2^32 + un1
+  single (.MUL .x1 .x10 .x1) ;;              -- [38] x1 = q1 * dLo
+  single (.SUB .x7 .x5 .x1) ;;               -- [39] x7 = un21
+  -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
+  single (.DIVU .x5 .x7 .x6) ;;              -- [40] x5 = q0
+  single (.MUL .x1 .x5 .x6) ;;               -- [41]
+  single (.SUB .x11 .x7 .x1) ;;              -- [42] x11 = rhat2
+  -- Refine q0: clamp
+  SRLI .x1 .x5 32 ;;                          -- [43]
+  single (.BEQ .x1 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
+  ADDI .x5 .x5 4095 ;;                        -- [45] q0--
+  single (.ADD .x11 .x11 .x6) ;;             -- [46] rhat2 += dHi
+  -- [47] Phase 2b guard (rhat2c ≥ 2^32 ⟹ skip mul-check)
+  SRLI .x1 .x11 32 ;;                         -- [47] x1 = rhat2c >> 32
+  single (.BNE .x1 .x0 36) ;;                -- [48] if nonzero → skip to [57]
+  -- [49] Product check for q0
+  LD .x1 .x12 3952 ;;                         -- [49] dLo
+  single (.MUL .x7 .x5 .x1) ;;               -- [50] x7 = q0 * dLo
+  SLLI .x1 .x11 32 ;;                         -- [51] rhat2 << 32
+  LD .x11 .x12 3944 ;;                        -- [52] un0
+  single (.OR .x1 .x1 .x11) ;;               -- [53] x1 = rhat2*2^32 + un0
+  single (.BLTU .x1 .x7 8) ;;                -- [54] if rhs < lhs → correct [56]
+  JAL .x0 8 ;;                                 -- [55] skip → [57]
+  ADDI .x5 .x5 4095 ;;                        -- [56] q0--
+  -- Combine: q = q1*2^32 + q0
+  SLLI .x11 .x10 32 ;;                        -- [57] q1 << 32
+  single (.OR .x11 .x11 .x5) ;;              -- [58] x11 = q
+  -- Restore and return
+  LD .x2 .x12 3968 ;;                         -- [59] restore return addr
+  JALR .x0 .x2 0                              -- [60] return
+  -- Total: 61 instructions (51 + 10 for 2nd D3 correction)
+
 -- ============================================================================
 -- Main division program phases
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -130,6 +130,15 @@ def n4CallAddbackBeqSemanticHolds (a b : EvmWord) : Prop :=
     predicate — Lean evaluates the Prop directly on the concrete
     Word inputs.
 
+    **Precise bug class**: the algorithm is correct iff `q1' = q_true_1`
+    (high digit exact), which holds iff Knuth's D3 correction loop
+    finishes within 1 iteration. The bug fires precisely on inputs
+    where Knuth's D3 needs the 2nd correction iteration — initial
+    `q̂ = q_true_1 + 2` AND both 1st and 2nd D3 checks fire. Our
+    1-correction `div128Quot` only does the 1st. In our counterexample,
+    `q̂ = 2^31 + 2`, after 1 correction `q1' = 2^31 + 1`, but
+    `q_true_1 = 2^31` (Knuth's full loop would do 2 corrections).
+
     **Implication**: this theorem proves that
     `n4CallAddbackBeqSemanticHolds_of_*` (any closure from runtime
     conditions) cannot exist — the predicate is genuinely false on

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq.lean
@@ -156,6 +156,56 @@ theorem n4CallAddbackBeqSemanticHolds_counterexample :
   unfold n4CallAddbackBeqSemanticHolds
   decide
 
+/-- **Fix verification**: `div128Quot_v2` (the FIXED version with 2 D3
+    iterations, in `LoopDefs/Iter.lean`) produces the CORRECT quotient
+    on the counterexample input where the original buggy `div128Quot`
+    fails. Kernel-checked via `decide`.
+
+    This proves the migration target works (qHat overshoot drops from
+    2^32-1 to just 1, within Knuth-B bound). The remaining work is to
+    update the actual RISC-V program at `Program.lean:divK_div128` to
+    add the corresponding 2nd D3 correction (~6 instructions after the
+    existing one at lines 80-87), then migrate use-sites from
+    `div128Quot` to `div128Quot_v2`.
+
+    On the counterexample input, `div128Quot_v2 = q_true + 1 =
+    9223372041149743103`, which is within Knuth-B bound (≤ q_true + 2).
+    The outer addback BEQ branch's single-addback path then corrects
+    by 1, giving the correct final `q_out = q_true`. -/
+theorem div128Quot_v2_fixes_counterexample :
+    let a3 : Word := BitVec.ofNat 64 (2^63 + 2^33)
+    let b2 : Word := BitVec.ofNat 64 (2^33 - 1)
+    let b3 : Word := 1
+    let shift := (clzResult b3).1
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| ((0:Word) >>> (antiShift.toNat % 64))
+    -- q_true = 9223372041149743102 (val256(a) / val256(b))
+    -- div128Quot_v2 produces q_true + 1 = 9223372041149743103
+    -- which is within Knuth-B bound (≤ q_true + 2), so outer addback BEQ
+    -- single-addback path corrects to q_true.
+    (div128Quot_v2 u4 u3 b3').toNat = 9223372041149743103 := by
+  decide
+
+/-- **Bug confirmation**: `div128Quot` (the current/buggy version)
+    produces the WRONG quotient on the counterexample input. The
+    discrepancy is `2^32 - 2`. Pairs with `div128Quot_v2_fixes_counterexample`
+    to demonstrate the fix is necessary. -/
+theorem div128Quot_buggy_on_counterexample :
+    let a3 : Word := BitVec.ofNat 64 (2^63 + 2^33)
+    let b2 : Word := BitVec.ofNat 64 (2^33 - 1)
+    let b3 : Word := 1
+    let shift := (clzResult b3).1
+    let antiShift := signExtend12 (0 : BitVec 12) - shift
+    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
+    let u4 := a3 >>> (antiShift.toNat % 64)
+    let u3 := (a3 <<< (shift.toNat % 64)) ||| ((0:Word) >>> (antiShift.toNat % 64))
+    -- Buggy version produces 9223372045444710397 (overshoots true quotient
+    -- 9223372041149743102 by 2^32 - 1 = 4294967295).
+    (div128Quot u4 u3 b3').toNat = 9223372045444710397 := by
+  decide
+
 theorem n4CallAddbackBeqSemanticHolds_def {a b : EvmWord} :
     n4CallAddbackBeqSemanticHolds a b =
     (let shift := (clzResult (b.getLimbN 3)).1.toNat % 64


### PR DESCRIPTION
## Summary

Fixes the EVM-level DIV algorithm correctness bug discovered in PR #1387 (formal counterexample theorem `n4CallAddbackBeqSemanticHolds_counterexample`). Adds **parallel "v2" definitions** for both the Lean abstraction and the RISC-V program, implementing Knuth's classical 2-iteration D3 correction loop (TAOCP 4.3.1).

## What's added

### Lean abstraction
- **`div128Quot_v2`** (`LoopDefs/Iter.lean:158-209`): adds Phase 1b 2nd D3 correction. Reuses the existing `div128Quot_phase2b_q0'` helper (which already encodes Knuth's classical D3 single step with the `rhat' < B` guard).

### RISC-V program
- **`divK_div128_v2`** (`Program.lean:127-228`): mirrors `div128Quot_v2`. Adds 10 RISC-V instructions for the 2nd D3 correction, structured identically to Phase 2b's existing guarded D3 step.
- Total: 61 instructions (vs 51 in `divK_div128`).

### Verification (kernel-checked, `decide`)
- **`div128Quot_v2_fixes_counterexample`**: on the bug input, `div128Quot_v2` produces `q_true + 1` (overshoot drops from 2^32-1 to 1), within Knuth-B bound. Outer addback BEQ single-addback path corrects to q_true.
- **`div128Quot_buggy_on_counterexample`**: proves the original `div128Quot` produces the wrong answer on the same input. Pairs with the v2 theorem to demonstrate the fix is necessary.

## Why parallel definitions (not in-place modification)?

Modifying `div128Quot` / `divK_div128` in-place would invalidate ~1000 downstream theorems (verified — got `whnf` heartbeat exhaustion on `LoopBodyN4` when I tried). The parallel `_v2` definitions allow incremental migration without breaking the existing build.

## Migration plan (NOT in this PR)

1. Add equivalence lemma `divK_div128_v2 ↔ div128Quot_v2`.
2. Migrate main loop body's JAL offset to call `divK_div128_v2`.
3. Re-prove downstream specs (LoopBodyN4 etc.) for the new shape.
4. Remove the buggy `div128Quot` and `divK_div128`.
5. Remove `n4CallAddbackBeqSemanticHolds_counterexample` (becomes vacuous under the fix).

Steps 1-5 are multi-iteration work tracked in subsequent PRs.

## Test plan

- [x] `div128Quot_v2_fixes_counterexample`: kernel-checked via `decide`.
- [x] `div128Quot_buggy_on_counterexample`: kernel-checked via `decide`.
- [x] Full project `lake build` succeeds with no sorries (the new defs are parallel, no existing proofs depend on them).
- [x] No code changes in existing paths (call-skip, max-skip, max-addback all unchanged).

## References

- Counterexample theorem: `n4CallAddbackBeqSemanticHolds_counterexample` (PR #1387).
- Memory: `project_n4callbeq_addback_overshoot_2pow32.md`, `project_knuth_d_one_correction_design.md`.
- Knuth TAOCP 4.3.1, Algorithm D, Step D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)