### PR TITLE
refactor(Add): drop `single` wrappers in evm_add program

### DIFF
--- a/EvmAsm/Evm64/Add/Program.lean
+++ b/EvmAsm/Evm64/Add/Program.lean
@@ -19,22 +19,22 @@ open EvmAsm.Rv64
 def evm_add : Program :=
   -- Limb 0 (5 instructions)
   LD .x7 .x12 0 ;; LD .x6 .x12 32 ;;
-  single (.ADD .x7 .x7 .x6) ;; single (.SLTU .x5 .x7 .x6) ;; SD .x12 .x7 32 ;;
+  ADD .x7 .x7 .x6 ;; SLTU .x5 .x7 .x6 ;; SD .x12 .x7 32 ;;
   -- Limb 1 (8 instructions)
   LD .x7 .x12 8 ;; LD .x6 .x12 40 ;;
-  single (.ADD .x7 .x7 .x6) ;; single (.SLTU .x11 .x7 .x6) ;;
-  single (.ADD .x7 .x7 .x5) ;; single (.SLTU .x6 .x7 .x5) ;;
-  single (.OR .x5 .x11 .x6) ;; SD .x12 .x7 40 ;;
+  ADD .x7 .x7 .x6 ;; SLTU .x11 .x7 .x6 ;;
+  ADD .x7 .x7 .x5 ;; SLTU .x6 .x7 .x5 ;;
+  OR' .x5 .x11 .x6 ;; SD .x12 .x7 40 ;;
   -- Limb 2 (8 instructions)
   LD .x7 .x12 16 ;; LD .x6 .x12 48 ;;
-  single (.ADD .x7 .x7 .x6) ;; single (.SLTU .x11 .x7 .x6) ;;
-  single (.ADD .x7 .x7 .x5) ;; single (.SLTU .x6 .x7 .x5) ;;
-  single (.OR .x5 .x11 .x6) ;; SD .x12 .x7 48 ;;
+  ADD .x7 .x7 .x6 ;; SLTU .x11 .x7 .x6 ;;
+  ADD .x7 .x7 .x5 ;; SLTU .x6 .x7 .x5 ;;
+  OR' .x5 .x11 .x6 ;; SD .x12 .x7 48 ;;
   -- Limb 3 (8 instructions)
   LD .x7 .x12 24 ;; LD .x6 .x12 56 ;;
-  single (.ADD .x7 .x7 .x6) ;; single (.SLTU .x11 .x7 .x6) ;;
-  single (.ADD .x7 .x7 .x5) ;; single (.SLTU .x6 .x7 .x5) ;;
-  single (.OR .x5 .x11 .x6) ;; SD .x12 .x7 56 ;;
+  ADD .x7 .x7 .x6 ;; SLTU .x11 .x7 .x6 ;;
+  ADD .x7 .x7 .x5 ;; SLTU .x6 .x7 .x5 ;;
+  OR' .x5 .x11 .x6 ;; SD .x12 .x7 56 ;;
   -- sp adjustment
   ADDI .x12 .x12 32
 


### PR DESCRIPTION
## Summary

- Replace `single (.ADD ...)` / `single (.SLTU ...)` / `single (.OR ...)` in `EvmAsm/Evm64/Add/Program.lean` with the existing macro-assembler wrappers `ADD` / `SLTU` / `OR'` (already defined in `EvmAsm/Rv64/Program.lean`).
- Definitionally equivalent — `evm_add` reduces to the same `List Instr` as before, so all downstream specs/proofs continue to apply unchanged.

## Notes

A pure `Coe Instr Program` instance is not enough on its own: the elaborator resolves `(.ADD ...)` against the expected type `Program` (i.e. looks for `Program.ADD`/`List.ADD`) *before* considering coercions, so dot-notation literals would not auto-lift. The wrappers in `Rv64/Program.lean` are exactly the "abbreviation" path that works here.

The lone `OR'` (with prime) is a pre-existing inconsistency — `OR`/`AND`/`XOR`/`MUL`/`DIV`/`REM` are primed in `Rv64/Program.lean`. Dropping the primes is a separate, larger cleanup.

## Test plan

- [x] `lake build` — full package builds (3543/3543 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)