### PR TITLE
chore(import): #1045 drop unused DivN4Lemmas import from CLZLemmas

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -34,6 +34,7 @@ import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble
 
 -- Standalone leaves:
+import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 import EvmAsm.Evm64.EvmWordArith.SkipBorrowExtract
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.AddbackBorrowExtract

--- a/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CLZLemmas.lean
@@ -15,7 +15,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.CLZ
-import EvmAsm.Evm64.EvmWordArith.DivN4Lemmas
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Per `lake exe shake`, `EvmAsm.Evm64.EvmWordArith.CLZLemmas` does not use anything from `EvmAsm.Evm64.EvmWordArith.DivN4Lemmas`. Drop the unused import.

`lake build` is green locally.

Refs #1045 (beads evm-asm-6qj).

## Note on shake reliability

Tested ~10 other shake suggestions during this slice; almost all were false positives (shake doesn't track attribute-driven simp lemmas, `open` namespaces, or transitive type-class instance imports — common patterns in this repo). Most of the remaining ~660 lines of suggestions need manual case-by-case verification rather than a bulk apply. This PR ships the one slice that built cleanly.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).