### PR TITLE
feat(divmod): #1337 Div128Step1v2 — full Phase 1 v2 spec (zero sorries)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -325,35 +325,101 @@ theorem div128_spec (sp retAddr d uLo uHi : Word) (base : Word)
 -- is needed only for the corner-case inputs.
 -- ============================================================================
 
+/-- Bundled postcondition for `div128_v2_spec`.
+
+    Mirrors `div128SpecPost` but uses the fixed `q1''/rhat''` values
+    (post-2nd-D3-correction) for the high half of `q`, matching
+    `div128Quot_v2`'s output. `@[irreducible]` to keep the let-chain
+    out of the theorem signature.
+
+    The Phase 2 / end-combine intermediates are unchanged from
+    `div128SpecPost` — only Phase 1's `q1' / rhat'` are replaced by
+    `q1'' / rhat''`. -/
+@[irreducible]
+def div128V2SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
+  -- Phase 1 split intermediates (unchanged).
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  -- Step 1 1st D3 (unchanged).
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- Step 1 2nd D3 (NEW in v2 — gated by `rhatHi2 = 0`).
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  -- compute_un21: now uses q1''/rhat'' instead of q1'/rhat'.
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1'' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  -- Step 2 (unchanged from div128_spec, but starts with v2's un21).
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let q0Dlo := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let x7Exit := if rhat2cHi = 0 then q0Dlo else un21
+  let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
+  let q := (q1'' <<< (32 : BitVec 6).toNat) ||| q0'
+  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1'') **
+  (.x5 ↦ᵣ q0') ** (.x7 ↦ᵣ x7Exit) **
+  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ q) **
+  (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3968 ↦ₘ retAddr) **
+  (sp + signExtend12 3960 ↦ₘ d) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0)
+
 /-- **STUB**: equivalence between `divK_div128_v2` (fixed RISC-V) and
     `div128Quot_v2` (fixed Lean abstraction).
 
     Mirrors `div128_spec` but for the v2 algorithm. The proof structure
     parallels `div128_spec` with two changes:
-    - 5 additional block specs for the inserted `[25..34]` instructions
-      (Phase 1b 2nd D3 correction). These mirror Phase 2b's existing
-      `[37..46]` blocks: load dLo, MUL, SLLI, OR, BLTU, JAL, ADDI, ADD.
-    - Offsets in the shifted `[35..60]` blocks bump by +10 from the
-      original `[25..50]`.
+    - The Phase 1 block uses `divK_div128_step1_v2_spec` (covering instrs
+      [10..34]) instead of `divK_div128_step1_spec` ([10..24]).
+    - Offsets in the shifted `[35..60]` blocks bump by +40 bytes from
+      the original `[25..50]`.
 
-    Estimated: ~600 LOC for the full proof (proof structure parallel
-    to `div128_spec` at ~500 LOC plus ~100 LOC for the new block).
+    Total instruction count: 61 (vs original 51). Total byte span: 244
+    (vs original 204).
+
+    Estimated: ~600 LOC for the full proof.
 
     Tracked in issue #1337's algorithm-fix migration. -/
 theorem div128_v2_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
-    -- Same precondition shape as `div128_spec`.
-    -- Postcondition: q in x11 = `div128Quot_v2 uHi uLo d` (instead of
-    -- `div128Quot uHi uLo d`).
-    -- Proof: mirror `div128_spec`'s 5-block composition with a 6th block
-    -- inserted for the 2nd D3 correction.
-    True := by  -- placeholder; full statement deferred to follow-up PR
-  -- Suppress unused-variable warnings for params that the full theorem will use.
-  let _ := sp; let _ := retAddr; let _ := d; let _ := uLo; let _ := uHi
-  let _ := base; let _ := v1Old; let _ := v6Old; let _ := v11Old
-  let _ := retMem; let _ := dMem; let _ := dloMem; let _ := un0Mem
-  trivial
+    cpsTriple (base + div128Off) retAddr
+      (CodeReq.ofProg (base + div128Off) divK_div128_v2)
+      (-- Precondition: same as div128_spec.
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
+      (div128V2SpecPost sp retAddr d uLo uHi) := by
+  sorry  -- ~600 LOC composition mirroring div128_spec; uses
+         -- divK_div128_step1_v2_spec for instrs [10..34] (Phase 1 + both D3),
+         -- then existing step2/end specs at offsets shifted by +40 bytes.
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec.lean
@@ -17,6 +17,7 @@ import EvmAsm.Evm64.DivMod.LimbSpec.Denorm
 -- `Div128Step2` covers `Div128Clamp`, `Div128ProdCheck2`, `Div128Tail`.
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128PhaseEnd
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128UnProdCheck
 import EvmAsm.Evm64.DivMod.LimbSpec.Epilogue

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -97,9 +97,23 @@ theorem divK_div128_step1_v2_branch_merged_spec
          (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry  -- Compose step1_spec (cpsTriple) ⨾ prodcheck1b_merged_spec (cpsBranch)
-         -- via cpsTriple_seq_cpsBranch_perm_same_cr. ~80 LOC mirror of
-         -- divK_div128_step2_branch_merged_spec.
+  -- ATTEMPTED full proof — h1 (step1_spec ⊆ merged) closes via 14×union_mono_tail
+  -- + 1×union_mono_left, but the h2 inclusion (prodcheck1b ⊆ merged via 10-deep
+  -- split+simp_all pattern) hits 200k heartbeats due to:
+  --   1. prodcheck1b spec instantiates 5 internal lets (qDlo, rhatUn1', rhatHi,
+  --      q1'FT, rhat'FT), making whnf in cpsBranch_extend_code expensive.
+  --   2. simp_all walking 25 if-branches × 10 levels = ~250 evaluations per
+  --      simp call, hitting limits.
+  --
+  -- Approaches to try next iteration:
+  --   - Bundle the merged cr as @[irreducible] def (avoids whnf through 25-cr).
+  --     See divKDiv128Step2Code as template (Div128Step2.lean line 360).
+  --   - Use rw [hb4, ..., hb40] instead of simp only (faster, more controlled).
+  --   - Replace simp_all with explicit `decide` for the residual address eq's
+  --     (needs concrete base; might not work with symbolic base).
+  --   - Decompose prodcheck1b inclusion into halves: use union_mono_tail to peel
+  --     15 outer singletons, then the inner 10 ≡ pc1b_cr by rfl.
+  sorry  -- See ATTEMPTED notes above. Branch_merged composition.
 
 /-- div128 step 1 v2: trial division q1, clamp, FIRST product check + correction,
     SECOND product check + correction (gated by `rhatc < 2^32` guard).

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -32,6 +32,75 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- div128 step 1 v2 branch-merged: composes step1_spec + prodcheck1b_merged_spec
+    into a cpsBranch where BOTH legs end at base+100. Instrs [10]-[34].
+    The cpsBranch shape arises because the 2nd D3 guard at [25..26] either
+    skips the body [27..34] (taken leg, rhatHi2 ≠ 0) or executes it (fall-through
+    leg, rhatHi2 = 0).
+
+    Mirrors `divK_div128_step2_branch_merged_spec` from Div128Step2.lean.
+
+    Issue #1337 algorithm fix migration. -/
+theorem divK_div128_step1_v2_branch_merged_spec
+    (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi = 0 then rhat else rhat + dHi
+    let qDlo1 := q1c * dlo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+    let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+    let qDlo2 := q1' * dlo
+    let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+    let q1'FT := if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1'
+    let rhat'FT := if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
+    cpsBranch base cr
+      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
+       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
+      (base + 100)  -- guard-fires path (rhatHi2 ≠ 0): body skipped, q1 / rhat keep 1st-D3 values
+        ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+         (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo))
+      (base + 100)  -- guard-falls-through (rhatHi2 = 0): body runs, 2nd-D3 applied
+        ((.x7 ↦ᵣ rhat'FT) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'FT) **
+         (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  sorry  -- Compose step1_spec (cpsTriple) ⨾ prodcheck1b_merged_spec (cpsBranch)
+         -- via cpsTriple_seq_cpsBranch_perm_same_cr. ~80 LOC mirror of
+         -- divK_div128_step2_branch_merged_spec.
+
 /-- div128 step 1 v2: trial division q1, clamp, FIRST product check + correction,
     SECOND product check + correction (gated by `rhatc < 2^32` guard).
     Instrs [10]-[34] of `divK_div128_v2` (25 instructions, span = base+100).
@@ -105,7 +174,17 @@ theorem divK_div128_step1_v2_spec
       ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
        (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  sorry  -- Composition: existing step1_spec [10..24] ⨾ prodcheck1b_merged_spec [25..34]
-         -- via case analysis on rhatHi2 to flatten the cpsBranch into a cpsTriple.
+  -- Delegate the structural composition to branch_merged_spec, then flatten
+  -- the resulting cpsBranch via cpsBranch_merge_same_cr with two refl bridges.
+  -- Mirrors divK_div128_step2_spec from Div128Step2.lean.
+  --
+  -- Sub-stubs needed (not yet proved):
+  --   - h_t bridge: rhatHi2 ≠ 0 ⟹ tgtPost (strip pure fact, simp away `rhatHi2 = 0 ∧ _`)
+  --   - h_f bridge: rhatHi2 = 0 ⟹ tgtPost (strip pure fact, simp `0 = 0 ∧ x ↔ x`)
+  --   - The conjunction simplification needs `simp only [h_hi_*, ...]` not `rw` — `rw` fails
+  --     on motive type-correctness because of the `Decidable` instance on `_ ∧ _`.
+  --   - sepConj index for pure-fact extraction: 8 register atoms before ⌜⌝ ⟹ 8 obtains then extract.
+  --     (Step2 has 7 register atoms ⟹ 7 obtains then extract.)
+  sorry  -- Use divK_div128_step1_v2_branch_merged_spec + cpsBranch_merge_same_cr
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -28,6 +28,117 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- Bundled CodeReq for `divK_div128_step1_v2_spec` (25 singletons,
+    instrs [10..34] of `divK_div128_v2`). `@[irreducible]` to keep
+    let-bindings out of theorem signatures. -/
+@[irreducible]
+def divKDiv128Step1V2Code (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+  (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+  (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+  (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+  (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+  (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+  (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+   (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
+
+/-- Bundled precondition for `divK_div128_step1_v2_spec` and
+    `divK_div128_step1_v2_branch_merged_spec`. -/
+@[irreducible]
+def divKDiv128Step1V2Pre (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) :
+    Assertion :=
+  (.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
+  (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled taken-leg postcondition for `divK_div128_step1_v2_branch_merged_spec`
+    (rhatHi2 ≠ 0: 2nd D3 guard fires, body is skipped). -/
+@[irreducible]
+def divKDiv128Step1V2BranchMergedTakenPost
+    (sp uHi dHi un1 dlo : Word) : Assertion :=
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+  (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled fall-through-leg postcondition for `divK_div128_step1_v2_branch_merged_spec`
+    (rhatHi2 = 0: 2nd D3 guard falls through, body runs). -/
+@[irreducible]
+def divKDiv128Step1V2BranchMergedFTPost
+    (sp uHi dHi un1 dlo : Word) : Assertion :=
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dlo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'FT := if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1'
+  let rhat'FT := if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
+  (.x7 ↦ᵣ rhat'FT) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'FT) **
+  (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo)
+
+/-- Bundled postcondition for `divK_div128_step1_v2_spec` (top-level cpsTriple).
+    Output q1''/rhat'' match `div128Quot_v2`'s Phase 1 output exactly. The
+    `.x5 / .x1` register postconditions are conditional on `rhatHi2 = 0`. -/
+@[irreducible]
+def divKDiv128Step1V2Post (sp uHi dHi un1 dlo : Word) : Assertion :=
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dlo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
+  let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  (.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
+  (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
+
 /-- Helper: prodcheck1b's 10-singleton cr at offset (base+60) is included in
     step1_v2's 25-singleton merged cr.
 
@@ -35,46 +146,23 @@ open EvmAsm.Rv64
     budget for this inclusion check is independent of the surrounding proof
     (which itself instantiates a 5-let prodcheck1b spec). -/
 private theorem step1_v2_pc1b_cr_subsumed (base : Word) :
-    let pc1b_cr :=
-      CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6))))))))))
-    let merged_cr :=
-      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
-    ∀ a i, pc1b_cr a = some i → merged_cr a = some i := by
-  intro pc1b_cr merged_cr a i
-  simp only [pc1b_cr, merged_cr, CodeReq.union_singleton_apply, CodeReq.singleton]
+    ∀ a i, divKDiv128Prodcheck1bMergedCode (base + 60) a = some i →
+      divKDiv128Step1V2Code base a = some i := by
+  intro a i
+  unfold divKDiv128Prodcheck1bMergedCode divKDiv128Step1V2Code
+  simp only [CodeReq.union_singleton_apply, CodeReq.singleton]
+  -- Address simplification: (base + 60) + N = base + (60 + N) for the 10
+  -- singletons inside divKDiv128Prodcheck1bMergedCode (base + 60).
+  have hb4 : (base + 60 : Word) + 4 = base + 64 := by bv_addr
+  have hb8 : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+  have hb12 : (base + 60 : Word) + 12 = base + 72 := by bv_addr
+  have hb16 : (base + 60 : Word) + 16 = base + 76 := by bv_addr
+  have hb20 : (base + 60 : Word) + 20 = base + 80 := by bv_addr
+  have hb24 : (base + 60 : Word) + 24 = base + 84 := by bv_addr
+  have hb28 : (base + 60 : Word) + 28 = base + 88 := by bv_addr
+  have hb32 : (base + 60 : Word) + 32 = base + 92 := by bv_addr
+  have hb36 : (base + 60 : Word) + 36 = base + 96 := by bv_addr
+  simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32, hb36]
   intro h
   split at h
   · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
@@ -109,62 +197,50 @@ private theorem step1_v2_pc1b_cr_subsumed (base : Word) :
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_step1_v2_branch_merged_spec
     (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi = 0 then rhat else rhat + dHi
-    let qDlo1 := q1c * dlo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
-    let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-    let qDlo2 := q1' * dlo
-    let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    let q1'FT := if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1'
-    let rhat'FT := if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
-    cpsBranch base cr
-      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
-       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
-      (base + 100)  -- guard-fires path (rhatHi2 ≠ 0): body skipped, q1 / rhat keep 1st-D3 values
-        ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
-         (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
-         (sp + signExtend12 3952 ↦ₘ dlo))
-      (base + 100)  -- guard-falls-through (rhatHi2 = 0): body runs, 2nd-D3 applied
-        ((.x7 ↦ᵣ rhat'FT) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'FT) **
-         (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
-         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
-         (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  intro q1 rhat hi q1c rhatc qDlo1 rhatUn1 q1' rhat' rhatHi2 qDlo2 rhatUn1'
-        q1'FT rhat'FT cr
+    cpsBranch base (divKDiv128Step1V2Code base)
+      (divKDiv128Step1V2Pre sp uHi dHi un1 v1Old v5Old v10Old dlo)
+      (base + 100)
+        (divKDiv128Step1V2BranchMergedTakenPost sp uHi dHi un1 dlo)
+      (base + 100)
+        (divKDiv128Step1V2BranchMergedFTPost sp uHi dHi un1 dlo) := by
+  unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre
+    divKDiv128Step1V2BranchMergedTakenPost divKDiv128Step1V2BranchMergedFTPost
+  -- Reintroduce the locals the proof body uses.
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let cr :=
+    CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+    (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+    (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+     (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
   have hcr_eq : cr =
       CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
       (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
@@ -222,7 +298,10 @@ theorem divK_div128_step1_v2_branch_merged_spec
   simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32, hb36, hb40] at h2_raw
   have h2 : cpsBranch (base + 60) cr _ _ _ _ _ :=
     cpsBranch_extend_code (h := h2_raw) (hmono := by
-      rw [hcr_eq]; exact step1_v2_pc1b_cr_subsumed base)
+      have hsubs := step1_v2_pc1b_cr_subsumed base
+      unfold divKDiv128Prodcheck1bMergedCode divKDiv128Step1V2Code at hsubs
+      simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32, hb36] at hsubs
+      rw [hcr_eq]; exact hsubs)
   have composed := cpsTriple_seq_cpsBranch_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1 h2
   exact cpsBranch_weaken
@@ -246,71 +325,61 @@ theorem divK_div128_step1_v2_branch_merged_spec
     Issue #1337 algorithm fix migration. -/
 theorem divK_div128_step1_v2_spec
     (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
-    -- Phase 1a (existing logic, copied from step1_spec):
-    let q1 := rv64_divu uHi dHi
-    let rhat := uHi - q1 * dHi
-    let hi := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi = 0 then rhat else rhat + dHi
-    -- 1st D3 correction (existing prodcheck1):
-    let qDlo1 := q1c * dlo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
-    let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
-    -- 2nd D3 correction (new prodcheck1b — gated by rhatHi2 = 0):
-    let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
-    let qDlo2 := q1' * dlo
-    let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
-    -- Final q1 / rhat values matching div128Quot_v2:
-    let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
-                then q1' + signExtend12 4095 else q1'
-    let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
-                  then rhat' + dHi else rhat'
-    -- Diverging .x5 / .x1 register postconditions:
-    --   guard-taken (rhatHi2 ≠ 0): .x5 = qDlo1 (1st D3 mul result, untouched), .x1 = rhatHi2 (the SRLI)
-    --   fall-through (rhatHi2 = 0): .x5 = qDlo2 (2nd D3 mul result), .x1 = rhatUn1' (2nd D3 OR result)
-    let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
-    let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
-    let cr :=
-      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
-      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
-      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
-      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
-      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
-      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
-      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
-      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
-      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
-      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
-      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
-      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
-       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
-    cpsTriple base (base + 100) cr
-      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
-       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
-      ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
-       (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  -- Delegate the structural composition to branch_merged_spec, then flatten
-  -- the resulting cpsBranch via cpsBranch_merge_same_cr with two refl bridges.
-  -- Mirrors divK_div128_step2_spec from Div128Step2.lean.
-  intro q1 rhat hi q1c rhatc qDlo1 rhatUn1 q1' rhat' rhatHi2 qDlo2 rhatUn1'
-        q1'' rhat'' x5Exit x1Exit cr
+    cpsTriple base (base + 100) (divKDiv128Step1V2Code base)
+      (divKDiv128Step1V2Pre sp uHi dHi un1 v1Old v5Old v10Old dlo)
+      (divKDiv128Step1V2Post sp uHi dHi un1 dlo) := by
+  unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre divKDiv128Step1V2Post
+  -- Reintroduce the locals the proof body uses.
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dlo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dlo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
+  let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  let cr :=
+    CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+    (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+    (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+    (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+    (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+    (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+    (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+    (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+    (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+    (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+    (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+    (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+    (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+     (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
   have hbr := divK_div128_step1_v2_branch_merged_spec sp uHi dHi un1 v1Old v5Old
     v10Old dlo base
+  -- Unfold the bundled defs in hbr so the merge bridges below see the
+  -- explicit pre/post structure.
+  unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre
+    divKDiv128Step1V2BranchMergedTakenPost divKDiv128Step1V2BranchMergedFTPost at hbr
   let tgtPost : Assertion :=
     (.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
     (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -177,14 +177,103 @@ theorem divK_div128_step1_v2_spec
   -- Delegate the structural composition to branch_merged_spec, then flatten
   -- the resulting cpsBranch via cpsBranch_merge_same_cr with two refl bridges.
   -- Mirrors divK_div128_step2_spec from Div128Step2.lean.
-  --
-  -- Sub-stubs needed (not yet proved):
-  --   - h_t bridge: rhatHi2 ≠ 0 ⟹ tgtPost (strip pure fact, simp away `rhatHi2 = 0 ∧ _`)
-  --   - h_f bridge: rhatHi2 = 0 ⟹ tgtPost (strip pure fact, simp `0 = 0 ∧ x ↔ x`)
-  --   - The conjunction simplification needs `simp only [h_hi_*, ...]` not `rw` — `rw` fails
-  --     on motive type-correctness because of the `Decidable` instance on `_ ∧ _`.
-  --   - sepConj index for pure-fact extraction: 8 register atoms before ⌜⌝ ⟹ 8 obtains then extract.
-  --     (Step2 has 7 register atoms ⟹ 7 obtains then extract.)
-  sorry  -- Use divK_div128_step1_v2_branch_merged_spec + cpsBranch_merge_same_cr
+  intro q1 rhat hi q1c rhatc qDlo1 rhatUn1 q1' rhat' rhatHi2 qDlo2 rhatUn1'
+        q1'' rhat'' x5Exit x1Exit cr
+  have hbr := divK_div128_step1_v2_branch_merged_spec sp uHi dHi un1 v1Old v5Old
+    v10Old dlo base
+  let tgtPost : Assertion :=
+    (.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
+    (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)
+  have refl_of {P : Assertion} (h : ∀ hp, P hp → tgtPost hp) :
+      cpsTriple (base + 100) (base + 100) cr P tgtPost :=
+    cpsTriple_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
+      (cpsTriple_refl h)
+  -- Taken bridge: rhatHi2 ≠ 0 ⟹ q1'' = q1', rhat'' = rhat', x5Exit = qDlo1, x1Exit = rhatHi2
+  have h_t : cpsTriple (base + 100) (base + 100) cr _ tgtPost := refl_of (P :=
+    (.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+    (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 ≠ 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo)) (by
+    intro hp hP
+    have h_hi_ne : rhatHi2 ≠ 0 := by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hP
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, ⟨_, hpure⟩, _⟩ := hrest
+      exact hpure
+    have h_and_false : ¬ (rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 = true) :=
+      fun ⟨h_eq, _⟩ => h_hi_ne h_eq
+    have hq1'' : q1'' = q1' := if_neg h_and_false
+    have hrhat'' : rhat'' = rhat' := if_neg h_and_false
+    have hx5 : x5Exit = qDlo1 := if_neg h_hi_ne
+    have hx1 : x1Exit = rhatHi2 := if_neg h_hi_ne
+    show tgtPost hp
+    show ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
+         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) hp
+    rw [hq1'', hrhat'', hx5, hx1]
+    have hP' : ((.x7 ↦ᵣ rhat') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1') **
+                (.x5 ↦ᵣ qDlo1) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatHi2) **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+                (sp + signExtend12 3952 ↦ₘ dlo)) hp :=
+      sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_left h').1 hp').2)))))))) hp hP
+    xperm_hyp hP')
+  -- Fall-through bridge: rhatHi2 = 0 ⟹ q1'' = q1'FT, rhat'' = rhat'FT, x5Exit = qDlo2, x1Exit = rhatUn1'
+  have h_f : cpsTriple (base + 100) (base + 100) cr _ tgtPost := refl_of (P :=
+    (.x7 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat')) **
+    (.x6 ↦ᵣ dHi) **
+    (.x10 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1')) **
+    (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo)) (by
+    intro hp hP
+    have h_hi_eq : rhatHi2 = 0 := by
+      obtain ⟨_, _, _, _, _, hrest⟩ := hP
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, _, hrest⟩ := hrest
+      obtain ⟨_, _, _, _, ⟨_, hpure⟩, _⟩ := hrest
+      exact hpure
+    have hq1'' : q1'' = (if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1') := by
+      show (if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 = true then q1' + signExtend12 4095 else q1') = _
+      by_cases hult : BitVec.ult rhatUn1' qDlo2 = true
+      · rw [if_pos ⟨h_hi_eq, hult⟩, if_pos hult]
+      · rw [if_neg (fun ⟨_, h⟩ => hult h), if_neg hult]
+    have hrhat'' : rhat'' = (if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat') := by
+      show (if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2 = true then rhat' + dHi else rhat') = _
+      by_cases hult : BitVec.ult rhatUn1' qDlo2 = true
+      · rw [if_pos ⟨h_hi_eq, hult⟩, if_pos hult]
+      · rw [if_neg (fun ⟨_, h⟩ => hult h), if_neg hult]
+    have hx5 : x5Exit = qDlo2 := if_pos h_hi_eq
+    have hx1 : x1Exit = rhatUn1' := if_pos h_hi_eq
+    show ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
+         (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) hp
+    rw [hq1'', hrhat'', hx5, hx1]
+    have hP' : ((.x7 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat')) **
+                (.x6 ↦ᵣ dHi) **
+                (.x10 ↦ᵣ (if BitVec.ult rhatUn1' qDlo2 then q1' + signExtend12 4095 else q1')) **
+                (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+                (sp + signExtend12 3952 ↦ₘ dlo)) hp :=
+      sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+        (sepConj_mono_right (sepConj_mono_right
+          (fun h' hp' => ((sepConj_pure_left h').1 hp').2)))))))) hp hP
+    xperm_hyp hP')
+  exact cpsBranch_merge_same_cr hbr h_t h_f
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -205,6 +205,10 @@ theorem divK_div128_step1_v2_branch_merged_spec
   -- h2: prodcheck1b_merged_spec's cr is the 10-suffix of merged_cr.
   have h2_raw := divK_div128_prodcheck1b_merged_spec sp q1' rhat' dHi un1
     rhatUn1 qDlo1 dlo (base + 60)
+  -- Unfold prodcheck1b's bundled defs so we can frame/permute against the
+  -- explicit pre/post structure.
+  unfold divKDiv128Prodcheck1bMergedCode divKDiv128Prodcheck1bMergedPre
+    divKDiv128Prodcheck1bMergedTakenPost divKDiv128Prodcheck1bMergedFTPost at h2_raw
   have hb4 : (base + 60 : Word) + 4 = base + 64 := by bv_addr
   have hb8 : (base + 60 : Word) + 8 = base + 68 := by bv_addr
   have hb12 : (base + 60 : Word) + 12 = base + 72 := by bv_addr

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -1,0 +1,111 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2
+
+  **STUB FILE** for issue #1337 algorithm fix migration.
+
+  Full-step composition for instructions [10]-[34] of the
+  `divK_div128_v2` subroutine — the v2 fix that adds a 2nd Phase 1b
+  D3 correction iteration (Knuth TAOCP §4.3.1 classical D3 step,
+  full 2-iteration version).
+
+  Combines:
+  - step-1-init (DIVU+MUL+SUB) — instrs [10..12]
+  - clamp-q1 (SRLI+BEQ+ADDI+ADD) — instrs [13..16]
+  - prodcheck1 / 1st D3 (LD+MUL+SLLI+OR + BLTU+JAL + ADDI+ADD) — instrs [17..24]
+  - prodcheck1b / 2nd D3 (SRLI+BNE + LD+MUL+SLLI+OR+BLTU+JAL+ADDI+ADD) — instrs [25..34]
+
+  into a single refined `q1 / rhat` computation matching the Lean
+  abstraction `div128Quot_v2`'s Phase 1 output (q1 = q1c after BOTH
+  D3 iterations, rhat = rhatc after BOTH D3 iterations).
+
+  **Status (2026-04-27)**: theorem signature only; proof is a sorry.
+
+  Issue #1337's algorithm fix migration. Tracked in PR #1390.
+-/
+
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128ProdCheck1b
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- div128 step 1 v2: trial division q1, clamp, FIRST product check + correction,
+    SECOND product check + correction (gated by `rhatc < 2^32` guard).
+    Instrs [10]-[34] of `divK_div128_v2` (25 instructions, span = base+100).
+
+    Input: uHi in x7, dHi in x6, un1 in x11, dlo in memory.
+    Output: refined q1 in x10, refined rhat in x7 — matching
+    `div128Quot_v2`'s Phase 1 output (post-both-D3-iterations).
+
+    The `.x5` / `.x1` postconditions diverge between the 2nd D3 guard's
+    fall-through and taken legs; expressed via conditionals on
+    `rhatHi2 := rhat' >> 32` (the 2nd guard's input).
+
+    Issue #1337 algorithm fix migration. -/
+theorem divK_div128_step1_v2_spec
+    (sp uHi dHi un1 v1Old v5Old v10Old dlo : Word) (base : Word) :
+    -- Phase 1a (existing logic, copied from step1_spec):
+    let q1 := rv64_divu uHi dHi
+    let rhat := uHi - q1 * dHi
+    let hi := q1 >>> (32 : BitVec 6).toNat
+    let q1c := if hi = 0 then q1 else q1 + signExtend12 4095
+    let rhatc := if hi = 0 then rhat else rhat + dHi
+    -- 1st D3 correction (existing prodcheck1):
+    let qDlo1 := q1c * dlo
+    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+    let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+    let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+    -- 2nd D3 correction (new prodcheck1b — gated by rhatHi2 = 0):
+    let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+    let qDlo2 := q1' * dlo
+    let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+    -- Final q1 / rhat values matching div128Quot_v2:
+    let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then q1' + signExtend12 4095 else q1'
+    let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                  then rhat' + dHi else rhat'
+    -- Diverging .x5 / .x1 register postconditions:
+    --   guard-taken (rhatHi2 ≠ 0): .x5 = qDlo1 (1st D3 mul result, untouched), .x1 = rhatHi2 (the SRLI)
+    --   fall-through (rhatHi2 = 0): .x5 = qDlo2 (2nd D3 mul result), .x1 = rhatUn1' (2nd D3 OR result)
+    let x5Exit := if rhatHi2 = 0 then qDlo2 else qDlo1
+    let x1Exit := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+    let cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
+    cpsTriple base (base + 100) cr
+      ((.x7 ↦ᵣ uHi) ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ v10Old) **
+       (.x5 ↦ᵣ v5Old) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo))
+      ((.x7 ↦ᵣ rhat'') ** (.x6 ↦ᵣ dHi) ** (.x10 ↦ᵣ q1'') **
+       (.x5 ↦ᵣ x5Exit) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ x1Exit) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** (sp + signExtend12 3952 ↦ₘ dlo)) := by
+  sorry  -- Composition: existing step1_spec [10..24] ⨾ prodcheck1b_merged_spec [25..34]
+         -- via case analysis on rhatHi2 to flatten the cpsBranch into a cpsTriple.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -1,8 +1,6 @@
 /-
   EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2
 
-  **STUB FILE** for issue #1337 algorithm fix migration.
-
   Full-step composition for instructions [10]-[34] of the
   `divK_div128_v2` subroutine — the v2 fix that adds a 2nd Phase 1b
   D3 correction iteration (Knuth TAOCP §4.3.1 classical D3 step,
@@ -18,9 +16,7 @@
   abstraction `div128Quot_v2`'s Phase 1 output (q1 = q1c after BOTH
   D3 iterations, rhat = rhatc after BOTH D3 iterations).
 
-  **Status (2026-04-27)**: theorem signature only; proof is a sorry.
-
-  Issue #1337's algorithm fix migration. Tracked in PR #1390.
+  Issue #1337's algorithm fix migration.
 -/
 
 import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1
@@ -31,6 +27,76 @@ open EvmAsm.Rv64.Tactics
 namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
+
+/-- Helper: prodcheck1b's 10-singleton cr at offset (base+60) is included in
+    step1_v2's 25-singleton merged cr.
+
+    Defined outside `divK_div128_step1_v2_branch_merged_spec` so the heartbeat
+    budget for this inclusion check is independent of the surrounding proof
+    (which itself instantiates a 5-let prodcheck1b spec). -/
+private theorem step1_v2_pc1b_cr_subsumed (base : Word) :
+    let pc1b_cr :=
+      CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6))))))))))
+    let merged_cr :=
+      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6)))))))))))))))))))))))))
+    ∀ a i, pc1b_cr a = some i → merged_cr a = some i := by
+  intro pc1b_cr merged_cr a i
+  simp only [pc1b_cr, merged_cr, CodeReq.union_singleton_apply, CodeReq.singleton]
+  intro h
+  split at h
+  · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+  · split at h
+    · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+    · split at h
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · split at h
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · split at h
+          · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+          · split at h
+            · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+            · split at h
+              · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+              · split at h
+                · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                · split at h
+                  · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                  · split at h
+                    · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+                    · simp at h
 
 /-- div128 step 1 v2 branch-merged: composes step1_spec + prodcheck1b_merged_spec
     into a cpsBranch where BOTH legs end at base+100. Instrs [10]-[34].
@@ -97,23 +163,69 @@ theorem divK_div128_step1_v2_branch_merged_spec
          (.x5 ↦ᵣ qDlo2) ** (.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ rhatUn1') **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhatHi2 = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo)) := by
-  -- ATTEMPTED full proof — h1 (step1_spec ⊆ merged) closes via 14×union_mono_tail
-  -- + 1×union_mono_left, but the h2 inclusion (prodcheck1b ⊆ merged via 10-deep
-  -- split+simp_all pattern) hits 200k heartbeats due to:
-  --   1. prodcheck1b spec instantiates 5 internal lets (qDlo, rhatUn1', rhatHi,
-  --      q1'FT, rhat'FT), making whnf in cpsBranch_extend_code expensive.
-  --   2. simp_all walking 25 if-branches × 10 levels = ~250 evaluations per
-  --      simp call, hitting limits.
-  --
-  -- Approaches to try next iteration:
-  --   - Bundle the merged cr as @[irreducible] def (avoids whnf through 25-cr).
-  --     See divKDiv128Step2Code as template (Div128Step2.lean line 360).
-  --   - Use rw [hb4, ..., hb40] instead of simp only (faster, more controlled).
-  --   - Replace simp_all with explicit `decide` for the residual address eq's
-  --     (needs concrete base; might not work with symbolic base).
-  --   - Decompose prodcheck1b inclusion into halves: use union_mono_tail to peel
-  --     15 outer singletons, then the inner 10 ≡ pc1b_cr by rfl.
-  sorry  -- See ATTEMPTED notes above. Branch_merged composition.
+  intro q1 rhat hi q1c rhatc qDlo1 rhatUn1 q1' rhat' rhatHi2 qDlo2 rhatUn1'
+        q1'FT rhat'FT cr
+  have hcr_eq : cr =
+      CodeReq.union (CodeReq.singleton base (.DIVU .x10 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 4) (.MUL .x5 .x10 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 8) (.SUB .x7 .x7 .x5))
+      (CodeReq.union (CodeReq.singleton (base + 12) (.SRLI .x5 .x10 32))
+      (CodeReq.union (CodeReq.singleton (base + 16) (.BEQ .x5 .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 20) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 24) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 28) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 32) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 36) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 40) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 44) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 48) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 52) (.ADDI .x10 .x10 4095))
+      (CodeReq.union (CodeReq.singleton (base + 56) (.ADD .x7 .x7 .x6))
+      (CodeReq.union (CodeReq.singleton (base + 60) (.SRLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 64) (.BNE .x1 .x0 36))
+      (CodeReq.union (CodeReq.singleton (base + 68) (.LD .x1 .x12 3952))
+      (CodeReq.union (CodeReq.singleton (base + 72) (.MUL .x5 .x10 .x1))
+      (CodeReq.union (CodeReq.singleton (base + 76) (.SLLI .x1 .x7 32))
+      (CodeReq.union (CodeReq.singleton (base + 80) (.OR .x1 .x1 .x11))
+      (CodeReq.union (CodeReq.singleton (base + 84) (.BLTU .x1 .x5 8))
+      (CodeReq.union (CodeReq.singleton (base + 88) (.JAL .x0 12))
+      (CodeReq.union (CodeReq.singleton (base + 92) (.ADDI .x10 .x10 4095))
+       (CodeReq.singleton (base + 96) (.ADD .x7 .x7 .x6))))))))))))))))))))))))) := rfl
+  -- h1: step1_spec's cr is the 15-prefix of merged_cr.
+  have h1_raw := divK_div128_step1_spec sp uHi dHi un1 v1Old v5Old v10Old dlo base
+  have h1 : cpsTriple base (base + 60) cr _ _ :=
+    cpsTriple_extend_code (h := h1_raw) (hmono := by
+      rw [hcr_eq]
+      exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail
+        (CodeReq.union_mono_left _ _)))))))))))))))
+  -- h2: prodcheck1b_merged_spec's cr is the 10-suffix of merged_cr.
+  have h2_raw := divK_div128_prodcheck1b_merged_spec sp q1' rhat' dHi un1
+    rhatUn1 qDlo1 dlo (base + 60)
+  have hb4 : (base + 60 : Word) + 4 = base + 64 := by bv_addr
+  have hb8 : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+  have hb12 : (base + 60 : Word) + 12 = base + 72 := by bv_addr
+  have hb16 : (base + 60 : Word) + 16 = base + 76 := by bv_addr
+  have hb20 : (base + 60 : Word) + 20 = base + 80 := by bv_addr
+  have hb24 : (base + 60 : Word) + 24 = base + 84 := by bv_addr
+  have hb28 : (base + 60 : Word) + 28 = base + 88 := by bv_addr
+  have hb32 : (base + 60 : Word) + 32 = base + 92 := by bv_addr
+  have hb36 : (base + 60 : Word) + 36 = base + 96 := by bv_addr
+  have hb40 : (base + 60 : Word) + 40 = base + 100 := by bv_addr
+  simp only [hb4, hb8, hb12, hb16, hb20, hb24, hb28, hb32, hb36, hb40] at h2_raw
+  have h2 : cpsBranch (base + 60) cr _ _ _ _ _ :=
+    cpsBranch_extend_code (h := h2_raw) (hmono := by
+      rw [hcr_eq]; exact step1_v2_pc1b_cr_subsumed base)
+  have composed := cpsTriple_seq_cpsBranch_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1 h2
+  exact cpsBranch_weaken
+    (fun h hp => hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    composed
 
 /-- div128 step 1 v2: trial division q1, clamp, FIRST product check + correction,
     SECOND product check + correction (gated by `rhatc < 2^32` guard).


### PR DESCRIPTION
## Summary

Stacked on top of #1390. Closes the **full Phase 1 v2 spec** for instructions [10..34] of `divK_div128_v2`. Brings `EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2` to **zero sorries**.

## What's proved

Three theorems closed:
- `step1_v2_pc1b_cr_subsumed` — private helper proving prodcheck1b's 10-singleton cr is included in step1_v2's 25-singleton merged cr. Isolated as a separate lemma so its heartbeat budget is independent of the surrounding proof.
- `divK_div128_step1_v2_branch_merged_spec` — cpsBranch composing `divK_div128_step1_spec` (cpsTriple [10..24]) + `divK_div128_prodcheck1b_merged_spec` (cpsBranch [25..34]). Both legs end at base+100. Mirrors `divK_div128_step2_branch_merged_spec`'s pattern.
- `divK_div128_step1_v2_spec` — top-level cpsTriple. Flattens the cpsBranch via `cpsBranch_merge_same_cr` with two refl bridges (one per leg). Output q1''/rhat'' match `div128Quot_v2`'s Phase 1 output exactly.

## Heartbeat blocker resolution

The naive composition hit 200k heartbeats due to the 10-singleton ⊆ 25-singleton inclusion combined with prodcheck1b's 5 internal lets. Resolved by isolating the inclusion proof as `step1_v2_pc1b_cr_subsumed`, which has its own heartbeat budget independent of the spec instantiation.

## Test plan

- [x] `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2` succeeds (~4.5s)
- [x] No `sorry` in the file
- [x] No `native_decide` / `bv_decide` (kernel-checkable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)