### PR TITLE
feat(rlp): add list-then-byte mixed two-element list decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -195,6 +195,15 @@ theorem decode_pair_list_byte_then_empty_string
       some (.list [.bytes [b], .bytes []], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems, h]
 
+/-- Mixed-content two-element list: an empty list followed by a small
+    byte. `decode [0xC2, 0xC0, b] = some (.list [.list [], .bytes [b]], [])`
+    when `b < 0x80`. -/
+theorem decode_pair_list_empty_list_then_byte
+    (b : Byte) (h : b.toNat < 0x80) :
+    decode [(0xC2 : Byte), (0xC0 : Byte), b] =
+      some (.list [.list [], .bytes [b]], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems, h]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_pair_list_empty_list_then_byte`: for any small byte `b < 0x80`,
```
decode [0xC2, 0xC0, b] = some (.list [.list [], .bytes [b]], [])
```

Companion to `decode_pair_list_byte_then_empty_string` (#1398); the two together exercise both orderings of mixed-content pair lists. Demonstrates that the decoder transparently handles mixed inner item types (list and bytes) in a single pair.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)