### PR TITLE
feat(rlp): add byte-then-empty-list pair decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -204,6 +204,16 @@ theorem decode_pair_list_empty_list_then_byte
       some (.list [.list [], .bytes [b]], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems, h]
 
+/-- Mixed-content two-element list: a small byte followed by an empty
+    list. `decode [0xC2, b, 0xC0] = some (.list [.bytes [b], .list []], [])`
+    when `b < 0x80`. Companion to `decode_pair_list_empty_list_then_byte`
+    in the reverse order. -/
+theorem decode_pair_list_byte_then_empty_list
+    (b : Byte) (h : b.toNat < 0x80) :
+    decode [(0xC2 : Byte), b, (0xC0 : Byte)] =
+      some (.list [.bytes [b], .list []], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems, h]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_pair_list_byte_then_empty_list`: for any small byte `b < 0x80`,
```
decode [0xC2, b, 0xC0] = some (.list [.bytes [b], .list []], [])
```

Companion to `decode_pair_list_empty_list_then_byte` (#1400) in the reverse order — completes both byte/list orderings of the mixed-content pair list.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)