### PR TITLE
refactor(seplogic): add ofProg_singleton and ofProg_pair, use in 4 RLP files

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongAcc.lean
@@ -75,14 +75,10 @@ theorem rlp_phase2_long_acc_spec (len byte : Word) (base : Word) :
   simp only [rlp_phase2_long_acc_post_unfold]
   -- Reshape the code requirement: a 2-instruction `ofProg` is the disjoint
   -- union of two singletons.
-  have hcr_eq : CodeReq.ofProg base rlp_phase2_long_acc_prog =
+  rw [show CodeReq.ofProg base rlp_phase2_long_acc_prog =
       (CodeReq.singleton base (.SLLI .x11 .x11 8)).union
-      (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) := by
-    funext a
-    simp only [rlp_phase2_long_acc_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
-      CodeReq.union, CodeReq.empty]
-    cases (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) a <;> rfl
-  rw [hcr_eq]
+      (CodeReq.singleton (base + 4) (.ADD .x11 .x11 .x12)) from
+    CodeReq.ofProg_pair]
   -- Disjointness of the two singletons (distinct PCs).
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.SLLI .x11 .x11 8))

--- a/EvmAsm/Rv64/RLP/Phase2Short.lean
+++ b/EvmAsm/Rv64/RLP/Phase2Short.lean
@@ -89,13 +89,8 @@ theorem rlp_phase2_short_length_spec (v5 v11Old : Word)
       (rlp_phase2_short_length_post v5 k) := by
   simp only [rlp_phase2_short_length_post_unfold]
   -- The one-instruction `ofProg` reduces to a singleton CodeReq.
-  have hcr : CodeReq.ofProg base (rlp_phase2_short_length_prog k) =
-      CodeReq.singleton base (.ADDI .x11 .x5 (-k)) := by
-    funext a
-    simp only [rlp_phase2_short_length_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
-      CodeReq.union, CodeReq.empty]
-    cases (CodeReq.singleton base (.ADDI .x11 .x5 (-k))) a <;> rfl
-  rw [hcr]
+  rw [show CodeReq.ofProg base (rlp_phase2_short_length_prog k) =
+      CodeReq.singleton base (.ADDI .x11 .x5 (-k)) from CodeReq.ofProg_singleton]
   exact addi_spec_gen .x11 .x5 v11Old v5 (-k) base (by nofun)
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase3ShortString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3ShortString.lean
@@ -77,14 +77,9 @@ theorem rlp_phase3_short_string_spec (v5 v11Old v13 : Word) (base : Word) :
        (.x11 ↦ᵣ (v5 + signExtend12 (-(0x80 : BitVec 12)))) **
        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12)))) := by
   -- Reshape the two-instruction `ofProg` into a singleton-union pair.
-  have hcr_eq : CodeReq.ofProg base rlp_phase3_short_string_prog =
+  rw [show CodeReq.ofProg base rlp_phase3_short_string_prog =
       (CodeReq.singleton base (.ADDI .x11 .x5 (-0x80))).union
-      (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) := by
-    funext a
-    simp only [rlp_phase3_short_string_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
-      CodeReq.union, CodeReq.empty]
-    cases (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) a <;> rfl
-  rw [hcr_eq]
+      (CodeReq.singleton (base + 4) (.ADDI .x13 .x13 1)) from CodeReq.ofProg_pair]
   -- Disjointness of the two singletons (distinct PCs).
   have hd : CodeReq.Disjoint
       (CodeReq.singleton base (.ADDI .x11 .x5 (-0x80)))

--- a/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
+++ b/EvmAsm/Rv64/RLP/Phase3SingleByte.lean
@@ -59,13 +59,8 @@ theorem rlp_phase3_single_byte_spec (v11Old : Word) (base : Word) :
       ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x11 ↦ᵣ (1 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
   -- The one-instruction `ofProg` reduces to a singleton CodeReq.
-  have hcr : CodeReq.ofProg base rlp_phase3_single_byte_prog =
-      CodeReq.singleton base (.ADDI .x11 .x0 1) := by
-    funext a
-    simp only [rlp_phase3_single_byte_prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
-      CodeReq.union, CodeReq.empty]
-    cases (CodeReq.singleton base (.ADDI .x11 .x0 1)) a <;> rfl
-  rw [hcr]
+  rw [show CodeReq.ofProg base rlp_phase3_single_byte_prog =
+      CodeReq.singleton base (.ADDI .x11 .x0 1) from CodeReq.ofProg_singleton]
   -- ADDI x11, x0, 1: x11 ← 0 + signExtend12 1 = 1.
   have h := addi_spec_gen .x11 .x0 v11Old (0 : Word) 1 base (by nofun)
   -- Normalize the post: 0 + signExtend12 1 = 1.

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2061,6 +2061,18 @@ theorem ofProg_cons {base : Word} {i : Instr} {rest : List Instr} :
 
 theorem ofProg_nil {base : Word} : ofProg base [] = empty := rfl
 
+/-- A one-instruction program reshapes into a single `singleton`. -/
+theorem ofProg_singleton {base : Word} {i : Instr} :
+    ofProg base [i] = singleton base i := by
+  rw [ofProg_cons, ofProg_nil, union_empty_right]
+
+/-- A two-instruction program reshapes into the union of two `singleton`s
+    at the consecutive 4-byte-aligned addresses. -/
+theorem ofProg_pair {base : Word} {i1 i2 : Instr} :
+    ofProg base [i1, i2] =
+      (singleton base i1).union (singleton (base + 4) i2) := by
+  rw [ofProg_cons, ofProg_singleton]
+
 /-- If an address doesn't match any instruction position in a program block,
     the ofProg CodeReq returns none at that address. -/
 theorem ofProg_none_range (base : Word) (prog : List Instr) {a : Word}


### PR DESCRIPTION
## Summary
The recurring pattern across many RLP per-step specs:

\`\`\`lean
have hcr : CodeReq.ofProg base prog = singleton ... := by
  funext a
  simp only [prog, CodeReq.ofProg_cons, CodeReq.ofProg_nil,
    CodeReq.union, CodeReq.empty]
  cases ... <;> rfl
\`\`\`

is just the repeated unfolding \`ofProg_cons → ofProg_nil → union_empty_right\`. Add two reusable lemmas in \`EvmAsm/Rv64/SepLogic.lean\`:

- \`CodeReq.ofProg_singleton : ofProg base [i] = singleton base i\`
- \`CodeReq.ofProg_pair : ofProg base [i1, i2] = (singleton base i1).union (singleton (base+4) i2)\`

Replace the inline \`funext + simp + cases\` blocks in:
- \`Phase2LongAcc.lean\` (2-instr prog, uses \`ofProg_pair\`)
- \`Phase3SingleByte.lean\` (1-instr prog, uses \`ofProg_singleton\`)
- \`Phase2Short.lean\` (1-instr prog, uses \`ofProg_singleton\`)
- \`Phase3ShortString.lean\` (2-instr prog, uses \`ofProg_pair\`)

Net: -7 lines.

The new lemmas are also available for future per-step specs and any other 1- or 2-instruction \`ofProg\` reshapes that may emerge.

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds locally (899 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)