### PR TITLE
refactor: drop spurious parens in SepLogic — bulk batch (#1075, batch 3)

### DIFF
--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -438,9 +438,9 @@ theorem holdsFor_pcIs {v : Word} {s : MachineState} :
   simp only [Assertion.holdsFor, pcIs]
   constructor
   · rintro ⟨h, hcompat, rfl⟩
-    exact (PartialState.CompatibleWith_singletonPC).mp hcompat
+    exact PartialState.CompatibleWith_singletonPC.mp hcompat
   · intro heq
-    exact ⟨_, (PartialState.CompatibleWith_singletonPC).mpr heq, rfl⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonPC.mpr heq, rfl⟩
 
 @[simp]
 theorem holdsFor_emp {s : MachineState} :
@@ -452,7 +452,7 @@ theorem holdsFor_emp {s : MachineState} :
 theorem holdsFor_regOwn {r : Reg} {s : MachineState} :
     (regOwn r).holdsFor s ↔ True := by
   simp only [iff_true, regOwn, Assertion.holdsFor]
-  exact ⟨_, (PartialState.CompatibleWith_singletonReg).mpr rfl,
+  exact ⟨_, PartialState.CompatibleWith_singletonReg.mpr rfl,
          s.getReg r, rfl⟩
 
 @[simp]
@@ -462,7 +462,7 @@ theorem holdsFor_memOwn {a : Word} {s : MachineState} :
   constructor
   · rintro ⟨_, _, _, _, hvalid⟩; exact hvalid
   · intro hvalid
-    exact ⟨_, (PartialState.CompatibleWith_singletonMem).mpr rfl,
+    exact ⟨_, PartialState.CompatibleWith_singletonMem.mpr rfl,
            s.getMem a, rfl, hvalid⟩
 
 theorem regIs_implies_regOwn (r : Reg) {v : Word} :
@@ -515,13 +515,13 @@ theorem holdsFor_sepConj_regIs_regIs {r1 r2 : Reg} {v1 v2 : Word} {s : MachineSt
     rw [regIs] at hp1 hp2; subst hp1; subst hp2
     rw [← hunion] at hcompat
     rw [PartialState.CompatibleWith_union hd] at hcompat
-    exact ⟨(PartialState.CompatibleWith_singletonReg).mp hcompat.1,
-           (PartialState.CompatibleWith_singletonReg).mp hcompat.2⟩
+    exact ⟨PartialState.CompatibleWith_singletonReg.mp hcompat.1,
+           PartialState.CompatibleWith_singletonReg.mp hcompat.2⟩
   · intro ⟨h1, h2⟩
     have hd := singletonReg_disjoint_singletonReg hne (v1 := v1) (v2 := v2)
     exact ⟨_, (PartialState.CompatibleWith_union hd).mpr
-      ⟨(PartialState.CompatibleWith_singletonReg).mpr h1,
-       (PartialState.CompatibleWith_singletonReg).mpr h2⟩,
+      ⟨PartialState.CompatibleWith_singletonReg.mpr h1,
+       PartialState.CompatibleWith_singletonReg.mpr h2⟩,
       _, _, hd, rfl, rfl, rfl⟩
 
 theorem holdsFor_sepConj_regIs_memIs {r : Reg} {v : Word} {a : Word} {w : Word}
@@ -533,14 +533,14 @@ theorem holdsFor_sepConj_regIs_memIs {r : Reg} {v : Word} {a : Word} {w : Word}
     rw [regIs] at hp1; obtain ⟨hp2, hvalid⟩ := hp2; subst hp1; subst hp2
     rw [← hunion] at hcompat
     rw [PartialState.CompatibleWith_union hd] at hcompat
-    exact ⟨(PartialState.CompatibleWith_singletonReg).mp hcompat.1,
-           (PartialState.CompatibleWith_singletonMem).mp hcompat.2,
+    exact ⟨PartialState.CompatibleWith_singletonReg.mp hcompat.1,
+           PartialState.CompatibleWith_singletonMem.mp hcompat.2,
            hvalid⟩
   · intro ⟨h1, h2, hvalid⟩
     have hd := singletonReg_disjoint_singletonMem r v a w
     exact ⟨_, (PartialState.CompatibleWith_union hd).mpr
-      ⟨(PartialState.CompatibleWith_singletonReg).mpr h1,
-       (PartialState.CompatibleWith_singletonMem).mpr h2⟩,
+      ⟨PartialState.CompatibleWith_singletonReg.mpr h1,
+       PartialState.CompatibleWith_singletonMem.mpr h2⟩,
       _, _, hd, rfl, rfl, ⟨rfl, hvalid⟩⟩
 
 -- ============================================================================
@@ -1020,9 +1020,9 @@ theorem holdsFor_publicValuesIs {vals : List (BitVec 8)} {s : MachineState} :
   simp only [Assertion.holdsFor, publicValuesIs]
   constructor
   · rintro ⟨h, hcompat, rfl⟩
-    exact (PartialState.CompatibleWith_singletonPublicValues).mp hcompat
+    exact PartialState.CompatibleWith_singletonPublicValues.mp hcompat
   · intro heq
-    exact ⟨_, (PartialState.CompatibleWith_singletonPublicValues).mpr heq, rfl⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonPublicValues.mpr heq, rfl⟩
 
 -- ============================================================================
 -- pcFree for publicValuesIs
@@ -1055,13 +1055,13 @@ theorem holdsFor_sepConj_regIs_publicValuesIs {r : Reg} {v : Word}
     rw [regIs] at hp1; rw [publicValuesIs] at hp2; subst hp1; subst hp2
     rw [← hunion] at hcompat
     rw [PartialState.CompatibleWith_union hd] at hcompat
-    exact ⟨(PartialState.CompatibleWith_singletonReg).mp hcompat.1,
-           (PartialState.CompatibleWith_singletonPublicValues).mp hcompat.2⟩
+    exact ⟨PartialState.CompatibleWith_singletonReg.mp hcompat.1,
+           PartialState.CompatibleWith_singletonPublicValues.mp hcompat.2⟩
   · intro ⟨h1, h2⟩
     have hd := singletonReg_disjoint_singletonPublicValues r v vals
     exact ⟨_, (PartialState.CompatibleWith_union hd).mpr
-      ⟨(PartialState.CompatibleWith_singletonReg).mpr h1,
-       (PartialState.CompatibleWith_singletonPublicValues).mpr h2⟩,
+      ⟨PartialState.CompatibleWith_singletonReg.mpr h1,
+       PartialState.CompatibleWith_singletonPublicValues.mpr h2⟩,
       _, _, hd, rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -1099,9 +1099,9 @@ theorem holdsFor_privateInputIs {vals : List (BitVec 8)} {s : MachineState} :
   simp only [Assertion.holdsFor, privateInputIs]
   constructor
   · rintro ⟨h, hcompat, rfl⟩
-    exact (PartialState.CompatibleWith_singletonPrivateInput).mp hcompat
+    exact PartialState.CompatibleWith_singletonPrivateInput.mp hcompat
   · intro heq
-    exact ⟨_, (PartialState.CompatibleWith_singletonPrivateInput).mpr heq, rfl⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonPrivateInput.mpr heq, rfl⟩
 
 -- ============================================================================
 -- pcFree for privateInputIs
@@ -1134,13 +1134,13 @@ theorem holdsFor_sepConj_regIs_privateInputIs {r : Reg} {v : Word}
     rw [regIs] at hp1; rw [privateInputIs] at hp2; subst hp1; subst hp2
     rw [← hunion] at hcompat
     rw [PartialState.CompatibleWith_union hd] at hcompat
-    exact ⟨(PartialState.CompatibleWith_singletonReg).mp hcompat.1,
-           (PartialState.CompatibleWith_singletonPrivateInput).mp hcompat.2⟩
+    exact ⟨PartialState.CompatibleWith_singletonReg.mp hcompat.1,
+           PartialState.CompatibleWith_singletonPrivateInput.mp hcompat.2⟩
   · intro ⟨h1, h2⟩
     have hd := singletonReg_disjoint_singletonPrivateInput r v vals
     exact ⟨_, (PartialState.CompatibleWith_union hd).mpr
-      ⟨(PartialState.CompatibleWith_singletonReg).mpr h1,
-       (PartialState.CompatibleWith_singletonPrivateInput).mpr h2⟩,
+      ⟨PartialState.CompatibleWith_singletonReg.mpr h1,
+       PartialState.CompatibleWith_singletonPrivateInput.mpr h2⟩,
       _, _, hd, rfl, rfl, rfl⟩
 
 -- ============================================================================
@@ -1384,9 +1384,9 @@ theorem holdsFor_sepConj_regIs_regIs_regIs {r1 r2 r3 : Reg} {v1 v2 v3 : Word}
   have ⟨hc_r1, hc_r23⟩ := (PartialState.CompatibleWith_union hd_outer).mp hcompat
   rw [← hunion_inner] at hc_r23
   have ⟨hc_r2, hc_r3⟩ := (PartialState.CompatibleWith_union hd_inner).mp hc_r23
-  exact ⟨(PartialState.CompatibleWith_singletonReg).mp hc_r1,
-         (PartialState.CompatibleWith_singletonReg).mp hc_r2,
-         (PartialState.CompatibleWith_singletonReg).mp hc_r3⟩
+  exact ⟨PartialState.CompatibleWith_singletonReg.mp hc_r1,
+         PartialState.CompatibleWith_singletonReg.mp hc_r2,
+         PartialState.CompatibleWith_singletonReg.mp hc_r3⟩
 
 -- ============================================================================
 -- Preservation of holdsFor through setReg for disjoint registers
@@ -1400,9 +1400,9 @@ theorem holdsFor_regIs_setReg_other {r r' : Reg} {v v' : Word} {s : MachineState
   obtain ⟨h_partial, hcompat, hreg⟩ := h
   simp only [regIs] at hreg; subst hreg
   have hcompat' : (PartialState.singletonReg r v).CompatibleWith (s.setReg r' v') := by
-    apply (PartialState.CompatibleWith_singletonReg).mpr
+    apply PartialState.CompatibleWith_singletonReg.mpr
     rw [MachineState.getReg_setReg_ne s r' r v' hne.symm]
-    exact (PartialState.CompatibleWith_singletonReg).mp hcompat
+    exact PartialState.CompatibleWith_singletonReg.mp hcompat
   exact ⟨PartialState.singletonReg r v, hcompat', rfl⟩
 
 /-- If a 2-register conjunction doesn't mention register r, it's preserved by setReg r. -/
@@ -1417,14 +1417,14 @@ theorem holdsFor_sepConj_regIs_regIs_setReg_other {r1 r2 r : Reg} {v1 v2 v' : Wo
   have hcompat' : (PartialState.singletonReg r1 v1).union (PartialState.singletonReg r2 v2) |>.CompatibleWith (s.setReg r v') := by
     apply (PartialState.CompatibleWith_union hd).mpr
     constructor
-    · apply (PartialState.CompatibleWith_singletonReg).mpr
+    · apply PartialState.CompatibleWith_singletonReg.mpr
       rw [MachineState.getReg_setReg_ne s r r1 v' hne1.symm]
       have ⟨hc1, _⟩ := (PartialState.CompatibleWith_union hd).mp hcompat
-      exact (PartialState.CompatibleWith_singletonReg).mp hc1
-    · apply (PartialState.CompatibleWith_singletonReg).mpr
+      exact PartialState.CompatibleWith_singletonReg.mp hc1
+    · apply PartialState.CompatibleWith_singletonReg.mpr
       rw [MachineState.getReg_setReg_ne s r r2 v' hne2.symm]
       have ⟨_, hc2⟩ := (PartialState.CompatibleWith_union hd).mp hcompat
-      exact (PartialState.CompatibleWith_singletonReg).mp hc2
+      exact PartialState.CompatibleWith_singletonReg.mp hc2
   exact ⟨(PartialState.singletonReg r1 v1).union (PartialState.singletonReg r2 v2), hcompat',
           PartialState.singletonReg r1 v1, PartialState.singletonReg r2 v2, hd, rfl, rfl, rfl⟩
 
@@ -1966,9 +1966,9 @@ theorem holdsFor_instrAt {a : Word} {i : Instr} {s : MachineState} :
   simp only [Assertion.holdsFor, instrAt]
   constructor
   · rintro ⟨h, hcompat, rfl⟩
-    exact (PartialState.CompatibleWith_singletonCode).mp hcompat
+    exact PartialState.CompatibleWith_singletonCode.mp hcompat
   · intro heq
-    exact ⟨_, (PartialState.CompatibleWith_singletonCode).mpr heq, rfl⟩
+    exact ⟨_, PartialState.CompatibleWith_singletonCode.mpr heq, rfl⟩
 
 -- ============================================================================
 -- pcFree for code assertions


### PR DESCRIPTION
## Summary
Per #1075, removes 35 more redundant parentheses around a single identifier followed by a field projection or method call in \`EvmAsm/Rv64/SepLogic.lean\`.

Pattern fixed throughout: \`(PartialState.CompatibleWith_singletonX).mp/.mpr → ....mp/.mpr\` (across \`Reg\`, \`Mem\`, \`PC\`, \`Code\`, \`PublicValues\`, \`PrivateInput\` variants and a few mixed conjuncts).

Edits are disjoint from #1424 (lines 427/433) and #1425 (lines 409/411/419/421) — those 6 lines are intentionally left in their original paren form so the three batches do not conflict.

## Test plan
- [x] \`lake build EvmAsm.Rv64.SepLogic\` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)