### PR TITLE
feat(divmod): #1337 v4 stack bridge — n=4 call+addback BEQ

### DIFF
--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -144,7 +144,17 @@ def divK_div128 : Program :=
     **Migration**: callers of `divK_div128` should be updated to call
     `divK_div128_v2` (this requires updating offsets in the main loop
     at `divK_loopBody`, since the subroutine moved). Once all use-sites
-    migrate, the buggy `divK_div128` should be removed. -/
+    migrate, the buggy `divK_div128` should be removed.
+
+    **NOTE (2026-04-29)**: v2 has only Phase 1b 2-correction; Phase 2b
+    is still 1-correction. PR #1418 closed `n4CallAddbackBeqSemanticHolds_v4`
+    for the FULL 2-correction algorithm `div128Quot_v4`, but to apply
+    that closure to the deployed program we need a `divK_div128_v4`
+    variant (~10 new instructions for Phase 2b 2nd D3 correction +
+    ~2 for register save/restore of rhat2c, since x11 is clobbered
+    by `LD un0` in the existing layout). See
+    `~/.claude/projects/-home-zksecurity-evm-asm/memory/project_v2_to_v4_migration_plan.md`
+    for the staged migration plan. -/
 def divK_div128_v2 : Program :=
   -- Save return addr and d
   SD .x12 .x2 3968 ;;                         -- [0]  save return addr

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -153,8 +153,8 @@ def divK_div128 : Program :=
     variant (~10 new instructions for Phase 2b 2nd D3 correction +
     ~2 for register save/restore of rhat2c, since x11 is clobbered
     by `LD un0` in the existing layout). See
-    `~/.claude/projects/-home-zksecurity-evm-asm/memory/project_v2_to_v4_migration_plan.md`
-    for the staged migration plan. -/
+    the local memory file `project_v2_to_v4_migration_plan.md`
+    (under `~/.claude/projects/...`) for the staged migration plan. -/
 def divK_div128_v2 : Program :=
   -- Save return addr and d
   SD .x12 .x2 3968 ;;                         -- [0]  save return addr

--- a/EvmAsm/Evm64/DivMod/SpecCallV4StackBridge.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallV4StackBridge.lean
@@ -1,0 +1,84 @@
+/-
+  EvmAsm.Evm64.DivMod.SpecCallV4StackBridge
+
+  Bridges between v4 closure proofs (in `SpecCallV4.lean`) and the
+  EVM-stack-level specs (in `SpecCallAddbackBeq.lean`). Provides v4
+  mirrors of bridges originally written for v1 (`div128Quot`).
+
+  Companion to `SpecCallV4.lean` (the v4 closure proofs) and
+  `SpecCallAddbackBeq.lean` (the v1 stack specs).
+-/
+
+import EvmAsm.Evm64.DivMod.SpecCallV4
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmWord (val256)
+
+/-- **v4 mirror of `n4_call_addback_beq_div_mod_getLimbN`**: under
+    `n4CallAddbackBeqSemanticHolds_v4` (the v4 semantic-holds, which uses
+    `div128Quot_v4` for the trial quotient), the post-addback corrected
+    quotient `q_out` equals `(EvmWord.div a b).getLimbN 0`, and the
+    upper three limbs of `EvmWord.div a b` are all zero.
+
+    Same proof shape as the v1 version — only uses `div128Quot_v4`
+    instead of `div128Quot`. The final equality `q_target = EvmWord.div a b`
+    is established via `BitVec.eq_of_toNat_eq` on the toNat values. -/
+theorem n4_call_addback_beq_div_mod_getLimbN_v4 (a b : EvmWord)
+    (hbnz : b ≠ 0)
+    (hsem : n4CallAddbackBeqSemanticHolds_v4 a b) :
+    let shift := (clzResult (b.getLimbN 3)).1.toNat % 64
+    let antiShift :=
+      (signExtend12 (0 : BitVec 12) - (clzResult (b.getLimbN 3)).1).toNat % 64
+    let b3' := ((b.getLimbN 3) <<< shift) ||| ((b.getLimbN 2) >>> antiShift)
+    let b2' := ((b.getLimbN 2) <<< shift) ||| ((b.getLimbN 1) >>> antiShift)
+    let b1' := ((b.getLimbN 1) <<< shift) ||| ((b.getLimbN 0) >>> antiShift)
+    let b0' := (b.getLimbN 0) <<< shift
+    let u4 := (a.getLimbN 3) >>> antiShift
+    let u3 := ((a.getLimbN 3) <<< shift) ||| ((a.getLimbN 2) >>> antiShift)
+    let u2 := ((a.getLimbN 2) <<< shift) ||| ((a.getLimbN 1) >>> antiShift)
+    let u1 := ((a.getLimbN 1) <<< shift) ||| ((a.getLimbN 0) >>> antiShift)
+    let u0 := (a.getLimbN 0) <<< shift
+    let qHat := div128Quot_v4 u4 u3 b3'
+    let ms := mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3
+    let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 b0' b1' b2' b3'
+    let q_out : Word :=
+      if carry = 0 then qHat + signExtend12 4095 + signExtend12 4095
+      else qHat + signExtend12 4095
+    (EvmWord.div a b).getLimbN 0 = q_out ∧
+    (EvmWord.div a b).getLimbN 1 = 0 ∧
+    (EvmWord.div a b).getLimbN 2 = 0 ∧
+    (EvmWord.div a b).getLimbN 3 = 0 := by
+  intro shift antiShift b3' b2' b1' b0' u4 u3 u2 u1 u0 qHat ms carry q_out
+  rw [n4CallAddbackBeqSemanticHolds_v4_def] at hsem
+  change q_out.toNat = val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) /
+         val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) at hsem
+  have ha_val : val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
+      = a.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
+      = b.toNat := by
+    simp only [← EvmWord.getLimb_as_getLimbN_0, ← EvmWord.getLimb_as_getLimbN_1,
+               ← EvmWord.getLimb_as_getLimbN_2, ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  rw [ha_val, hb_val] at hsem
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div
+    rw [if_neg hbnz]
+    exact BitVec.toNat_udiv
+  set q_target : EvmWord := EvmWord.fromLimbs fun i : Fin 4 =>
+    match i with | 0 => q_out | 1 => 0 | 2 => 0 | 3 => 0 with hq_target
+  have hq_target_toNat : q_target.toNat = q_out.toNat := by
+    simp [q_target, EvmWord.fromLimbs_toNat]
+  have hq_eq_div : q_target = EvmWord.div a b :=
+    BitVec.eq_of_toNat_eq (by omega)
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hq_eq_div]; exact EvmWord.getLimbN_fromLimbs_3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -73,6 +73,24 @@ theorem rlp_phase2_long_loop_body_post_unfold
      (dwordAddr ↦ₘ wordVal) ** ⌜P⌝) := by
   delta rlp_phase2_long_loop_body_post; rfl
 
+/-! ## Concrete `cnt' = cnt + signExtend12 (-1)` evaluations
+
+Each per-iteration loop closure (`rlp_phase2_long_loop_*_byte_spec`)
+specializes the body spec at a specific counter value `N : Word` and
+needs the concrete decremented value `N - 1` to flow through the
+post. These eight lemmas package the recurring `(N : Word) +
+signExtend12 (-1 : BitVec 12) = (N - 1 : Word) := by decide` boiler.
+-/
+
+theorem cnt_dec_1 : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by decide
+theorem cnt_dec_2 : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by decide
+theorem cnt_dec_3 : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by decide
+theorem cnt_dec_4 : (4 : Word) + signExtend12 (-1 : BitVec 12) = (3 : Word) := by decide
+theorem cnt_dec_5 : (5 : Word) + signExtend12 (-1 : BitVec 12) = (4 : Word) := by decide
+theorem cnt_dec_6 : (6 : Word) + signExtend12 (-1 : BitVec 12) = (5 : Word) := by decide
+theorem cnt_dec_7 : (7 : Word) + signExtend12 (-1 : BitVec 12) = (6 : Word) := by decide
+theorem cnt_dec_8 : (8 : Word) + signExtend12 (-1 : BitVec 12) = (7 : Word) := by decide
+
 /-- Extract the pure proposition `P` carried by the loop-body post.
 
     Any caller that has built `rlp_phase2_long_loop_body_post len ptr cnt

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
@@ -95,9 +95,7 @@ theorem rlp_phase2_long_loop_eight_byte_spec
   simp only [rlp_phase2_long_loop_eight_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (8 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (8 : Word) + signExtend12 (-1 : BitVec 12) = (7 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_8] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (8 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -80,9 +80,7 @@ theorem rlp_phase2_long_loop_five_byte_spec
   simp only [rlp_phase2_long_loop_five_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (5 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (5 : Word) + signExtend12 (-1 : BitVec 12) = (4 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_5] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (5 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -77,9 +77,7 @@ theorem rlp_phase2_long_loop_four_byte_spec
   -- Iter 1: body at cnt = 4. cnt' = 3.
   have body := rlp_phase2_long_loop_body_spec len ptr (4 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (4 : Word) + signExtend12 (-1 : BitVec 12) = (3 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_4] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (4 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -77,9 +77,7 @@ theorem rlp_phase2_long_loop_one_byte_spec
   have body := rlp_phase2_long_loop_body_spec len ptr (1 : Word) v12Old
     wordVal dwordAddr base back halign hvalid
   -- For cnt = 1, `cnt' = (1 : Word) + signExtend12 (-1 : BitVec 12) = 0`.
-  have hcnt' : (1 : Word) + signExtend12 (-1 : BitVec 12) = (0 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_1] at body
   -- The taken post carries `⌜(0 : Word) ≠ 0⌝`, which is False. Extract it
   -- via six layers of destructuring and derive the contradiction.
   set byteZext := (extractByte wordVal (byteOffset ptr)).zeroExtend 64

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
@@ -88,9 +88,7 @@ theorem rlp_phase2_long_loop_seven_byte_spec
   simp only [rlp_phase2_long_loop_seven_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (7 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (7 : Word) + signExtend12 (-1 : BitVec 12) = (6 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_7] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (7 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
@@ -83,9 +83,7 @@ theorem rlp_phase2_long_loop_six_byte_spec
   simp only [rlp_phase2_long_loop_six_byte_post_unfold]
   have body := rlp_phase2_long_loop_body_spec len ptr (6 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (6 : Word) + signExtend12 (-1 : BitVec 12) = (5 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_6] at body
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,
       rlp_phase2_long_loop_body_post len ptr (6 : Word) byte1 wordVal

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -82,9 +82,7 @@ theorem rlp_phase2_long_loop_three_byte_spec
   -- Iter 1: body spec at cnt = 3. cnt' = 2.
   have body := rlp_phase2_long_loop_body_spec len ptr (3 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
-  have hcnt' : (3 : Word) + signExtend12 (-1 : BitVec 12) = (2 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_3] at body
   -- The fall-through carries `⌜(2 : Word) = 0⌝`, which is False.
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopTwo.lean
@@ -83,9 +83,7 @@ theorem rlp_phase2_long_loop_two_byte_spec
   have body := rlp_phase2_long_loop_body_spec len ptr (2 : Word) v12Old
     wordVal dwordAddr base back halign1 hvalid1
   -- cnt' = 2 + signExtend12 (-1) = 1. Rewrite.
-  have hcnt' : (2 : Word) + signExtend12 (-1 : BitVec 12) = (1 : Word) := by
-    decide
-  rw [hcnt'] at body
+  rw [cnt_dec_2] at body
   -- The fall-through carries `⌜(1 : Word) = 0⌝`, which is False.
   set byte1 := (extractByte wordVal (byteOffset ptr)).zeroExtend 64
   have h_absurd : ∀ hp,


### PR DESCRIPTION
## Summary

Builds the v4 EVM-stack-level closure for the n=4 call+addback BEQ branch, layered atop PR #1418 (now ready).

This iteration: adds `n4_call_addback_beq_div_mod_getLimbN_v4` — the v4 mirror of v1's bridge from `n4CallAddbackBeqSemanticHolds_v4` to limb-level identities. Same proof shape as v1; uses `div128Quot_v4` internally.

## Path forward

Next sub-stubs to add to this branch:
- v4 mirror of bundled pre-spec for the call+addback BEQ branch.
- `evm_div_n4_call_addback_beq_stack_spec_v4` (uses v4 hsem).
- `evm_div_n4_call_addback_beq_stack_spec_unconditional_v4` (discharges hsem via PR #1418's closure).

## Test plan

- [x] `n4_call_addback_beq_div_mod_getLimbN_v4` typechecks (no sorry).
- [ ] CI passes.
- [ ] No regressions in v1 stack specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)