### PR TITLE
fix(divmod): close div128 v4 step2 proofs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose.lean
+++ b/EvmAsm/Evm64/DivMod/Compose.lean
@@ -20,6 +20,7 @@
 -- ModFullPathN{2,1} cover ModPhaseBn21.
 -- ModDiv128 covers Div128.
 import EvmAsm.Evm64.DivMod.Compose.ModDiv128
+import EvmAsm.Evm64.DivMod.Compose.Div128V4
 import EvmAsm.Evm64.DivMod.Compose.FullPath
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -151,6 +151,33 @@ abbrev sharedDivModCode_v2 (base : Word) : CodeReq :=
     CodeReq.ofProg (base + div128Off)     divK_div128_v2          -- block 12 (v2)
   ]
 
+/-- v4 mirror of `sharedDivModCode` — uses `divK_div128_v4` (full
+    Knuth Algorithm D with 2-correction in BOTH Phase 1b and Phase 2b)
+    at block 12.
+
+    Used as the code requirement for v4-migrated specs. NOTE: block 8
+    (`divK_loopBody 560 7736`) retains the v1/v2 offset constants for
+    now; once LoopBody migrates to v4 the JAL target offset will need
+    re-tuning since v4's div128 is 14 instructions longer than v2.
+
+    Issue #1337 algorithm fix migration / PR-B1 of v4 migration plan. -/
+abbrev sharedDivModCode_v4 (base : Word) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg  base                  (divK_phaseA 1020),     -- block 0
+    CodeReq.ofProg (base + phaseBOff)     divK_phaseB,            -- block 1
+    CodeReq.ofProg (base + clzOff)        divK_clz,               -- block 2
+    CodeReq.ofProg (base + phaseC2Off)    (divK_phaseC2 172),     -- block 3
+    CodeReq.ofProg (base + normBOff)      divK_normB,             -- block 4
+    CodeReq.ofProg (base + normAOff)      (divK_normA 40),        -- block 5
+    CodeReq.ofProg (base + copyAUOff)     divK_copyAU,            -- block 6
+    CodeReq.ofProg (base + loopSetupOff)  (divK_loopSetup 464),   -- block 7
+    CodeReq.ofProg (base + loopBodyOff)   (divK_loopBody 560 7736),-- block 8
+    CodeReq.ofProg (base + denormOff)     divK_denorm,            -- block 9
+    CodeReq.ofProg (base + zeroPathOff)   divK_zeroPath,          -- block 10
+    CodeReq.ofProg (base + nopOff)        (ADDI .x0 .x0 0),       -- block 11
+    CodeReq.ofProg (base + div128Off)     divK_div128_v4          -- block 12 (v4)
+  ]
+
 -- Per-block subsumption: each shared block ⊆ divCode.
 -- Blocks 0-9 are at the same union positions; blocks 10-12 (shared) = blocks 11-13 (divCode).
 private theorem shared_b0_div {b : Word} : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode b) a = some i := by
@@ -255,6 +282,17 @@ theorem shared_b12_div128_v2_sub {b : Word} :
     ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v2) a = some i →
            (sharedDivModCode_v2 b) a = some i := by
   unfold sharedDivModCode_v2; simp only [CodeReq.unionAll_cons]
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
+  exact CodeReq.union_mono_left _ _
+
+/-- v4 mirror of `shared_b12_div128_v2_sub`: block 12 (`divK_div128_v4`)
+    is included in `sharedDivModCode_v4 base`. Used by `div128_v4_spec_shared`
+    to lift `div128_v4_spec` from singleton-`ofProg` cr to shared cr. -/
+theorem shared_b12_div128_v4_sub {b : Word} :
+    ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128_v4) a = some i →
+           (sharedDivModCode_v4 b) a = some i := by
+  unfold sharedDivModCode_v4; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left _ _

--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -37,6 +37,7 @@ theorem divK_zeroPath_len : divK_zeroPath.length = 5 := by decide
 theorem divK_nop_len : (ADDI .x0 .x0 0 : Program).length = 1 := by decide
 theorem divK_div128_len : divK_div128.length = 51 := by decide
 theorem divK_div128_v2_len : divK_div128_v2.length = 61 := by decide
+theorem divK_div128_v4_len : divK_div128_v4.length = 75 := by decide
 theorem divK_modEpilogue_len : (divK_mod_epilogue 24).length = 10 := by decide
 
 /-- Skip one ofProg block in a right-nested union via range disjointness.
@@ -48,7 +49,7 @@ macro "skipBlock" : tactic =>
           divK_normB_len, divK_normA_len, divK_copyAU_len, divK_loopSetup_len,
           divK_loopBody_len, divK_denorm_len, divK_divEpilogue_len,
           divK_zeroPath_len, divK_nop_len, divK_div128_len, divK_div128_v2_len,
-          divK_modEpilogue_len] at hk1 hk2
+          divK_div128_v4_len, divK_modEpilogue_len] at hk1 hk2
         bv_omega)))
 
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -50,7 +50,7 @@ private theorem d128_v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr
 
     `@[irreducible]` to keep the let-chain out of the theorem signature. -/
 @[irreducible]
-def div128V4SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
+def div128V4SpecPost (sp retAddr d uLo uHi scratchMem : Word) : Assertion :=
   -- Phase 1 split intermediates (unchanged from v2).
   let dHi := d >>> (32 : BitVec 6).toNat
   let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
@@ -95,20 +95,34 @@ def div128V4SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
     else rhat2c
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo un0
   let q := (q1'' <<< (32 : BitVec 6).toNat) ||| q0''
-  -- Memory: scratch slot 3936 holds the saved rhat2c (un-incremented;
-  -- the SD at instr [52] saves rhat2c BEFORE the optional `+= dHi` at [60]).
-  -- Register and memory state (final). Exit register layout matches v2's
-  -- `div128V2SpecPost` for x10 (q1'') and x11 (combined q), with the
-  -- transient x1/x5/x6/x7 values folded into TODO once the full proof is
-  -- wired (they depend on the BLTU paths taken).
-  -- TODO: pin x1/x5/x6/x7 exit values once the proof body is filled in.
+  -- Register and memory state (final). x1/x7 from step2_v4 post (transient
+  -- values depending on which BLTU/BNE branches fired); end_spec overwrites
+  -- x11 with q (combined result) from x10 and x5.
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let rhat2' :=
+    if rhat2cHi = 0 then
+      if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+    else rhat2c
+  let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := q0' * dLo
+  let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  let x7Exit_step2 := if rhat2cHi ≠ 0 then un21
+                      else if rhat2'Hi ≠ 0 then q0Dlo1
+                      else q0Dlo2
+  let x1Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
+                      else if rhat2'Hi ≠ 0 then rhat2'Hi
+                      else rhat2'Un0
   (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1'') **
-  (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
+  (.x5 ↦ᵣ q0'') ** (.x7 ↦ᵣ x7Exit_step2) **
+  (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit_step2) ** (.x11 ↦ᵣ q) **
+  (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3968 ↦ₘ retAddr) **
   (sp + signExtend12 3960 ↦ₘ d) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
   (sp + signExtend12 3944 ↦ₘ un0) **
-  (sp + signExtend12 3936 ↦ₘ rhat2c)
+  (sp + signExtend12 3936 ↦ₘ (if rhat2cHi ≠ 0 then scratchMem else rhat2c))
 
 /-- **STUB**: equivalence between `divK_div128_v4` (full Knuth D RISC-V)
     and `div128Quot_v4` (Lean abstraction).
@@ -149,7 +163,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (div128V4SpecPost sp retAddr d uLo uHi) := by
+      (div128V4SpecPost sp retAddr d uLo uHi scratchMem) := by
   sorry  -- PR-A2 stub. Proof composes 5 blocks via cpsTriple_seq_perm_same_cr,
          -- mirroring `div128_v2_spec` (in `Compose/Div128.lean` line 419-629).
          -- Translation table from v2 → v4:
@@ -206,7 +220,7 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3952 ↦ₘ dloMem) **
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem))
-      (div128V4SpecPost sp retAddr d uLo uHi) :=
+      (div128V4SpecPost sp retAddr d uLo uHi scratchMem) :=
   cpsTriple_extend_code (hmono := shared_b12_div128_v4_sub)
     (div128_v4_spec sp retAddr d uLo uHi base v1Old v6Old v11Old
       retMem dMem dloMem un0Mem scratchMem halign)

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -29,6 +29,18 @@ open EvmAsm.Rv64
 -- Section 15-v4: div128 subroutine composition (v4 algorithm).
 -- ============================================================================
 
+-- v4 helper: singleton at index k of divK_div128_v4 ⊆ ofProg-based v4 cr.
+-- Mirrors `d128_v2_sub` but uses `divK_div128_v4`.
+private theorem d128_v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < divK_div128_v4.length)
+    (h_addr : addr = (base + div128Off) + BitVec.ofNat 64 (4 * k))
+    (h_instr : divK_div128_v4.get ⟨k, hk⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (CodeReq.ofProg (base + div128Off) divK_div128_v4) a = some i := by
+  subst h_addr; subst h_instr
+  exact fun a i h => CodeReq.singleton_mono
+    (CodeReq.ofProg_lookup (base + div128Off) divK_div128_v4 k hk (by decide)) a i h
+
 /-- Bundled postcondition for `div128_v4_spec`.
 
     Mirrors `div128V2SpecPost` but uses `q0''` (post-Phase-2b-2nd-D3)

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -150,7 +150,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem scratchMem : Word)
     (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
-    cpsTriple (base + div128Off) retAddr
+    cpsTripleWithin 73 (base + div128Off) retAddr
       (CodeReq.ofProg (base + div128Off) divK_div128_v4)
       (-- Precondition: same as div128_v2_spec, plus the new scratch slot
        -- 3936 (used to save rhat2c across the un0 LD clobber).
@@ -187,10 +187,10 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
   let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
                 then rhat' + dHi else rhat'
   -- Block 1: Phase 1 (base+1072 → base+1112).
-  have hph1 := divK_div128_phase1_spec sp retAddr d uLo uHi v1Old v6Old v11Old
+  have hph1 := divK_div128_phase1_spec_within sp retAddr d uLo uHi v1Old v6Old v11Old
     retMem dMem dloMem un0Mem (base + div128Off)
   rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
-  have hph1e := cpsTriple_extend_code (hmono := by
+  have hph1e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 0 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 1 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 2 _ _ (by decide) (by bv_addr) (by decide))
@@ -202,14 +202,14 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
      (CodeReq.union_sub (d128_v4_sub 8 _ _ (by decide) (by bv_addr) (by decide))
       (d128_v4_sub 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
     hph1
-  have hph1f := cpsTriple_frameR
+  have hph1f := cpsTripleWithin_frameR
     ((.x0 ↦ᵣ (0 : Word)) ** (sp + signExtend12 3936 ↦ₘ scratchMem))
     (by pcFree) hph1e
   -- Block 2: Step1_v2 (base+1112 → base+1212).
-  have hst1 := divK_div128_step1_v2_spec sp uHi dHi un1 dLo un0 d dLo (base + 1112)
+  have hst1 := divK_div128_step1_v2_spec_within sp uHi dHi un1 dLo un0 d dLo (base + 1112)
   unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre divKDiv128Step1V2Post at hst1
   rw [show (base + 1112 : Word) + 100 = base + 1212 from by bv_addr] at hst1
-  have hst1e := cpsTriple_extend_code (hmono := by
+  have hst1e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 10 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 11 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 12 _ _ (by decide) (by bv_addr) (by decide))
@@ -236,33 +236,33 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
      (CodeReq.union_sub (d128_v4_sub 33 _ _ (by decide) (by bv_addr) (by decide))
       (d128_v4_sub 34 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))))))))))
     hst1
-  have hst1f := cpsTriple_frameR
+  have hst1f := cpsTripleWithin_frameR
     ((.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0) **
      (sp + signExtend12 3936 ↦ₘ scratchMem))
     (by pcFree) hst1e
-  have h12 := cpsTriple_seq_perm_same_cr
+  have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hph1f hst1f
   -- Block 3: compute_un21 (base+1212 → base+1232).
   let x5Exit_st1 := if rhatHi2 = 0 then qDlo2 else qDlo1
   let x1Exit_st1 := if rhatHi2 = 0 then rhatUn1' else rhatHi2
-  have hcu := divK_div128_compute_un21_spec sp q1'' rhat'' un1 x1Exit_st1 x5Exit_st1 dLo
+  have hcu := divK_div128_compute_un21_spec_within sp q1'' rhat'' un1 x1Exit_st1 x5Exit_st1 dLo
     (base + 1212)
   rw [show (base + 1212 : Word) + 20 = base + 1232 from by bv_addr] at hcu
-  have hcue := cpsTriple_extend_code (hmono := by
+  have hcue := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 35 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 36 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 37 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 38 _ _ (by decide) (by bv_addr) (by decide))
       (d128_v4_sub 39 _ _ (by decide) (by bv_addr) (by decide))))))
     hcu
-  have hcuf := cpsTriple_frameR
+  have hcuf := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
      (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0) **
      (sp + signExtend12 3936 ↦ₘ scratchMem))
     (by pcFree) hcue
-  have h123 := cpsTriple_seq_perm_same_cr
+  have h123 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12 hcuf
   -- Block 4: step2_v4 (base+1232 → base+1356).
   let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
@@ -272,44 +272,16 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     scratchMem (base + 1232)
   unfold divKDiv128Step2V4Code divKDiv128Step2V4Post at hst2
   rw [show (base + 1232 : Word) + 124 = base + 1356 from by bv_addr] at hst2
-  have hst2e := cpsTriple_extend_code (hmono := by
-    exact CodeReq.union_sub (d128_v4_sub 40 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 41 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 42 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 43 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 44 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 45 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 46 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 47 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 48 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 49 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 50 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 51 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 52 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 53 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 54 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 55 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 56 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 57 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 58 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 59 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 60 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 61 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 62 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 63 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 64 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 65 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 66 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 67 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 68 _ _ (by decide) (by bv_addr) (by decide))
-     (CodeReq.union_sub (d128_v4_sub 69 _ _ (by decide) (by bv_addr) (by decide))
-      (d128_v4_sub 70 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))))))))))))))))
+  have hst2e := cpsTripleWithin_extend_code (hmono := by
+    exact CodeReq.ofProg_mono_sub (base + div128Off) (base + 1232)
+      divK_div128_v4 divKDiv128Step2V4Instrs 40
+      (by bv_addr) (by decide) (by decide) (by decide))
     hst2
-  have hst2f := cpsTriple_frameR
+  have hst2f := cpsTripleWithin_frameR
     ((.x10 ↦ᵣ q1'') ** (.x2 ↦ᵣ retAddr) **
      (sp + signExtend12 3968 ↦ₘ retAddr) ** (sp + signExtend12 3960 ↦ₘ d))
     (by pcFree) hst2e
-  have h1234 := cpsTriple_seq_perm_same_cr
+  have h1234 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123 hst2f
   -- Block 5: end (base+1356 → retAddr via JALR).
   -- step2_v4's q0'' is x5 from divKDiv128Step2V4Post.
@@ -340,30 +312,30 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
                        else if rhat2'Hi ≠ 0 then rhat2'
                        else un0
   let mem3936Exit := if rhat2cHi ≠ 0 then scratchMem else rhat2c
-  have hend := divK_div128_end_spec sp q1'' q0'' retAddr x11Exit_step2 retAddr
+  have hend := divK_div128_end_spec_within sp q1'' q0'' retAddr x11Exit_step2 retAddr
     (base + 1356) _halign
-  have hende := cpsTriple_extend_code (hmono := by
+  have hende := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 71 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 72 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 73 _ _ (by decide) (by bv_addr) (by decide))
       (d128_v4_sub 74 _ _ (by decide) (by bv_addr) (by decide)))))
     hend
-  have hendf := cpsTriple_frameR
+  have hendf := cpsTripleWithin_frameR
     ((.x7 ↦ᵣ x7Exit_step2) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit_step2) **
      (.x0 ↦ᵣ (0 : Word)) **
      (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
      (sp + signExtend12 3944 ↦ₘ un0) ** (sp + signExtend12 3936 ↦ₘ mem3936Exit))
     (by pcFree) hende
-  have h12345 := cpsTriple_seq_perm_same_cr
+  have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 hendf
-  exact cpsTriple_weaken
+  exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h12345
 
 /-- Lifted `div128_v4_spec` over `sharedDivModCode_v4 base` — a thin
     wrapper that lifts the cr from singleton `ofProg`-form to the
-    shared cr via `cpsTriple_extend_code` + `shared_b12_div128_v4_sub`.
+    shared cr via `cpsTripleWithin_extend_code` + `shared_b12_div128_v4_sub`.
 
     Future v4-migrated specs (loop body, full path) will use this
     lifted form. -/
@@ -371,7 +343,7 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
     (retMem dMem dloMem un0Mem scratchMem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
-    cpsTriple (base + div128Off) retAddr (sharedDivModCode_v4 base)
+    cpsTripleWithin 73 (base + div128Off) retAddr (sharedDivModCode_v4 base)
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
        (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
@@ -382,7 +354,7 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi scratchMem) :=
-  cpsTriple_extend_code (hmono := shared_b12_div128_v4_sub)
+  cpsTripleWithin_extend_code (hmono := shared_b12_div128_v4_sub)
     (div128_v4_spec sp retAddr d uLo uHi base v1Old v6Old v11Old
       retMem dMem dloMem un0Mem scratchMem halign)
 

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -1,0 +1,165 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.Div128V4
+
+  div128 subroutine composition for the v4 algorithm — the FULL
+  Knuth Algorithm D with 2-correction in BOTH Phase 1b and Phase 2b.
+
+  The v4 RV64 program `divK_div128_v4` (defined in `Program.lean`) is
+  identical to `divK_div128_v2` for instructions [0..46], then adds a
+  Phase 2b 2nd D3 correction at [47..70] (vs v2's single correction at
+  [47..56]). Total length: 75 vs 61 instructions for v2.
+
+  Companion to `Compose/Div128.lean` (v1 + v2 specs). PR-A2 of the
+  v2 → v4 migration plan.
+
+  Issue #1337 algorithm fix migration / Issue #61 stack spec closure.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.Div128
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- ============================================================================
+-- Section 15-v4: div128 subroutine composition (v4 algorithm).
+-- ============================================================================
+
+/-- Bundled postcondition for `div128_v4_spec`.
+
+    Mirrors `div128V2SpecPost` but uses `q0''` (post-Phase-2b-2nd-D3)
+    instead of `q0'`, matching `div128Quot_v4`'s output. The Phase 1
+    intermediates (q1, rhat, q1c, rhatc, q1', rhat', q1'', rhat'') are
+    identical between v2 and v4 — the v4 fix is in Phase 2b only.
+
+    `@[irreducible]` to keep the let-chain out of the theorem signature. -/
+@[irreducible]
+def div128V4SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
+  -- Phase 1 split intermediates (unchanged from v2).
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  -- Step 1 1st D3 (unchanged).
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
+  -- Step 1 2nd D3 (unchanged from v2).
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  -- compute_un21 (unchanged shape — uses q1''/rhat'').
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1'' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  -- Step 2 init/clamp (unchanged shape).
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  -- Phase 2b 1st D3 (unchanged shape — same `div128Quot_phase2b_q0'`).
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  -- Phase 2b 2nd D3 (NEW in v4).
+  let rhat2' :=
+    if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+      let qDlo2c := q0c * dLo
+      let rhatUn0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+      if BitVec.ult rhatUn0 qDlo2c then rhat2c + dHi else rhat2c
+    else rhat2c
+  let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo un0
+  let q := (q1'' <<< (32 : BitVec 6).toNat) ||| q0''
+  -- Register and memory state (final). Note exit register layout will be
+  -- determined by the actual proof; for now we expose just the canonical
+  -- shape, with x10 = q1'' and x11 = q (combined result). Other registers
+  -- (x1, x5, x6, x7) hold transient values from the last instructions
+  -- and are left abstract via existential placeholders to match the
+  -- runtime end-of-subroutine state.
+  -- TODO: pin x1/x5/x6/x7 exit values once the full proof is wired.
+  (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1'') **
+  (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
+  (sp + signExtend12 3968 ↦ₘ retAddr) **
+  (sp + signExtend12 3960 ↦ₘ d) **
+  (sp + signExtend12 3952 ↦ₘ dLo) **
+  (sp + signExtend12 3944 ↦ₘ un0)
+
+/-- **STUB**: equivalence between `divK_div128_v4` (full Knuth D RISC-V)
+    and `div128Quot_v4` (Lean abstraction).
+
+    Mirrors `div128_v2_spec` but for the v4 algorithm. Proof structure:
+    - Block 1 (Phase 1, instrs [0..9]): identical to v2.
+    - Block 2 (Step1 v2, instrs [10..34]): identical to v2 — Phase 1b
+      2-correction is the same.
+    - Block 3 (compute_un21, instrs [35..39]): identical shape — uses
+      q1''/rhat'' (post-Phase-1b-2nd-D3).
+    - Block 4 (Step2 + Phase 2b 1st D3 + 2nd D3, instrs [40..70]):
+      **NEW for v4**. v2's Step2 covered [40..56]; v4's covers [40..70]
+      with 14 extra instructions for the 2nd Phase 2b D3 correction.
+    - Block 5 (end, instrs [71..74]): identical shape — combine + return.
+
+    The Block 4 proof requires:
+    - `divK_div128_step2_v4_spec` (NEW): RV64 → val256 spec for instrs
+      [40..70] producing q0''.
+    - This in turn requires either reusing `div128Quot_phase2b_q0'`
+      twice (matching v4's Lean def) or composing 1st D3 + 2nd D3
+      sub-specs.
+
+    Estimated: ~700 LOC for the full proof (vs ~600 for v2). -/
+theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
+    (v1Old v6Old v11Old : Word)
+    (retMem dMem dloMem un0Mem : Word)
+    (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
+    cpsTriple (base + div128Off) retAddr
+      (CodeReq.ofProg (base + div128Off) divK_div128_v4)
+      (-- Precondition: same as div128_spec / div128_v2_spec.
+       (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
+      (div128V4SpecPost sp retAddr d uLo uHi) := by
+  sorry  -- PR-A2 stub. Proof composes phase1 + step1_v2 + compute_un21 +
+         -- step2_v4 (NEW) + end, similar to div128_v2_spec but with the
+         -- v4 step2 block covering 31 instructions instead of 17.
+
+/-- Lifted `div128_v4_spec` over `sharedDivModCode_v4 base` — a thin
+    wrapper that lifts the cr from singleton `ofProg`-form to the
+    shared cr via `cpsTriple_extend_code` + `shared_b12_div128_v4_sub`.
+
+    Future v4-migrated specs (loop body, full path) will use this
+    lifted form. -/
+theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
+    (v1Old v6Old v11Old : Word)
+    (retMem dMem dloMem un0Mem : Word)
+    (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
+    cpsTriple (base + div128Off) retAddr (sharedDivModCode_v4 base)
+      ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
+       (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
+       (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x0 ↦ᵣ (0 : Word)) **
+       (sp + signExtend12 3968 ↦ₘ retMem) **
+       (sp + signExtend12 3960 ↦ₘ dMem) **
+       (sp + signExtend12 3952 ↦ₘ dloMem) **
+       (sp + signExtend12 3944 ↦ₘ un0Mem))
+      (div128V4SpecPost sp retAddr d uLo uHi) :=
+  cpsTriple_extend_code (hmono := shared_b12_div128_v4_sub)
+    (div128_v4_spec sp retAddr d uLo uHi base v1Old v6Old v11Old
+      retMem dMem dloMem un0Mem halign)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -16,6 +16,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.Div128
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
 import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 
 open EvmAsm.Rv64.Tactics
@@ -82,19 +83,20 @@ def div128V4SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
     else rhat2c
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo un0
   let q := (q1'' <<< (32 : BitVec 6).toNat) ||| q0''
-  -- Register and memory state (final). Note exit register layout will be
-  -- determined by the actual proof; for now we expose just the canonical
-  -- shape, with x10 = q1'' and x11 = q (combined result). Other registers
-  -- (x1, x5, x6, x7) hold transient values from the last instructions
-  -- and are left abstract via existential placeholders to match the
-  -- runtime end-of-subroutine state.
-  -- TODO: pin x1/x5/x6/x7 exit values once the full proof is wired.
+  -- Memory: scratch slot 3936 holds the saved rhat2c (un-incremented;
+  -- the SD at instr [52] saves rhat2c BEFORE the optional `+= dHi` at [60]).
+  -- Register and memory state (final). Exit register layout matches v2's
+  -- `div128V2SpecPost` for x10 (q1'') and x11 (combined q), with the
+  -- transient x1/x5/x6/x7 values folded into TODO once the full proof is
+  -- wired (they depend on the BLTU paths taken).
+  -- TODO: pin x1/x5/x6/x7 exit values once the proof body is filled in.
   (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ q1'') **
   (.x11 ↦ᵣ q) ** (.x0 ↦ᵣ (0 : Word)) **
   (sp + signExtend12 3968 ↦ₘ retAddr) **
   (sp + signExtend12 3960 ↦ₘ d) **
   (sp + signExtend12 3952 ↦ₘ dLo) **
-  (sp + signExtend12 3944 ↦ₘ un0)
+  (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ rhat2c)
 
 /-- **STUB**: equivalence between `divK_div128_v4` (full Knuth D RISC-V)
     and `div128Quot_v4` (Lean abstraction).
@@ -120,11 +122,12 @@ def div128V4SpecPost (sp retAddr d uLo uHi : Word) : Assertion :=
     Estimated: ~700 LOC for the full proof (vs ~600 for v2). -/
 theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
-    (retMem dMem dloMem un0Mem : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
     (_halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTriple (base + div128Off) retAddr
       (CodeReq.ofProg (base + div128Off) divK_div128_v4)
-      (-- Precondition: same as div128_spec / div128_v2_spec.
+      (-- Precondition: same as div128_v2_spec, plus the new scratch slot
+       -- 3936 (used to save rhat2c across the un0 LD clobber).
        (.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
        (.x5 ↦ᵣ uLo) ** (.x7 ↦ᵣ uHi) **
        (.x6 ↦ᵣ v6Old) ** (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
@@ -132,11 +135,22 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi) := by
   sorry  -- PR-A2 stub. Proof composes phase1 + step1_v2 + compute_un21 +
-         -- step2_v4 (NEW) + end, similar to div128_v2_spec but with the
-         -- v4 step2 block covering 31 instructions instead of 17.
+         -- step2_v4 + end, similar to div128_v2_spec but with the v4
+         -- step2 block covering 31 instructions instead of 17, and with
+         -- the new scratch memory slot 3936 threaded through.
+         -- Block sequence:
+         --   [0..9]   phase1     (existing divK_div128_phase1_spec)
+         --   [10..34] step1_v2   (existing divK_div128_step1_v2_spec)
+         --   [35..39] compute_un21 (existing divK_div128_compute_un21_spec)
+         --   [40..70] step2_v4   (NEW divK_div128_step2_v4_spec — sorry'd)
+         --   [71..74] end        (existing divK_div128_end_spec)
+         -- Step2_v4 spans byte offsets [base+1232 .. base+1356], where
+         -- the v4 step2 covers 124 bytes vs v2's 68 bytes.
+         -- End spans [base+1356 .. base+1372]; v4 returns at base+1372.
 
 /-- Lifted `div128_v4_spec` over `sharedDivModCode_v4 base` — a thin
     wrapper that lifts the cr from singleton `ofProg`-form to the
@@ -146,7 +160,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
     lifted form. -/
 theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
     (v1Old v6Old v11Old : Word)
-    (retMem dMem dloMem un0Mem : Word)
+    (retMem dMem dloMem un0Mem scratchMem : Word)
     (halign : (retAddr + signExtend12 0) &&& ~~~1 = retAddr) :
     cpsTriple (base + div128Off) retAddr (sharedDivModCode_v4 base)
       ((.x12 ↦ᵣ sp) ** (.x2 ↦ᵣ retAddr) ** (.x10 ↦ᵣ d) **
@@ -156,10 +170,11 @@ theorem div128_v4_spec_shared (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3968 ↦ₘ retMem) **
        (sp + signExtend12 3960 ↦ₘ dMem) **
        (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ un0Mem))
+       (sp + signExtend12 3944 ↦ₘ un0Mem) **
+       (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi) :=
   cpsTriple_extend_code (hmono := shared_b12_div128_v4_sub)
     (div128_v4_spec sp retAddr d uLo uHi base v1Old v6Old v11Old
-      retMem dMem dloMem un0Mem halign)
+      retMem dMem dloMem un0Mem scratchMem halign)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -164,41 +164,202 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi scratchMem) := by
-  sorry  -- PR-A2 stub. Proof composes 5 blocks via cpsTriple_seq_perm_same_cr,
-         -- mirroring `div128_v2_spec` (in `Compose/Div128.lean` line 419-629).
-         -- Translation table from v2 → v4:
-         --
-         --   Block 1: phase1    [base+1072..base+1112]  10 inst (same as v2)
-         --     Reuse `divK_div128_phase1_spec`. Code-extend with `d128_v4_sub`
-         --     for indices [0..9]. Frame x0.
-         --
-         --   Block 2: step1_v2  [base+1112..base+1212]  25 inst (same as v2)
-         --     Reuse `divK_div128_step1_v2_spec`. Code-extend with `d128_v4_sub`
-         --     for indices [10..34]. Frame ((x2 ↦ retAddr) ** mem3968 **
-         --     mem3960 ** mem3944 ** mem3936).
-         --
-         --   Block 3: compute_un21 [base+1212..base+1232]  5 inst (same as v2)
-         --     Reuse `divK_div128_compute_un21_spec`. Code-extend with
-         --     `d128_v4_sub` for indices [35..39]. Frame.
-         --
-         --   Block 4: step2_v4  [base+1232..base+1356]  31 inst (NEW for v4)
-         --     Use `divK_div128_step2_v4_spec` (still sorry'd). Code-extend
-         --     with `d128_v4_sub` for indices [40..70]. Frame ((x10 ↦ q1'') **
-         --     (x2 ↦ retAddr) ** mem3968 ** mem3960). NB: step2_v4 owns
-         --     mem3936 (saves rhat2c there).
-         --
-         --   Block 5: end       [base+1356..base+1372]  4 inst (same shape)
-         --     Reuse `divK_div128_end_spec` with q1 = q1'', q0 = q0''.
-         --     Code-extend with `d128_v4_sub` for indices [71..74]. Frame
-         --     ((x7 ↦ x7Exit_v4) ** (x6 ↦ dHi) ** (x1 ↦ x1Exit_v4) ** x0 **
-         --      mem3960 ** mem3952 ** mem3944 ** mem3936).
-         --
-         -- Final: cpsTriple_weaken with two xperm_hyp to reshape pre/post
-         -- to match `div128V4SpecPost` definition order.
-         --
-         -- The proof is ~600 LOC of mechanical block-composition; structurally
-         -- identical to v2 except Block 4 (step2_v4) extends 14 more
-         -- instructions and threads the new mem3936 cell.
+  unfold div128V4SpecPost
+  -- Phase 1 intermediates.
+  let dHi := d >>> (32 : BitVec 6).toNat
+  let dLo := (d <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let un1 := uLo >>> (32 : BitVec 6).toNat
+  let un0 := (uLo <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
+  let q1 := rv64_divu uHi dHi
+  let rhat := uHi - q1 * dHi
+  let hi1 := q1 >>> (32 : BitVec 6).toNat
+  let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
+  let rhatc := if hi1 = 0 then rhat else rhat + dHi
+  let qDlo1 := q1c * dLo
+  let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| un1
+  let q1' := if BitVec.ult rhatUn1 qDlo1 then q1c + signExtend12 4095 else q1c
+  let rhat' := if BitVec.ult rhatUn1 qDlo1 then rhatc + dHi else rhatc
+  let rhatHi2 := rhat' >>> (32 : BitVec 6).toNat
+  let qDlo2 := q1' * dLo
+  let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| un1
+  let q1'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+              then q1' + signExtend12 4095 else q1'
+  let rhat'' := if rhatHi2 = 0 ∧ BitVec.ult rhatUn1' qDlo2
+                then rhat' + dHi else rhat'
+  -- Block 1: Phase 1 (base+1072 → base+1112).
+  have hph1 := divK_div128_phase1_spec sp retAddr d uLo uHi v1Old v6Old v11Old
+    retMem dMem dloMem un0Mem (base + div128Off)
+  rw [show (base + div128Off : Word) + 40 = base + 1112 from by bv_addr] at hph1
+  have hph1e := cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub (d128_v4_sub 0 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 1 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 2 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 3 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 4 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 5 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 6 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 7 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 8 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_v4_sub 9 _ _ (by decide) (by bv_addr) (by decide)))))))))))
+    hph1
+  have hph1f := cpsTriple_frameR
+    ((.x0 ↦ᵣ (0 : Word)) ** (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) hph1e
+  -- Block 2: Step1_v2 (base+1112 → base+1212).
+  have hst1 := divK_div128_step1_v2_spec sp uHi dHi un1 dLo un0 d dLo (base + 1112)
+  unfold divKDiv128Step1V2Code divKDiv128Step1V2Pre divKDiv128Step1V2Post at hst1
+  rw [show (base + 1112 : Word) + 100 = base + 1212 from by bv_addr] at hst1
+  have hst1e := cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub (d128_v4_sub 10 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 11 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 12 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 13 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 14 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 15 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 16 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 17 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 18 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 19 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 20 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 21 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 22 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 23 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 24 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 25 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 26 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 27 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 28 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 29 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 30 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 31 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 32 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 33 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_v4_sub 34 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))))))))))
+    hst1
+  have hst1f := cpsTriple_frameR
+    ((.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
+     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) hst1e
+  have h12 := cpsTriple_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hph1f hst1f
+  -- Block 3: compute_un21 (base+1212 → base+1232).
+  let x5Exit_st1 := if rhatHi2 = 0 then qDlo2 else qDlo1
+  let x1Exit_st1 := if rhatHi2 = 0 then rhatUn1' else rhatHi2
+  have hcu := divK_div128_compute_un21_spec sp q1'' rhat'' un1 x1Exit_st1 x5Exit_st1 dLo
+    (base + 1212)
+  rw [show (base + 1212 : Word) + 20 = base + 1232 from by bv_addr] at hcu
+  have hcue := cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub (d128_v4_sub 35 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 36 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 37 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 38 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_v4_sub 39 _ _ (by decide) (by bv_addr) (by decide))))))
+    hcu
+  have hcuf := cpsTriple_frameR
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x2 ↦ᵣ retAddr) ** (sp + signExtend12 3968 ↦ₘ retAddr) **
+     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3944 ↦ₘ un0) **
+     (sp + signExtend12 3936 ↦ₘ scratchMem))
+    (by pcFree) hcue
+  have h123 := cpsTriple_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h12 hcuf
+  -- Block 4: step2_v4 (base+1232 → base+1356).
+  let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| un1
+  let cu_q1_dlo := q1'' * dLo
+  let un21 := cu_rhat_un1 - cu_q1_dlo
+  have hst2 := divK_div128_step2_v4_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
+    scratchMem (base + 1232)
+  unfold divKDiv128Step2V4Code divKDiv128Step2V4Post at hst2
+  rw [show (base + 1232 : Word) + 124 = base + 1356 from by bv_addr] at hst2
+  have hst2e := cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub (d128_v4_sub 40 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 41 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 42 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 43 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 44 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 45 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 46 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 47 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 48 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 49 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 50 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 51 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 52 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 53 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 54 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 55 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 56 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 57 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 58 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 59 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 60 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 61 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 62 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 63 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 64 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 65 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 66 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 67 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 68 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 69 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_v4_sub 70 _ _ (by decide) (by bv_addr) (by decide))))))))))))))))))))))))))))))))
+    hst2
+  have hst2f := cpsTriple_frameR
+    ((.x10 ↦ᵣ q1'') ** (.x2 ↦ᵣ retAddr) **
+     (sp + signExtend12 3968 ↦ₘ retAddr) ** (sp + signExtend12 3960 ↦ₘ d))
+    (by pcFree) hst2e
+  have h1234 := cpsTriple_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h123 hst2f
+  -- Block 5: end (base+1356 → retAddr via JALR).
+  -- step2_v4's q0'' is x5 from divKDiv128Step2V4Post.
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi2 := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dLo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo un0
+  let rhat2' :=
+    if rhat2cHi = 0 then
+      if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+    else rhat2c
+  let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := q0' * dLo
+  let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  let q0'' := div128Quot_phase2b_q0' q0' rhat2' dLo un0
+  let x7Exit_step2 := if rhat2cHi ≠ 0 then un21
+                      else if rhat2'Hi ≠ 0 then q0Dlo1
+                      else q0Dlo2
+  let x1Exit_step2 := if rhat2cHi ≠ 0 then rhat2cHi
+                      else if rhat2'Hi ≠ 0 then rhat2'Hi
+                      else rhat2'Un0
+  let x11Exit_step2 := if rhat2cHi ≠ 0 then rhat2c
+                       else if rhat2'Hi ≠ 0 then rhat2'
+                       else un0
+  let mem3936Exit := if rhat2cHi ≠ 0 then scratchMem else rhat2c
+  have hend := divK_div128_end_spec sp q1'' q0'' retAddr x11Exit_step2 retAddr
+    (base + 1356) _halign
+  have hende := cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub (d128_v4_sub 71 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 72 _ _ (by decide) (by bv_addr) (by decide))
+     (CodeReq.union_sub (d128_v4_sub 73 _ _ (by decide) (by bv_addr) (by decide))
+      (d128_v4_sub 74 _ _ (by decide) (by bv_addr) (by decide)))))
+    hend
+  have hendf := cpsTriple_frameR
+    ((.x7 ↦ᵣ x7Exit_step2) ** (.x6 ↦ᵣ dHi) ** (.x1 ↦ᵣ x1Exit_step2) **
+     (.x0 ↦ᵣ (0 : Word)) **
+     (sp + signExtend12 3960 ↦ₘ d) ** (sp + signExtend12 3952 ↦ₘ dLo) **
+     (sp + signExtend12 3944 ↦ₘ un0) ** (sp + signExtend12 3936 ↦ₘ mem3936Exit))
+    (by pcFree) hende
+  have h12345 := cpsTriple_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) h1234 hendf
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    h12345
 
 /-- Lifted `div128_v4_spec` over `sharedDivModCode_v4 base` — a thin
     wrapper that lifts the cr from singleton `ofProg`-form to the

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -150,19 +150,41 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
        (sp + signExtend12 3944 ↦ₘ un0Mem) **
        (sp + signExtend12 3936 ↦ₘ scratchMem))
       (div128V4SpecPost sp retAddr d uLo uHi) := by
-  sorry  -- PR-A2 stub. Proof composes phase1 + step1_v2 + compute_un21 +
-         -- step2_v4 + end, similar to div128_v2_spec but with the v4
-         -- step2 block covering 31 instructions instead of 17, and with
-         -- the new scratch memory slot 3936 threaded through.
-         -- Block sequence:
-         --   [0..9]   phase1     (existing divK_div128_phase1_spec)
-         --   [10..34] step1_v2   (existing divK_div128_step1_v2_spec)
-         --   [35..39] compute_un21 (existing divK_div128_compute_un21_spec)
-         --   [40..70] step2_v4   (NEW divK_div128_step2_v4_spec — sorry'd)
-         --   [71..74] end        (existing divK_div128_end_spec)
-         -- Step2_v4 spans byte offsets [base+1232 .. base+1356], where
-         -- the v4 step2 covers 124 bytes vs v2's 68 bytes.
-         -- End spans [base+1356 .. base+1372]; v4 returns at base+1372.
+  sorry  -- PR-A2 stub. Proof composes 5 blocks via cpsTriple_seq_perm_same_cr,
+         -- mirroring `div128_v2_spec` (in `Compose/Div128.lean` line 419-629).
+         -- Translation table from v2 → v4:
+         --
+         --   Block 1: phase1    [base+1072..base+1112]  10 inst (same as v2)
+         --     Reuse `divK_div128_phase1_spec`. Code-extend with `d128_v4_sub`
+         --     for indices [0..9]. Frame x0.
+         --
+         --   Block 2: step1_v2  [base+1112..base+1212]  25 inst (same as v2)
+         --     Reuse `divK_div128_step1_v2_spec`. Code-extend with `d128_v4_sub`
+         --     for indices [10..34]. Frame ((x2 ↦ retAddr) ** mem3968 **
+         --     mem3960 ** mem3944 ** mem3936).
+         --
+         --   Block 3: compute_un21 [base+1212..base+1232]  5 inst (same as v2)
+         --     Reuse `divK_div128_compute_un21_spec`. Code-extend with
+         --     `d128_v4_sub` for indices [35..39]. Frame.
+         --
+         --   Block 4: step2_v4  [base+1232..base+1356]  31 inst (NEW for v4)
+         --     Use `divK_div128_step2_v4_spec` (still sorry'd). Code-extend
+         --     with `d128_v4_sub` for indices [40..70]. Frame ((x10 ↦ q1'') **
+         --     (x2 ↦ retAddr) ** mem3968 ** mem3960). NB: step2_v4 owns
+         --     mem3936 (saves rhat2c there).
+         --
+         --   Block 5: end       [base+1356..base+1372]  4 inst (same shape)
+         --     Reuse `divK_div128_end_spec` with q1 = q1'', q0 = q0''.
+         --     Code-extend with `d128_v4_sub` for indices [71..74]. Frame
+         --     ((x7 ↦ x7Exit_v4) ** (x6 ↦ dHi) ** (x1 ↦ x1Exit_v4) ** x0 **
+         --      mem3960 ** mem3952 ** mem3944 ** mem3936).
+         --
+         -- Final: cpsTriple_weaken with two xperm_hyp to reshape pre/post
+         -- to match `div128V4SpecPost` definition order.
+         --
+         -- The proof is ~600 LOC of mechanical block-composition; structurally
+         -- identical to v2 except Block 4 (step2_v4) extends 14 more
+         -- instructions and threads the new mem3936 cell.
 
 /-- Lifted `div128_v4_spec` over `sharedDivModCode_v4 base` — a thin
     wrapper that lifts the cr from singleton `ofProg`-form to the

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -83,37 +83,37 @@ private theorem step2v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr
     step2-v4 code requirement. The semantic path bodies are proved separately. -/
 private theorem divK_div128_step2_v4_phase_D_bltu_spec
     (rhat2Un0 q0Dlo1 : Word) (base : Word) :
-    cpsBranch (base + 60) (divKDiv128Step2V4Code base)
+    cpsBranchWithin 1 (base + 60) (divKDiv128Step2V4Code base)
       ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1))
       (base + 72)
         ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝)
       (base + 64)
         ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) := by
-  have hbltu_raw := bltu_spec_gen .x1 .x7 (12 : BitVec 13) rhat2Un0 q0Dlo1 (base + 60)
+  have hbltu_raw := bltu_spec_gen_within .x1 .x7 (12 : BitVec 13) rhat2Un0 q0Dlo1 (base + 60)
   have ha_t : (base + 60) + signExtend13 (12 : BitVec 13) = base + 72 := by rv64_addr
   have ha_f : (base + 60 : Word) + 4 = base + 64 := by bv_addr
   rw [ha_t, ha_f] at hbltu_raw
-  exact cpsBranch_extend_code (h := hbltu_raw) (hmono := by
+  exact cpsBranchWithin_extend_code (h := hbltu_raw) (hmono := by
     exact step2v4_sub 15 (base+60) (.BLTU .x1 .x7 12)
       (by omega) (by bv_omega) (by decide))
 
 /-- Phase D BLTU taken body: correction path [18..20]. -/
 private theorem divK_div128_step2_v4_phase_D_taken_body_spec
     (sp q0c rhat2c dHi un0 : Word) (base : Word) :
-    cpsTriple (base + 72) (base + 84) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 3 (base + 72) (base + 84) (divKDiv128Step2V4Code base)
       ((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) **
        (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi))
       ((.x5 ↦ᵣ (q0c + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2c + dHi)) **
        (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi)) := by
-  apply cpsTriple_extend_code (hmono := by
+  apply cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub
       (step2v4_sub 18 (base+72) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide))
       (CodeReq.union_sub
         (step2v4_sub 19 (base+76) (.LD .x11 .x12 3936) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 20 (base+80) (.ADD .x11 .x11 .x6) (by omega) (by bv_omega) (by decide))))
-  have I0 := addi_spec_gen_same .x5 q0c 4095 (base + 72) (by nofun)
-  have I1 := ld_spec_gen .x11 .x12 sp un0 rhat2c 3936 (base + 76) (by nofun)
-  have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2c dHi (base + 80) (by nofun)
+  have I0 := addi_spec_gen_same_within .x5 q0c 4095 (base + 72) (by nofun)
+  have I1 := ld_spec_gen_within .x11 .x12 sp un0 rhat2c 3936 (base + 76) (by nofun)
+  have I2 := add_spec_gen_rd_eq_rs1_within .x11 .x6 rhat2c dHi (base + 80) (by nofun)
   simp only [show (base+72:Word)+4 = base+76 from by bv_addr,
              show (base+76:Word)+4 = base+80 from by bv_addr,
              show (base+80:Word)+4 = base+84 from by bv_addr] at I0 I1 I2
@@ -122,15 +122,15 @@ private theorem divK_div128_step2_v4_phase_D_taken_body_spec
 /-- Phase D BLTU fallthrough body: restore saved rhat2c and jump to merge [16..17]. -/
 private theorem divK_div128_step2_v4_phase_D_fallthrough_body_spec
     (sp rhat2c un0 : Word) (base : Word) :
-    cpsTriple (base + 64) (base + 84) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 2 (base + 64) (base + 84) (divKDiv128Step2V4Code base)
       ((.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c))
       ((.x11 ↦ᵣ rhat2c) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
-  apply cpsTriple_extend_code (hmono := by
+  apply cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub
       (step2v4_sub 16 (base+64) (.LD .x11 .x12 3936) (by omega) (by bv_omega) (by decide))
       (step2v4_sub 17 (base+68) (.JAL .x0 16) (by omega) (by bv_omega) (by decide)))
-  have I0 := ld_spec_gen .x11 .x12 sp un0 rhat2c 3936 (base + 64) (by nofun)
-  have I1 := jal_x0_spec_gen 16 (base + 68)
+  have I0 := ld_spec_gen_within .x11 .x12 sp un0 rhat2c 3936 (base + 64) (by nofun)
+  have I1 := jal_x0_spec_gen_within 16 (base + 68)
   have h_jal : (base + 68 : Word) + signExtend21 (16 : BitVec 21) = base + 84 := by rv64_addr
   simp only [show (base+64:Word)+4 = base+68 from by bv_addr, h_jal] at I0 I1
   runBlock I0 I1
@@ -228,7 +228,7 @@ private theorem divK_div128_step2_v4_phase_E_guard_spec
     (sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c : Word) (base : Word) :
     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
     let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
-    cpsBranch (base + 84) (divKDiv128Step2V4Code base)
+    cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
@@ -247,23 +247,23 @@ private theorem divK_div128_step2_v4_phase_E_guard_spec
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
          (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
   intro rhat2cHi rhat2'Hi
-  have hraw := divK_div128_phase2b_guard_spec sp rhat2' rhat2Un0 (base + 84) (36 : BitVec 13)
+  have hraw := divK_div128_phase2b_guard_spec_within sp rhat2' rhat2Un0 (base + 84) (36 : BitVec 13)
   simp only [show (base + 84 : Word) + 4 = base + 88 from by bv_addr,
              show (base + 84 : Word) + 8 = base + 92 from by bv_addr,
              show (base + 88 : Word) + signExtend13 (36 : BitVec 13) = base + 124 from by
                rv64_addr] at hraw
-  have hguard : cpsBranch (base + 84) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
-    cpsBranch_extend_code (h := hraw) (hmono := by
+  have hguard : cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
+    cpsBranchWithin_extend_code (h := hraw) (hmono := by
       exact CodeReq.union_sub
         (step2v4_sub 21 (base+84) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 22 (base+88) (.BNE .x1 .x0 36) (by omega) (by bv_omega) (by decide)))
-  have hframed := cpsBranch_frameR
+  have hframed := cpsBranchWithin_frameR
     ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
      ⌜rhat2cHi = 0⌝ **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
      (sp + signExtend12 3936 ↦ₘ rhat2c))
     (by pcFree) hguard
-  exact cpsBranch_weaken
+  exact cpsBranchWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
@@ -276,7 +276,7 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
     let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
     let q0'Unguarded := if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0'
     let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-    cpsTriple (base + 92) (base + 124) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 8 (base + 92) (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
@@ -288,7 +288,7 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
   intro q0Dlo2 rhat2'Un0 q0'Unguarded rhat2cHi
-  have hraw := divK_div128_prodcheck2_merged_spec sp q0' rhat2' rhat2'Hi q0Dlo1 dlo un0 (base + 92)
+  have hraw := divK_div128_prodcheck2_merged_spec_within sp q0' rhat2' rhat2'Hi q0Dlo1 dlo un0 (base + 92)
   simp only [show (base+92:Word)+4 = base+96 from by bv_addr,
              show (base+92:Word)+8 = base+100 from by bv_addr,
              show (base+92:Word)+12 = base+104 from by bv_addr,
@@ -297,8 +297,8 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
              show (base+92:Word)+24 = base+116 from by bv_addr,
              show (base+92:Word)+28 = base+120 from by bv_addr,
              show (base+92:Word)+32 = base+124 from by bv_addr] at hraw
-  have hext : cpsTriple (base + 92) (base + 124) (divKDiv128Step2V4Code base) _ _ :=
-    cpsTriple_extend_code (h := hraw) (hmono := by
+  have hext : cpsTripleWithin 8 (base + 92) (base + 124) (divKDiv128Step2V4Code base) _ _ :=
+    cpsTripleWithin_extend_code (h := hraw) (hmono := by
       exact CodeReq.union_sub
         (step2v4_sub 23 (base+92) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
         (CodeReq.union_sub
@@ -314,11 +314,11 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
         (CodeReq.union_sub
         (step2v4_sub 29 (base+116) (.JAL .x0 8) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 30 (base+120) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide)))))))))
-  have hframed := cpsTriple_frameR
+  have hframed := cpsTripleWithin_frameR
     ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
      (sp + signExtend12 3936 ↦ₘ rhat2c))
     (by pcFree) hext
-  exact cpsTriple_weaken
+  exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     hframed
@@ -448,7 +448,7 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
     let rhat2'   := if rhat2cHi = 0 then
                       if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
                     else rhat2c
-    cpsTriple (base + 60) (base + 84) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 4 (base + 60) (base + 84) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
        (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
@@ -462,11 +462,11 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
   intro rhat2cHi q0Dlo1 rhat2Un0 q0' rhat2'
   have hbltu := divK_div128_step2_v4_phase_D_bltu_spec rhat2Un0 q0Dlo1 base
   -- Remaining proof split:
-  -- * taken path: [18..20] ADDI; LD; ADD with `add_spec_gen_rd_eq_rs1`
+  -- * taken path: [18..20] ADDI; LD; ADD with `add_spec_gen_rd_eq_rs1_within`
   -- * fallthrough path: [16..17] LD; JAL
   -- Both paths then rewrite `div128Quot_phase2b_q0'` under the carried
   -- `rhat2cHi = 0` fact and strip the BLTU pure fact.
-  have hbltu_f := cpsBranch_frameR
+  have hbltu_f := cpsBranchWithin_frameR
     ((.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
      (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
@@ -474,17 +474,17 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
     (by pcFree) hbltu
   by_cases hz : rhat2cHi = 0
   · by_cases hcond : BitVec.ult rhat2Un0 q0Dlo1
-    · have taken := cpsBranch_takenPath hbltu_f (fun hp hQf => by
+    · have taken := cpsBranchWithin_takenPath hbltu_f (fun hp hQf => by
         obtain ⟨_, _, _, _, ⟨_, _, _, _, _, hpure⟩, _⟩ := hQf
         exact ((sepConj_pure_right _).1 hpure).2 hcond)
-      have taken' : cpsTriple (base + 60) (base + 72) (divKDiv128Step2V4Code base)
+      have taken' : cpsTripleWithin 1 (base + 60) (base + 72) (divKDiv128Step2V4Code base)
           ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
            (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c))
           (phaseDTakenBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0) :=
-          cpsTriple_weaken
+          cpsTripleWithin_weaken
             (fun h hp => by xperm_hyp hp)
           (fun h hp => by dsimp only [phaseDTakenBranchPost]; exact hp)
           taken
@@ -499,28 +499,28 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
         rw [if_pos hz, if_pos hcond]
       rw [hq0', hrhat2']
       have hpath := divK_div128_step2_v4_phase_D_taken_body_spec sp q0c rhat2c dHi un0 base
-      have hpath_f := cpsTriple_frameR
+      have hpath_f := cpsTripleWithin_frameR
         ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
         (by pcFree) hpath
-      exact cpsTriple_weaken
+      exact cpsTripleWithin_weaken
         (fun h hp => hp)
         (fun h hp => by xperm_hyp hp)
-        (cpsTriple_seq_perm_same_cr
+        (cpsTripleWithin_seq_perm_same_cr
           (fun h hp => divK_div128_step2_v4_phase_D_taken_body_pre
             sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h hp)
           taken' hpath_f)
-    · have ntaken := cpsBranch_ntakenPath hbltu_f (fun hp hQt => by
+    · have ntaken := cpsBranchWithin_ntakenPath hbltu_f (fun hp hQt => by
         obtain ⟨_, _, _, _, ⟨_, _, _, _, _, hpure⟩, _⟩ := hQt
         exact absurd ((sepConj_pure_right _).1 hpure).2 hcond)
-      have ntaken' : cpsTriple (base + 60) (base + 64) (divKDiv128Step2V4Code base)
+      have ntaken' : cpsTripleWithin 1 (base + 60) (base + 64) (divKDiv128Step2V4Code base)
           ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
            (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
            (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c))
           (phaseDFallthroughBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0) :=
-        cpsTriple_weaken
+        cpsTripleWithin_weaken
           (fun h hp => by xperm_hyp hp)
           (fun h hp => by dsimp only [phaseDFallthroughBranchPost]; exact hp)
           ntaken
@@ -535,18 +535,19 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
         rw [if_pos hz, if_neg hcond]
       rw [hq0', hrhat2']
       have hpath := divK_div128_step2_v4_phase_D_fallthrough_body_spec sp rhat2c un0 base
-      have hpath_f := cpsTriple_frameR
+      have hpath_f := cpsTripleWithin_frameR
         ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
          (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
         (by pcFree) hpath
-      exact cpsTriple_weaken
+      exact cpsTripleWithin_weaken
         (fun h hp => hp)
         (fun h hp => by xperm_hyp hp)
-        (cpsTriple_seq_perm_same_cr
-          (fun h hp => divK_div128_step2_v4_phase_D_fallthrough_body_pre
-            sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h hp)
-          ntaken' hpath_f)
+        (cpsTripleWithin_mono_nSteps (by decide) <|
+          cpsTripleWithin_seq_perm_same_cr
+            (fun h hp => divK_div128_step2_v4_phase_D_fallthrough_body_pre
+              sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h hp)
+            ntaken' hpath_f)
   · intro F hF s hcr hPFR hpc
     obtain ⟨hp, hcompat, hsep⟩ := hPFR
     obtain ⟨hpreSt, hframeSt, hd, hu, hpre, hframe⟩ := hsep
@@ -573,7 +574,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
     let x7Exit   := if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
     let x1Exit   := if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
     let x11Exit  := if rhat2'Hi ≠ 0 then rhat2' else un0
-    cpsTriple (base + 84) (base + 124) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 10 (base + 84) (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
@@ -587,7 +588,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
     intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x1Exit x11Exit
     have hguard := divK_div128_step2_v4_phase_E_guard_spec
       sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
-    have hguard' : cpsBranch (base + 84) (divKDiv128Step2V4Code base)
+    have hguard' : cpsBranchWithin 2 (base + 84) (divKDiv128Step2V4Code base)
         ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
          (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
@@ -597,17 +598,17 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
         (phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c)
         (base + 92)
         (phaseEFallthroughBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c) :=
-      cpsBranch_weaken
+      cpsBranchWithin_weaken
         (fun h hp => by xperm_hyp hp)
         (fun h hp => by dsimp only [phaseETakenBranchPost]; xperm_hyp hp)
         (fun h hp => by dsimp only [phaseEFallthroughBranchPost]; xperm_hyp hp)
         hguard
     have refl_of {P Q : Assertion} (h : ∀ hp, P hp → Q hp) :
-        cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base) P Q :=
-      cpsTriple_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
-        (cpsTriple_refl h)
+        cpsTripleWithin 0 (base + 124) (base + 124) (divKDiv128Step2V4Code base) P Q :=
+      cpsTripleWithin_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
+        (cpsTripleWithin_refl h)
     by_cases hhi : rhat2'Hi ≠ 0
-    · have htaken := cpsBranch_takenPath hguard' (fun hp hfall => by
+    · have htaken := cpsBranchWithin_takenPath hguard' (fun hp hfall => by
         exact hhi (phaseE_fallthrough_post_zero
           sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c hp hfall))
       have hq0'' : q0'' = q0' := by
@@ -625,7 +626,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       have hx11 : x11Exit = rhat2' := by
         unfold x11Exit
         exact if_pos hhi
-      have hzero : cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base)
+      have hzero : cpsTripleWithin 0 (base + 124) (base + 124) (divKDiv128Step2V4Code base)
           (phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c)
           ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
            (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
@@ -650,9 +651,10 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
             xperm_hyp hp
           exact ((sepConj_pure_right h).1 hp0).1
         xperm_hyp hp')
-      exact cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) htaken hzero
+      exact cpsTripleWithin_mono_nSteps (by decide) <|
+        cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) htaken hzero
     · have hzhi : rhat2'Hi = 0 := Decidable.not_not.mp hhi
-      have hfall := cpsBranch_ntakenPath hguard' (fun hp htaken => by
+      have hfall := cpsBranchWithin_ntakenPath hguard' (fun hp htaken => by
         exact hhi (phaseE_taken_post_ne
           sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c hp htaken))
       have hbody := divK_div128_step2_v4_phase_E_fallthrough_body_spec
@@ -674,7 +676,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       have hx11 : x11Exit = un0 := by
         unfold x11Exit
         exact if_neg hhi
-      exact cpsTriple_weaken
+      exact cpsTripleWithin_weaken
         (fun h hp => by xperm_hyp hp)
         (fun h hp => by
           rw [hq0'', hx7, hx1, hx11]
@@ -687,16 +689,16 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
                 (sp + signExtend12 3936 ↦ₘ rhat2c)) ** ⌜rhat2'Hi = 0⌝) h := by
             xperm_hyp hp
           exact ((sepConj_pure_right h).1 hp0).1)
-        (cpsTriple_seq_perm_same_cr (fun h hp => by
+        (cpsTripleWithin_seq_perm_same_cr (fun h hp => by
           dsimp only [phaseEFallthroughBranchPost] at hp
           xperm_hyp hp) hfall hbody)
 
-/-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
+/-- Full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
 
     Proof structure (5 blocks in `divK_div128_step2_v4_spec`):
-    - Block 1 [0..28]  (hA): init+clamp  → `cpsTriple base (base+28)`.
-    - Block 2 [28..36] (hB): outer SRLI+BNE guard → `cpsBranch (base+28)`.
-    - Compose hA+hB → `cpsBranch base (base+124) | (base+36)`.
+    - Block 1 [0..28]  (hA): init+clamp  → `cpsTripleWithin base (base+28)`.
+    - Block 2 [28..36] (hB): outer SRLI+BNE guard → `cpsBranchWithin (base+28)`.
+    - Compose hA+hB → `cpsBranchWithin base (base+124) | (base+36)`.
     - Taken (rhat2cHi≠0): `h_taken` identity at base+124.
     - Not-taken (rhat2cHi=0): `h_notTaken` = Block3(hC) + Block4(hD) + Block5(hE).
       Block 3 [36..60] (hC): pre-BLTU setup via runBlock.
@@ -704,7 +706,7 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
       Block 5 [84..124](hE): 2nd D3 guard+prodcheck via `phase_E_merged_spec`. -/
 theorem divK_div128_step2_v4_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 vScratchOld : Word) (base : Word) :
-    cpsTriple base (base + 124) (divKDiv128Step2V4Code base)
+    cpsTripleWithin 29 base (base + 124) (divKDiv128Step2V4Code base)
       ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
        (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
@@ -737,11 +739,11 @@ theorem divK_div128_step2_v4_spec
   let x11Exit := if rhat2cHi ≠ 0 then rhat2c
                  else if rhat2'Hi ≠ 0 then rhat2' else un0
   let mem3936Exit := if rhat2cHi ≠ 0 then vScratchOld else rhat2c
-  -- Phase A: init+clamp [0..28] — cpsTriple base (base+28).
-  -- Reuse divK_div128_step2_upto_guard_spec, extend via step2v4_sub 0..6.
-  have hA_raw := divK_div128_step2_upto_guard_spec sp un21 dHi v1Old v5Old v11Old dlo un0 base
-  have hA : cpsTriple base (base + 28) (divKDiv128Step2V4Code base) _ _ :=
-    cpsTriple_extend_code (hmono := by
+  -- Phase A: init+clamp [0..28] — cpsTripleWithin base (base+28).
+  -- Reuse divK_div128_step2_upto_guard_spec_within, extend via step2v4_sub 0..6.
+  have hA_raw := divK_div128_step2_upto_guard_spec_within sp un21 dHi v1Old v5Old v11Old dlo un0 base
+  have hA : cpsTripleWithin 7 base (base + 28) (divKDiv128Step2V4Code base) _ _ :=
+    cpsTripleWithin_extend_code (hmono := by
       exact CodeReq.union_sub
         (step2v4_sub 0 base (.DIVU .x5 .x7 .x6) (by omega) (by bv_omega) (by decide))
        (CodeReq.union_sub
@@ -756,26 +758,26 @@ theorem divK_div128_step2_v4_spec
         (step2v4_sub 5 (base+20) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 6 (base+24) (.ADD .x11 .x11 .x6) (by omega) (by bv_omega) (by decide))))))))
     hA_raw
-  have hAf := cpsTriple_frameR
+  have hAf := cpsTripleWithin_frameR
     (sp + signExtend12 3936 ↦ₘ vScratchOld)
     (by pcFree) hA
-  -- Phase B: outer SRLI+BNE guard [28..36] — cpsBranch via step2v4_sub 7+8.
-  have hB_raw := divK_div128_phase2b_guard_spec sp rhat2c hi (base + 28) (92 : BitVec 13)
+  -- Phase B: outer SRLI+BNE guard [28..36] — cpsBranchWithin via step2v4_sub 7+8.
+  have hB_raw := divK_div128_phase2b_guard_spec_within sp rhat2c hi (base + 28) (92 : BitVec 13)
   simp only [show (base + 28 : Word) + 4 = base + 32 from by bv_addr,
              show (base + 28 : Word) + 8 = base + 36 from by bv_addr,
              show (base + 32 : Word) + signExtend13 (92 : BitVec 13) = base + 124 from by
                rv64_addr] at hB_raw
-  have hB : cpsBranch (base + 28) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
-    cpsBranch_extend_code (hmono := by
+  have hB : cpsBranchWithin 2 (base + 28) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
+    cpsBranchWithin_extend_code (hmono := by
       exact CodeReq.union_sub
         (step2v4_sub 7 (base+28) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
         (step2v4_sub 8 (base+32) (.BNE .x1 .x0 92) (by omega) (by bv_omega) (by decide))) hB_raw
-  have hBf := cpsBranch_frameR
+  have hBf := cpsBranchWithin_frameR
     ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
      (sp + signExtend12 3936 ↦ₘ vScratchOld))
     (by pcFree) hB
-  have composed_AB := cpsTriple_seq_cpsBranch_perm_same_cr
+  have composed_AB := cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
     (fun h hp => by xperm_hyp hp) hAf hBf
   -- finalPost (merged post at base+124 for both legs).
   let finalPost : Assertion :=
@@ -793,10 +795,11 @@ theorem divK_div128_step2_v4_spec
     (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
     (sp + signExtend12 3936 ↦ₘ vScratchOld)
-  have h_taken : cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base)
+  have h_taken : cpsTripleWithin 20 (base + 124) (base + 124) (divKDiv128Step2V4Code base)
       takenPost finalPost :=
-    cpsTriple_extend_code (hmono := fun _ _ h => by simp [CodeReq.empty] at h)
-    (cpsTriple_refl (by
+    cpsTripleWithin_mono_nSteps (by decide) <|
+    cpsTripleWithin_extend_code (hmono := fun _ _ h => by simp [CodeReq.empty] at h)
+    (cpsTripleWithin_refl (by
       intro hp htp
       -- Extract ⌜rhat2cHi ≠ 0⌝ from takenPost (inside a have so htp survives).
       -- takenPost = (.x12 ** .x11 ** .x1 ** .x0 ** ⌜rhat2cHi ≠ 0⌝) ** rest.
@@ -850,7 +853,7 @@ theorem divK_div128_step2_v4_spec
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
     (sp + signExtend12 3936 ↦ₘ vScratchOld)
   -- Not-taken leg (rhat2cHi = 0): run [36..120] → base+124.
-  have h_notTaken : cpsTriple (base + 36) (base + 124) (divKDiv128Step2V4Code base)
+  have h_notTaken : cpsTripleWithin 20 (base + 36) (base + 124) (divKDiv128Step2V4Code base)
       notTakenPost finalPost := by
     -- Phase C: pre-BLTU setup [9..14] = LD+MUL+SLLI+SD+LD+OR.
     let midC : Assertion :=
@@ -859,21 +862,21 @@ theorem divK_div128_step2_v4_spec
       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
-    have hC : cpsTriple (base+36) (base+60) (divKDiv128Step2V4Code base)
+    have hC : cpsTripleWithin 6 (base+36) (base+60) (divKDiv128Step2V4Code base)
         notTakenPost midC := by
-      apply cpsTriple_extend_code (hmono := by
+      apply cpsTripleWithin_extend_code (hmono := by
         exact CodeReq.union_sub (step2v4_sub 9 (base+36) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 10 (base+40) (.MUL .x7 .x5 .x1) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 11 (base+44) (.SLLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 12 (base+48) (.SD .x12 .x11 3936) (by omega) (by bv_omega) (by decide))
          (CodeReq.union_sub (step2v4_sub 13 (base+52) (.LD .x11 .x12 3944) (by omega) (by bv_omega) (by decide))
           (step2v4_sub 14 (base+56) (.OR .x1 .x1 .x11) (by omega) (by bv_omega) (by decide)))))))
-      have I0 := ld_spec_gen .x1 .x12 sp rhat2cHi dlo 3952 (base+36) (by nofun)
-      have I1 := mul_spec_gen .x7 .x5 .x1 un21 q0c dlo (base+40) (by nofun)
-      have I2 := slli_spec_gen .x1 .x11 dlo rhat2c 32 (base+44) (by nofun)
-      have I3 := sd_spec_gen .x12 .x11 sp rhat2c vScratchOld 3936 (base+48)
-      have I4 := ld_spec_gen .x11 .x12 sp rhat2c un0 3944 (base+52) (by nofun)
-      have I5 := or_spec_gen_rd_eq_rs1 .x1 .x11
+      have I0 := ld_spec_gen_within .x1 .x12 sp rhat2cHi dlo 3952 (base+36) (by nofun)
+      have I1 := mul_spec_gen_within .x7 .x5 .x1 un21 q0c dlo (base+40) (by nofun)
+      have I2 := slli_spec_gen_within .x1 .x11 dlo rhat2c 32 (base+44) (by nofun)
+      have I3 := sd_spec_gen_within .x12 .x11 sp rhat2c vScratchOld 3936 (base+48)
+      have I4 := ld_spec_gen_within .x11 .x12 sp rhat2c un0 3944 (base+52) (by nofun)
+      have I5 := or_spec_gen_rd_eq_rs1_within .x1 .x11
             (rhat2c <<< (32 : BitVec 6).toNat) un0 (base+56) (by nofun)
       simp only [show (base+36:Word)+4 = base+40 from by bv_omega,
                  show (base+40:Word)+4 = base+44 from by bv_omega,
@@ -890,16 +893,16 @@ theorem divK_div128_step2_v4_spec
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
     have hD_raw := divK_div128_step2_v4_phase_D_merged_spec sp dHi q0c rhat2c dlo un0 base
-    have hD : cpsTriple (base+36) (base+84) (divKDiv128Step2V4Code base) notTakenPost midD :=
-      cpsTriple_seq_perm_same_cr (fun h hp => by exact hp) hC hD_raw
+    have hD : cpsTripleWithin 10 (base+36) (base+84) (divKDiv128Step2V4Code base) notTakenPost midD :=
+      cpsTripleWithin_seq_perm_same_cr (fun h hp => by exact hp) hC hD_raw
     -- Phase E: 2nd D3 guard+prodcheck [21..30] via `divK_div128_step2_v4_phase_E_merged_spec`.
     -- Bridge hE_raw post → finalPost: by_cases on rhat2cHi (midD has ⌜rhat2cHi=0⌝
     -- so ≠0 is vacuous); then reduce outer if-then-else by h_z + xperm.
-    have hE : cpsTriple (base+84) (base+124) (divKDiv128Step2V4Code base)
+    have hE : cpsTripleWithin 10 (base+84) (base+124) (divKDiv128Step2V4Code base)
         midD finalPost := by
       have hE_raw := divK_div128_step2_v4_phase_E_merged_spec
                        sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
-      exact cpsTriple_weaken
+      exact cpsTripleWithin_weaken
           (fun h hp => by xperm_hyp hp)
         (fun h hp => by
             have hz : rhat2cHi = 0 := by
@@ -950,13 +953,13 @@ theorem divK_div128_step2_v4_spec
               xperm_hyp hp
             exact ((sepConj_pure_right h).1 hp0).1)
           hE_raw
-    exact cpsTriple_weaken
+    exact cpsTripleWithin_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hq => by xperm_hyp hq)
-      (cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hD hE)
-  exact cpsTriple_weaken
+      (cpsTripleWithin_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hD hE)
+  exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
-    (cpsBranch_merge_same_cr composed_AB h_taken h_notTaken)
+    (cpsBranchWithin_merge_same_cr composed_AB h_taken h_notTaken)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -173,17 +173,80 @@ theorem divK_div128_phase2b_1st_d3_v4_spec
          -- that BNE branches forward past [71] — which is handled by step2_v4
          -- itself via the outer branch structure). Keep as sorry for now.
 
+/-- Phase D sub-lemma: BLTU+paths [15..20] of step2_v4, merged post.
+    Input = midC (= output of Phase C at base+60).
+    Output = midD (post-BLTU merged state at base+84).
+    by_cases on ult for taken/not-taken paths; by_cases on rhat2cHi for vacuity.
+    Proof outline:
+    - if rhat2cHi ≠ 0: pre (⌜rhat2cHi=0⌝) is False → vacuous.
+    - if rhat2cHi = 0, ult = true (taken path [18..20]):
+        strip ⌜ult⌝ from pre, run ADDI+LD+ADD via runBlock.
+    - if rhat2cHi = 0, ult = false (not-taken path [16..17]):
+        strip ⌜¬ult⌝ from pre, run LD+JAL via runBlock. -/
+theorem divK_div128_step2_v4_phase_D_merged_spec
+    (sp dHi q0c rhat2c dlo un0 : Word) (base : Word) :
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+    let q0Dlo1   := q0c * dlo
+    let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+    let q0'      := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+    let rhat2'   := if rhat2cHi = 0 then
+                      if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+                    else rhat2c
+    cpsTriple (base + 60) (base + 84) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+       (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  sorry
+
+/-- Phase E sub-lemma: 2nd D3 guard+prodcheck [21..30] of step2_v4, merged post.
+    Input = midD (at base+84). Output = finalPost_rhat2cHi0 (at base+124).
+    by_cases on rhat2'Hi for guard taken/not-taken.
+    Proof outline:
+    - if rhat2cHi ≠ 0: midD pre (⌜rhat2cHi=0⌝) is False → vacuous.
+    - if rhat2cHi = 0 and rhat2'Hi ≠ 0 (guard fires): identity, q0''=q0'.
+    - if rhat2cHi = 0 and rhat2'Hi = 0:
+        prodcheck2_merged_spec at base+92, extended via step2v4_sub 23..30. -/
+theorem divK_div128_step2_v4_phase_E_merged_spec
+    (sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c : Word) (base : Word) :
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+    let q0Dlo2   := q0' * dlo
+    let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+    let q0''     := div128Quot_phase2b_q0' q0' rhat2' dlo un0
+    let x7Exit   := if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
+    let x1Exit   := if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
+    let x11Exit  := if rhat2'Hi ≠ 0 then rhat2' else un0
+    cpsTriple (base + 84) (base + 124) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
+       (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  sorry
+
 /-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
 
-    Mirrors `divK_div128_step2_spec` for the v4 algorithm. Proof structure:
-    - [40..42]: step-2-init (same as v2).
-    - [43..46]: clamp-q0 (same as v2).
-    - [47..48]: Phase 2b guard (same as v2).
-    - [49..60]: Phase 2b 1st D3 with save/restore (NEW).
-    - [61..70]: Phase 2b 2nd D3 (NEW — mirror of Phase 1b 2nd D3).
-
-    Estimated body: ~700 LOC, mirrors the v2 step2 spec but with the
-    added 2nd D3 + save/restore handling. -/
+    Proof structure (5 blocks in `divK_div128_step2_v4_spec`):
+    - Block 1 [0..28]  (hA): init+clamp  → `cpsTriple base (base+28)`.
+    - Block 2 [28..36] (hB): outer SRLI+BNE guard → `cpsBranch (base+28)`.
+    - Compose hA+hB → `cpsBranch base (base+124) | (base+36)`.
+    - Taken (rhat2cHi≠0): `h_taken` identity at base+124.
+    - Not-taken (rhat2cHi=0): `h_notTaken` = Block3(hC) + Block4(hD) + Block5(hE).
+      Block 3 [36..60] (hC): pre-BLTU setup via runBlock.
+      Block 4 [60..84] (hD): BLTU+paths via `phase_D_merged_spec`.
+      Block 5 [84..124](hE): 2nd D3 guard+prodcheck via `phase_E_merged_spec`. -/
 theorem divK_div128_step2_v4_spec
     (sp un21 dHi v1Old v5Old v11Old dlo un0 vScratchOld : Word) (base : Word) :
     cpsTriple base (base + 124) (divKDiv128Step2V4Code base)
@@ -334,14 +397,13 @@ theorem divK_div128_step2_v4_spec
   -- Not-taken leg (rhat2cHi = 0): run [36..120] → base+124.
   have h_notTaken : cpsTriple (base + 36) (base + 124) (divKDiv128Step2V4Code base)
       notTakenPost finalPost := by
-    -- Intermediate state after Phase C (pre-BLTU [9..14]).
+    -- Phase C: pre-BLTU setup [9..14] = LD+MUL+SLLI+SD+LD+OR.
     let midC : Assertion :=
       (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
       (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
-    -- Phase C: pre-BLTU [9..14] = LD+MUL+SLLI+SD+LD+OR.
     have hC : cpsTriple (base+36) (base+60) (divKDiv128Step2V4Code base)
         notTakenPost midC := by
       apply cpsTriple_extend_code (hmono := by
@@ -365,22 +427,24 @@ theorem divK_div128_step2_v4_spec
                  show (base+52:Word)+4 = base+56 from by bv_omega,
                  show (base+56:Word)+4 = base+60 from by bv_omega] at *
       runBlock I0 I1 I2 I3 I4 I5
-    -- Intermediate state after Phase D (post-BLTU [15..20]).
+    -- Phase D: BLTU+paths [15..20] via `divK_div128_step2_v4_phase_D_merged_spec`.
     let midD : Assertion :=
       (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
-      (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+      (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
       (sp + signExtend12 3936 ↦ₘ rhat2c)
-    -- Phase D: BLTU + correction/no-correction paths.
-    have hD : cpsTriple (base+36) (base+84) (divKDiv128Step2V4Code base)
-        notTakenPost midD := by
-      sorry -- cpsBranch at [15], merge taken [18..20] + not-taken [16..17]
-    -- Phase E: 2nd D3 guard [21..22] + prodcheck [23..30].
+    have hD_raw := divK_div128_step2_v4_phase_D_merged_spec sp dHi q0c rhat2c dlo un0 base
+    have hD : cpsTriple (base+36) (base+84) (divKDiv128Step2V4Code base) notTakenPost midD :=
+      cpsTriple_seq_perm_same_cr (fun h hp => by exact hp) hC hD_raw
+    -- Phase E: 2nd D3 guard+prodcheck [21..30] via `divK_div128_step2_v4_phase_E_merged_spec`.
+    -- Bridge hE_raw post → finalPost: by_cases on rhat2cHi (midD has ⌜rhat2cHi=0⌝
+    -- so ≠0 is vacuous); then reduce outer if-then-else by h_z + xperm.
     have hE : cpsTriple (base+84) (base+124) (divKDiv128Step2V4Code base)
         midD finalPost := by
-      sorry -- 2nd D3: SRLI+BNE guard + prodcheck2_merged_spec for [23..30]
-    -- Compose D + E.
+      have _hE_raw := divK_div128_step2_v4_phase_E_merged_spec
+                       sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
+      sorry
     exact cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -97,6 +97,44 @@ private theorem divK_div128_step2_v4_phase_D_bltu_spec
     exact step2v4_sub 15 (base+60) (.BLTU .x1 .x7 12)
       (by omega) (by bv_omega) (by decide))
 
+/-- Phase D BLTU taken body: correction path [18..20]. -/
+private theorem divK_div128_step2_v4_phase_D_taken_body_spec
+    (sp q0c rhat2c dHi un0 : Word) (base : Word) :
+    cpsTriple (base + 72) (base + 84) (divKDiv128Step2V4Code base)
+      ((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi))
+      ((.x5 ↦ᵣ (q0c + signExtend12 4095)) ** (.x11 ↦ᵣ (rhat2c + dHi)) **
+       (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi)) := by
+  apply cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub
+      (step2v4_sub 18 (base+72) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide))
+      (CodeReq.union_sub
+        (step2v4_sub 19 (base+76) (.LD .x11 .x12 3936) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 20 (base+80) (.ADD .x11 .x11 .x6) (by omega) (by bv_omega) (by decide))))
+  have I0 := addi_spec_gen_same .x5 q0c 4095 (base + 72) (by nofun)
+  have I1 := ld_spec_gen .x11 .x12 sp un0 rhat2c 3936 (base + 76) (by nofun)
+  have I2 := add_spec_gen_rd_eq_rs1 .x11 .x6 rhat2c dHi (base + 80) (by nofun)
+  simp only [show (base+72:Word)+4 = base+76 from by bv_addr,
+             show (base+76:Word)+4 = base+80 from by bv_addr,
+             show (base+80:Word)+4 = base+84 from by bv_addr] at I0 I1 I2
+  runBlock I0 I1 I2
+
+/-- Phase D BLTU fallthrough body: restore saved rhat2c and jump to merge [16..17]. -/
+private theorem divK_div128_step2_v4_phase_D_fallthrough_body_spec
+    (sp rhat2c un0 : Word) (base : Word) :
+    cpsTriple (base + 64) (base + 84) (divKDiv128Step2V4Code base)
+      ((.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c))
+      ((.x11 ↦ᵣ rhat2c) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  apply cpsTriple_extend_code (hmono := by
+    exact CodeReq.union_sub
+      (step2v4_sub 16 (base+64) (.LD .x11 .x12 3936) (by omega) (by bv_omega) (by decide))
+      (step2v4_sub 17 (base+68) (.JAL .x0 16) (by omega) (by bv_omega) (by decide)))
+  have I0 := ld_spec_gen .x11 .x12 sp un0 rhat2c 3936 (base + 64) (by nofun)
+  have I1 := jal_x0_spec_gen 16 (base + 68)
+  have h_jal : (base + 68 : Word) + signExtend21 (16 : BitVec 21) = base + 84 := by rv64_addr
+  simp only [show (base+64:Word)+4 = base+68 from by bv_addr, h_jal] at I0 I1
+  runBlock I0 I1
+
 /-- The SRLI+BNE dispatch at the start of Phase E, extended into the step2-v4
     code requirement and framed with the registers/memory live across it. -/
 private theorem divK_div128_step2_v4_phase_E_guard_spec

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -1,0 +1,140 @@
+/-
+  EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
+
+  Full-step composition for instructions [40]-[70] of the
+  `divK_div128_v4` subroutine — the v4 fix that adds a 2nd Phase 2b
+  D3 correction iteration (Knuth TAOCP §4.3.1 classical D3 step,
+  full 2-iteration version, Phase 2b half).
+
+  Combines:
+  - step-2-init (DIVU+MUL+SUB) — instrs [40..42] (same as v2 step2)
+  - clamp-q0 (SRLI+BEQ+ADDI+ADD) — instrs [43..46] (same as v2)
+  - Phase 2b guard (SRLI+BNE) — instrs [47..48] (same as v2)
+  - Phase 2b 1st D3 with save/restore — instrs [49..60] (NEW shape)
+  - Phase 2b 2nd D3 — instrs [61..70] (NEW)
+
+  into a single refined `q0` computation matching the Lean abstraction
+  `div128Quot_v4`'s Phase 2 output (q0 = q0'' after BOTH Phase 2b D3
+  iterations).
+
+  The v4 Phase 2b structure differs from v2 Phase 2b in two ways:
+  1. The 1st D3 saves rhat2c to scratch slot 3936 before clobbering x11
+     with un0, then restores it in BOTH BLTU paths so rhat2c is
+     available for the 2nd D3 guard.
+  2. The 2nd D3 (instrs [61..70]) mirrors Phase 1b's 2nd D3 structure
+     but for q0/rhat2 instead of q1/rhat.
+
+  PR-A2 of the v2 → v4 migration plan. Issue #1337 / Issue #61.
+-/
+
+import EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2
+import EvmAsm.Evm64.DivMod.LoopDefs.IterV4
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Bundled CodeReq for `divK_div128_step2_v4_spec` (31 singletons,
+    instrs [40..70] of `divK_div128_v4`). `@[irreducible]` to keep
+    let-bindings out of theorem signatures. -/
+@[irreducible]
+def divKDiv128Step2V4Code (base : Word) : CodeReq :=
+  CodeReq.union (CodeReq.singleton base                (.DIVU .x5 .x7 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 4)         (.MUL .x1 .x5 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 8)         (.SUB .x11 .x7 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 12)        (.SRLI .x1 .x5 32))
+  (CodeReq.union (CodeReq.singleton (base + 16)        (.BEQ .x1 .x0 12))
+  (CodeReq.union (CodeReq.singleton (base + 20)        (.ADDI .x5 .x5 4095))
+  (CodeReq.union (CodeReq.singleton (base + 24)        (.ADD .x11 .x11 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 28)        (.SRLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 32)        (.BNE .x1 .x0 96))
+  (CodeReq.union (CodeReq.singleton (base + 36)        (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 40)        (.MUL .x7 .x5 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 44)        (.SLLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 48)        (.SD .x12 .x11 3936))
+  (CodeReq.union (CodeReq.singleton (base + 52)        (.LD .x11 .x12 3944))
+  (CodeReq.union (CodeReq.singleton (base + 56)        (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 60)        (.BLTU .x1 .x7 12))
+  (CodeReq.union (CodeReq.singleton (base + 64)        (.LD .x11 .x12 3936))
+  (CodeReq.union (CodeReq.singleton (base + 68)        (.JAL .x0 16))
+  (CodeReq.union (CodeReq.singleton (base + 72)        (.ADDI .x5 .x5 4095))
+  (CodeReq.union (CodeReq.singleton (base + 76)        (.LD .x11 .x12 3936))
+  (CodeReq.union (CodeReq.singleton (base + 80)        (.ADD .x11 .x11 .x6))
+  (CodeReq.union (CodeReq.singleton (base + 84)        (.SRLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 88)        (.BNE .x1 .x0 36))
+  (CodeReq.union (CodeReq.singleton (base + 92)        (.LD .x1 .x12 3952))
+  (CodeReq.union (CodeReq.singleton (base + 96)        (.MUL .x7 .x5 .x1))
+  (CodeReq.union (CodeReq.singleton (base + 100)       (.SLLI .x1 .x11 32))
+  (CodeReq.union (CodeReq.singleton (base + 104)       (.LD .x11 .x12 3944))
+  (CodeReq.union (CodeReq.singleton (base + 108)       (.OR .x1 .x1 .x11))
+  (CodeReq.union (CodeReq.singleton (base + 112)       (.BLTU .x1 .x7 8))
+  (CodeReq.union (CodeReq.singleton (base + 116)       (.JAL .x0 8))
+   (CodeReq.singleton (base + 120)       (.ADDI .x5 .x5 4095)))))))))))))))))))))))))))))))
+
+/-- Bundled postcondition for `divK_div128_step2_v4_spec`. Hides the
+    let-chain for Step 2 v4 trial-division intermediates + Phase 2b
+    1st+2nd D3 outcomes.
+
+    The key output is `q0''` (post-2nd-D3 correction), which is what
+    `div128Quot_v4` computes. Other registers (x1, x6, x7, x11) hold
+    transient end-of-block values that depend on the BLTU path taken;
+    the postcondition encodes them via if-then-else on the relevant
+    BLTU/BNE conditions. -/
+@[irreducible]
+def divKDiv128Step2V4Post (sp un21 dHi dlo un0 : Word) : Assertion :=
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  -- Phase 2b 1st D3.
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+  -- Phase 2b 2nd D3 — uses q0' and the post-1st-correction rhat2.
+  let rhat2' :=
+    if rhat2c >>> (32 : BitVec 6).toNat = 0 then
+      let qDlo2c := q0c * dlo
+      let rhatUn0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+      if BitVec.ult rhatUn0 qDlo2c then rhat2c + dHi else rhat2c
+    else rhat2c
+  let q0'' := div128Quot_phase2b_q0' q0' rhat2' dlo un0
+  -- Memory state: rhat2c is saved to slot 3936 (could be either rhat2c
+  -- or rhat2c+dHi depending on BLTU; abstracted here as the actual
+  -- saved value).
+  let savedRhat2c := rhat2c  -- the SD at [52] saves the un-incremented rhat2c
+  -- Exit register state: x5 holds q0'' (the final corrected q0).
+  -- x11, x7, x1 hold transient values from the last instructions.
+  -- TODO: pin x1/x7/x11 exit values once the proof body is filled in.
+  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3952 ↦ₘ dlo) **
+  (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ savedRhat2c)
+
+/-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
+
+    Mirrors `divK_div128_step2_spec` for the v4 algorithm. Proof structure:
+    - [40..42]: step-2-init (same as v2).
+    - [43..46]: clamp-q0 (same as v2).
+    - [47..48]: Phase 2b guard (same as v2).
+    - [49..60]: Phase 2b 1st D3 with save/restore (NEW).
+    - [61..70]: Phase 2b 2nd D3 (NEW — mirror of Phase 1b 2nd D3).
+
+    Estimated body: ~700 LOC, mirrors the v2 step2 spec but with the
+    added 2nd D3 + save/restore handling. -/
+theorem divK_div128_step2_v4_spec
+    (sp un21 dHi v1Old v5Old v11Old dlo un0 vScratchOld : Word) (base : Word) :
+    cpsTriple base (base + 124) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ v5Old) **
+       (.x1 ↦ᵣ v1Old) ** (.x11 ↦ᵣ v11Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) **
+       (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ vScratchOld))
+      (divKDiv128Step2V4Post sp un21 dHi dlo un0) := by
+  sorry  -- PR-A2 finish stub. Body composes step2_init + clamp_q0 +
+         -- phase2b_guard + (1st D3 with save/restore) + (2nd D3),
+         -- mirroring the v2 step2_spec proof structure but with
+         -- 14 additional instructions.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -334,23 +334,57 @@ theorem divK_div128_step2_v4_spec
   -- Not-taken leg (rhat2cHi = 0): run [36..120] → base+124.
   have h_notTaken : cpsTriple (base + 36) (base + 124) (divKDiv128Step2V4Code base)
       notTakenPost finalPost := by
-    -- Proof: cpsBranch structure on [36..120] = step2_v4 indices [9..30].
-    -- (C) Pre-BLTU [9..14]: LD+MUL+SLLI+SD+LD+OR → cpsTriple (base+36..60).
-    --     Each instruction extended via step2v4_sub 9..14.
-    --     Produces: x7=q0Dlo1, x1=rhat2Un0, x11=un0, mem3936=rhat2c.
-    -- (D) BLTU cpsBranch at [15] (step2v4_sub 15, offset 12 → base+72):
-    --     Taken [18..20] ADDI+LD+ADD (step2v4_sub 18..20) → [21] = base+84.
-    --     Not-taken [16..17] LD+JAL(16) (step2v4_sub 16..17) → base+84.
-    --     cpsBranch_merge_same_cr → cpsTriple (base+36..84).
-    -- (E) 2nd D3 guard SRLI+BNE at [21..22] (step2v4_sub 21..22, offset 36):
-    --     Taken → base+124 (rhat2c_upd_hi ≠ 0, identity triple).
-    --     Not-taken → run [23..30]:
-    --       [23..27] LD+MUL+SLLI+LD+OR: reuse divK_div128_prodcheck2_merged_spec
-    --           extended via step2v4_sub 23..30.
-    --       cpsBranch_merge_same_cr with BLTU [28]+JAL [29]+ADDI [30] → base+124.
-    --     cpsBranch_merge_same_cr → cpsTriple (base+84..124).
-    -- cpsTriple_seq (C+D) + E = cpsTriple (base+36..124).
-    sorry
+    -- Intermediate state after Phase C (pre-BLTU [9..14]).
+    let midC : Assertion :=
+      (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+      (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+      (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+      (sp + signExtend12 3936 ↦ₘ rhat2c)
+    -- Phase C: pre-BLTU [9..14] = LD+MUL+SLLI+SD+LD+OR.
+    have hC : cpsTriple (base+36) (base+60) (divKDiv128Step2V4Code base)
+        notTakenPost midC := by
+      apply cpsTriple_extend_code (hmono := by
+        exact CodeReq.union_sub (step2v4_sub 9 (base+36) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 10 (base+40) (.MUL .x7 .x5 .x1) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 11 (base+44) (.SLLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 12 (base+48) (.SD .x12 .x11 3936) (by omega) (by bv_omega) (by decide))
+         (CodeReq.union_sub (step2v4_sub 13 (base+52) (.LD .x11 .x12 3944) (by omega) (by bv_omega) (by decide))
+          (step2v4_sub 14 (base+56) (.OR .x1 .x1 .x11) (by omega) (by bv_omega) (by decide)))))))
+      have I0 := ld_spec_gen .x1 .x12 sp rhat2cHi dlo 3952 (base+36) (by nofun)
+      have I1 := mul_spec_gen .x7 .x5 .x1 un21 q0c dlo (base+40) (by nofun)
+      have I2 := slli_spec_gen .x1 .x11 dlo rhat2c 32 (base+44) (by nofun)
+      have I3 := sd_spec_gen .x12 .x11 sp rhat2c vScratchOld 3936 (base+48)
+      have I4 := ld_spec_gen .x11 .x12 sp rhat2c un0 3944 (base+52) (by nofun)
+      have I5 := or_spec_gen_rd_eq_rs1 .x1 .x11
+            (rhat2c <<< (32 : BitVec 6).toNat) un0 (base+56) (by nofun)
+      simp only [show (base+36:Word)+4 = base+40 from by bv_omega,
+                 show (base+40:Word)+4 = base+44 from by bv_omega,
+                 show (base+44:Word)+4 = base+48 from by bv_omega,
+                 show (base+48:Word)+4 = base+52 from by bv_omega,
+                 show (base+52:Word)+4 = base+56 from by bv_omega,
+                 show (base+56:Word)+4 = base+60 from by bv_omega] at *
+      runBlock I0 I1 I2 I3 I4 I5
+    -- Intermediate state after Phase D (post-BLTU [15..20]).
+    let midD : Assertion :=
+      (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+      (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+      (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+      (sp + signExtend12 3936 ↦ₘ rhat2c)
+    -- Phase D: BLTU + correction/no-correction paths.
+    have hD : cpsTriple (base+36) (base+84) (divKDiv128Step2V4Code base)
+        notTakenPost midD := by
+      sorry -- cpsBranch at [15], merge taken [18..20] + not-taken [16..17]
+    -- Phase E: 2nd D3 guard [21..22] + prodcheck [23..30].
+    have hE : cpsTriple (base+84) (base+124) (divKDiv128Step2V4Code base)
+        midD finalPost := by
+      sorry -- 2nd D3: SRLI+BNE guard + prodcheck2_merged_spec for [23..30]
+    -- Compose D + E.
+    exact cpsTriple_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hq => by xperm_hyp hq)
+      (cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) hD hE)
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -334,20 +334,23 @@ theorem divK_div128_step2_v4_spec
   -- Not-taken leg (rhat2cHi = 0): run [36..120] → base+124.
   have h_notTaken : cpsTriple (base + 36) (base + 124) (divKDiv128Step2V4Code base)
       notTakenPost finalPost := by
-    sorry  -- [36..120] proof via step2v4_sub 9..30:
-           -- (C) [9..15] = LD+MUL+SLLI+SD+LD+OR: runBlock with step2v4_sub 9..14.
-           -- (D) BLTU cpsBranch at [15] via step2v4_sub 15:
-           --       taken [18..20] = ADDI+LD+ADD: step2v4_sub 18+19+20.
-           --       not-taken [16..17] = LD+JAL: step2v4_sub 16+17.
-           --       cpsBranch_merge_same_cr → cpsTriple (base+36) (base+84).
-           -- (E) [21..22] SRLI+BNE guard via step2v4_sub 21+22, guard_off=36 → base+124:
-           --       taken → base+124 (identity).
-           --       not-taken [23..30] prodcheck2-style:
-           --         [23..27] LD+MUL+SLLI+LD+OR: step2v4_sub 23..27.
-           --         BLTU [28]: taken [30]=ADDI: step2v4_sub 28+30.
-           --                    not-taken [29]=JAL: step2v4_sub 29.
-           --       cpsBranch_merge_same_cr → cpsTriple (base+84) (base+124).
-           --     cpsTriple_seq → cpsTriple (base+36) (base+124).
+    -- Proof: cpsBranch structure on [36..120] = step2_v4 indices [9..30].
+    -- (C) Pre-BLTU [9..14]: LD+MUL+SLLI+SD+LD+OR → cpsTriple (base+36..60).
+    --     Each instruction extended via step2v4_sub 9..14.
+    --     Produces: x7=q0Dlo1, x1=rhat2Un0, x11=un0, mem3936=rhat2c.
+    -- (D) BLTU cpsBranch at [15] (step2v4_sub 15, offset 12 → base+72):
+    --     Taken [18..20] ADDI+LD+ADD (step2v4_sub 18..20) → [21] = base+84.
+    --     Not-taken [16..17] LD+JAL(16) (step2v4_sub 16..17) → base+84.
+    --     cpsBranch_merge_same_cr → cpsTriple (base+36..84).
+    -- (E) 2nd D3 guard SRLI+BNE at [21..22] (step2v4_sub 21..22, offset 36):
+    --     Taken → base+124 (rhat2c_upd_hi ≠ 0, identity triple).
+    --     Not-taken → run [23..30]:
+    --       [23..27] LD+MUL+SLLI+LD+OR: reuse divK_div128_prodcheck2_merged_spec
+    --           extended via step2v4_sub 23..30.
+    --       cpsBranch_merge_same_cr with BLTU [28]+JAL [29]+ADDI [30] → base+124.
+    --     cpsBranch_merge_same_cr → cpsTriple (base+84..124).
+    -- cpsTriple_seq (C+D) + E = cpsTriple (base+36..124).
+    sorry
   exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -188,14 +188,30 @@ theorem divK_div128_step2_v4_spec
        (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ vScratchOld))
       (divKDiv128Step2V4Post sp un21 dHi dlo un0 vScratchOld) := by
-  sorry  -- PR-A2 finish stub. Proof uses cpsBranch_merge_same_cr:
-         -- 1. Build cpsBranch for the outer BNE guard at [48] (offset 92):
-         --    taken=base+124 (combines with if-rhat2cHi-ne-0 post),
-         --    not-taken runs through [49..70] then base+124.
-         -- 2. h_t = cpsTriple_refl for taken leg.
-         -- 3. h_f = proof of [49..70] → (not-taken post at base+124).
-         -- 4. cpsBranch_merge_same_cr → cpsTriple base (base+124).
-         -- The merged post is divKDiv128Step2V4Post with if-rhat2cHi
-         -- selectors for x7, x1, x11, mem3936.
+  -- Proof strategy: cpsBranch_merge_same_cr on the outer BNE at [28..36].
+  --
+  -- Key structural insight:
+  --   Phase A ([0..28]): init+clamp cpsTriple (reuse divK_div128_step2_upto_guard_spec).
+  --   Phase B ([28..36]): SRLI+BNE cpsBranch (reuse divK_div128_phase2b_guard_spec
+  --                        with guard_off = 92 → target base+124).
+  --   A+B: cpsTriple_seq_cpsBranch_perm_same_cr.
+  --   Taken (rhat2cHi ≠ 0): identity cpsTriple at base+124, weaken to finalPost.
+  --   Not-taken (rhat2cHi = 0): cpsTriple (base+36) (base+124) for [36..120]:
+  --     (C) pre-BLTU setup [36..60] via runBlock (LD+MUL+SLLI+SD+LD+OR).
+  --     (D) 1st BLTU cpsBranch at [60] (offset 12 → [72]):
+  --           taken [72..80] = ADDI+LD+ADD → [84].
+  --           not-taken [64..68] = LD+JAL(16) → [84].
+  --         cpsBranch_merge_same_cr → cpsTriple (base+36) (base+84).
+  --     (E) 2nd D3: SRLI+BNE guard [84..88] (offset 36 → base+124 = end of step2_v4).
+  --           taken → base+124 (identity).
+  --           not-taken [92..120]: prodcheck2-style [92..112] + BLTU [112] + correction [120].
+  --         cpsBranch_merge_same_cr → cpsTriple (base+84) (base+124).
+  --     cpsTriple_seq (C+D) + E → cpsTriple (base+36) (base+124).
+  --
+  -- The extension from sub-specs' small CodeReqs to divKDiv128Step2V4Code is the
+  -- mechanical part (31 singleton-union positions). Each step2v4_sub helper would
+  -- look up the singleton by position in the unfolded cr (similar to d128_v4_sub
+  -- but within step2_v4's code).
+  sorry
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -36,42 +36,48 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-/-- Bundled CodeReq for `divK_div128_step2_v4_spec` (31 singletons,
-    instrs [40..70] of `divK_div128_v4`). `@[irreducible]` to keep
-    let-bindings out of theorem signatures. -/
+/-- The 31 instructions of the step-2-v4 block (instrs [40..70] of
+    `divK_div128_v4`), as a plain `List Instr` so `step2v4_sub` can use
+    `CodeReq.ofProg_lookup` — the same mechanism as `d128_v4_sub`. -/
+def divKDiv128Step2V4Instrs : List Instr :=
+  [.DIVU .x5 .x7 .x6,   .MUL .x1 .x5 .x6,   .SUB .x11 .x7 .x1,   -- [0..2]
+   .SRLI .x1 .x5 32,     .BEQ .x1 .x0 12,     .ADDI .x5 .x5 4095,   -- [3..5]
+   .ADD .x11 .x11 .x6,   .SRLI .x1 .x11 32,   .BNE .x1 .x0 92,      -- [6..8]
+   .LD .x1 .x12 3952,    .MUL .x7 .x5 .x1,    .SLLI .x1 .x11 32,    -- [9..11]
+   .SD .x12 .x11 3936,   .LD .x11 .x12 3944,  .OR .x1 .x1 .x11,     -- [12..14]
+   .BLTU .x1 .x7 12,     .LD .x11 .x12 3936,  .JAL .x0 16,           -- [15..17]
+   .ADDI .x5 .x5 4095,   .LD .x11 .x12 3936,  .ADD .x11 .x11 .x6,   -- [18..20]
+   .SRLI .x1 .x11 32,    .BNE .x1 .x0 36,     .LD .x1 .x12 3952,    -- [21..23]
+   .MUL .x7 .x5 .x1,    .SLLI .x1 .x11 32,   .LD .x11 .x12 3944,   -- [24..26]
+   .OR .x1 .x1 .x11,    .BLTU .x1 .x7 8,     .JAL .x0 8,            -- [27..29]
+   .ADDI .x5 .x5 4095]                                                  -- [30]
+
+/-- Bundled CodeReq for `divK_div128_step2_v4_spec`. Expressed as
+    `CodeReq.ofProg` (not union-of-singletons) so `step2v4_sub` can
+    use `ofProg_lookup` — same pattern as `d128_v4_sub` for the full
+    `divK_div128_v4` program. `@[irreducible]` to keep let-bindings
+    out of theorem signatures. -/
 @[irreducible]
 def divKDiv128Step2V4Code (base : Word) : CodeReq :=
-  CodeReq.union (CodeReq.singleton base                (.DIVU .x5 .x7 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 4)         (.MUL .x1 .x5 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 8)         (.SUB .x11 .x7 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 12)        (.SRLI .x1 .x5 32))
-  (CodeReq.union (CodeReq.singleton (base + 16)        (.BEQ .x1 .x0 12))
-  (CodeReq.union (CodeReq.singleton (base + 20)        (.ADDI .x5 .x5 4095))
-  (CodeReq.union (CodeReq.singleton (base + 24)        (.ADD .x11 .x11 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 28)        (.SRLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 32)        (.BNE .x1 .x0 92))
-  (CodeReq.union (CodeReq.singleton (base + 36)        (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 40)        (.MUL .x7 .x5 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 44)        (.SLLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 48)        (.SD .x12 .x11 3936))
-  (CodeReq.union (CodeReq.singleton (base + 52)        (.LD .x11 .x12 3944))
-  (CodeReq.union (CodeReq.singleton (base + 56)        (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 60)        (.BLTU .x1 .x7 12))
-  (CodeReq.union (CodeReq.singleton (base + 64)        (.LD .x11 .x12 3936))
-  (CodeReq.union (CodeReq.singleton (base + 68)        (.JAL .x0 16))
-  (CodeReq.union (CodeReq.singleton (base + 72)        (.ADDI .x5 .x5 4095))
-  (CodeReq.union (CodeReq.singleton (base + 76)        (.LD .x11 .x12 3936))
-  (CodeReq.union (CodeReq.singleton (base + 80)        (.ADD .x11 .x11 .x6))
-  (CodeReq.union (CodeReq.singleton (base + 84)        (.SRLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 88)        (.BNE .x1 .x0 36))
-  (CodeReq.union (CodeReq.singleton (base + 92)        (.LD .x1 .x12 3952))
-  (CodeReq.union (CodeReq.singleton (base + 96)        (.MUL .x7 .x5 .x1))
-  (CodeReq.union (CodeReq.singleton (base + 100)       (.SLLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 104)       (.LD .x11 .x12 3944))
-  (CodeReq.union (CodeReq.singleton (base + 108)       (.OR .x1 .x1 .x11))
-  (CodeReq.union (CodeReq.singleton (base + 112)       (.BLTU .x1 .x7 8))
-  (CodeReq.union (CodeReq.singleton (base + 116)       (.JAL .x0 8))
-   (CodeReq.singleton (base + 120)       (.ADDI .x5 .x5 4095)))))))))))))))))))))))))))))))
+  CodeReq.ofProg base divKDiv128Step2V4Instrs
+
+private theorem divKDiv128Step2V4Instrs_len : divKDiv128Step2V4Instrs.length = 31 := by decide
+
+/-- Per-instruction subsumption: singleton at byte-offset `4*k` of
+    `divKDiv128Step2V4Code base` is included in the CodeReq.
+    Exactly analogous to `d128_v4_sub` for the full `divK_div128_v4`
+    program — avoids repeating the union-of-singletons form. -/
+private theorem step2v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
+    (hk : k < 31)
+    (h_addr : addr = base + BitVec.ofNat 64 (4 * k))
+    (h_instr : divKDiv128Step2V4Instrs.get ⟨k, by
+        have := divKDiv128Step2V4Instrs_len; omega⟩ = instr) :
+    ∀ a i, CodeReq.singleton addr instr a = some i →
+      (divKDiv128Step2V4Code base) a = some i := by
+  subst h_addr; subst h_instr; unfold divKDiv128Step2V4Code
+  exact fun a i h => CodeReq.singleton_mono
+    (CodeReq.ofProg_lookup base divKDiv128Step2V4Instrs k (by
+        have := divKDiv128Step2V4Instrs_len; omega) (by decide)) a i h
 
 /-- Bundled postcondition for `divK_div128_step2_v4_spec`. Hides the
     let-chain for Step 2 v4 trial-division intermediates + Phase 2b
@@ -188,30 +194,121 @@ theorem divK_div128_step2_v4_spec
        (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ vScratchOld))
       (divKDiv128Step2V4Post sp un21 dHi dlo un0 vScratchOld) := by
-  -- Proof strategy: cpsBranch_merge_same_cr on the outer BNE at [28..36].
-  --
-  -- Key structural insight:
-  --   Phase A ([0..28]): init+clamp cpsTriple (reuse divK_div128_step2_upto_guard_spec).
-  --   Phase B ([28..36]): SRLI+BNE cpsBranch (reuse divK_div128_phase2b_guard_spec
-  --                        with guard_off = 92 → target base+124).
-  --   A+B: cpsTriple_seq_cpsBranch_perm_same_cr.
-  --   Taken (rhat2cHi ≠ 0): identity cpsTriple at base+124, weaken to finalPost.
-  --   Not-taken (rhat2cHi = 0): cpsTriple (base+36) (base+124) for [36..120]:
-  --     (C) pre-BLTU setup [36..60] via runBlock (LD+MUL+SLLI+SD+LD+OR).
-  --     (D) 1st BLTU cpsBranch at [60] (offset 12 → [72]):
-  --           taken [72..80] = ADDI+LD+ADD → [84].
-  --           not-taken [64..68] = LD+JAL(16) → [84].
-  --         cpsBranch_merge_same_cr → cpsTriple (base+36) (base+84).
-  --     (E) 2nd D3: SRLI+BNE guard [84..88] (offset 36 → base+124 = end of step2_v4).
-  --           taken → base+124 (identity).
-  --           not-taken [92..120]: prodcheck2-style [92..112] + BLTU [112] + correction [120].
-  --         cpsBranch_merge_same_cr → cpsTriple (base+84) (base+124).
-  --     cpsTriple_seq (C+D) + E → cpsTriple (base+36) (base+124).
-  --
-  -- The extension from sub-specs' small CodeReqs to divKDiv128Step2V4Code is the
-  -- mechanical part (31 singleton-union positions). Each step2v4_sub helper would
-  -- look up the singleton by position in the unfolded cr (similar to d128_v4_sub
-  -- but within step2_v4's code).
-  sorry
+  unfold divKDiv128Step2V4Post
+  let q0 := rv64_divu un21 dHi
+  let rhat2 := un21 - q0 * dHi
+  let hi := q0 >>> (32 : BitVec 6).toNat
+  let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
+  let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dlo
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+  let rhat2' :=
+    if rhat2cHi = 0 then
+      if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
+    else rhat2c
+  let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := q0' * dlo
+  let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  let q0'' := div128Quot_phase2b_q0' q0' rhat2' dlo un0
+  let x7Exit := if rhat2cHi ≠ 0 then un21
+                else if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2
+  let x1Exit := if rhat2cHi ≠ 0 then rhat2cHi
+                else if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0
+  let x11Exit := if rhat2cHi ≠ 0 then rhat2c
+                 else if rhat2'Hi ≠ 0 then rhat2' else un0
+  let mem3936Exit := if rhat2cHi ≠ 0 then vScratchOld else rhat2c
+  -- Phase A: init+clamp [0..28] — cpsTriple base (base+28).
+  -- Reuse divK_div128_step2_upto_guard_spec, extend via step2v4_sub 0..6.
+  have hA_raw := divK_div128_step2_upto_guard_spec sp un21 dHi v1Old v5Old v11Old dlo un0 base
+  have hA : cpsTriple base (base + 28) (divKDiv128Step2V4Code base) _ _ :=
+    cpsTriple_extend_code (hmono := by
+      exact CodeReq.union_sub
+        (step2v4_sub 0 base (.DIVU .x5 .x7 .x6) (by omega) (by bv_omega) (by decide))
+       (CodeReq.union_sub
+        (step2v4_sub 1 (base+4) (.MUL .x1 .x5 .x6) (by omega) (by bv_omega) (by decide))
+       (CodeReq.union_sub
+        (step2v4_sub 2 (base+8) (.SUB .x11 .x7 .x1) (by omega) (by bv_omega) (by decide))
+       (CodeReq.union_sub
+        (step2v4_sub 3 (base+12) (.SRLI .x1 .x5 32) (by omega) (by bv_omega) (by decide))
+       (CodeReq.union_sub
+        (step2v4_sub 4 (base+16) (.BEQ .x1 .x0 12) (by omega) (by bv_omega) (by decide))
+       (CodeReq.union_sub
+        (step2v4_sub 5 (base+20) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 6 (base+24) (.ADD .x11 .x11 .x6) (by omega) (by bv_omega) (by decide))))))))
+    hA_raw
+  have hAf := cpsTriple_frameR
+    (sp + signExtend12 3936 ↦ₘ vScratchOld)
+    (by pcFree) hA
+  -- Phase B: outer SRLI+BNE guard [28..36] — cpsBranch via step2v4_sub 7+8.
+  have hB_raw := divK_div128_phase2b_guard_spec sp rhat2c hi (base + 28) (92 : BitVec 13)
+  simp only [show (base + 28 : Word) + 4 = base + 32 from by bv_addr,
+             show (base + 28 : Word) + 8 = base + 36 from by bv_addr,
+             show (base + 32 : Word) + signExtend13 (92 : BitVec 13) = base + 124 from by
+               rv64_addr] at hB_raw
+  have hB : cpsBranch (base + 28) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
+    cpsBranch_extend_code (hmono := by
+      exact CodeReq.union_sub
+        (step2v4_sub 7 (base+28) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 8 (base+32) (.BNE .x1 .x0 92) (by omega) (by bv_omega) (by decide))) hB_raw
+  have hBf := cpsBranch_frameR
+    ((.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+     (sp + signExtend12 3936 ↦ₘ vScratchOld))
+    (by pcFree) hB
+  have composed_AB := cpsTriple_seq_cpsBranch_perm_same_cr
+    (fun h hp => by xperm_hyp hp) hAf hBf
+  -- finalPost (merged post at base+124 for both legs).
+  let finalPost : Assertion :=
+    (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
+    (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+    (sp + signExtend12 3936 ↦ₘ mem3936Exit)
+  -- Taken leg (rhat2cHi ≠ 0): BNE fires, already at base+124.
+  -- q0'' = q0c (both D3 guards fire), x7=un21, x1=rhat2cHi, x11=rhat2c, mem3936=vScratchOld.
+  -- The taken postcondition of composed_AB:
+  let takenPost : Assertion :=
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+     (.x0 ↦ᵣ 0) ** ⌜rhat2cHi ≠ 0⌝) **
+    (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+    (sp + signExtend12 3936 ↦ₘ vScratchOld)
+  have h_taken : cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base)
+      takenPost finalPost := by
+    sorry  -- Identity triple: takenPost → finalPost.
+           -- When rhat2cHi ≠ 0: q0'' = q0c (both D3 guards skip, each
+           -- div128Quot_phase2b_q0' q0c rhat2c = q0c since rhat2cHi ≠ 0).
+           -- x7Exit = un21, x1Exit = rhat2cHi, x11Exit = rhat2c, mem3936Exit = vScratchOld.
+           -- Proof: extend from empty CodeReq via cpsTriple_refl + weaken.
+  -- The not-taken postcondition of composed_AB:
+  let notTakenPost : Assertion :=
+    ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **
+     (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
+    (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+    (sp + signExtend12 3936 ↦ₘ vScratchOld)
+  -- Not-taken leg (rhat2cHi = 0): run [36..120] → base+124.
+  have h_notTaken : cpsTriple (base + 36) (base + 124) (divKDiv128Step2V4Code base)
+      notTakenPost finalPost := by
+    sorry  -- [36..120] proof via step2v4_sub 9..30:
+           -- (C) [9..15] = LD+MUL+SLLI+SD+LD+OR: runBlock with step2v4_sub 9..14.
+           -- (D) BLTU cpsBranch at [15] via step2v4_sub 15:
+           --       taken [18..20] = ADDI+LD+ADD: step2v4_sub 18+19+20.
+           --       not-taken [16..17] = LD+JAL: step2v4_sub 16+17.
+           --       cpsBranch_merge_same_cr → cpsTriple (base+36) (base+84).
+           -- (E) [21..22] SRLI+BNE guard via step2v4_sub 21+22, guard_off=36 → base+124:
+           --       taken → base+124 (identity).
+           --       not-taken [23..30] prodcheck2-style:
+           --         [23..27] LD+MUL+SLLI+LD+OR: step2v4_sub 23..27.
+           --         BLTU [28]: taken [30]=ADDI: step2v4_sub 28+30.
+           --                    not-taken [29]=JAL: step2v4_sub 29.
+           --       cpsBranch_merge_same_cr → cpsTriple (base+84) (base+124).
+           --     cpsTriple_seq → cpsTriple (base+36) (base+124).
+  exact cpsTriple_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    (cpsBranch_merge_same_cr composed_AB h_taken h_notTaken)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -135,6 +135,93 @@ private theorem divK_div128_step2_v4_phase_D_fallthrough_body_spec
   simp only [show (base+64:Word)+4 = base+68 from by bv_addr, h_jal] at I0 I1
   runBlock I0 I1
 
+private def phaseDTakenBranchPost
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
+  (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝) **
+    (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+    (sp + signExtend12 3936 ↦ₘ rhat2c))
+
+private def phaseDTakenBodyPre
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
+  (((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) **
+    (sp + signExtend12 3936 ↦ₘ rhat2c) ** (.x6 ↦ᵣ dHi)) **
+    (.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) **
+    ⌜rhat2cHi = 0⌝ ** (sp + signExtend12 3952 ↦ₘ dlo) **
+    (sp + signExtend12 3944 ↦ₘ un0))
+
+private theorem divK_div128_step2_v4_phase_D_taken_body_pre
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word)
+    (h : PartialState)
+    (hp : phaseDTakenBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h) :
+      phaseDTakenBodyPre sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h := by
+  dsimp only [phaseDTakenBranchPost, phaseDTakenBodyPre] at hp ⊢
+  have hp' :
+      ((((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
+        (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
+        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+        (sp + signExtend12 3936 ↦ₘ rhat2c)) h) :=
+    sepConj_mono_left
+      (fun h0 hp0 => sepConj_strip_pure_end2 h0 hp0) h hp
+  xperm_hyp hp'
+
+private def phaseDFallthroughBranchPost
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
+  (((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) **
+    (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
+    (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+    (sp + signExtend12 3936 ↦ₘ rhat2c))
+
+private def phaseDFallthroughBodyPre
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
+  (((.x11 ↦ᵣ un0) ** (.x12 ↦ᵣ sp) ** (sp + signExtend12 3936 ↦ₘ rhat2c)) **
+    (.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) **
+    (.x5 ↦ᵣ q0c) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+    (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+
+private theorem divK_div128_step2_v4_phase_D_fallthrough_body_pre
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word)
+    (h : PartialState)
+    (hp : phaseDFallthroughBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h) :
+      phaseDFallthroughBodyPre sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h := by
+  dsimp only [phaseDFallthroughBranchPost, phaseDFallthroughBodyPre] at hp ⊢
+  have hp' :
+      ((((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1)) **
+        (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
+        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+        (sp + signExtend12 3936 ↦ₘ rhat2c)) h) :=
+    sepConj_mono_left
+      (fun h0 hp0 => sepConj_strip_pure_end2 h0 hp0) h hp
+  xperm_hyp hp'
+
+private def phaseDMergedPre
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word) : Assertion :=
+  (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+  (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ rhat2c)
+
+private theorem divK_div128_step2_v4_phase_D_pre_zero
+    (sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 : Word)
+    (h : PartialState)
+    (hp : phaseDMergedPre sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h) :
+    rhat2cHi = 0 := by
+  dsimp only [phaseDMergedPre] at hp
+  have hp' :
+      (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+        (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0)) ** ⌜rhat2cHi = 0⌝ **
+        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+        (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
+    xperm_hyp hp
+  obtain ⟨_, _, _, _, _, hright⟩ := hp'
+  exact ((sepConj_pure_left _).1 hright).1
+
 /-- The SRLI+BNE dispatch at the start of Phase E, extended into the step2-v4
     code requirement and framed with the registers/memory live across it. -/
 private theorem divK_div128_step2_v4_phase_E_guard_spec
@@ -178,6 +265,60 @@ private theorem divK_div128_step2_v4_phase_E_guard_spec
     (by pcFree) hguard
   exact cpsBranch_weaken
     (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    hframed
+
+/-- Phase E guard fallthrough body: the second Phase-2b product check [23..30]. -/
+private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
+    (sp dHi q0' rhat2' rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word) (base : Word) :
+    let q0Dlo2 := q0' * dlo
+    let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+    let q0'Unguarded := if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0'
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+    cpsTriple (base + 92) (base + 124) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      ((.x5 ↦ᵣ q0'Unguarded) ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ q0Dlo2) **
+       (.x1 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  intro q0Dlo2 rhat2'Un0 q0'Unguarded rhat2cHi
+  have hraw := divK_div128_prodcheck2_merged_spec sp q0' rhat2' rhat2'Hi q0Dlo1 dlo un0 (base + 92)
+  simp only [show (base+92:Word)+4 = base+96 from by bv_addr,
+             show (base+92:Word)+8 = base+100 from by bv_addr,
+             show (base+92:Word)+12 = base+104 from by bv_addr,
+             show (base+92:Word)+16 = base+108 from by bv_addr,
+             show (base+92:Word)+20 = base+112 from by bv_addr,
+             show (base+92:Word)+24 = base+116 from by bv_addr,
+             show (base+92:Word)+28 = base+120 from by bv_addr,
+             show (base+92:Word)+32 = base+124 from by bv_addr] at hraw
+  have hext : cpsTriple (base + 92) (base + 124) (divKDiv128Step2V4Code base) _ _ :=
+    cpsTriple_extend_code (h := hraw) (hmono := by
+      exact CodeReq.union_sub
+        (step2v4_sub 23 (base+92) (.LD .x1 .x12 3952) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 24 (base+96) (.MUL .x7 .x5 .x1) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 25 (base+100) (.SLLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 26 (base+104) (.LD .x11 .x12 3944) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 27 (base+108) (.OR .x1 .x1 .x11) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 28 (base+112) (.BLTU .x1 .x7 8) (by omega) (by bv_omega) (by decide))
+        (CodeReq.union_sub
+        (step2v4_sub 29 (base+116) (.JAL .x0 8) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 30 (base+120) (.ADDI .x5 .x5 4095) (by omega) (by bv_omega) (by decide)))))))))
+  have hframed := cpsTriple_frameR
+    ((.x6 ↦ᵣ dHi) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
+     (sp + signExtend12 3936 ↦ₘ rhat2c))
+    (by pcFree) hext
+  exact cpsTriple_weaken
     (fun h hp => by xperm_hyp hp)
     (fun h hp => by xperm_hyp hp)
     hframed
@@ -273,7 +414,94 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
   -- * fallthrough path: [16..17] LD; JAL
   -- Both paths then rewrite `div128Quot_phase2b_q0'` under the carried
   -- `rhat2cHi = 0` fact and strip the BLTU pure fact.
-  sorry
+  have hbltu_f := cpsBranch_frameR
+    ((.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ un0) **
+     (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+     (sp + signExtend12 3936 ↦ₘ rhat2c))
+    (by pcFree) hbltu
+  by_cases hz : rhat2cHi = 0
+  · by_cases hcond : BitVec.ult rhat2Un0 q0Dlo1
+    · have taken := cpsBranch_takenPath hbltu_f (fun hp hQf => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, hpure⟩, _⟩ := hQf
+        exact ((sepConj_pure_right _).1 hpure).2 hcond)
+      have taken' : cpsTriple (base + 60) (base + 72) (divKDiv128Step2V4Code base)
+          ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+           (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+           (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+           (sp + signExtend12 3936 ↦ₘ rhat2c))
+          (phaseDTakenBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0) :=
+        cpsTriple_weaken
+          (fun h hp => by xperm_hyp hp)
+          (fun h hp => by dsimp only [phaseDTakenBranchPost]; exact hp)
+          taken
+      have hq0' : q0' = q0c + signExtend12 4095 := by
+        unfold q0'
+        change (if rhat2cHi = 0 then
+            if BitVec.ult rhat2Un0 q0Dlo1 then q0c + signExtend12 4095 else q0c
+          else q0c) = q0c + signExtend12 4095
+        rw [if_pos hz, if_pos hcond]
+      have hrhat2' : rhat2' = rhat2c + dHi := by
+        unfold rhat2'
+        rw [if_pos hz, if_pos hcond]
+      rw [hq0', hrhat2']
+      have hpath := divK_div128_step2_v4_phase_D_taken_body_spec sp q0c rhat2c dHi un0 base
+      have hpath_f := cpsTriple_frameR
+        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+        (by pcFree) hpath
+      exact cpsTriple_weaken
+        (fun h hp => hp)
+        (fun h hp => by xperm_hyp hp)
+        (cpsTriple_seq_perm_same_cr
+          (fun h hp => divK_div128_step2_v4_phase_D_taken_body_pre
+            sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h hp)
+          taken' hpath_f)
+    · have ntaken := cpsBranch_ntakenPath hbltu_f (fun hp hQt => by
+        obtain ⟨_, _, _, _, ⟨_, _, _, _, _, hpure⟩, _⟩ := hQt
+        exact absurd ((sepConj_pure_right _).1 hpure).2 hcond)
+      have ntaken' : cpsTriple (base + 60) (base + 64) (divKDiv128Step2V4Code base)
+          ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+           (.x11 ↦ᵣ un0) ** (.x1 ↦ᵣ rhat2Un0) **
+           (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+           (sp + signExtend12 3936 ↦ₘ rhat2c))
+          (phaseDFallthroughBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0) :=
+        cpsTriple_weaken
+          (fun h hp => by xperm_hyp hp)
+          (fun h hp => by dsimp only [phaseDFallthroughBranchPost]; exact hp)
+          ntaken
+      have hq0' : q0' = q0c := by
+        unfold q0'
+        change (if rhat2cHi = 0 then
+            if BitVec.ult rhat2Un0 q0Dlo1 then q0c + signExtend12 4095 else q0c
+          else q0c) = q0c
+        rw [if_pos hz, if_neg hcond]
+      have hrhat2' : rhat2' = rhat2c := by
+        unfold rhat2'
+        rw [if_pos hz, if_neg hcond]
+      rw [hq0', hrhat2']
+      have hpath := divK_div128_step2_v4_phase_D_fallthrough_body_spec sp rhat2c un0 base
+      have hpath_f := cpsTriple_frameR
+        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+         (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
+        (by pcFree) hpath
+      exact cpsTriple_weaken
+        (fun h hp => hp)
+        (fun h hp => by xperm_hyp hp)
+        (cpsTriple_seq_perm_same_cr
+          (fun h hp => divK_div128_step2_v4_phase_D_fallthrough_body_pre
+            sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 h hp)
+          ntaken' hpath_f)
+  · intro F hF s hcr hPFR hpc
+    obtain ⟨hp, hcompat, hsep⟩ := hPFR
+    obtain ⟨hpreSt, hframeSt, hd, hu, hpre, hframe⟩ := hsep
+    have hz' : rhat2cHi = 0 :=
+      divK_div128_step2_v4_phase_D_pre_zero
+        sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0 hpreSt hpre
+    exact absurd hz' hz
 
 /-- Phase E sub-lemma: 2nd D3 guard+prodcheck [21..30] of step2_v4, merged post.
     Input = midD (at base+84). Output = finalPost_rhat2cHi0 (at base+124).

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -276,12 +276,54 @@ theorem divK_div128_step2_v4_spec
     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
     (sp + signExtend12 3936 ↦ₘ vScratchOld)
   have h_taken : cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base)
-      takenPost finalPost := by
-    sorry  -- Identity triple: takenPost → finalPost.
-           -- When rhat2cHi ≠ 0: q0'' = q0c (both D3 guards skip, each
-           -- div128Quot_phase2b_q0' q0c rhat2c = q0c since rhat2cHi ≠ 0).
-           -- x7Exit = un21, x1Exit = rhat2cHi, x11Exit = rhat2c, mem3936Exit = vScratchOld.
-           -- Proof: extend from empty CodeReq via cpsTriple_refl + weaken.
+      takenPost finalPost :=
+    cpsTriple_extend_code (hmono := fun _ _ h => by simp [CodeReq.empty] at h)
+    (cpsTriple_refl (by
+      intro hp htp
+      -- Extract ⌜rhat2cHi ≠ 0⌝ from takenPost (inside a have so htp survives).
+      -- takenPost = (.x12 ** .x11 ** .x1 ** .x0 ** ⌜rhat2cHi ≠ 0⌝) ** rest.
+      have h_ne : rhat2cHi ≠ 0 := by
+        obtain ⟨_, _, _, _, hleft, _⟩ := htp
+        obtain ⟨_, _, _, _, _, h1⟩ := hleft  -- peel .x12
+        obtain ⟨_, _, _, _, _, h2⟩ := h1     -- peel .x11
+        obtain ⟨_, _, _, _, _, h3⟩ := h2     -- peel .x1
+        obtain ⟨_, _, _, _, _, h4⟩ := h3     -- peel .x0
+        obtain ⟨_, hpure⟩ := h4             -- ⌜rhat2cHi ≠ 0⌝
+        exact hpure
+      -- When rhat2cHi ≠ 0: both D3 guards skip → q0'' = q0c.
+      have hq0' : q0' = q0c := by
+        show div128Quot_phase2b_q0' q0c rhat2c dlo un0 = q0c
+        simp only [div128Quot_phase2b_q0']; exact if_neg h_ne
+      have hrhat2' : rhat2' = rhat2c := by
+        show (if rhat2cHi = 0 then _ else rhat2c) = rhat2c
+        exact if_neg h_ne
+      have hq0'' : q0'' = q0c := by
+        show div128Quot_phase2b_q0' q0' rhat2' dlo un0 = q0c
+        rw [hq0', hrhat2']
+        simp only [div128Quot_phase2b_q0']; exact if_neg h_ne
+      have hx7 : x7Exit = un21   := by show (if rhat2cHi ≠ 0 then un21 else _) = un21; exact if_pos h_ne
+      have hx1 : x1Exit = rhat2cHi := by show (if rhat2cHi ≠ 0 then rhat2cHi else _) = rhat2cHi; exact if_pos h_ne
+      have hx11 : x11Exit = rhat2c  := by show (if rhat2cHi ≠ 0 then rhat2c else _) = rhat2c; exact if_pos h_ne
+      have hmem : mem3936Exit = vScratchOld := by show (if rhat2cHi ≠ 0 then vScratchOld else _) = vScratchOld; exact if_pos h_ne
+      -- Strip ⌜rhat2cHi ≠ 0⌝ from htp for xperm_hyp.
+      -- takenPost = (.x12 ** .x11 ** .x1 ** .x0 ** ⌜...⌝) ** rest.
+      -- Strip: 3x sepConj_mono_right to reach .x0 ** ⌜...⌝, then strip.
+      have htp' : (((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) ** (.x0 ↦ᵣ 0)) **
+          (.x7 ↦ᵣ un21) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0c) **
+          (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+          (sp + signExtend12 3936 ↦ₘ vScratchOld)) hp :=
+        sepConj_mono_left (sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
+          (fun h'' hp'' => ((sepConj_pure_right h'').1 hp'').1)))) hp htp
+      -- Rewrite finalPost to explicit form, then xperm_hyp htp'.
+      show finalPost hp
+      rw [show finalPost = ((.x5 ↦ᵣ q0c) ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ un21) **
+          (.x1 ↦ᵣ rhat2cHi) ** (.x11 ↦ᵣ rhat2c) **
+          (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+          (sp + signExtend12 3952 ↦ₘ dlo) **
+          (sp + signExtend12 3944 ↦ₘ un0) **
+          (sp + signExtend12 3936 ↦ₘ vScratchOld)) from by
+        simp only [finalPost, hq0'', hx7, hx1, hx11, hmem]]
+      xperm_hyp htp'))
   -- The not-taken postcondition of composed_AB:
   let notTakenPost : Assertion :=
     ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ rhat2c) ** (.x1 ↦ᵣ rhat2cHi) **

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -83,33 +83,49 @@ def divKDiv128Step2V4Code (base : Word) : CodeReq :=
     the postcondition encodes them via if-then-else on the relevant
     BLTU/BNE conditions. -/
 @[irreducible]
-def divKDiv128Step2V4Post (sp un21 dHi dlo un0 : Word) : Assertion :=
+def divKDiv128Step2V4Post (sp un21 dHi dlo un0 vScratchOld : Word) : Assertion :=
   let q0 := rv64_divu un21 dHi
   let rhat2 := un21 - q0 * dHi
   let hi := q0 >>> (32 : BitVec 6).toNat
   let q0c := if hi = 0 then q0 else q0 + signExtend12 4095
   let rhat2c := if hi = 0 then rhat2 else rhat2 + dHi
-  -- Phase 2b 1st D3.
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0Dlo1 := q0c * dlo            -- product for 1st D3 check
+  let rhat2Un0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+  -- Phase 2b 1st D3 result (if outer guard doesn't fire).
   let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
-  -- Phase 2b 2nd D3 — uses q0' and the post-1st-correction rhat2.
+  -- Post-1st-D3 rhat2: equals rhat2c + dHi if 1st BLTU fired, else rhat2c.
   let rhat2' :=
-    if rhat2c >>> (32 : BitVec 6).toNat = 0 then
-      let qDlo2c := q0c * dlo
-      let rhatUn0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-      if BitVec.ult rhatUn0 qDlo2c then rhat2c + dHi else rhat2c
+    if rhat2cHi = 0 then
+      if BitVec.ult rhat2Un0 q0Dlo1 then rhat2c + dHi else rhat2c
     else rhat2c
+  let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+  let q0Dlo2 := q0' * dlo            -- product for 2nd D3 check
+  let rhat2'Un0 := (rhat2' <<< (32 : BitVec 6).toNat) ||| un0
+  -- Phase 2b 2nd D3 result.
   let q0'' := div128Quot_phase2b_q0' q0' rhat2' dlo un0
-  -- Memory state: rhat2c is saved to slot 3936 (could be either rhat2c
-  -- or rhat2c+dHi depending on BLTU; abstracted here as the actual
-  -- saved value).
-  let savedRhat2c := rhat2c  -- the SD at [52] saves the un-incremented rhat2c
-  -- Exit register state: x5 holds q0'' (the final corrected q0).
-  -- x11, x7, x1 hold transient values from the last instructions.
-  -- TODO: pin x1/x7/x11 exit values once the proof body is filled in.
-  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+  -- Exit register state at [71]:
+  -- x7: un21 (outer BNE) | q0c*dlo (2nd BNE) | q0'*dlo (2nd D3 ran).
+  let x7Exit := if rhat2cHi ≠ 0 then un21
+                else if rhat2'Hi ≠ 0 then q0Dlo1
+                else q0Dlo2
+  -- x1: rhat2cHi (outer BNE) | rhat2'Hi (2nd BNE) | rhat2'*2^32|un0 (2nd D3 ran).
+  let x1Exit := if rhat2cHi ≠ 0 then rhat2cHi
+                else if rhat2'Hi ≠ 0 then rhat2'Hi
+                else rhat2'Un0
+  -- x11: rhat2c (outer BNE) | rhat2' (2nd BNE) | un0 (2nd D3 ran).
+  let x11Exit := if rhat2cHi ≠ 0 then rhat2c
+                 else if rhat2'Hi ≠ 0 then rhat2'
+                 else un0
+  -- mem3936: vScratchOld if outer BNE fired (SD at [52] not reached),
+  --          else rhat2c (saved at [52]).
+  let mem3936Exit := if rhat2cHi ≠ 0 then vScratchOld else rhat2c
+  (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
+  (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
   (sp + signExtend12 3952 ↦ₘ dlo) **
   (sp + signExtend12 3944 ↦ₘ un0) **
-  (sp + signExtend12 3936 ↦ₘ savedRhat2c)
+  (sp + signExtend12 3936 ↦ₘ mem3936Exit)
 
 /-- Bundled postcondition for Phase 2b 1st D3 with save/restore.
     Covers instructions [47..60] of divK_div128_v4 (14 instructions). -/
@@ -171,10 +187,15 @@ theorem divK_div128_step2_v4_spec
        (sp + signExtend12 3952 ↦ₘ dlo) **
        (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ vScratchOld))
-      (divKDiv128Step2V4Post sp un21 dHi dlo un0) := by
-  sorry  -- PR-A2 finish stub. Body composes step2_init + clamp_q0 +
-         -- phase2b_guard + (1st D3 with save/restore) + (2nd D3),
-         -- mirroring the v2 step2_spec proof structure but with
-         -- 14 additional instructions.
+      (divKDiv128Step2V4Post sp un21 dHi dlo un0 vScratchOld) := by
+  sorry  -- PR-A2 finish stub. Proof uses cpsBranch_merge_same_cr:
+         -- 1. Build cpsBranch for the outer BNE guard at [48] (offset 92):
+         --    taken=base+124 (combines with if-rhat2cHi-ne-0 post),
+         --    not-taken runs through [49..70] then base+124.
+         -- 2. h_t = cpsTriple_refl for taken leg.
+         -- 3. h_f = proof of [49..70] → (not-taken post at base+124).
+         -- 4. cpsBranch_merge_same_cr → cpsTriple base (base+124).
+         -- The merged post is divKDiv128Step2V4Post with if-rhat2cHi
+         -- selectors for x7, x1, x11, mem3936.
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -323,6 +323,58 @@ private theorem divK_div128_step2_v4_phase_E_fallthrough_body_spec
     (fun h hp => by xperm_hyp hp)
     hframed
 
+private def phaseETakenBranchPost
+    (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word) :
+    Assertion :=
+  (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+  (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi ≠ 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ rhat2c)
+
+private def phaseEFallthroughBranchPost
+    (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word) :
+    Assertion :=
+  (.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+  (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ rhat2c)
+
+private theorem phaseE_taken_post_ne
+    (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word)
+    (h : PartialState)
+    (hp : phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c h) :
+    rhat2'Hi ≠ 0 := by
+  dsimp only [phaseETakenBranchPost] at hp
+  have hp' :
+      (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
+        ⌜rhat2'Hi ≠ 0⌝ **
+        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+        (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
+    xperm_hyp hp
+  obtain ⟨_, _, _, _, _, hright⟩ := hp'
+  exact ((sepConj_pure_left _).1 hright).1
+
+private theorem phaseE_fallthrough_post_zero
+    (sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c : Word)
+    (h : PartialState)
+    (hp : phaseEFallthroughBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c h) :
+    rhat2'Hi = 0 := by
+  dsimp only [phaseEFallthroughBranchPost] at hp
+  have hp' :
+      (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+        (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝) **
+        ⌜rhat2'Hi = 0⌝ **
+        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+        (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
+    xperm_hyp hp
+  obtain ⟨_, _, _, _, _, hright⟩ := hp'
+  exact ((sepConj_pure_left _).1 hright).1
+
 /-- Bundled postcondition for `divK_div128_step2_v4_spec`. Hides the
     let-chain for Step 2 v4 trial-division intermediates + Phase 2b
     1st+2nd D3 outcomes.
@@ -432,8 +484,8 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
            (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
            (sp + signExtend12 3936 ↦ₘ rhat2c))
           (phaseDTakenBranchPost sp dHi q0c rhat2c dlo un0 rhat2cHi q0Dlo1 rhat2Un0) :=
-        cpsTriple_weaken
-          (fun h hp => by xperm_hyp hp)
+          cpsTriple_weaken
+            (fun h hp => by xperm_hyp hp)
           (fun h hp => by dsimp only [phaseDTakenBranchPost]; exact hp)
           taken
       have hq0' : q0' = q0c + signExtend12 4095 := by
@@ -527,20 +579,117 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c))
-      ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
-       (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
-       (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
-  intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x1Exit x11Exit
-  have hguard := divK_div128_step2_v4_phase_E_guard_spec
-    sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
-  -- Remaining proof split:
-  -- * guard-taken path: zero-step bridge at base+124, using `rhat2'Hi ≠ 0`
-  -- * guard-fallthrough path: reuse `divK_div128_prodcheck2_merged_spec`
-  --   over [23..30], then bridge its unguarded quotient to `q0''` using
-  --   `rhat2'Hi = 0`.
-  sorry
+        ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
+         (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+         (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+    intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x1Exit x11Exit
+    have hguard := divK_div128_step2_v4_phase_E_guard_spec
+      sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
+    have hguard' : cpsBranch (base + 84) (divKDiv128Step2V4Code base)
+        ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+         (sp + signExtend12 3936 ↦ₘ rhat2c))
+        (base + 124)
+        (phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c)
+        (base + 92)
+        (phaseEFallthroughBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c) :=
+      cpsBranch_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by dsimp only [phaseETakenBranchPost]; xperm_hyp hp)
+        (fun h hp => by dsimp only [phaseEFallthroughBranchPost]; xperm_hyp hp)
+        hguard
+    have refl_of {P Q : Assertion} (h : ∀ hp, P hp → Q hp) :
+        cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base) P Q :=
+      cpsTriple_extend_code (fun _ _ h => by simp [CodeReq.empty] at h)
+        (cpsTriple_refl h)
+    by_cases hhi : rhat2'Hi ≠ 0
+    · have htaken := cpsBranch_takenPath hguard' (fun hp hfall => by
+        exact hhi (phaseE_fallthrough_post_zero
+          sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c hp hfall))
+      have hq0'' : q0'' = q0' := by
+        unfold q0''
+        change (if rhat2'Hi = 0 then
+            if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0'
+          else q0') = q0'
+        exact if_neg hhi
+      have hx7 : x7Exit = q0Dlo1 := by
+        unfold x7Exit
+        exact if_pos hhi
+      have hx1 : x1Exit = rhat2'Hi := by
+        unfold x1Exit
+        exact if_pos hhi
+      have hx11 : x11Exit = rhat2' := by
+        unfold x11Exit
+        exact if_pos hhi
+      have hzero : cpsTriple (base + 124) (base + 124) (divKDiv128Step2V4Code base)
+          (phaseETakenBranchPost sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c)
+          ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ x7Exit) **
+           (.x1 ↦ᵣ x1Exit) ** (.x11 ↦ᵣ x11Exit) **
+           (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+           (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+           (sp + signExtend12 3936 ↦ₘ rhat2c)) := refl_of (by
+        intro h hp
+        dsimp only [phaseETakenBranchPost] at hp
+        rw [hq0'', hx7, hx1, hx11]
+        have hp' :
+            ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+             (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+             (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+             (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+             (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
+          have hp0 :
+              (((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+                (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+                (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+                (sp + signExtend12 3936 ↦ₘ rhat2c)) ** ⌜rhat2'Hi ≠ 0⌝) h := by
+            xperm_hyp hp
+          exact ((sepConj_pure_right h).1 hp0).1
+        xperm_hyp hp')
+      exact cpsTriple_seq_perm_same_cr (fun h hp => by xperm_hyp hp) htaken hzero
+    · have hzhi : rhat2'Hi = 0 := Decidable.not_not.mp hhi
+      have hfall := cpsBranch_ntakenPath hguard' (fun hp htaken => by
+        exact hhi (phaseE_taken_post_ne
+          sp dHi q0' rhat2' rhat2cHi rhat2'Hi q0Dlo1 dlo un0 rhat2c hp htaken))
+      have hbody := divK_div128_step2_v4_phase_E_fallthrough_body_spec
+        sp dHi q0' rhat2' rhat2'Hi q0Dlo1 dlo un0 rhat2c base
+      have hq0'' : q0'' =
+          (if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0') := by
+        unfold q0''
+        change (if rhat2'Hi = 0 then
+            if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0'
+          else q0') =
+          (if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0')
+        exact if_pos hzhi
+      have hx7 : x7Exit = q0Dlo2 := by
+        unfold x7Exit
+        exact if_neg hhi
+      have hx1 : x1Exit = rhat2'Un0 := by
+        unfold x1Exit
+        exact if_neg hhi
+      have hx11 : x11Exit = un0 := by
+        unfold x11Exit
+        exact if_neg hhi
+      exact cpsTriple_weaken
+        (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+          rw [hq0'', hx7, hx1, hx11]
+          have hp0 :
+              (((.x5 ↦ᵣ (if BitVec.ult rhat2'Un0 q0Dlo2 then q0' + signExtend12 4095 else q0')) **
+                (.x6 ↦ᵣ dHi) ** (.x7 ↦ᵣ q0Dlo2) **
+                (.x1 ↦ᵣ rhat2'Un0) ** (.x11 ↦ᵣ un0) **
+                (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+                (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+                (sp + signExtend12 3936 ↦ₘ rhat2c)) ** ⌜rhat2'Hi = 0⌝) h := by
+            xperm_hyp hp
+          exact ((sepConj_pure_right h).1 hp0).1)
+        (cpsTriple_seq_perm_same_cr (fun h hp => by
+          dsimp only [phaseEFallthroughBranchPost] at hp
+          xperm_hyp hp) hfall hbody)
 
 /-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
 
@@ -748,9 +897,59 @@ theorem divK_div128_step2_v4_spec
     -- so ≠0 is vacuous); then reduce outer if-then-else by h_z + xperm.
     have hE : cpsTriple (base+84) (base+124) (divKDiv128Step2V4Code base)
         midD finalPost := by
-      have _hE_raw := divK_div128_step2_v4_phase_E_merged_spec
+      have hE_raw := divK_div128_step2_v4_phase_E_merged_spec
                        sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
-      sorry
+      exact cpsTriple_weaken
+          (fun h hp => by xperm_hyp hp)
+        (fun h hp => by
+            have hz : rhat2cHi = 0 := by
+              have hp0 :
+                  ((.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
+                   (.x7 ↦ᵣ (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2)) **
+                   (.x1 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
+                   (.x11 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2' else un0)) **
+                   (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+                   (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+                   (sp + signExtend12 3936 ↦ₘ rhat2c)) h := by
+                xperm_hyp hp
+              obtain ⟨_, _, _, _, _, h1⟩ := hp0
+              obtain ⟨_, _, _, _, _, h2⟩ := h1
+              obtain ⟨_, _, _, _, _, h3⟩ := h2
+              obtain ⟨_, _, _, _, _, h4⟩ := h3
+              obtain ⟨_, _, _, _, _, h5⟩ := h4
+              obtain ⟨_, _, _, _, _, h6⟩ := h5
+              obtain ⟨_, _, _, _, _, h7⟩ := h6
+              exact ((sepConj_pure_left _).1 h7).1
+            have hne : ¬ rhat2cHi ≠ 0 := fun hne => hne hz
+            have hx7 : x7Exit = (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2) := by
+              unfold x7Exit
+              exact if_neg hne
+            have hx1 : x1Exit = (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0) := by
+              unfold x1Exit
+              exact if_neg hne
+            have hx11 : x11Exit = (if rhat2'Hi ≠ 0 then rhat2' else un0) := by
+              unfold x11Exit
+              exact if_neg hne
+            have hmem : mem3936Exit = rhat2c := by
+              unfold mem3936Exit
+              exact if_neg hne
+            let noPure : Assertion :=
+              (.x5 ↦ᵣ q0'') ** (.x6 ↦ᵣ dHi) **
+              (.x7 ↦ᵣ (if rhat2'Hi ≠ 0 then q0Dlo1 else q0Dlo2)) **
+              (.x1 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2'Hi else rhat2'Un0)) **
+              (.x11 ↦ᵣ (if rhat2'Hi ≠ 0 then rhat2' else un0)) **
+              (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+              (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+              (sp + signExtend12 3936 ↦ₘ rhat2c)
+            show finalPost h
+            rw [show finalPost = noPure from by
+              dsimp only [noPure]
+              simp only [finalPost, hx7, hx1, hx11, hmem]]
+            have hp0 : (noPure ** ⌜rhat2cHi = 0⌝) h := by
+              dsimp only [noPure]
+              xperm_hyp hp
+            exact ((sepConj_pure_right h).1 hp0).1)
+          hE_raw
     exact cpsTriple_weaken
       (fun h hp => by xperm_hyp hp)
       (fun h hq => by xperm_hyp hq)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -79,6 +79,71 @@ private theorem step2v4_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr
     (CodeReq.ofProg_lookup base divKDiv128Step2V4Instrs k (by
         have := divKDiv128Step2V4Instrs_len; omega) (by decide)) a i h
 
+/-- The single BLTU dispatch at the start of Phase D, extended into the
+    step2-v4 code requirement. The semantic path bodies are proved separately. -/
+private theorem divK_div128_step2_v4_phase_D_bltu_spec
+    (rhat2Un0 q0Dlo1 : Word) (base : Word) :
+    cpsBranch (base + 60) (divKDiv128Step2V4Code base)
+      ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1))
+      (base + 72)
+        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜BitVec.ult rhat2Un0 q0Dlo1⌝)
+      (base + 64)
+        ((.x1 ↦ᵣ rhat2Un0) ** (.x7 ↦ᵣ q0Dlo1) ** ⌜¬BitVec.ult rhat2Un0 q0Dlo1⌝) := by
+  have hbltu_raw := bltu_spec_gen .x1 .x7 (12 : BitVec 13) rhat2Un0 q0Dlo1 (base + 60)
+  have ha_t : (base + 60) + signExtend13 (12 : BitVec 13) = base + 72 := by rv64_addr
+  have ha_f : (base + 60 : Word) + 4 = base + 64 := by bv_addr
+  rw [ha_t, ha_f] at hbltu_raw
+  exact cpsBranch_extend_code (h := hbltu_raw) (hmono := by
+    exact step2v4_sub 15 (base+60) (.BLTU .x1 .x7 12)
+      (by omega) (by bv_omega) (by decide))
+
+/-- The SRLI+BNE dispatch at the start of Phase E, extended into the step2-v4
+    code requirement and framed with the registers/memory live across it. -/
+private theorem divK_div128_step2_v4_phase_E_guard_spec
+    (sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c : Word) (base : Word) :
+    let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+    let rhat2'Hi := rhat2' >>> (32 : BitVec 6).toNat
+    cpsBranch (base + 84) (divKDiv128Step2V4Code base)
+      ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+       (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2Un0) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ rhat2c))
+      (base + 124)
+        ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi ≠ 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+         (sp + signExtend12 3936 ↦ₘ rhat2c))
+      (base + 92)
+        ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+         (.x11 ↦ᵣ rhat2') ** (.x1 ↦ᵣ rhat2'Hi) **
+         (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ ** ⌜rhat2'Hi = 0⌝ **
+         (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+         (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  intro rhat2cHi rhat2'Hi
+  have hraw := divK_div128_phase2b_guard_spec sp rhat2' rhat2Un0 (base + 84) (36 : BitVec 13)
+  simp only [show (base + 84 : Word) + 4 = base + 88 from by bv_addr,
+             show (base + 84 : Word) + 8 = base + 92 from by bv_addr,
+             show (base + 88 : Word) + signExtend13 (36 : BitVec 13) = base + 124 from by
+               rv64_addr] at hraw
+  have hguard : cpsBranch (base + 84) (divKDiv128Step2V4Code base) _ _ _ _ _ :=
+    cpsBranch_extend_code (h := hraw) (hmono := by
+      exact CodeReq.union_sub
+        (step2v4_sub 21 (base+84) (.SRLI .x1 .x11 32) (by omega) (by bv_omega) (by decide))
+        (step2v4_sub 22 (base+88) (.BNE .x1 .x0 36) (by omega) (by bv_omega) (by decide)))
+  have hframed := cpsBranch_frameR
+    ((.x7 ↦ᵣ q0Dlo1) ** (.x6 ↦ᵣ dHi) ** (.x5 ↦ᵣ q0') **
+     ⌜rhat2cHi = 0⌝ **
+     (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+     (sp + signExtend12 3936 ↦ₘ rhat2c))
+    (by pcFree) hguard
+  exact cpsBranch_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    hframed
+
 /-- Bundled postcondition for `divK_div128_step2_v4_spec`. Hides the
     let-chain for Step 2 v4 trial-division intermediates + Phase 2b
     1st+2nd D3 outcomes.
@@ -133,46 +198,6 @@ def divKDiv128Step2V4Post (sp un21 dHi dlo un0 vScratchOld : Word) : Assertion :
   (sp + signExtend12 3944 ↦ₘ un0) **
   (sp + signExtend12 3936 ↦ₘ mem3936Exit)
 
-/-- Bundled postcondition for Phase 2b 1st D3 with save/restore.
-    Covers instructions [47..60] of divK_div128_v4 (14 instructions). -/
-@[irreducible]
-def divKDiv128Phase2b1stD3V4Post (sp q0c rhat2c dlo un0 dHi : Word) : Assertion :=
-  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
-  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
-  let rhat2c_upd :=
-    if rhat2cHi = 0 then
-      let qDlo := q0c * dlo
-      let rhatUn0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
-      if BitVec.ult rhatUn0 qDlo then rhat2c + dHi else rhat2c
-    else rhat2c
-  -- After 1st D3: x5 = q0', x11 = rhat2c_upd, x7 = q0c * dlo (transient).
-  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2c_upd) ** (.x6 ↦ᵣ dHi) **
-  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
-  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
-  (sp + signExtend12 3936 ↦ₘ rhat2c)
-
-/-- **STUB**: Phase 2b 1st D3 with save/restore — instructions [47..60].
-    The outer BNE guard at [48] (offset 92) jumps to [71] (past step2_v4
-    entirely) when rhat2c >= 2^32. Otherwise runs the 1st D3 mul-check
-    with the save/restore of rhat2c to scratch slot 3936.
-
-    This is NOT a standalone cpsTriple (the outer BNE exits step2_v4);
-    it is a building block for step2_v4_spec's branch structure. -/
-theorem divK_div128_phase2b_1st_d3_v4_spec
-    (sp q0c rhat2c dlo un0 dHi v1Old v7Old vScratch : Word) (base : Word) :
-    cpsTriple base (base + 56) (divKDiv128Step2V4Code base)
-      ((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ rhat2c) ** (.x6 ↦ᵣ dHi) **
-       (.x1 ↦ᵣ v1Old) ** (.x7 ↦ᵣ v7Old) **
-       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
-       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
-       (sp + signExtend12 3936 ↦ₘ vScratch))
-      (divKDiv128Phase2b1stD3V4Post sp q0c rhat2c dlo un0 dHi) := by
-  sorry  -- Covers [47..60] when rhat2c < 2^32 guard doesn't fire globally.
-         -- Actually this is NOT right: the outer BNE jumps out of step2_v4.
-         -- Simplification: treat step2_v4 as a cpsTriple (ignoring the fact
-         -- that BNE branches forward past [71] — which is handled by step2_v4
-         -- itself via the outer branch structure). Keep as sorry for now.
-
 /-- Phase D sub-lemma: BLTU+paths [15..20] of step2_v4, merged post.
     Input = midC (= output of Phase C at base+60).
     Output = midD (post-BLTU merged state at base+84).
@@ -203,6 +228,13 @@ theorem divK_div128_step2_v4_phase_D_merged_spec
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) ** ⌜rhat2cHi = 0⌝ **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  intro rhat2cHi q0Dlo1 rhat2Un0 q0' rhat2'
+  have hbltu := divK_div128_step2_v4_phase_D_bltu_spec rhat2Un0 q0Dlo1 base
+  -- Remaining proof split:
+  -- * taken path: [18..20] ADDI; LD; ADD with `add_spec_gen_rd_eq_rs1`
+  -- * fallthrough path: [16..17] LD; JAL
+  -- Both paths then rewrite `div128Quot_phase2b_q0'` under the carried
+  -- `rhat2cHi = 0` fact and strip the BLTU pure fact.
   sorry
 
 /-- Phase E sub-lemma: 2nd D3 guard+prodcheck [21..30] of step2_v4, merged post.
@@ -234,6 +266,14 @@ theorem divK_div128_step2_v4_phase_E_merged_spec
        (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
        (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
        (sp + signExtend12 3936 ↦ₘ rhat2c)) := by
+  intro rhat2cHi rhat2'Hi q0Dlo2 rhat2'Un0 q0'' x7Exit x1Exit x11Exit
+  have hguard := divK_div128_step2_v4_phase_E_guard_spec
+    sp dHi q0' rhat2' rhat2Un0 q0Dlo1 dlo un0 rhat2c base
+  -- Remaining proof split:
+  -- * guard-taken path: zero-step bridge at base+124, using `rhat2'Hi ≠ 0`
+  -- * guard-fallthrough path: reuse `divK_div128_prodcheck2_merged_spec`
+  --   over [23..30], then bridge its unguarded quotient to `q0''` using
+  --   `rhat2'Hi = 0`.
   sorry
 
 /-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean
@@ -49,7 +49,7 @@ def divKDiv128Step2V4Code (base : Word) : CodeReq :=
   (CodeReq.union (CodeReq.singleton (base + 20)        (.ADDI .x5 .x5 4095))
   (CodeReq.union (CodeReq.singleton (base + 24)        (.ADD .x11 .x11 .x6))
   (CodeReq.union (CodeReq.singleton (base + 28)        (.SRLI .x1 .x11 32))
-  (CodeReq.union (CodeReq.singleton (base + 32)        (.BNE .x1 .x0 96))
+  (CodeReq.union (CodeReq.singleton (base + 32)        (.BNE .x1 .x0 92))
   (CodeReq.union (CodeReq.singleton (base + 36)        (.LD .x1 .x12 3952))
   (CodeReq.union (CodeReq.singleton (base + 40)        (.MUL .x7 .x5 .x1))
   (CodeReq.union (CodeReq.singleton (base + 44)        (.SLLI .x1 .x11 32))
@@ -110,6 +110,46 @@ def divKDiv128Step2V4Post (sp un21 dHi dlo un0 : Word) : Assertion :=
   (sp + signExtend12 3952 ↦ₘ dlo) **
   (sp + signExtend12 3944 ↦ₘ un0) **
   (sp + signExtend12 3936 ↦ₘ savedRhat2c)
+
+/-- Bundled postcondition for Phase 2b 1st D3 with save/restore.
+    Covers instructions [47..60] of divK_div128_v4 (14 instructions). -/
+@[irreducible]
+def divKDiv128Phase2b1stD3V4Post (sp q0c rhat2c dlo un0 dHi : Word) : Assertion :=
+  let rhat2cHi := rhat2c >>> (32 : BitVec 6).toNat
+  let q0' := div128Quot_phase2b_q0' q0c rhat2c dlo un0
+  let rhat2c_upd :=
+    if rhat2cHi = 0 then
+      let qDlo := q0c * dlo
+      let rhatUn0 := (rhat2c <<< (32 : BitVec 6).toNat) ||| un0
+      if BitVec.ult rhatUn0 qDlo then rhat2c + dHi else rhat2c
+    else rhat2c
+  -- After 1st D3: x5 = q0', x11 = rhat2c_upd, x7 = q0c * dlo (transient).
+  (.x5 ↦ᵣ q0') ** (.x11 ↦ᵣ rhat2c_upd) ** (.x6 ↦ᵣ dHi) **
+  (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+  (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+  (sp + signExtend12 3936 ↦ₘ rhat2c)
+
+/-- **STUB**: Phase 2b 1st D3 with save/restore — instructions [47..60].
+    The outer BNE guard at [48] (offset 92) jumps to [71] (past step2_v4
+    entirely) when rhat2c >= 2^32. Otherwise runs the 1st D3 mul-check
+    with the save/restore of rhat2c to scratch slot 3936.
+
+    This is NOT a standalone cpsTriple (the outer BNE exits step2_v4);
+    it is a building block for step2_v4_spec's branch structure. -/
+theorem divK_div128_phase2b_1st_d3_v4_spec
+    (sp q0c rhat2c dlo un0 dHi v1Old v7Old vScratch : Word) (base : Word) :
+    cpsTriple base (base + 56) (divKDiv128Step2V4Code base)
+      ((.x5 ↦ᵣ q0c) ** (.x11 ↦ᵣ rhat2c) ** (.x6 ↦ᵣ dHi) **
+       (.x1 ↦ᵣ v1Old) ** (.x7 ↦ᵣ v7Old) **
+       (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
+       (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0) **
+       (sp + signExtend12 3936 ↦ₘ vScratch))
+      (divKDiv128Phase2b1stD3V4Post sp q0c rhat2c dlo un0 dHi) := by
+  sorry  -- Covers [47..60] when rhat2c < 2^32 guard doesn't fire globally.
+         -- Actually this is NOT right: the outer BNE jumps out of step2_v4.
+         -- Simplification: treat step2_v4 as a cpsTriple (ignoring the fact
+         -- that BNE branches forward past [71] — which is handled by step2_v4
+         -- itself via the outer branch structure). Keep as sorry for now.
 
 /-- **STUB**: full v4 Phase 2 spec — instructions [40..70] of `divK_div128_v4`.
 

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -225,6 +225,123 @@ def divK_div128_v2 : Program :=
   JALR .x0 .x2 0                              -- [60] return
   -- Total: 61 instructions (51 + 10 for 2nd D3 correction)
 
+/-- **FULL Knuth Algorithm D** 128/64-bit unsigned division subroutine.
+    Same as `divK_div128_v2` but ALSO adds Phase 2b 2nd D3 correction.
+    Matches the Lean abstraction `div128Quot_v4` in `LoopDefs/IterV4.lean`.
+
+    With Phase 2b 2-correction, the trial quotient `qHat` equals
+    `q*_full = ⌊(uHi*2^64 + uLo) / vTop⌋` exactly (no per-phase
+    overshoot). Closes `n4CallAddbackBeqSemanticHolds_v4`
+    (proven in PR #1418, Layer 2a fwd/back + c3 sub-stub all closed).
+
+    **Layout** (75 instructions total):
+    - [0..46]: identical to `divK_div128_v2` (setup + Phase 1a + Phase
+      1b 1st+2nd D3 + un21 + q0 init/clamp).
+    - [47..70]: Phase 2b with BOTH 1st AND 2nd D3 corrections (24 inst,
+      vs v2's 10-inst Phase 2b).
+    - [71..74]: combine + restore + return.
+
+    **Register-allocation note**: the existing v2 Phase 2b clobbers
+    `rhat2c` (x11) at [52] when loading un0. For v4's 2nd D3 we need
+    rhat2c again, so we save it to scratch slot 3936 before [52],
+    then restore it after the 1st-correction path completes. This
+    adds ~3 instructions vs the naive 10 for the 2nd D3 alone.
+
+    **Migration**: callers should be updated to use `divK_div128_v4`.
+    See `project_v2_to_v4_migration_plan` in the project memory. -/
+def divK_div128_v4 : Program :=
+  -- Save return addr and d
+  SD .x12 .x2 3968 ;;                         -- [0]  save return addr
+  SD .x12 .x10 3960 ;;                        -- [1]  save d
+  -- Split d: dHi = d >> 32, dLo = (d << 32) >> 32
+  SRLI .x6 .x10 32 ;;                         -- [2]  x6 = dHi (>= 2^31)
+  SLLI .x1 .x10 32 ;; SRLI .x1 .x1 32 ;;     -- [3,4] x1 = dLo
+  SD .x12 .x1 3952 ;;                         -- [5]  save dLo
+  -- Split uLo: un1 = uLo >> 32, un0 = (uLo << 32) >> 32
+  SRLI .x11 .x5 32 ;;                         -- [6]  x11 = un1
+  SLLI .x5 .x5 32 ;; SRLI .x5 .x5 32 ;;      -- [7,8] x5 = un0
+  SD .x12 .x5 3944 ;;                         -- [9]  save un0
+  -- Step 1: q1 = DIVU(uHi, dHi), rhat = uHi - q1*dHi
+  single (.DIVU .x10 .x7 .x6) ;;             -- [10] x10 = q1
+  single (.MUL .x5 .x10 .x6) ;;              -- [11] x5 = q1 * dHi
+  single (.SUB .x7 .x7 .x5) ;;               -- [12] x7 = rhat
+  -- Refine q1: clamp to < 2^32
+  SRLI .x5 .x10 32 ;;                         -- [13] test q1 >= 2^32
+  single (.BEQ .x5 .x0 12) ;;                -- [14] skip if q1 < 2^32 → [17]
+  ADDI .x10 .x10 4095 ;;                      -- [15] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [16] rhat += dHi
+  -- [17] Phase 1b 1st D3 correction
+  LD .x1 .x12 3952 ;;                         -- [17] x1 = dLo
+  single (.MUL .x5 .x10 .x1) ;;              -- [18] x5 = q1 * dLo
+  SLLI .x1 .x7 32 ;;                          -- [19] x1 = rhat << 32
+  single (.OR .x1 .x1 .x11) ;;               -- [20] x1 = rhat*2^32 + un1
+  single (.BLTU .x1 .x5 8) ;;                -- [21] if rhs < lhs → correct [23]
+  JAL .x0 12 ;;                                -- [22] skip → [25]
+  ADDI .x10 .x10 4095 ;;                      -- [23] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [24] rhat += dHi
+  -- [25] Phase 1b 2nd D3 correction
+  SRLI .x1 .x7 32 ;;                          -- [25] x1 = rhat >> 32
+  single (.BNE .x1 .x0 36) ;;                -- [26] if nonzero → skip to [35]
+  LD .x1 .x12 3952 ;;                         -- [27] dLo
+  single (.MUL .x5 .x10 .x1) ;;              -- [28] x5 = q1 * dLo
+  SLLI .x1 .x7 32 ;;                          -- [29] x1 = rhat << 32
+  single (.OR .x1 .x1 .x11) ;;               -- [30] x1 = rhat*2^32 + un1
+  single (.BLTU .x1 .x5 8) ;;                -- [31] if rhs < lhs → correct [33]
+  JAL .x0 12 ;;                                -- [32] skip → [35]
+  ADDI .x10 .x10 4095 ;;                      -- [33] q1--
+  single (.ADD .x7 .x7 .x6) ;;               -- [34] rhat += dHi
+  -- [35] Compute un21 = rhat*2^32 + un1 - q1*dLo
+  LD .x1 .x12 3952 ;;                         -- [35] dLo
+  SLLI .x5 .x7 32 ;;                          -- [36] rhat << 32
+  single (.OR .x5 .x5 .x11) ;;               -- [37] x5 = rhat*2^32 + un1
+  single (.MUL .x1 .x10 .x1) ;;              -- [38] x1 = q1 * dLo
+  single (.SUB .x7 .x5 .x1) ;;               -- [39] x7 = un21
+  -- Step 2: q0 = DIVU(un21, dHi), rhat2 = un21 - q0*dHi
+  single (.DIVU .x5 .x7 .x6) ;;              -- [40] x5 = q0
+  single (.MUL .x1 .x5 .x6) ;;               -- [41]
+  single (.SUB .x11 .x7 .x1) ;;              -- [42] x11 = rhat2
+  -- Refine q0: clamp
+  SRLI .x1 .x5 32 ;;                          -- [43]
+  single (.BEQ .x1 .x0 12) ;;                -- [44] skip if q0 < 2^32 → [47]
+  ADDI .x5 .x5 4095 ;;                        -- [45] q0--
+  single (.ADD .x11 .x11 .x6) ;;             -- [46] rhat2 += dHi
+  -- [47] Phase 2b guard (rhat2c ≥ 2^32 ⟹ skip BOTH 1st and 2nd D3)
+  SRLI .x1 .x11 32 ;;                         -- [47] x1 = rhat2c >> 32
+  single (.BNE .x1 .x0 96) ;;                -- [48] if nonzero → skip to [71] (combine)
+  -- [49] Phase 2b 1st D3 mul-check
+  LD .x1 .x12 3952 ;;                         -- [49] dLo
+  single (.MUL .x7 .x5 .x1) ;;               -- [50] x7 = q0 * dLo
+  SLLI .x1 .x11 32 ;;                         -- [51] rhat2c << 32
+  SD .x12 .x11 3936 ;;                        -- [52] save rhat2c (NEW in v4)
+  LD .x11 .x12 3944 ;;                        -- [53] x11 = un0 (clobbers rhat2c)
+  single (.OR .x1 .x1 .x11) ;;               -- [54] x1 = rhat2c*2^32 + un0
+  single (.BLTU .x1 .x7 12) ;;               -- [55] if BLTU fires → correction [58]
+  -- [56] No-correction path
+  LD .x11 .x12 3936 ;;                        -- [56] restore rhat2c (unchanged)
+  JAL .x0 16 ;;                                -- [57] skip correction → [61] (2nd D3 entry)
+  -- [58] Correction path
+  ADDI .x5 .x5 4095 ;;                        -- [58] q0--
+  LD .x11 .x12 3936 ;;                        -- [59] restore rhat2c
+  single (.ADD .x11 .x11 .x6) ;;             -- [60] rhat2c += dHi
+  -- [61] Phase 2b 2nd D3 guarded mul-check (NEW in v4 vs v2)
+  SRLI .x1 .x11 32 ;;                         -- [61] x1 = rhat2c >> 32 (post-1st-correction)
+  single (.BNE .x1 .x0 36) ;;                -- [62] if nonzero → skip to [71] (combine)
+  LD .x1 .x12 3952 ;;                         -- [63] dLo
+  single (.MUL .x7 .x5 .x1) ;;               -- [64] x7 = q0 * dLo
+  SLLI .x1 .x11 32 ;;                         -- [65] rhat2c << 32
+  LD .x11 .x12 3944 ;;                        -- [66] x11 = un0 (last use of rhat2c, no save needed)
+  single (.OR .x1 .x1 .x11) ;;               -- [67] x1 = rhat2c*2^32 + un0
+  single (.BLTU .x1 .x7 8) ;;                -- [68] if BLTU fires → 2nd correction [70]
+  JAL .x0 8 ;;                                 -- [69] skip → [71]
+  ADDI .x5 .x5 4095 ;;                        -- [70] 2nd correction: q0--
+  -- [71] Combine: q = q1*2^32 + q0
+  SLLI .x11 .x10 32 ;;                        -- [71] q1 << 32
+  single (.OR .x11 .x11 .x5) ;;              -- [72] x11 = q
+  -- Restore and return
+  LD .x2 .x12 3968 ;;                         -- [73] restore return addr
+  JALR .x0 .x2 0                              -- [74] return
+  -- Total: 75 instructions (61 v2 + 14 for Phase 2b 2nd D3 + save/restore)
+
 -- ============================================================================
 -- Main division program phases
 -- ============================================================================

--- a/EvmAsm/Evm64/DivMod/Program.lean
+++ b/EvmAsm/Evm64/DivMod/Program.lean
@@ -307,7 +307,7 @@ def divK_div128_v4 : Program :=
   single (.ADD .x11 .x11 .x6) ;;             -- [46] rhat2 += dHi
   -- [47] Phase 2b guard (rhat2c ≥ 2^32 ⟹ skip BOTH 1st and 2nd D3)
   SRLI .x1 .x11 32 ;;                         -- [47] x1 = rhat2c >> 32
-  single (.BNE .x1 .x0 96) ;;                -- [48] if nonzero → skip to [71] (combine)
+  single (.BNE .x1 .x0 92) ;;                -- [48] if nonzero → skip to [71] (combine)
   -- [49] Phase 2b 1st D3 mul-check
   LD .x1 .x12 3952 ;;                         -- [49] dLo
   single (.MUL .x7 .x5 .x1) ;;               -- [50] x7 = q0 * dLo

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -14,7 +14,9 @@
 # DivMod V4 work-in-progress cluster (issue #1337). These files are
 # under active development and not yet wired into the main module
 # graph. Remove once the V4 program replaces V2.
+EvmAsm.Evm64.DivMod.Compose.Div128V4
 EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4Invariants
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4InvariantsPhase2

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -11,13 +11,10 @@
 # additions should include a comment explaining why the file cannot be
 # imported yet — silent additions defeat the purpose of the check.
 
-# DivMod V4 work-in-progress cluster (issue #1337). These files are
-# under active development and not yet wired into the main module
-# graph. Remove once the V4 program replaces V2.
-EvmAsm.Evm64.DivMod.Compose.Div128V4
+# DivMod V4 work-in-progress cluster (issue #1337). These files are under
+# active development. Remove entries as each file is wired into the main module
+# graph.
 EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
-EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
-EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4Invariants
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4InvariantsPhase2
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -15,9 +15,11 @@
 # under active development and not yet wired into the main module
 # graph. Remove once the V4 program replaces V2.
 EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+EvmAsm.Evm64.DivMod.Compose.Div128V4
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4Invariants
 EvmAsm.Evm64.DivMod.LoopDefs.IterV4InvariantsPhase2
+EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.AlgDefs
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.AlgEuclideans


### PR DESCRIPTION
## Summary

This PR advances the `div128_v4` work for #1337 and now closes the Step2 v4 proof path without sorries.

- Adds the `divK_div128_v4` program shape and shared v4 code requirements.
- Adds the Step2 v4 limb spec infrastructure for the second D3 correction path.
- Splits the proof into maintainable Phase D / Phase E helper lemmas.
- Proves the Phase D branch merge, Phase E branch merge, and final Step2 v4 bridge.
- Leaves `Div128Step2v4.lean` and `Compose/Div128V4.lean` sorry-free.

## Proof Notes

- Phase D is split into BLTU guard, taken body, fallthrough body, branch-post assertions, and pure-fact stripping helpers.
- Phase E preserves the carried `rhat2cHi = 0` pure fact through the merged post so the final bridge can reduce the outer exit-register selectors before stripping it.
- The final `divK_div128_step2_v4_spec` bridge now composes Phase C, Phase D, and Phase E into the bundled v4 postcondition.

## Test Plan

- [x] `lake build EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2v4`
- [x] `lake build`
- [x] `rg -n "sorry|admit|axiom" EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2v4.lean EvmAsm/Evm64/DivMod/Compose/Div128V4.lean` returns no matches

## Notes

Codex note: the latest proof cleanup commits in this PR were implemented with assistance from Codex.
