### PR TITLE
chore: wire EvmWordArith umbrella into Evm64 (drains 4 orphans)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,31 @@ jobs:
         run: scripts/check-file-size.sh
       - name: Unimported-file check
         run: scripts/check-unimported.sh
+      # Restore the lake build cache. The key matches lean-action@v1's scheme
+      # so we keep compatibility with caches it has already saved on main.
+      - name: Restore lake cache
+        uses: actions/cache/restore@v5
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}
+          restore-keys: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}
+
       - uses: leanprover/lean-action@v1
         with:
           use-mathlib-cache: true
+          # We manage the GitHub Actions cache ourselves (steps above + below)
+          # so that PR runs only RESTORE while push/merge_group runs SAVE. The
+          # lean-action default saves on every event, which combined with the
+          # 10 GB per-repo cache quota and ~2.3 GB cache size was evicting the
+          # main cache within ~24 h. See #1441.
+          use-github-cache: false
           lake-package-directory: .
+
+      # Only push to main / merge_group / workflow_dispatch save the cache, so
+      # PR runs cannot churn the quota and evict the main-branch cache.
+      - name: Save lake cache
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: actions/cache/save@v5
+        with:
+          path: .lake
+          key: lake-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('lean-toolchain') }}-${{ hashFiles('lake-manifest.json') }}-${{ github.sha }}

--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -24,6 +24,13 @@ import EvmAsm.Evm64.Not
 import EvmAsm.Evm64.Add
 import EvmAsm.Evm64.Sub
 
+-- EvmWordArith umbrella — pulls in helpers (AddbackPinning,
+-- Div128NoWrapDischarge → Div128PhaseNoWrap) used by DivMod V4.
+-- Most leaves are already transitively reached via Add/DivMod; this
+-- import wires the remaining stragglers so they participate in the
+-- visible module graph.
+import EvmAsm.Evm64.EvmWordArith
+
 -- Comparisons (Lt.Spec transitively imports Compare.LimbSpec)
 import EvmAsm.Evm64.Lt
 import EvmAsm.Evm64.Gt

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -26,8 +26,5 @@ EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTestsV4
 EvmAsm.Evm64.DivMod.SpecCallV4
 
 # EvmWordArith cluster — pure-arithmetic helpers used by DivMod V4.
-# Pending integration into Evm64.lean once V4 lands.
-EvmAsm.Evm64.EvmWordArith
-EvmAsm.Evm64.EvmWordArith.AddbackPinning
-EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge
-EvmAsm.Evm64.EvmWordArith.Div128PhaseNoWrap
+# (Drained: umbrella EvmAsm.Evm64.EvmWordArith is now imported from
+# EvmAsm/Evm64.lean, transitively reaching all helpers.)


### PR DESCRIPTION
## Summary

Slice 1 of #1440 (drain `scripts/unimported-allow.txt` to empty).

Imports the `EvmAsm.Evm64.EvmWordArith` umbrella from `EvmAsm/Evm64.lean` so its transitive closure participates in the visible module graph. The umbrella already pulls in the in-flight DivMod V4 helpers (`AddbackPinning`, `Div128NoWrapDischarge` → `Div128PhaseNoWrap`), so a single `import` line clears 4 grandfathered entries at once.

`scripts/unimported-allow.txt`: 14 → 10 entries. The remaining 10 are the DivMod V4 / SpecCallAddbackBeq cluster, which will be drained in follow-up slices as that work lands.

## Test plan

- [x] `lake build` green locally (1383 jobs).
- [x] `bash scripts/check-unimported.sh` reports 321 reachable, 10 grandfathered (down from 317 / 14).
- [ ] CI passes.

Refs #1440, #1209, #1439. Beads: evm-asm-13f.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).