### PR TITLE
refactor(rlp): deduplicate Phase1Disjoint by reusing Phase1's helpers

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1.lean
+++ b/EvmAsm/Rv64/RLP/Phase1.lean
@@ -233,7 +233,7 @@ abbrev rlp_phase1_classifier_code
 
 /-- Two cascade-step `CodeReq`s whose bases are 8 bytes apart are disjoint.
     Helper for the classifier composition. -/
-private theorem step_code_Disjoint_8 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
+theorem step_code_Disjoint_8 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
     (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 8)) :=
@@ -246,7 +246,7 @@ private theorem step_code_Disjoint_8 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
       (CodeReq.Disjoint.singleton (by bv_omega)))
 
 /-- Cascade-step at `base` is disjoint from step at `base + 16`. -/
-private theorem step_code_Disjoint_16 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
+theorem step_code_Disjoint_16 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
     (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 16)) :=
@@ -259,7 +259,7 @@ private theorem step_code_Disjoint_16 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13
       (CodeReq.Disjoint.singleton (by bv_omega)))
 
 /-- Cascade-step at `base` is disjoint from step at `base + 24`. -/
-private theorem step_code_Disjoint_24 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
+theorem step_code_Disjoint_24 (k1 k2 : BitVec 12) (off1 off2 : BitVec 13)
     (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 24)) :=

--- a/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
+++ b/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
@@ -9,12 +9,11 @@
   shapes (8 / 16 / 24 byte gaps), each of which holds for any
   threshold/offset by `bv_omega` on the addresses.
 
-  These public helpers give downstream consumers (cascade-prefix
-  specs, full-path specs) a single re-exported entry point so they
-  do not need to either:
-    * reach into `Phase1.lean`'s `private` `step_code_Disjoint_{8,16,24}`
-      helpers, or
-    * re-prove the same `bv_omega` shape inline at every call site.
+  These public helpers re-export the corresponding `step_code_Disjoint_{8,16,24}`
+  helpers from `Phase1.lean` so downstream consumers (cascade-prefix
+  specs, full-path specs) have a single public entry point and do
+  not need to re-prove the same `bv_omega` shape inline at every
+  call site.
 -/
 
 import EvmAsm.Rv64.RLP.Phase1
@@ -32,38 +31,20 @@ theorem rlp_phase1_step_code_disjoint_8
     (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 8)) :=
-  CodeReq.Disjoint.union_left
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
+  step_code_Disjoint_8 k1 k2 off1 off2 base
 
 /-- Two cascade-step `CodeReq`s at bases 16 bytes apart are disjoint. -/
 theorem rlp_phase1_step_code_disjoint_16
     (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 16)) :=
-  CodeReq.Disjoint.union_left
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
+  step_code_Disjoint_16 k1 k2 off1 off2 base
 
 /-- Two cascade-step `CodeReq`s at bases 24 bytes apart are disjoint. -/
 theorem rlp_phase1_step_code_disjoint_24
     (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
     (rlp_phase1_step_code k1 off1 base).Disjoint
       (rlp_phase1_step_code k2 off2 (base + 24)) :=
-  CodeReq.Disjoint.union_left
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
-    (CodeReq.Disjoint.union_right
-      (CodeReq.Disjoint.singleton (by bv_omega))
-      (CodeReq.Disjoint.singleton (by bv_omega)))
+  step_code_Disjoint_24 k1 k2 off1 off2 base
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary
- The three public theorems \`rlp_phase1_step_code_disjoint_{8,16,24}\` in \`EvmAsm/Rv64/RLP/Phase1Disjoint.lean\` had bodies copied verbatim from the private \`step_code_Disjoint_{8,16,24}\` helpers in \`EvmAsm/Rv64/RLP/Phase1.lean\`.
- Drop the \`private\` modifier on those helpers in \`Phase1.lean\` and replace each duplicated public body in \`Phase1Disjoint.lean\` with a one-line delegating call.
- Public-facing names and signatures in \`Phase1Disjoint.lean\` are unchanged; all existing callers (\`Phase1CascadePrefixE{2,3,4,5}.lean\`, \`Phase1E{2,3}FullPath.lean\`) keep working unchanged.
- Net: -19 lines.

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds locally (entire RLP RV64 namespace, 899 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)