### PR TITLE
refactor: drop more spurious parens around single identifiers (#1075, batch 2)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -179,7 +179,7 @@ theorem ushiftRight_eq_zero_iff {val : Word} (K : Nat) :
   · intro hz
     have h0 : (val >>> K).toNat = 0 := by rw [hz]; rfl
     rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow] at h0
-    rcases (Nat.div_eq_zero_iff).mp h0 with hc | hc
+    rcases Nat.div_eq_zero_iff.mp h0 with hc | hc
     · exact absurd hc (by positivity)
     · exact hc
   · intro hlt
@@ -287,7 +287,7 @@ theorem ushiftRight_ne_zero_of_msb {val : Word} {K : Nat} (hK : K ≤ 63)
   have h0 : (val >>> K).toNat = 0 := by rw [h]; rfl
   rw [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow] at h0 ⊢; simp
   have hlt : val.toNat < 2^K := by
-    rcases (Nat.div_eq_zero_iff).mp h0 with h | h
+    rcases Nat.div_eq_zero_iff.mp h0 with h | h
     · exact absurd h (by positivity)
     · exact h
   have : 2^K ≤ (2 : Nat)^63 := Nat.pow_le_pow_right (by omega) hK; omega

--- a/EvmAsm/Evm64/EvmWordArith/Div.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div.lean
@@ -131,8 +131,8 @@ theorem bv_udiv_umod_unique {n : Nat} {a b q r : BitVec n}
     · rw [Nat.add_mul, Nat.one_mul, Nat.mul_comm q.toNat b.toNat]; omega
   have hr_eq : r.toNat = a.toNat % b.toNat := by
     have := Nat.div_add_mod a.toNat b.toNat; rw [← hq_eq] at this; omega
-  exact ⟨BitVec.eq_of_toNat_eq (hq_eq ▸ (BitVec.toNat_udiv).symm),
-         BitVec.eq_of_toNat_eq (hr_eq ▸ (BitVec.toNat_umod).symm)⟩
+  exact ⟨BitVec.eq_of_toNat_eq (hq_eq ▸ BitVec.toNat_udiv.symm),
+         BitVec.eq_of_toNat_eq (hr_eq ▸ BitVec.toNat_umod.symm)⟩
 
 -- ============================================================================
 -- EvmWord-level division correctness framework

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -406,9 +406,9 @@ theorem holdsFor_regIs {r : Reg} {v : Word} {s : MachineState} :
   simp only [Assertion.holdsFor, regIs]
   constructor
   · rintro ⟨h, hcompat, rfl⟩
-    exact (PartialState.CompatibleWith_singletonReg).mp hcompat
+    exact PartialState.CompatibleWith_singletonReg.mp hcompat
   · intro heq
-    exact ⟨_, (PartialState.CompatibleWith_singletonReg).mpr heq, rfl⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonReg.mpr heq, rfl⟩
 
 @[simp]
 theorem holdsFor_memIs {a : Word} {v : Word} {s : MachineState} :
@@ -416,9 +416,9 @@ theorem holdsFor_memIs {a : Word} {v : Word} {s : MachineState} :
   simp only [Assertion.holdsFor, memIs]
   constructor
   · rintro ⟨h, hcompat, rfl, hvalid⟩
-    exact ⟨(PartialState.CompatibleWith_singletonMem).mp hcompat, hvalid⟩
+    exact ⟨PartialState.CompatibleWith_singletonMem.mp hcompat, hvalid⟩
   · rintro ⟨heq, hvalid⟩
-    exact ⟨_, (PartialState.CompatibleWith_singletonMem).mpr heq, rfl, hvalid⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonMem.mpr heq, rfl, hvalid⟩
 
 /-- The validity hypothesis that `memIs` now encodes: if `(a ↦ₘ v).holdsFor s`
     then `a` is a valid dword-aligned memory address. -/


### PR DESCRIPTION
## Summary
Follow-up to #1424. Removes 8 more redundant parentheses around a single identifier followed by a field projection or method call:

- \`EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean\` (2): \`(Nat.div_eq_zero_iff).mp → Nat.div_eq_zero_iff.mp\`
- \`EvmAsm/Evm64/EvmWordArith/Div.lean\` (2): \`(BitVec.toNat_udiv).symm → BitVec.toNat_udiv.symm\`, similarly for \`toNat_umod\`
- \`EvmAsm/Rv64/SepLogic.lean\` (4): \`(PartialState.CompatibleWith_singleton{Reg,Mem}).mp/.mpr → ....mp/.mpr\`

These SepLogic lines (409/411/419/421) are disjoint from #1424's diff (427/433) so the two PRs do not conflict.

## Test plan
- [x] \`lake build EvmAsm.Evm64.EvmWordArith.CLZLemmas EvmAsm.Evm64.EvmWordArith.Div EvmAsm.Rv64.SepLogic\` succeeds locally (1008 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)