### PR TITLE
feat(divmod): #1337 Div128ProdCheck1b — prove 2nd D3 block (zero sorries)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -303,4 +303,57 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (fun h hq => by xperm_hyp hq)
     h12345
 
+-- ============================================================================
+-- Section 15.v2: divK_div128_v2 subroutine composition (issue #1337 fix)
+--
+-- Parallel to `div128_spec` but for the FIXED `divK_div128_v2` subroutine
+-- (with Knuth's classical 2nd D3 correction iteration). Mirrors the Lean
+-- abstraction `div128Quot_v2`.
+--
+-- This is a **STUB** awaiting the full multi-iteration migration:
+-- 1. Add 5 new block specs for the inserted [25..34] instructions
+--    (mirror of Phase 2b's existing [37..46] block specs).
+-- 2. Adjust offsets for the shifted [35..60] block specs
+--    (originally [25..50]).
+-- 3. Compose blocks via `runBlock` / `seqFrame` (similar to `div128_spec`).
+--
+-- Until the migration is complete, callers should continue using
+-- `div128_spec` with the buggy `divK_div128`. The buggy version is
+-- correct for inputs that don't reach Knuth's D3 2nd-iteration regime
+-- (per the analysis in
+-- `memory/project_n4callbeq_addback_overshoot_2pow32.md`); the v2 fix
+-- is needed only for the corner-case inputs.
+-- ============================================================================
+
+/-- **STUB**: equivalence between `divK_div128_v2` (fixed RISC-V) and
+    `div128Quot_v2` (fixed Lean abstraction).
+
+    Mirrors `div128_spec` but for the v2 algorithm. The proof structure
+    parallels `div128_spec` with two changes:
+    - 5 additional block specs for the inserted `[25..34]` instructions
+      (Phase 1b 2nd D3 correction). These mirror Phase 2b's existing
+      `[37..46]` blocks: load dLo, MUL, SLLI, OR, BLTU, JAL, ADDI, ADD.
+    - Offsets in the shifted `[35..60]` blocks bump by +10 from the
+      original `[25..50]`.
+
+    Estimated: ~600 LOC for the full proof (proof structure parallel
+    to `div128_spec` at ~500 LOC plus ~100 LOC for the new block).
+
+    Tracked in issue #1337's algorithm-fix migration. -/
+theorem div128_v2_spec (sp retAddr d uLo uHi : Word) (base : Word)
+    (v1Old v6Old v11Old : Word)
+    (retMem dMem dloMem un0Mem : Word)
+    (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
+    -- Same precondition shape as `div128_spec`.
+    -- Postcondition: q in x11 = `div128Quot_v2 uHi uLo d` (instead of
+    -- `div128Quot uHi uLo d`).
+    -- Proof: mirror `div128_spec`'s 5-block composition with a 6th block
+    -- inserted for the 2nd D3 correction.
+    True := by  -- placeholder; full statement deferred to follow-up PR
+  -- Suppress unused-variable warnings for params that the full theorem will use.
+  let _ := sp; let _ := retAddr; let _ := d; let _ := uLo; let _ := uHi
+  let _ := base; let _ := v1Old; let _ := v6Old; let _ := v11Old
+  let _ := retMem; let _ := dMem; let _ := dloMem; let _ := un0Mem
+  trivial
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -57,7 +57,44 @@ theorem divK_div128_prodcheck1b_guard_spec
       (base + 8)
         ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ rhatHi) **
          (.x0 ↦ᵣ 0) ** ⌜rhatHi = 0⌝) := by
-  sorry  -- Mirror of divK_div128_phase2b_guard_spec proof (~50 LOC).
+  intro rhatHi cr
+  -- Step 1: SRLI .x1 .x7 32  (cpsTriple base → base+4)
+  have hsrli_raw := srli_spec_gen .x1 .x7 v1Old rhat 32 base (by nofun)
+  have hcr_srli : ∀ a i,
+      CodeReq.singleton base (.SRLI .x1 .x7 32) a = some i → cr a = some i := by
+    intro a i h
+    simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
+    split at h
+    · rename_i hab; simp_all
+    · simp at h
+  have hsrli := cpsTriple_extend_code hcr_srli hsrli_raw
+  have hsrli_framed := cpsTriple_frameR
+    ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0))
+    (by pcFree) hsrli
+  -- Step 2: BNE .x1 .x0 guard_off  (cpsBranch base+4 → ...)
+  have hbne_raw := bne_spec_gen .x1 .x0 guard_off rhatHi (0 : Word) (base + 4)
+  have hcr_bne : ∀ a i,
+      CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off) a = some i → cr a = some i := by
+    intro a i h
+    simp only [cr, CodeReq.union, CodeReq.singleton] at h ⊢
+    split at h
+    · rename_i hab; rw [beq_iff_eq] at hab; subst hab
+      have : (base + 4 : Word) ≠ base := by bv_omega
+      simp_all
+    · simp at h
+  have hbne := cpsBranch_extend_code hcr_bne hbne_raw
+  have hbne_framed := cpsBranch_frameR
+    ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat))
+    (by pcFree) hbne
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hsrli_framed hbne_framed
+  have h_addr_eq : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [h_addr_eq] at composed
+  exact cpsBranch_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
 
 /-- **Sub-stub B — body portion**: `[27..34]` LD/MUL/SLLI/OR/BLTU/JAL/ADDI/ADD.
     Identical structure to `divK_div128_prodcheck1_merged_spec` (the 1st

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -1,0 +1,106 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1b
+
+  **STUB FILE** for issue #1337 algorithm fix migration.
+
+  Provides the block spec for the **2nd D3 correction iteration** added
+  by `divK_div128_v2` (in `EvmAsm/Evm64/DivMod/Program.lean`). This is
+  the Phase 1b 2nd correction block — instructions [25..34] of the
+  fixed `divK_div128_v2` subroutine (10 instructions: SRLI guard +
+  BNE skip + 8-instruction D3 step mirroring `Div128ProdCheck1`).
+
+  The block spec proves that under the precondition `q1c, rhatc` (post
+  Phase 1a clamp + 1st D3 correction), the 10 instructions correctly
+  compute Knuth's classical 2nd D3 correction:
+  - if `rhatc < 2^32` (guard condition) AND
+    `q1c * dLo > rhatc * 2^32 + un1` (product test),
+    then q1' := q1c - 1, rhat' := rhatc + dHi.
+  - otherwise q1' := q1c, rhat' := rhatc.
+
+  **Status (2026-04-27)**: theorem signature only; proof is a sorry
+  pending the multi-iteration migration. Mirrors the structure of
+  `Div128ProdCheck1.divK_div128_prodcheck1_merged_spec` (the 1st D3
+  block) and `Div128ProdCheck2.div128Quot_phase2b_q0'`
+  (Phase 2b's guarded D3, structurally identical).
+
+  Issue #1337's algorithm fix migration. Tracked in PR #1389.
+-/
+
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck2
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64.AddrNorm (se21_12)
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- div128 product check 1b (Knuth classical 2nd D3 correction).
+    Instrs [25]-[34] of `divK_div128_v2`. Both guard branches and both
+    BLTU paths merge at `base + 40`.
+
+    Layout:
+    - [25] SRLI x1 x7 32       — rhat >> 32 (guard)
+    - [26] BNE  x1 x0 36       — if rhat ≥ 2^32, skip → [35]
+    - [27] LD   x1 x12 3952    — dLo (only if rhat < 2^32)
+    - [28] MUL  x5 x10 x1      — q1 * dLo
+    - [29] SLLI x1 x7 32       — rhat << 32
+    - [30] OR   x1 x1 x11      — rhat*2^32 + un1
+    - [31] BLTU x1 x5 8        — if rhs < lhs → correct [33]
+    - [32] JAL  x0 12          — skip → [35]
+    - [33] ADDI x10 x10 4095   — q1--
+    - [34] ADD  x7 x7 x6       — rhat += dHi
+
+    The guard at [25..26] mirrors Phase 2b's guard at
+    `divK_div128.[37..38]`; the body at [27..34] mirrors the 1st D3
+    block at `divK_div128.[17..24]` (= `divK_div128_prodcheck1_merged_spec`).
+
+    **Output spec**: matches the Lean abstraction
+    `div128Quot_v2`'s 2nd D3 step:
+    ```
+    let q1' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
+               then q1c - 1 else q1c
+    let rhat' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
+                 then rhatc + dHi else rhatc
+    ```
+
+    **Status**: `sorry`. Proof is parallel to
+    `divK_div128_prodcheck1_merged_spec` plus a guard-handling case
+    split (~50 LOC additional, ~250 LOC total mirroring
+    `Div128ProdCheck1.lean`).
+
+    Issue #1337 algorithm fix migration. -/
+theorem divK_div128_prodcheck1b_merged_spec
+    (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    let qDlo := q1c * dlo
+    let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    -- Guard: 2nd D3 fires only if rhatc < 2^32.
+    let guard_pass : Bool := (rhatc >>> (32 : BitVec 6).toNat) = (0 : Word)
+    let q1' :=
+      if guard_pass && BitVec.ult rhatUn1' qDlo
+      then q1c + signExtend12 4095 else q1c
+    let rhat' :=
+      if guard_pass && BitVec.ult rhatUn1' qDlo
+      then rhatc + dHi else rhatc
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
+    cpsTriple base (base + 40) cr
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  sorry
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -123,7 +123,9 @@ theorem divK_div128_prodcheck1b_body_spec
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
        (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry  -- Identical to divK_div128_prodcheck1_merged_spec's proof (~120 LOC).
+  -- Direct delegation: this body is structurally identical to the 1st D3 block's
+  -- merged spec — same 8 instructions at the same relative offsets.
+  exact divK_div128_prodcheck1_merged_spec sp q1c rhatc dHi un1 v1Old v5Old dlo base
 
 /-- div128 product check 1b (Knuth classical 2nd D3 correction).
     Instrs [25]-[34] of `divK_div128_v2`. Both guard branches and both

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -36,39 +36,75 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- **Sub-stub A — guard portion**: `[25..26]` SRLI + BNE (cpsBranch).
+    Mirrors `divK_div128_phase2b_guard_spec` but with `.x7` as the rhat
+    register (Phase 2b uses `.x11`).
+
+    Branches:
+    - **Taken** (rhatHi ≠ 0): branches to `(base + 4) + signExtend13 guard_off`.
+    - **Fall-through** (rhatHi = 0): continues to `base + 8`. -/
+theorem divK_div128_prodcheck1b_guard_spec
+    (sp rhat v1Old : Word) (base : Word) (guard_off : BitVec 13) :
+    let rhatHi := rhat >>> (32 : BitVec 6).toNat
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
+        (CodeReq.singleton (base + 4) (.BNE .x1 .x0 guard_off))
+    cpsBranch base cr
+      ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ v1Old) ** (.x0 ↦ᵣ 0))
+      ((base + 4) + signExtend13 guard_off)
+        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ rhatHi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhatHi ≠ 0⌝)
+      (base + 8)
+        ((.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ rhat) ** (.x1 ↦ᵣ rhatHi) **
+         (.x0 ↦ᵣ 0) ** ⌜rhatHi = 0⌝) := by
+  sorry  -- Mirror of divK_div128_phase2b_guard_spec proof (~50 LOC).
+
+/-- **Sub-stub B — body portion**: `[27..34]` LD/MUL/SLLI/OR/BLTU/JAL/ADDI/ADD.
+    Identical structure to `divK_div128_prodcheck1_merged_spec` (the 1st
+    D3 block); just at a different offset within `divK_div128_v2`.
+
+    Reachable only when the guard at [25..26] falls through (rhatc < 2^32). -/
+theorem divK_div128_prodcheck1b_body_spec
+    (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
+    let qDlo := q1c * dlo
+    let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    let q1' := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
+    cpsTriple base (base + 32) cr
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo))
+      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
+       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
+       (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  sorry  -- Identical to divK_div128_prodcheck1_merged_spec's proof (~120 LOC).
+
 /-- div128 product check 1b (Knuth classical 2nd D3 correction).
     Instrs [25]-[34] of `divK_div128_v2`. Both guard branches and both
     BLTU paths merge at `base + 40`.
 
-    Layout:
-    - [25] SRLI x1 x7 32       — rhat >> 32 (guard)
-    - [26] BNE  x1 x0 36       — if rhat ≥ 2^32, skip → [35]
-    - [27] LD   x1 x12 3952    — dLo (only if rhat < 2^32)
-    - [28] MUL  x5 x10 x1      — q1 * dLo
-    - [29] SLLI x1 x7 32       — rhat << 32
-    - [30] OR   x1 x1 x11      — rhat*2^32 + un1
-    - [31] BLTU x1 x5 8        — if rhs < lhs → correct [33]
-    - [32] JAL  x0 12          — skip → [35]
-    - [33] ADDI x10 x10 4095   — q1--
-    - [34] ADD  x7 x7 x6       — rhat += dHi
+    Composes:
+    - Sub-stub A (`divK_div128_prodcheck1b_guard_spec`): [25..26] guard.
+    - Sub-stub B (`divK_div128_prodcheck1b_body_spec`): [27..34] body.
+    - Identity for the guard-taken path (rhatHi ≠ 0 ⟹ skip body, q1 / rhat unchanged).
 
-    The guard at [25..26] mirrors Phase 2b's guard at
-    `divK_div128.[37..38]`; the body at [27..34] mirrors the 1st D3
-    block at `divK_div128.[17..24]` (= `divK_div128_prodcheck1_merged_spec`).
-
-    **Output spec**: matches the Lean abstraction
-    `div128Quot_v2`'s 2nd D3 step:
+    **Output spec**: matches the Lean abstraction `div128Quot_v2`'s
+    2nd D3 step:
     ```
     let q1' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
                then q1c - 1 else q1c
     let rhat' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
                  then rhatc + dHi else rhatc
     ```
-
-    **Status**: `sorry`. Proof is parallel to
-    `divK_div128_prodcheck1_merged_spec` plus a guard-handling case
-    split (~50 LOC additional, ~250 LOC total mirroring
-    `Div128ProdCheck1.lean`).
 
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_prodcheck1b_merged_spec
@@ -101,6 +137,6 @@ theorem divK_div128_prodcheck1b_merged_spec
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
        (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
        (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry
+  sorry  -- Composition of guard + body via cpsBranch dispatching, ~80 LOC.
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -131,33 +131,36 @@ theorem divK_div128_prodcheck1b_body_spec
     Instrs [25]-[34] of `divK_div128_v2`. Both guard branches and both
     BLTU paths merge at `base + 40`.
 
+    **Shape**: `cpsBranch` — mirrors `divK_div128_step2_branch_merged_spec`'s
+    pattern of "two paths converging at the same merge address but with
+    different register postconditions". The taken leg (rhatHi ≠ 0) skips
+    the body, leaving `.x5 = v5Old` and `.x1 = rhatHi` (the SRLI result).
+    The fall-through leg (rhatHi = 0) executes the body, producing
+    `.x5 = qDlo` and `.x1 = rhatUn1'`. Both legs end at `base + 40`.
+
     Composes:
     - Sub-stub A (`divK_div128_prodcheck1b_guard_spec`): [25..26] guard.
     - Sub-stub B (`divK_div128_prodcheck1b_body_spec`): [27..34] body.
-    - Identity for the guard-taken path (rhatHi ≠ 0 ⟹ skip body, q1 / rhat unchanged).
 
-    **Output spec**: matches the Lean abstraction `div128Quot_v2`'s
-    2nd D3 step:
+    **Output for `.x10` (q1) / `.x7` (rhat)** matches the Lean abstraction
+    `div128Quot_v2`'s 2nd D3 step:
     ```
     let q1' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
                then q1c - 1 else q1c
     let rhat' := if rhatc < 2^32 ∧ rhatUn1' < q1c * dLo
                  then rhatc + dHi else rhatc
     ```
+    (taken leg gives the `else q1c` / `else rhatc` directly via `rhatHi ≠ 0`.)
 
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_prodcheck1b_merged_spec
     (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
     let qDlo := q1c * dlo
     let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    -- Guard: 2nd D3 fires only if rhatc < 2^32.
-    let guard_pass : Bool := (rhatc >>> (32 : BitVec 6).toNat) = (0 : Word)
-    let q1' :=
-      if guard_pass && BitVec.ult rhatUn1' qDlo
-      then q1c + signExtend12 4095 else q1c
-    let rhat' :=
-      if guard_pass && BitVec.ult rhatUn1' qDlo
-      then rhatc + dHi else rhatc
+    let rhatHi := rhatc >>> (32 : BitVec 6).toNat
+    -- Fall-through leg only — the guard-taken leg keeps q1c / rhatc.
+    let q1'FT := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
+    let rhat'FT := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
     let cr :=
       CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
@@ -169,13 +172,20 @@ theorem divK_div128_prodcheck1b_merged_spec
       (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
       (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
        (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
-    cpsTriple base (base + 40) cr
+    cpsBranch base cr
       ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo))
-      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
-       (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry  -- Composition of guard + body via cpsBranch dispatching, ~80 LOC.
+      (base + 40)  -- guard-fires path (rhatHi ≠ 0): body is skipped
+        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+         (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ rhatHi) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+         ⌜rhatHi ≠ 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo))
+      (base + 40)  -- guard-doesn't-fire + body (rhatHi = 0): runs the mul-check
+        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1'FT) ** (.x7 ↦ᵣ rhat'FT) ** (.x11 ↦ᵣ un1) **
+         (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+         ⌜rhatHi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  sorry  -- Composition of guard cpsBranch + body cpsTriple via cpsBranch_seq pattern.
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -1,10 +1,8 @@
 /-
   EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1b
 
-  **STUB FILE** for issue #1337 algorithm fix migration.
-
-  Provides the block spec for the **2nd D3 correction iteration** added
-  by `divK_div128_v2` (in `EvmAsm/Evm64/DivMod/Program.lean`). This is
+  Block spec for the **2nd D3 correction iteration** added by
+  `divK_div128_v2` (in `EvmAsm/Evm64/DivMod/Program.lean`). This is
   the Phase 1b 2nd correction block — instructions [25..34] of the
   fixed `divK_div128_v2` subroutine (10 instructions: SRLI guard +
   BNE skip + 8-instruction D3 step mirroring `Div128ProdCheck1`).
@@ -17,11 +15,10 @@
     then q1' := q1c - 1, rhat' := rhatc + dHi.
   - otherwise q1' := q1c, rhat' := rhatc.
 
-  **Status (2026-04-27)**: theorem signature only; proof is a sorry
-  pending the multi-iteration migration. Mirrors the structure of
-  `Div128ProdCheck1.divK_div128_prodcheck1_merged_spec` (the 1st D3
-  block) and `Div128ProdCheck2.div128Quot_phase2b_q0'`
-  (Phase 2b's guarded D3, structurally identical).
+  The merged spec is shaped as a `cpsBranch` (mirroring
+  `divK_div128_step2_branch_merged_spec`) where both legs converge at
+  `base + 40` but carry different register postconditions for `.x5`
+  and `.x1` (the body's mul-check temporaries).
 
   Issue #1337's algorithm fix migration. Tracked in PR #1389.
 -/
@@ -186,6 +183,85 @@ theorem divK_div128_prodcheck1b_merged_spec
          (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
          ⌜rhatHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry  -- Composition of guard cpsBranch + body cpsTriple via cpsBranch_seq pattern.
+  intro qDlo rhatUn1' rhatHi q1'FT rhat'FT cr
+  have hcr_eq : cr =
+      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6)))))))))) := rfl
+  -- h1 = guard_spec sp rhatc v1Old base 36 (cpsBranch base..base+40|base+8)
+  have h1_raw := divK_div128_prodcheck1b_guard_spec sp rhatc v1Old base (36 : BitVec 13)
+  have ha_t : (base + 4 : Word) + signExtend13 (36 : BitVec 13) = base + 40 := by rv64_addr
+  rw [ha_t] at h1_raw
+  -- Extend guard's 2-singleton cr to merged's 10-singleton cr
+  have h1 : cpsBranch base cr _ _ _ _ _ :=
+    cpsBranch_extend_code (h := h1_raw) (hmono := by
+      rw [hcr_eq]; intro a i
+      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
+      split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · simp at h)
+  -- Frame guard with the unchanged-through-guard atoms
+  have h1f := cpsBranch_frameR
+    ((.x10 ↦ᵣ q1c) ** (.x11 ↦ᵣ un1) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ dHi) **
+     (sp + signExtend12 3952 ↦ₘ dlo))
+    (by pcFree) h1
+  -- h2 = body_spec at base+8 — body's v1Old becomes the SRLI result rhatHi
+  have h2_raw := divK_div128_prodcheck1b_body_spec sp q1c rhatc dHi un1 rhatHi v5Old dlo
+    (base + 8)
+  have hb4 : (base + 8 : Word) + 4 = base + 12 := by bv_addr
+  have hb8 : (base + 8 : Word) + 8 = base + 16 := by bv_addr
+  have hb12 : (base + 8 : Word) + 12 = base + 20 := by bv_addr
+  have hb16 : (base + 8 : Word) + 16 = base + 24 := by bv_addr
+  have hb20 : (base + 8 : Word) + 20 = base + 28 := by bv_addr
+  have hb24 : (base + 8 : Word) + 24 = base + 32 := by bv_addr
+  have hb28 : (base + 8 : Word) + 28 = base + 36 := by bv_addr
+  have hb32 : (base + 8 : Word) + 32 = base + 40 := by bv_addr
+  simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32] at h2_raw
+  have h2 : cpsTriple (base + 8) (base + 40) cr _ _ :=
+    cpsTriple_extend_code (h := h2_raw) (hmono := by
+      rw [hcr_eq]; intro a i
+      simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
+      split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · split at h
+          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+          · split at h
+            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+            · split at h
+              · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+              · split at h
+                · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                · split at h
+                  · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                  · split at h
+                    · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                    · simp at h)
+  -- Frame body with (.x0 ↦ᵣ 0) ** ⌜rhatHi = 0⌝ — both pass through unchanged
+  have h2f := cpsTriple_frameR
+    ((.x0 ↦ᵣ 0) ** ⌜rhatHi = 0⌝)
+    (by pcFree) h2
+  -- Compose: guard fall-through ⨾ body, with permutation matching guard's Q_f → body's pre
+  have composed := cpsBranch_seq_cpsTriple_with_perm_same_cr
+    (h1 := h1f)
+    (hperm := fun h hp => by xperm_hyp hp)
+    (h2 := h2f)
+    (ht1 := fun h hp => hp)
+  -- Weaken final post to merged_spec's right-associated shape
+  exact cpsBranch_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -93,6 +93,39 @@ theorem divK_div128_prodcheck1b_guard_spec
     (fun h hp => by xperm_hyp hp)
     composed
 
+/-- Bundled CodeReq for `divK_div128_prodcheck1b_body_spec` (8 singletons,
+    instrs [27..34]). `@[irreducible]` to keep let-bindings out of the
+    theorem signature. -/
+@[irreducible]
+def divKDiv128Prodcheck1bBodyCode (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
+   (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
+
+/-- Bundled precondition for `divK_div128_prodcheck1b_body_spec`. -/
+@[irreducible]
+def divKDiv128Prodcheck1bBodyPre (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) :
+    Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled postcondition for `divK_div128_prodcheck1b_body_spec`. -/
+@[irreducible]
+def divKDiv128Prodcheck1bBodyPost (sp q1c rhatc dHi un1 dlo : Word) : Assertion :=
+  let qDlo := q1c * dlo
+  let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
 /-- **Sub-stub B — body portion**: `[27..34]` LD/MUL/SLLI/OR/BLTU/JAL/ADDI/ADD.
     Identical structure to `divK_div128_prodcheck1_merged_spec` (the 1st
     D3 block); just at a different offset within `divK_div128_v2`.
@@ -100,29 +133,64 @@ theorem divK_div128_prodcheck1b_guard_spec
     Reachable only when the guard at [25..26] falls through (rhatc < 2^32). -/
 theorem divK_div128_prodcheck1b_body_spec
     (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
-    let qDlo := q1c * dlo
-    let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 28) (.ADD .x7 .x7 .x6))))))))
-    cpsTriple base (base + 32) cr
-      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) **
-       (sp + signExtend12 3952 ↦ₘ dlo))
-      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1') ** (.x7 ↦ᵣ rhat') ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) **
-       (sp + signExtend12 3952 ↦ₘ dlo)) := by
+    cpsTriple base (base + 32) (divKDiv128Prodcheck1bBodyCode base)
+      (divKDiv128Prodcheck1bBodyPre sp q1c rhatc dHi un1 v1Old v5Old dlo)
+      (divKDiv128Prodcheck1bBodyPost sp q1c rhatc dHi un1 dlo) := by
+  unfold divKDiv128Prodcheck1bBodyCode divKDiv128Prodcheck1bBodyPre
+    divKDiv128Prodcheck1bBodyPost
   -- Direct delegation: this body is structurally identical to the 1st D3 block's
   -- merged spec — same 8 instructions at the same relative offsets.
   exact divK_div128_prodcheck1_merged_spec sp q1c rhatc dHi un1 v1Old v5Old dlo base
+
+/-- Bundled CodeReq for `divK_div128_prodcheck1b_merged_spec` (10 singletons,
+    instrs [25..34]). `@[irreducible]` to keep let-bindings out of the
+    theorem signature. -/
+@[irreducible]
+def divKDiv128Prodcheck1bMergedCode (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
+   (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
+
+/-- Bundled precondition for `divK_div128_prodcheck1b_merged_spec`. -/
+@[irreducible]
+def divKDiv128Prodcheck1bMergedPre (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) :
+    Assertion :=
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled taken-leg postcondition for `divK_div128_prodcheck1b_merged_spec`
+    (rhatHi ≠ 0: guard fires, body is skipped). -/
+@[irreducible]
+def divKDiv128Prodcheck1bMergedTakenPost
+    (sp q1c rhatc dHi un1 v5Old dlo : Word) : Assertion :=
+  let rhatHi := rhatc >>> (32 : BitVec 6).toNat
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ rhatHi) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  ⌜rhatHi ≠ 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled fall-through-leg postcondition for `divK_div128_prodcheck1b_merged_spec`
+    (rhatHi = 0: guard falls through, body runs the 2nd D3 mul-check). -/
+@[irreducible]
+def divKDiv128Prodcheck1bMergedFTPost (sp q1c rhatc dHi un1 dlo : Word) :
+    Assertion :=
+  let qDlo := q1c * dlo
+  let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let rhatHi := rhatc >>> (32 : BitVec 6).toNat
+  let q1'FT := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
+  let rhat'FT := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
+  (.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1'FT) ** (.x7 ↦ᵣ rhat'FT) ** (.x11 ↦ᵣ un1) **
+  (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
+  ⌜rhatHi = 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo)
 
 /-- div128 product check 1b (Knuth classical 2nd D3 correction).
     Instrs [25]-[34] of `divK_div128_v2`. Both guard branches and both
@@ -152,38 +220,31 @@ theorem divK_div128_prodcheck1b_body_spec
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_prodcheck1b_merged_spec
     (sp q1c rhatc dHi un1 v1Old v5Old dlo : Word) (base : Word) :
-    let qDlo := q1c * dlo
-    let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let rhatHi := rhatc >>> (32 : BitVec 6).toNat
-    -- Fall-through leg only — the guard-taken leg keeps q1c / rhatc.
-    let q1'FT := if BitVec.ult rhatUn1' qDlo then q1c + signExtend12 4095 else q1c
-    let rhat'FT := if BitVec.ult rhatUn1' qDlo then rhatc + dHi else rhatc
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
-    cpsBranch base cr
-      ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-       (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ v1Old) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3952 ↦ₘ dlo))
-      (base + 40)  -- guard-fires path (rhatHi ≠ 0): body is skipped
-        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1c) ** (.x7 ↦ᵣ rhatc) ** (.x11 ↦ᵣ un1) **
-         (.x5 ↦ᵣ v5Old) ** (.x1 ↦ᵣ rhatHi) ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
-         ⌜rhatHi ≠ 0⌝ **
-         (sp + signExtend12 3952 ↦ₘ dlo))
-      (base + 40)  -- guard-doesn't-fire + body (rhatHi = 0): runs the mul-check
-        ((.x12 ↦ᵣ sp) ** (.x10 ↦ᵣ q1'FT) ** (.x7 ↦ᵣ rhat'FT) ** (.x11 ↦ᵣ un1) **
-         (.x5 ↦ᵣ qDlo) ** (.x1 ↦ᵣ rhatUn1') ** (.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) **
-         ⌜rhatHi = 0⌝ **
-         (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  intro qDlo rhatUn1' rhatHi q1'FT rhat'FT cr
+    cpsBranch base (divKDiv128Prodcheck1bMergedCode base)
+      (divKDiv128Prodcheck1bMergedPre sp q1c rhatc dHi un1 v1Old v5Old dlo)
+      (base + 40)
+        (divKDiv128Prodcheck1bMergedTakenPost sp q1c rhatc dHi un1 v5Old dlo)
+      (base + 40)
+        (divKDiv128Prodcheck1bMergedFTPost sp q1c rhatc dHi un1 dlo) := by
+  unfold divKDiv128Prodcheck1bMergedCode divKDiv128Prodcheck1bMergedPre
+    divKDiv128Prodcheck1bMergedTakenPost divKDiv128Prodcheck1bMergedFTPost
+  -- Reintroduce the locals the proof body uses (formerly let-bound in the
+  -- statement). With bundled defs in the signature, these locals are private
+  -- to the proof.
+  let qDlo := q1c * dlo
+  let rhatUn1' := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let rhatHi := rhatc >>> (32 : BitVec 6).toNat
+  let cr :=
+    CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.MUL .x5 .x10 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.SLLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 20) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 24) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.JAL .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.ADDI .x10 .x10 4095))
+     (CodeReq.singleton (base + 36) (.ADD .x7 .x7 .x6))))))))))
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.SRLI .x1 .x7 32))
       (CodeReq.union (CodeReq.singleton (base + 4) (.BNE .x1 .x0 36))
@@ -217,6 +278,10 @@ theorem divK_div128_prodcheck1b_merged_spec
   -- h2 = body_spec at base+8 — body's v1Old becomes the SRLI result rhatHi
   have h2_raw := divK_div128_prodcheck1b_body_spec sp q1c rhatc dHi un1 rhatHi v5Old dlo
     (base + 8)
+  -- Unfold the body's bundled forms so the rest of the proof works with the
+  -- explicit cr / pre / post structure.
+  unfold divKDiv128Prodcheck1bBodyCode divKDiv128Prodcheck1bBodyPre
+    divKDiv128Prodcheck1bBodyPost at h2_raw
   have hb4 : (base + 8 : Word) + 4 = base + 12 := by bv_addr
   have hb8 : (base + 8 : Word) + 8 = base + 16 := by bv_addr
   have hb12 : (base + 8 : Word) + 12 = base + 20 := by bv_addr


### PR DESCRIPTION
## Summary

Stacked on top of #1389. Closes the **2nd D3 correction block** spec for the `divK_div128_v2` algorithm fix (instructions [25..34]). Brings `EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1b` from a sorry-stub to **zero sorries**.

Also adds a migration-plan docstring stub for the eventual `div128_v2_spec` in `Compose/Div128.lean`.

## What's proved

Three theorems closed:
- `divK_div128_prodcheck1b_guard_spec` — SRLI + BNE guard (cpsBranch). Adapted from `divK_div128_phase2b_guard_spec` with `.x7` as the rhat register.
- `divK_div128_prodcheck1b_body_spec` — 8-instruction body. Delegated directly to the existing `divK_div128_prodcheck1_merged_spec` (same instructions at the same relative offsets — only register names differ).
- `divK_div128_prodcheck1b_merged_spec` — composition (cpsBranch). Mirrors `divK_div128_step2_branch_merged_spec` via `cpsBranch_seq_cpsTriple_with_perm_same_cr`.

## Why cpsBranch shape

The merged_spec emits a `cpsBranch` (both legs converging at `base + 40`) rather than a `cpsTriple`. On the guard-taken leg `.x5 = v5Old` and `.x1 = rhatHi` (untouched mul-check temporaries); on the fall-through leg `.x5 = qDlo` and `.x1 = rhatUn1'` (body-produced values). A unified cpsTriple cannot describe both legs simultaneously without conditional register postconditions — higher-level callers (`step1_v2_spec` to come) will case-analyze on `rhatHi` to recover a clean cpsTriple if needed.

## Test plan

- [x] `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1b` succeeds
- [x] No `sorry` in the file
- [x] No `native_decide` / `bv_decide` (kernel-checkable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)