### PR TITLE
refactor(rlp): factor out cnt_dec_{1..8} concrete BitVec lemmas

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -73,6 +73,24 @@ theorem rlp_phase2_long_loop_body_post_unfold
      (dwordAddr ↦ₘ wordVal) ** ⌜P⌝) := by
   delta rlp_phase2_long_loop_body_post; rfl
 
+/-! ## Concrete `cnt' = cnt + signExtend12 (-1)` evaluations
+
+Each per-iteration loop closure (`rlp_phase2_long_loop_*_byte_spec`)
+specializes the body spec at a specific counter value `N : Word` and
+needs the concrete decremented value `N - 1` to flow through the
+post. These eight lemmas package the recurring `(N : Word) +
+signExtend12 (-1 : BitVec 12) = (N - 1 : Word) := by decide` boiler.
+-/
+
+theorem cnt_dec_1 : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by decide
+theorem cnt_dec_2 : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by decide
+theorem cnt_dec_3 : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by decide
+theorem cnt_dec_4 : (4 : Word) + signExtend12 (-1 : BitVec 12) = (3 : Word) := by decide
+theorem cnt_dec_5 : (5 : Word) + signExtend12 (-1 : BitVec 12) = (4 : Word) := by decide
+theorem cnt_dec_6 : (6 : Word) + signExtend12 (-1 : BitVec 12) = (5 : Word) := by decide
+theorem cnt_dec_7 : (7 : Word) + signExtend12 (-1 : BitVec 12) = (6 : Word) := by decide
+theorem cnt_dec_8 : (8 : Word) + signExtend12 (-1 : BitVec 12) = (7 : Word) := by decide
+
 /-- Extract the pure proposition `P` carried by the loop-body post.
 
     Any caller that has built `rlp_phase2_long_loop_body_post len ptr cnt

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
@@ -95,9 +95,7 @@ theorem rlp_phase2_long_loop_eight_byte_spec
   simp only [rlp_phase2_long_loop_eight_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (8 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (8 : Word) + signExtend12 (-1 : BitVec 12) = (7 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_8] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (8 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -80,9 +80,7 @@ theorem rlp_phase2_long_loop_five_byte_spec
   simp only [rlp_phase2_long_loop_five_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (5 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (5 : Word) + signExtend12 (-1 : BitVec 12) = (4 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_5] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (5 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -77,9 +77,7 @@ theorem rlp_phase2_long_loop_four_byte_spec
   -- Iter 1: body at cnt = 4. cnt' = 3.
   have body := rlp_phase2_long_loop_body_spec len ptr (4 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (4 : Word) + signExtend12 (-1 : BitVec 12) = (3 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_4] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (4 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -77,9 +77,7 @@ theorem rlp_phase2_long_loop_one_byte_spec
   have body := rlp_phase2_long_loop_body_spec len ptr (1 : Word) v12Old
     wordVal dwordAddr base back halign hvalid
   -- For cnt = 1, `cnt' = (1 : Word) + signExtend12 (-1 : BitVec 12) = 0`.
-  have hcnt' : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_1] at body
   -- The taken post carries `⌜(0 : Word) ≠ 0⌝`, which is False. Extract it
   -- via six layers of destructuring and derive the contradiction.
   set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
@@ -88,9 +88,7 @@ theorem rlp_phase2_long_loop_seven_byte_spec
   simp only [rlp_phase2_long_loop_seven_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (7 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (7 : Word) + signExtend12 (-1 : BitVec 12) = (6 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_7] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (7 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
@@ -83,9 +83,7 @@ theorem rlp_phase2_long_loop_six_byte_spec
   simp only [rlp_phase2_long_loop_six_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (6 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (6 : Word) + signExtend12 (-1 : BitVec 12) = (5 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_6] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (6 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -82,9 +82,7 @@ theorem rlp_phase2_long_loop_three_byte_spec
   -- Iter 1: body spec at cnt = 3. cnt' = 2.
   have body := rlp_phase2_long_loop_body_spec len ptr (3 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_3] at body
   -- The fall-through carries `⌜(2 : Word) = 0⌝`, which is False.
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -83,9 +83,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
   have body := rlp_phase2_long_loop_body_spec len ptr (2 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
   -- cnt' = 2 + signExtend12 (-1) = 1. Rewrite.
-  have hcnt' : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_2] at body
   -- The fall-through carries `⌜(1 : Word) = 0⌝`, which is False.
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,


### PR DESCRIPTION
## Summary
Each per-iteration loop closure (\`rlp_phase2_long_loop_*_byte_spec\`) specializes the body spec at a specific counter value \`N : Word\` and needs the concrete decremented value \`N - 1\` to flow through the post. The recurring boilerplate

\`\`\`lean
have hcnt' : (N : Word) + signExtend12 (-1 : BitVec 12) = (N-1 : Word) := by
  decide
rw [hcnt'] at body
\`\`\`

now reduces to \`rw [cnt_dec_N] at body\`. Add the eight \`cnt_dec_{1..8}\` lemmas to \`Phase2LongLoopBody.lean\` and update all 8 call sites in \`Phase2LongLoop{One..Eight}.lean\`.

Net: very small (+2 net), but each closure becomes 2 lines shorter and the concrete arithmetic facts are now named & shareable for future loop closures or unrolled-iteration specs.

## Test plan
- [x] \`lake build EvmAsm.Rv64.RLP\` succeeds locally (entire RLP RV64 namespace, 899 jobs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)