### PR TITLE
refactor(rlp): add shifted-base disjointness helpers, replace 7 inline rewrites

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1CascadePrefixE3.lean
+++ b/EvmAsm/Rv64/RLP/Phase1CascadePrefixE3.lean
@@ -100,8 +100,6 @@ theorem rlp_phase1_cascade_prefix_e3_spec' (v5 v10 : Word)
     htarget hv5_lo hv5_mid hv5_hi
     (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
     (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
-      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h; exact h)
+    (rlp_phase1_step_code_disjoint_8_at_8 0xB8 0xC0 off2 off3 base)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1CascadePrefixE4.lean
+++ b/EvmAsm/Rv64/RLP/Phase1CascadePrefixE4.lean
@@ -129,14 +129,8 @@ theorem rlp_phase1_cascade_prefix_e4_spec' (v5 v10 : Word)
     (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
     (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
     (rlp_phase1_step_code_disjoint_24 0x80 0xF8 off1 off4 base)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
-      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h; exact h)
-    (by
-      have h := rlp_phase1_step_code_disjoint_16 0xB8 0xF8 off2 off4 (base + 8)
-      rw [show (base + 8 : Word) + 16 = base + 24 from by bv_omega] at h; exact h)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xC0 0xF8 off3 off4 (base + 16)
-      rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at h; exact h)
+    (rlp_phase1_step_code_disjoint_8_at_8 0xB8 0xC0 off2 off3 base)
+    (rlp_phase1_step_code_disjoint_16_at_8 0xB8 0xF8 off2 off4 base)
+    (rlp_phase1_step_code_disjoint_8_at_16 0xC0 0xF8 off3 off4 base)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1CascadePrefixE5.lean
+++ b/EvmAsm/Rv64/RLP/Phase1CascadePrefixE5.lean
@@ -125,14 +125,8 @@ theorem rlp_phase1_cascade_prefix_e5_spec' (v5 v10 : Word)
     (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
     (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
     (rlp_phase1_step_code_disjoint_24 0x80 0xF8 off1 off4 base)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
-      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h; exact h)
-    (by
-      have h := rlp_phase1_step_code_disjoint_16 0xB8 0xF8 off2 off4 (base + 8)
-      rw [show (base + 8 : Word) + 16 = base + 24 from by bv_omega] at h; exact h)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xC0 0xF8 off3 off4 (base + 16)
-      rw [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at h; exact h)
+    (rlp_phase1_step_code_disjoint_8_at_8 0xB8 0xC0 off2 off3 base)
+    (rlp_phase1_step_code_disjoint_16_at_8 0xB8 0xF8 off2 off4 base)
+    (rlp_phase1_step_code_disjoint_8_at_16 0xC0 0xF8 off3 off4 base)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
+++ b/EvmAsm/Rv64/RLP/Phase1Disjoint.lean
@@ -66,4 +66,35 @@ theorem rlp_phase1_step_code_disjoint_24
       (CodeReq.Disjoint.singleton (by bv_omega))
       (CodeReq.Disjoint.singleton (by bv_omega)))
 
+-- ============================================================================
+-- Pairwise step-code disjointness at shifted bases
+-- ============================================================================
+
+/-- Step at `base + 8` disjoint from step at `base + 16`.
+    Address-normalized variant of `rlp_phase1_step_code_disjoint_8`. -/
+theorem rlp_phase1_step_code_disjoint_8_at_8
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 (base + 8)).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 16)) := by
+  have h := rlp_phase1_step_code_disjoint_8 k1 k2 off1 off2 (base + 8)
+  rwa [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h
+
+/-- Step at `base + 8` disjoint from step at `base + 24`.
+    Address-normalized variant of `rlp_phase1_step_code_disjoint_16`. -/
+theorem rlp_phase1_step_code_disjoint_16_at_8
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 (base + 8)).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 24)) := by
+  have h := rlp_phase1_step_code_disjoint_16 k1 k2 off1 off2 (base + 8)
+  rwa [show (base + 8 : Word) + 16 = base + 24 from by bv_omega] at h
+
+/-- Step at `base + 16` disjoint from step at `base + 24`.
+    Address-normalized variant of `rlp_phase1_step_code_disjoint_8`. -/
+theorem rlp_phase1_step_code_disjoint_8_at_16
+    (k1 k2 : BitVec 12) (off1 off2 : BitVec 13) (base : Word) :
+    (rlp_phase1_step_code k1 off1 (base + 16)).Disjoint
+      (rlp_phase1_step_code k2 off2 (base + 24)) := by
+  have h := rlp_phase1_step_code_disjoint_8 k1 k2 off1 off2 (base + 16)
+  rwa [show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at h
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase1E3FullPath.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E3FullPath.lean
@@ -145,10 +145,7 @@ theorem rlp_phase1_e3_full_path_spec'
     e3_target htarget hv5_lo hv5_mid hv5_hi
     (rlp_phase1_step_code_disjoint_8 0x80 0xB8 off1 off2 base)
     (rlp_phase1_step_code_disjoint_16 0x80 0xC0 off1 off3 base)
-    (by
-      have h := rlp_phase1_step_code_disjoint_8 0xB8 0xC0 off2 off3 (base + 8)
-      rw [show (base + 8 : Word) + 8 = base + 16 from by bv_omega] at h
-      exact h)
+    (rlp_phase1_step_code_disjoint_8_at_8 0xB8 0xC0 off2 off3 base)
     hd_phase3
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
## Summary
- Adds three helper theorems in \`EvmAsm/Rv64/RLP/Phase1Disjoint.lean\` for the recurring shifted-base disjointness pattern: \`rlp_phase1_step_code_disjoint_{8_at_8, 16_at_8, 8_at_16}\`.
- Replaces 7 inline \`by have h := ...; rw [show ...] at h; exact h\` blocks across \`Phase1CascadePrefixE{3,4,5}.lean\` and \`Phase1E3FullPath.lean\` with one-line calls to the new helpers.
- Net: +14 lines (the helpers cost more than the inlines saved, but each callsite is now a one-liner instead of a 3-line tactic block; readability win).

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds locally (entire RLP RV64 namespace, 899 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)