### PR TITLE
feat(rlp): add singleton-list-of-two-byte-string decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -204,6 +204,16 @@ theorem decode_pair_list_empty_list_then_byte
       some (.list [.list [], .bytes [b]], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems, h]
 
+/-- Singleton list containing a two-byte short string:
+    `decode [0xC3, 0x82, b1, b2] = some (.list [.bytes [b1, b2]], [])`.
+    The outer short-list branch fires with payload length 3, the inner
+    `[0x82, b1, b2]` decodes as a two-byte short string, and the outer
+    list closes. -/
+theorem decode_singleton_list_two_byte_string (b1 b2 : Byte) :
+    decode [(0xC3 : Byte), (0x82 : Byte), b1, b2] =
+      some (.list [.bytes [b1, b2]], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_singleton_list_two_byte_string`: for arbitrary bytes `b1 b2`,
```
decode [0xC3, 0x82, b1, b2] = some (.list [.bytes [b1, b2]], [])
```

Demonstrates list-of-multibyte-string decoding: the outer short-list branch fires with payload length 3, the inner `[0x82, b1, b2]` decodes as a two-byte short string (canonical-form check bypassed because the inner payload is multi-byte), and the outer list closes.

Companion to `decode_singleton_list_small_byte` (#1383) and `decode_singleton_list_large_byte` (#1399); together they cover singleton lists wrapping all three single-byte / multibyte string shapes for the simplest payload length.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)