### PR TITLE
feat(rlp): add singleton-list-of-three-byte-string decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -244,6 +244,15 @@ theorem decode_singleton_list_two_byte_string (b1 b2 : Byte) :
       some (.list [.bytes [b1, b2]], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems]
 
+/-- Singleton list containing a three-byte short string:
+    `decode [0xC4, 0x83, b1, b2, b3] = some (.list [.bytes [b1, b2, b3]], [])`.
+    The outer short-list branch fires with payload length 4, the inner
+    `[0x83, b1, b2, b3]` decodes as a three-byte short string. -/
+theorem decode_singleton_list_three_byte_string (b1 b2 b3 : Byte) :
+    decode [(0xC4 : Byte), (0x83 : Byte), b1, b2, b3] =
+      some (.list [.bytes [b1, b2, b3]], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems]
+
 /-! ## decode (top-level wrapper) trivial cases -/
 
 /-- `decode []` returns `none` because `decodeAux 0 []` returns `none`. -/


### PR DESCRIPTION
## Summary

Adds `decode_singleton_list_three_byte_string`: for arbitrary bytes `b1 b2 b3`,
```
decode [0xC4, 0x83, b1, b2, b3] = some (.list [.bytes [b1, b2, b3]], [])
```

Extends `decode_singleton_list_two_byte_string` (#1402) by one byte of inner payload. Outer short-list branch fires with payload length 4, the inner `[0x83, b1, b2, b3]` decodes as a three-byte short string.

## Test plan

- [x] `lake build EvmAsm.EL.RLP.Properties` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)