### PR TITLE
feat(rlp): add mixed-content two-element list decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -167,6 +167,15 @@ theorem decode_pair_list_small_bytes
       some (.list [.bytes [b1], .bytes [b2]], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems, h1, h2]
 
+/-- Mixed-content two-element list: a small byte followed by an empty
+    string. `decode [0xC2, b, 0x80] = some (.list [.bytes [b], .bytes []], [])`
+    when `b < 0x80`. -/
+theorem decode_pair_list_byte_then_empty_string
+    (b : Byte) (h : b.toNat < 0x80) :
+    decode [(0xC2 : Byte), b, (0x80 : Byte)] =
+      some (.list [.bytes [b], .bytes []], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems, h]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_pair_list_byte_then_empty_string`: for any small byte `b < 0x80`,
```
decode [0xC2, b, 0x80] = some (.list [.bytes [b], .bytes []], [])
```

Demonstrates that the decoder handles heterogeneous two-element lists correctly: the first item is a single-byte payload, the second is the empty short-string. Together with `decode_pair_list_small_bytes` (#1388) and `decode_pair_list_empty_lists` (#1397) covers the three basic 2-element list shapes.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)