### PR TITLE
ci: add never-imported lean file check (closes #1209)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: File-size guardrail
         run: scripts/check-file-size.sh
+      - name: Unimported-file check
+        run: scripts/check-unimported.sh
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,8 @@ When adding or modifying proofs:
 
    If your new file declares an attribute via `register_simp_attr`, place the attribute-declaration file **before** any consumer file in the umbrella's import list so the attribute exists when the consumer is elaborated. Typical pattern: split into `FooAttr.lean` (declares the attribute) + `Foo.lean` (uses the attribute, imports `FooAttr`), then import both from the umbrella, attr first. See `Rv64/RegOpsAttr.lean` + `Rv64/RegOps.lean` or `Evm64/DivMod/AddrNormAttr.lean` + `Evm64/DivMod/AddrNorm.lean` for the canonical shape.
 
+   CI enforces this via `scripts/check-unimported.sh` (issue #1209): a `.lean` file under `EvmAsm/` that is not transitively reachable from `EvmAsm.lean` will fail the build unless it is grandfathered in `scripts/unimported-allow.txt`.
+
 ## Testing
 
 All concrete examples should pass with no sorries:

--- a/scripts/check-unimported.sh
+++ b/scripts/check-unimported.sh
@@ -1,0 +1,219 @@
+#!/usr/bin/env bash
+#
+# check-unimported.sh — fail when a committed .lean file under EvmAsm/ is
+# not transitively imported from the umbrella module EvmAsm.lean.
+#
+# Why this matters: lake will happily compile every reachable .lean file
+# in the library directory, so an orphan file *appears* to build fine.
+# But downstream consumers cannot `import` declarations that aren't
+# wired into the module graph from the root, so these files quietly rot
+# (see AGENTS.md §"New `.lean` files must be imported by the umbrella
+# module"). Tracked in issue #1209.
+#
+# Usage:
+#   scripts/check-unimported.sh           # exit 1 on any new orphan
+#   scripts/check-unimported.sh --report  # always exit 0; print full list
+#
+# A grandfathered allow-list lives at scripts/unimported-allow.txt —
+# one fully-qualified module name per line, '#' comments allowed.
+# Trim that file as orphans are absorbed or deleted.
+#
+# POSIX/bash, no external deps beyond find/awk/sort/comm.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROOT_MOD="EvmAsm"
+LIB_DIR="EvmAsm"
+ROOT_FILE="EvmAsm.lean"
+ALLOW_FILE="$ROOT/scripts/unimported-allow.txt"
+
+mode="enforce"
+if [[ ${1:-} == "--report" ]]; then
+  mode="report"
+fi
+
+cd "$ROOT"
+
+# Collect all module names from .lean files under EvmAsm/, plus the root.
+mapfile -t all_modules < <(
+  {
+    echo "$ROOT_MOD"
+    find "$LIB_DIR" -name '*.lean' -type f \
+      | sed -e 's|\.lean$||' -e 's|/|.|g'
+  } | LC_ALL=C sort -u
+)
+
+# Map module -> file path.
+mod_to_file() {
+  local m="$1"
+  if [[ "$m" == "$ROOT_MOD" ]]; then
+    echo "$ROOT_FILE"
+  else
+    echo "${m//./\/}.lean"
+  fi
+}
+
+# Extract direct EvmAsm.* imports from a file.
+direct_imports() {
+  local f="$1"
+  awk '
+    /^[[:space:]]*import[[:space:]]+EvmAsm(\.[A-Za-z0-9_]+)*[[:space:]]*$/ {
+      sub(/^[[:space:]]*import[[:space:]]+/, "")
+      sub(/[[:space:]]+$/, "")
+      print
+    }
+  ' "$f"
+}
+
+# BFS from $ROOT_MOD using only edges into modules that exist on disk.
+declare -A exists
+for m in "${all_modules[@]}"; do
+  exists["$m"]=1
+done
+
+declare -A visited
+queue=("$ROOT_MOD")
+while ((${#queue[@]})); do
+  cur="${queue[0]}"
+  queue=("${queue[@]:1}")
+  if [[ -n "${visited[$cur]:-}" ]]; then
+    continue
+  fi
+  visited["$cur"]=1
+  f="$(mod_to_file "$cur")"
+  if [[ ! -f "$f" ]]; then
+    continue
+  fi
+  while IFS= read -r dep; do
+    [[ -z "$dep" ]] && continue
+    if [[ -n "${exists[$dep]:-}" && -z "${visited[$dep]:-}" ]]; then
+      queue+=("$dep")
+    fi
+  done < <(direct_imports "$f")
+done
+
+# Compute unreached = all_modules \ visited (excluding root).
+unreached=()
+for m in "${all_modules[@]}"; do
+  [[ "$m" == "$ROOT_MOD" ]] && continue
+  if [[ -z "${visited[$m]:-}" ]]; then
+    unreached+=("$m")
+  fi
+done
+
+# Load allow-list.
+declare -A allowed
+if [[ -f "$ALLOW_FILE" ]]; then
+  while IFS= read -r line; do
+    line="${line%%#*}"
+    line="${line//[[:space:]]/}"
+    [[ -z "$line" ]] && continue
+    allowed["$line"]=1
+  done < "$ALLOW_FILE"
+fi
+
+# Partition unreached into known (allowed) and new (not allowed).
+new_orphans=()
+known_orphans=()
+for m in "${unreached[@]}"; do
+  if [[ -n "${allowed[$m]:-}" ]]; then
+    known_orphans+=("$m")
+  else
+    new_orphans+=("$m")
+  fi
+done
+
+# Detect stale allow-list entries (allowed but no longer orphaned, or file gone).
+stale_allow=()
+for m in "${!allowed[@]}"; do
+  if [[ -z "${exists[$m]:-}" ]]; then
+    stale_allow+=("$m  (file no longer exists)")
+  elif [[ -n "${visited[$m]:-}" ]]; then
+    stale_allow+=("$m  (now reachable)")
+  fi
+done
+
+if [[ "$mode" == "report" ]]; then
+  printf 'Total .lean modules: %d\n' "${#all_modules[@]}"
+  printf 'Reachable from %s: %d\n' "$ROOT_MOD" "${#visited[@]}"
+  printf 'Unreached: %d (%d allow-listed, %d new)\n' \
+    "${#unreached[@]}" "${#known_orphans[@]}" "${#new_orphans[@]}"
+  if ((${#new_orphans[@]})); then
+    printf '\nNEW orphans (not in allow-list):\n'
+    printf '  %s\n' "${new_orphans[@]}"
+  fi
+  if ((${#known_orphans[@]})); then
+    printf '\nGrandfathered orphans:\n'
+    printf '  %s\n' "${known_orphans[@]}"
+  fi
+  if ((${#stale_allow[@]})); then
+    printf '\nStale allow-list entries:\n'
+    printf '  %s\n' "${stale_allow[@]}"
+  fi
+  exit 0
+fi
+
+failed=0
+
+if ((${#new_orphans[@]})); then
+  cat >&2 <<EOF
+
+==================================================================
+Unimported-file check failed: ${#new_orphans[@]} new orphan(s).
+
+The following .lean file(s) exist under $LIB_DIR/ but are NOT
+transitively imported from $ROOT_FILE:
+
+EOF
+  printf '  %s\n' "${new_orphans[@]}" >&2
+  cat >&2 <<EOF
+
+Lake will still compile them because they live under the library
+directory, but downstream files cannot \`import\` them and they
+silently rot when the API around them changes.
+
+To fix, do ONE of:
+
+  1. Add an \`import <module>\` line to the appropriate umbrella
+     (EvmAsm/Rv64.lean, EvmAsm/Evm64.lean, EvmAsm/EL.lean, or a
+     deeper umbrella). See AGENTS.md §"New \`.lean\` files must be
+     imported by the umbrella module" for placement rules.
+
+  2. Delete the file if it is genuinely abandoned.
+
+  3. (Last resort, with reviewer sign-off) add the module name to
+     scripts/unimported-allow.txt with a \`#\` comment explaining
+     why it cannot yet be wired up. Trim the entry as soon as the
+     file is absorbed or removed.
+
+Tracked: issue #1209.
+==================================================================
+EOF
+  failed=1
+fi
+
+if ((${#stale_allow[@]})); then
+  cat >&2 <<EOF
+
+==================================================================
+Stale allow-list entries in scripts/unimported-allow.txt:
+
+EOF
+  printf '  %s\n' "${stale_allow[@]}" >&2
+  cat >&2 <<EOF
+
+Please remove these lines — the listed modules are no longer
+unimported orphans (either they were wired up, or the file was
+deleted).
+==================================================================
+EOF
+  failed=1
+fi
+
+if (( failed )); then
+  exit 1
+fi
+
+printf 'unimported-file check: %d modules, %d reachable, %d grandfathered orphan(s).\n' \
+  "${#all_modules[@]}" "${#visited[@]}" "${#known_orphans[@]}"

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -1,0 +1,33 @@
+# scripts/unimported-allow.txt
+#
+# Modules that exist as .lean files under EvmAsm/ but are intentionally
+# not transitively imported from EvmAsm.lean yet. Used by
+# scripts/check-unimported.sh (issue #1209) to grandfather pre-existing
+# orphans without blocking CI.
+#
+# Format: one fully-qualified module name per line. '#' starts a comment.
+#
+# Trim entries as files get wired into umbrellas or deleted. New
+# additions should include a comment explaining why the file cannot be
+# imported yet — silent additions defeat the purpose of the check.
+
+# DivMod V4 work-in-progress cluster (issue #1337). These files are
+# under active development and not yet wired into the main module
+# graph. Remove once the V4 program replaces V2.
+EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
+EvmAsm.Evm64.DivMod.LoopDefs.IterV4
+EvmAsm.Evm64.DivMod.LoopDefs.IterV4Invariants
+EvmAsm.Evm64.DivMod.LoopDefs.IterV4InvariantsPhase2
+EvmAsm.Evm64.DivMod.SpecCallAddbackBeq
+EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.AlgDefs
+EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.AlgEuclideans
+EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTests
+EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTestsV4
+EvmAsm.Evm64.DivMod.SpecCallV4
+
+# EvmWordArith cluster — pure-arithmetic helpers used by DivMod V4.
+# Pending integration into Evm64.lean once V4 lands.
+EvmAsm.Evm64.EvmWordArith
+EvmAsm.Evm64.EvmWordArith.AddbackPinning
+EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge
+EvmAsm.Evm64.EvmWordArith.Div128PhaseNoWrap


### PR DESCRIPTION
## Summary

Adds `scripts/check-unimported.sh`, wired into `.github/workflows/build.yml`, that fails CI when a `.lean` file under `EvmAsm/` is committed but not transitively imported from the root umbrella module `EvmAsm.lean`. Closes #1209.

Lake compiles every `.lean` file under the library directory regardless of whether anyone imports it, so orphan files appear to build fine but their declarations are invisible to downstream proofs and silently rot when the surrounding API changes. AGENTS.md already documented the hand rule (\"New \`.lean\` files must be imported by the umbrella module\"); this PR makes CI enforce it.

## Mechanics

- Script does a textual BFS from \`EvmAsm.lean\` over \`import EvmAsm.*\` edges. POSIX/bash, no external deps (find/awk/sort).
- Stale pre-existing orphans are grandfathered via a one-time allow-list at \`scripts/unimported-allow.txt\` (14 modules, all part of the in-flight DivMod V4 / EvmWordArith work — issue #1337).
- The check **also** flags **stale allow-list entries** (file deleted, or the module is now reachable) so the list trims itself as work lands.
- \`scripts/check-unimported.sh --report\` prints a non-failing summary for local diagnosis.

## Local verification

- \`scripts/check-unimported.sh\` → exits 0, reports \`331 modules, 317 reachable, 14 grandfathered orphan(s)\`.
- Synthetic new orphan → script exits 1 with the helpful error.
- Synthetic stale allow-list entry → script exits 1 with the stale-entry message.

## Notes

Draft because I'd like a sanity check on (a) the choice to grandfather rather than wire up the 14 existing orphans now, and (b) the AGENTS.md wording. The DivMod V4 cluster looks intentionally not-yet-wired, so absorbing it should be a separate PR by whoever owns that work.

---
Authored by @pirapira; implemented by Hermes-bot (\`evm-hermes\`).