### PR TITLE
chore: wire EvmWordArith umbrella into Evm64 (drains 4 orphans)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -24,6 +24,13 @@ import EvmAsm.Evm64.Not
 import EvmAsm.Evm64.Add
 import EvmAsm.Evm64.Sub
 
+-- EvmWordArith umbrella — pulls in helpers (AddbackPinning,
+-- Div128NoWrapDischarge → Div128PhaseNoWrap) used by DivMod V4.
+-- Most leaves are already transitively reached via Add/DivMod; this
+-- import wires the remaining stragglers so they participate in the
+-- visible module graph.
+import EvmAsm.Evm64.EvmWordArith
+
 -- Comparisons (Lt.Spec transitively imports Compare.LimbSpec)
 import EvmAsm.Evm64.Lt
 import EvmAsm.Evm64.Gt

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -26,8 +26,5 @@ EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTestsV4
 EvmAsm.Evm64.DivMod.SpecCallV4
 
 # EvmWordArith cluster — pure-arithmetic helpers used by DivMod V4.
-# Pending integration into Evm64.lean once V4 lands.
-EvmAsm.Evm64.EvmWordArith
-EvmAsm.Evm64.EvmWordArith.AddbackPinning
-EvmAsm.Evm64.EvmWordArith.Div128NoWrapDischarge
-EvmAsm.Evm64.EvmWordArith.Div128PhaseNoWrap
+# (Drained: umbrella EvmAsm.Evm64.EvmWordArith is now imported from
+# EvmAsm/Evm64.lean, transitively reaching all helpers.)


### PR DESCRIPTION
## Summary

Wires the four-file \`EvmWordArith\` cluster into the umbrella graph so it builds via the normal \`EvmAsm.lean → Evm64.lean → ...\` chain. Drains 4 of 14 entries from \`scripts/unimported-allow.txt\` — slice 1 of #1440.

\`EvmWordArith.lean\` already had the right internal imports; only the umbrella wiring was missing.

## Changes

- \`EvmAsm/Evm64.lean\` — \`import EvmAsm.Evm64.EvmWordArith\`
- \`scripts/unimported-allow.txt\` — drop the 4 EvmWordArith entries (cluster comment removed; DivMod V4 cluster left intact)

## Verification

- \`scripts/check-unimported.sh\` — passes (\`331 modules, 321 reachable, 10 grandfathered\`).
- \`lake build\` — clean local build, 1383 jobs.

## Notes

This replaces an earlier PR #1443 that accidentally included #1442's commit because the autonomous worker started its branch from whatever HEAD happened to be. Cron prompt + memory updated to require \`git checkout -b <branch> origin/main\` for every new feature branch.

---
Authored by @pirapira; implemented by Hermes-bot (\`evm-hermes\`).