### PR TITLE
feat(rlp): add three-element empty-byte-string list decode lemma

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -206,6 +206,15 @@ theorem decode_triple_list_empty_lists :
       some (.list [.list [], .list [], .list []], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems]
 
+/-- Three-element list of empty byte strings:
+    `decode [0xC3, 0x80, 0x80, 0x80] = some (.list [.bytes [], .bytes [], .bytes []], [])`.
+    The outer short-list branch fires with payload length 3, three empty
+    inner byte strings are decoded in sequence, then the outer closes. -/
+theorem decode_triple_list_empty_strings :
+    decode [(0xC3 : Byte), (0x80 : Byte), (0x80 : Byte), (0x80 : Byte)] =
+      some (.list [.bytes [], .bytes [], .bytes []], []) := by
+  simp [decode, decodeAux, takeBytes, decodeItems]
+
 /-- Mixed-content two-element list: a small byte followed by an empty
     string. `decode [0xC2, b, 0x80] = some (.list [.bytes [b], .bytes []], [])`
     when `b < 0x80`. -/


### PR DESCRIPTION
## Summary
- Adds `decode_triple_list_empty_strings` to `EvmAsm/EL/RLP/Properties.lean`, the empty-byte-string mirror of `decode_triple_list_empty_lists`
- Encoded form: `[0xC3, 0x80, 0x80, 0x80]` decodes to `[.bytes [], .bytes [], .bytes []]`
- Single-line `simp` proof following the established pattern

## Test plan
- [x] `lake build EvmAsm.EL.RLP.Properties` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)