### PR TITLE
ci: skip cache save on pull_request runs (#1441)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,31 @@ jobs:
         run: scripts/check-file-size.sh
       - name: Unimported-file check
         run: scripts/check-unimported.sh
+      # Restore the lake build cache. The key matches lean-action@v1's scheme
+      # so we keep compatibility with caches it has already saved on main.
+      - name: Restore lake cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true
+          # We manage the GitHub Actions cache ourselves (steps above + below)
+          # so that PR runs only RESTORE while push/merge_group runs SAVE. The
+          # lean-action default saves on every event, which combined with the
+          # 10 GB per-repo cache quota and ~2.3 GB cache size was evicting the
+          # main cache within ~24 h. See #1441.
+          use-github-cache: false
           lake-package-directory: .
+
+      # Only push to main / merge_group / workflow_dispatch save the cache, so
+      # PR runs cannot churn the quota and evict the main-branch cache.
+      - name: Save lake cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}


### PR DESCRIPTION
## Summary

Splits the lean-action GitHub-cache step into an explicit \`actions/cache/restore\` (always) + \`actions/cache/save\` (only when \`github.event_name != 'pull_request'\`). PR runs still **restore** the latest main-branch cache, but they no longer **save** their own.

Closes #1441 (recommended fix #1).

## Why

Each lean-action cache is ~2.3 GB and the per-repo cache quota is 10 GB with LRU eviction. Allowing every PR run to save its own cache was evicting the main-branch cache within ~24 h, leaving subsequent PR builds to cold-compile all 317 EvmAsm modules (~15 min \`lake build\`).

Concrete data from PR #1439's first build (run \`25156366335\`):
\`\`\`
Cache not found for input keys:
  lake-Linux-X64-<toolchain>-<manifest>-<sha>     ← exact, miss
  lake-Linux-X64-<toolchain>-<manifest>           ← restore-keys prefix, miss
\`\`\`
\`Replayed: 0\`, \`Built: 317\`, lake-build wall-clock 15m01s.

Meanwhile \`gh api .../actions/cache/usage\` showed **9.7 GB / 10 GB** with 3 active 2.3 GB lake caches, all owned by \`refs/pull/*/merge\`. The most recent main-branch cache (commit \`39726805\`, saved 2026-04-29) had already been evicted before this run.

## Mechanics

The \`actions/cache/restore\` step uses the **same key/restore-key scheme as lean-action@v1** (\`lake-<os>-<arch>-<toolchain-hash>-<manifest-hash>-<sha>\` with prefix-fallback), so any existing main-branch cache lean-action saved is still picked up. \`use-github-cache: false\` is passed to lean-action so it doesn't double-restore or double-save. The \`Save lake cache\` step is gated on \`github.event_name != 'pull_request'\`, which covers \`push\` to main, \`merge_group\`, and \`workflow_dispatch\`.

## Verification plan

This PR's own build will be a cold compile (no usable cache exists right now — main cache evicted). What we want to see in subsequent builds:

1. Once this lands on main, the \`push: main\` run for the merge commit saves a fresh main cache.
2. The next PR opened against main shows \`Cache restored from key: lake-Linux-X64-<toolchain-hash>-<manifest-hash>\` (the restore-key prefix) in the \`Restore lake cache\` step, and \`lake build\` reports many \`Replayed\` lines. Build time should drop to <5 min when the diff is small.
3. \`gh api repos/Verified-zkEVM/evm-asm/actions/cache/usage\` should stabilize around the size of one main cache (~2.3 GB) plus whatever other caches exist (Python setup, Mathlib azure cache lives elsewhere).

## Notes

- Conflicts with #1439 (which also touches \`build.yml\` to add the unimported-file check step). Whichever lands second will need a trivial rebase — the two changes are independent.
- Backup options listed in #1441 (narrowing the cached path, excluding mathlib oleans, manual eviction) remain available if this isn't enough on its own.

---
Authored by @pirapira; implemented by Hermes-bot (\`evm-hermes\`).