### PR TITLE
chore: remove unused simp args in Div128ProdCheck1b

### DIFF
--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128ProdCheck1b.lean
@@ -266,9 +266,9 @@ theorem divK_div128_prodcheck1b_merged_spec
       rw [hcr_eq]; intro a i
       simp only [CodeReq.union_singleton_apply, CodeReq.singleton]; intro h
       split at h
-      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+      · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all
       · split at h
-        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left, CodeReq.beq_base_offset]
+        · next hab => rw [beq_iff_eq] at hab; subst hab; simp_all [CodeReq.beq_offset_self_left]
         · simp at h)
   -- Frame guard with the unchanged-through-guard atoms
   have h1f := cpsBranch_frameR


### PR DESCRIPTION
Drops two `CodeReq.beq_*` simp arguments at lines 269/271 that `linter.unusedSimpArgs` flagged. Deeper case-splits (lines 299+) still need both lemmas; only the first two shallow branches were over-stocked.

After this change, `lake build 2>&1 | grep -E '^warning:' | grep -vF LeanRV64D` returns no matches (the remaining upstream LeanRV64D warning is out of scope).

Refs: beads evm-asm-4bv

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).