### PR TITLE
chore(imports): narrow comparison Program.lean imports per shake

### DIFF
--- a/EvmAsm/Evm64/Eq/Program.lean
+++ b/EvmAsm/Evm64/Eq/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM EQ program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -8,6 +8,7 @@
 -- `Eq.LimbSpec → Eq.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Eq.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Eq
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Gt/Program.lean
+++ b/EvmAsm/Evm64/Gt/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM GT program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/IsZero/Program.lean
+++ b/EvmAsm/Evm64/IsZero/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM ISZERO program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -7,6 +7,7 @@
 
 import EvmAsm.Evm64.IsZero.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.IsZero
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Lt/Program.lean
+++ b/EvmAsm/Evm64/Lt/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM LT program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sgt/Program.lean
+++ b/EvmAsm/Evm64/Sgt/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM SGT program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Replaces `import EvmAsm.Evm64.Stack` with the narrower `import EvmAsm.Rv64.Program` in the comparison opcode program files (`Lt`, `Gt`, `Eq`, `IsZero`, `Sgt`) per `lake exe shake` guidance. These `Program.lean` files only need the `Program` type, not the full Stack assertion library.

`Eq.Spec` and `IsZero.Spec` previously relied on the transitive `Evm64.Stack` import through their `Program.lean` siblings; this PR adds explicit `import EvmAsm.Evm64.Stack` in those two files to compensate.

**Build**: 1387 jobs pass clean.

Refs evm-asm-6qj, evm-asm-10l, #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).