### PR TITLE
refactor(rlp): factor h_absurd boilerplate via rlp_phase2_long_loop_body_post_pure

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -73,6 +73,29 @@ theorem rlp_phase2_long_loop_body_post_unfold
      (dwordAddr ↦ₘ wordVal) ** ⌜P⌝) := by
   delta rlp_phase2_long_loop_body_post; rfl
 
+/-- Extract the pure proposition `P` carried by the loop-body post.
+
+    Any caller that has built `rlp_phase2_long_loop_body_post len ptr cnt
+    byteZext wordVal dwordAddr P` for some witness `hp` can recover the
+    underlying `P` by traversing the six layers of `**` down to the
+    trailing `⌜P⌝`. The eight per-iteration loop closures
+    (`rlp_phase2_long_loop_*_byte_spec`) all use this to derive `False`
+    from the impossible BNE-taken or BNE-ntaken branch. -/
+theorem rlp_phase2_long_loop_body_post_pure
+    {len ptr cnt byteZext wordVal dwordAddr : Word} {P : Prop} :
+    ∀ hp,
+      rlp_phase2_long_loop_body_post len ptr cnt byteZext wordVal
+        dwordAddr P hp → P := by
+  intro hp hpost
+  simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  obtain ⟨_, _, _, _, _, hpost⟩ := hpost
+  exact hpost.2
+
 /-- `cpsBranch` spec for one pass through the long-form length-loop body.
 
     Composes `rlp_phase2_long_iter_spec` (the 5-instruction iteration

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
@@ -101,16 +101,8 @@ theorem rlp_phase2_long_loop_eight_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (8 : Word) byte1 wordVal
-         dwordAddr ((7 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((7 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   have tri1' : cpsTriple base base

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -86,16 +86,8 @@ theorem rlp_phase2_long_loop_five_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (5 : Word) byte1 wordVal
-         dwordAddr ((4 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((4 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   have tri1' : cpsTriple base base

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -83,16 +83,8 @@ theorem rlp_phase2_long_loop_four_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (4 : Word) byte1 wordVal
-         dwordAddr ((3 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((3 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   have tri1' : cpsTriple base base

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -85,16 +85,8 @@ theorem rlp_phase2_long_loop_one_byte_spec
   set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (1 : Word) byteZext wordVal
-         dwordAddr ((0 : Word) ≠ 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x11
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x13
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x14
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x12
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
-    exact hpost.2 rfl
+         dwordAddr ((0 : Word) ≠ 0) hp → False := fun hp hpost =>
+    rlp_phase2_long_loop_body_post_pure hp hpost rfl
   -- `cpsBranch_ntakenPath` drops the taken branch.
   have tri := cpsBranch_ntakenPath body h_absurd
   -- Weaken the post: unfold the `@[irreducible]` wrapper and strip the

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
@@ -94,16 +94,8 @@ theorem rlp_phase2_long_loop_seven_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (7 : Word) byte1 wordVal
-         dwordAddr ((6 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((6 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   have tri1' : cpsTriple base base

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
@@ -89,16 +89,8 @@ theorem rlp_phase2_long_loop_six_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (6 : Word) byte1 wordVal
-         dwordAddr ((5 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((5 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   have tri1' : cpsTriple base base

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -89,16 +89,8 @@ theorem rlp_phase2_long_loop_three_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (3 : Word) byte1 wordVal
-         dwordAddr ((2 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((2 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   have tri1 := cpsBranch_takenPath body h_absurd
   rw [hback] at tri1
   -- Weaken: unfold @[irreducible] + strip trailing `⌜(2 : Word) ≠ 0⌝`.

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -90,16 +90,8 @@ theorem rlp_phase2_long_loop_two_byte_spec
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (2 : Word) byte1 wordVal
-         dwordAddr ((1 : Word) = 0) hp → False := by
-    intro hp hpost
-    simp only [rlp_phase2_long_loop_body_post_unfold] at hpost
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x11
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x13
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x14
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x12
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel x0
-    obtain ⟨_, _, _, _, _, hpost⟩ := hpost -- peel memory
-    exact absurd hpost.2 (by decide)
+         dwordAddr ((1 : Word) = 0) hp → False := fun hp hpost =>
+    absurd (rlp_phase2_long_loop_body_post_pure hp hpost) (by decide)
   -- `cpsBranch_takenPath` drops fall-through. Keeps taken exit (loops back).
   have tri1 := cpsBranch_takenPath body h_absurd
   -- Taken exit is `(base + 20) + signExtend13 back = base` by hback.


### PR DESCRIPTION
## Summary
Across the 8 per-iteration loop closures (\`rlp_phase2_long_loop_{one,two,three,four,five,six,seven,eight}_byte_spec\`), the same 6-line \`obtain\` chain was duplicated to extract the impossible pure fact (\`(0 : Word) ≠ 0\`, \`(N : Word) = 0\` for N ≥ 1) from \`rlp_phase2_long_loop_body_post\`.

Add the helper in \`Phase2LongLoopBody.lean\`:

\`\`\`lean
theorem rlp_phase2_long_loop_body_post_pure {...} :
  ∀ hp, rlp_phase2_long_loop_body_post ... P hp → P
\`\`\`

and replace each 12-line \`h_absurd : ... := by ...\` block in Phase2LongLoop{One,Two,Three,Four,Five,Six,Seven,Eight} with a 3-line direct lambda using the helper.

Net: -41 lines (across 9 files: helper +23 in Body, -64 across the eight closures).

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds locally (entire RLP RV64 namespace, 899 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)