### PR TITLE
feat(rlp): add two-element empty-byte-string list decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -197,6 +197,15 @@ theorem decode_pair_list_empty_lists :
       some (.list [.list [], .list []], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems]
 
+/-- Two-element list of empty byte strings:
+    `decode [0xC2, 0x80, 0x80] = some (.list [.bytes [], .bytes []], [])`.
+    The outer short-list branch fires with payload length 2, two empty
+    inner byte strings are decoded in sequence, then the outer closes. -/
+theorem decode_pair_list_empty_strings :
+    decode [(0xC2 : Byte), (0x80 : Byte), (0x80 : Byte)] =
+      some (.list [.bytes [], .bytes []], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems]
+
 /-- Three-element list of empty lists:
     `decode [0xC3, 0xC0, 0xC0, 0xC0] = some (.list [.list [], .list [], .list []], [])`.
     The outer short-list branch fires with payload length 3, three empty


### PR DESCRIPTION
## Summary
- Adds `decode_pair_list_empty_strings` to `EvmAsm/EL/RLP/Properties.lean`, the empty-byte-string mirror of `decode_pair_list_empty_lists`
- Encoded form: `[0xC2, 0x80, 0x80]` decodes to `[.bytes [], .bytes []]`
- Single-line `simp` proof following the established pattern

## Test plan
- [x] `lake build EvmAsm.EL.RLP.Properties` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)