### PR TITLE
refactor: drop spurious parens around single identifiers (#1075)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Arithmetic.lean
@@ -26,9 +26,9 @@ theorem carry_toNat {x y : Word} :
   have := x.isLt; have := y.isLt
   have hsum : (x + y).toNat = (x.toNat + y.toNat) % 2^64 := BitVec.toNat_add x y
   split
-  · rename_i h; have := (ult_iff).mp h; rw [hsum] at this
+  · rename_i h; have := ult_iff.mp h; rw [hsum] at this
     simp [BitVec.toNat_ofNat]; omega
-  · rename_i h; have := mt (ult_iff).mpr h; rw [hsum] at this; push Not at this
+  · rename_i h; have := mt ult_iff.mpr h; rw [hsum] at this; push Not at this
     simp [BitVec.toNat_ofNat]; omega
 
 -- OR of two {0,1}-valued Words
@@ -270,8 +270,8 @@ theorem sub_borrow_chain_correct (a b : EvmWord) :
   -- Borrow flag toNat values
   have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
     simp only [borrow0]; split
-    · rename_i h; rw [if_pos ((ult_iff).mp h)]; rfl
-    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff).mpr hlt))]; rfl
+    · rename_i h; rw [if_pos (ult_iff.mp h)]; rfl
+    · rename_i h; rw [if_neg (fun hlt => h (ult_iff.mpr hlt))]; rfl
   -- borrow0 is 0 or 1
   have hb0_01 : borrow0.toNat = 0 ∨ borrow0.toNat = 1 := by
     rw [hb0_nat]; split <;> simp

--- a/EvmAsm/Evm64/EvmWordArith/Comparison.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Comparison.lean
@@ -39,8 +39,8 @@ theorem lt_borrow_chain_correct {a b : EvmWord} :
   -- Step 1: borrow0 tracks 1-limb comparison
   have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
     simp only [borrow0]; split
-    · rename_i h; rw [if_pos ((ult_iff).mp h)]; rfl
-    · rename_i h; rw [if_neg (fun hlt => h ((ult_iff).mpr hlt))]; rfl
+    · rename_i h; rw [if_pos (ult_iff.mp h)]; rfl
+    · rename_i h; rw [if_neg (fun hlt => h (ult_iff.mpr hlt))]; rfl
   -- Step 2: borrow1 tracks 2-limb comparison
   have hb1_or : borrow1 = if (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0)
       then (1 : Word) else 0 := borrow_or_iff
@@ -144,8 +144,8 @@ theorem slt_result_correct {a b : EvmWord} :
     -- Same structure as lt_borrow_chain_correct steps 1-3
     have hb0_nat : borrow0.toNat = if a0.toNat < b0.toNat then 1 else 0 := by
       simp only [borrow0]; split
-      · rename_i hh; rw [if_pos ((ult_iff).mp hh)]; rfl
-      · rename_i hh; rw [if_neg (fun hlt => hh ((ult_iff).mpr hlt))]; rfl
+      · rename_i hh; rw [if_pos (ult_iff.mp hh)]; rfl
+      · rename_i hh; rw [if_neg (fun hlt => hh (ult_iff.mpr hlt))]; rfl
     have hb1_cond : (BitVec.ult a1 b1 ∨ BitVec.ult temp1 borrow0) ↔
         (a0.toNat + a1.toNat * 2^64 < b0.toNat + b1.toNat * 2^64) := by
       rw [show BitVec.ult a1 b1 ↔ a1.toNat < b1.toNat from ult_iff,

--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -186,7 +186,7 @@ theorem div_correct_n3_no_shift
   intro a b q r
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 0 0 = q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n3).symm
+    accumulated_eq_val256_n3.symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 0 0 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub
@@ -213,7 +213,7 @@ theorem div_correct_n2_no_shift
   intro a b q r
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 q2 0 = q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n2).symm
+    accumulated_eq_val256_n2.symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 q2 0 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub
@@ -241,7 +241,7 @@ theorem div_correct_n1_no_shift
   have ⟨_, hr_lt⟩ := remainder_lt_of_ge_floor (val256_pos_of_or_ne_zero hbnz) hmulsub hge
   have hq_val : val256 q0 q1 q2 q3 =
       q3.toNat * 2^192 + q2.toNat * 2^128 + q1.toNat * 2^64 + q0.toNat :=
-    (accumulated_eq_val256_n1).symm
+    accumulated_eq_val256_n1.symm
   have hmulsub' : val256 a0 a1 a2 a3 =
       val256 q0 q1 q2 q3 * val256 b0 b1 b2 b3 + val256 r0 r1 r2 r3 := by
     rw [hq_val]; exact hmulsub

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -424,13 +424,13 @@ theorem holdsFor_memIs {a : Word} {v : Word} {s : MachineState} :
     then `a` is a valid dword-aligned memory address. -/
 theorem holdsFor_memIs_isValidDwordAccess {a : Word} {v : Word} {s : MachineState}
     (h : (memIs a v).holdsFor s) : isValidDwordAccess a = true :=
-  ((holdsFor_memIs).mp h).2
+  (holdsFor_memIs.mp h).2
 
 /-- The memory-content consequence of `memIs`: if `(a ↦ₘ v).holdsFor s`
     then `s.getMem a = v`. -/
 theorem holdsFor_memIs_getMem {a : Word} {v : Word} {s : MachineState}
     (h : (memIs a v).holdsFor s) : s.getMem a = v :=
-  ((holdsFor_memIs).mp h).1
+  (holdsFor_memIs.mp h).1
 
 @[simp]
 theorem holdsFor_pcIs {v : Word} {s : MachineState} :


### PR DESCRIPTION
## Summary
Per #1075, removes redundant parentheses around a single identifier followed by a field projection or method call. These are cosmetic-only and were left over from previous factorings.

11 occurrences fixed across:
- \`EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean\` (3): \`(accumulated_eq_val256_n{1,2,3}).symm → accumulated_eq_val256_n{1,2,3}.symm\`
- \`EvmAsm/Evm64/EvmWordArith/Arithmetic.lean\` (4): \`(ult_iff).{mp,mpr} → ult_iff.{mp,mpr}\`
- \`EvmAsm/Evm64/EvmWordArith/Comparison.lean\` (4): same as Arithmetic
- \`EvmAsm/Rv64/SepLogic.lean\` (2): \`((holdsFor_memIs).mp h).N → (holdsFor_memIs.mp h).N\`

Net: 13 / 13 char swaps; pure whitespace/parens churn.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith EvmAsm.Rv64.SepLogic\` succeeds locally (955 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)