### PR TITLE
refactor(rlp): use CodeReq.ofProg_pair in Phase3LongString tail decomposition

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase3LongString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3LongString.lean
@@ -98,10 +98,8 @@ theorem rlp_phase3_long_string_spec
   -- Sub-decompose the tail similarly: singleton ∪ singleton.
   have hcr_tail : CodeReq.ofProg (base + 4) [.ADDI .x11 .x0 0, .ADDI .x13 .x13 1] =
       (CodeReq.singleton (base + 4) (.ADDI .x11 .x0 0)).union
-      (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) := by
-    funext a
-    simp only [CodeReq.ofProg_cons, CodeReq.ofProg_nil, CodeReq.union, CodeReq.empty]
-    cases (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) a <;> rfl
+      (CodeReq.singleton ((base + 4) + 4) (.ADDI .x13 .x13 1)) :=
+    CodeReq.ofProg_pair
   -- Step 1: ADDI x14, x5, -0xB7 at base.
   have s1Base := addi_spec_gen .x14 .x5 v14Old v5 (-0xB7) base (by nofun)
   have s1 : cpsTriple base (base + 4)


### PR DESCRIPTION
## Summary
Follow-up to #1422 (which added \`CodeReq.ofProg_pair\` and used it in 4 RLP files). \`Phase3LongString.lean\` has a 3-instruction prog and decomposes the tail (instructions 2–3) via the same boilerplate that #1422 replaced: \`funext + simp [...] + cases ... <;> rfl\`.

Replace it with a one-line \`exact CodeReq.ofProg_pair\` call.

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP.Phase3LongString\` succeeds locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)