### PR TITLE
fix(divmod): bound n3 loop unified spec

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -11,4 +11,5 @@ import EvmAsm.Evm64.DivMod.Spec
 -- FullPathN2LoopUnified + FullPathN2Cases + FullPath.
 import EvmAsm.Evm64.DivMod.Shift0Dispatcher
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -95,7 +95,7 @@ private theorem evm_div_n3_loop_unified_inst
     (hbltu_0 : bltu_0 = BitVec.ult
       (iterN3 bltu_1 b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word)).2.2.2.1 b2')
     (hcarry2 : Carry2NzAll b0' b1' b2' b3') :
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (divCode base)
+    cpsTripleWithin 404 (base + loopBodyOff) (base + denormOff) (divCode base)
       (loopN3PreWithScratch sp jMem (3 : Word) shift u0 v10Old v11Old antiShift
         b0' b1' b2' b3' u1 u2 u3 u4 (0 : Word) u0 (0 : Word) (0 : Word)
         retMem dMem dloMem scratch_un0)
@@ -130,7 +130,7 @@ theorem evm_div_n3_preloop_loop_unified_spec (bltu_1 bltu_0 : Bool) (sp base : W
       ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
       ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))) :
-    cpsTripleWithin 10000 base (base + denormOff) (divCode base)
+    cpsTripleWithin 507 base (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b2).2 >>> (63 : Nat)) **
        (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **

--- a/scripts/unimported-allow.txt
+++ b/scripts/unimported-allow.txt
@@ -14,7 +14,6 @@
 # DivMod V4 work-in-progress cluster (issue #1337). These files are under
 # active development. Remove entries as each file is wired into the main module
 # graph.
-EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTests
 EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTestsV4


### PR DESCRIPTION
## Summary
- replace the remaining FullPathN3LoopUnified placeholder nSteps with exact bounds 404 and 507
- import FullPathN3LoopUnified through DivMod.lean so it is no longer grandfathered in scripts/unimported-allow.txt

## Verification
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
- lake build EvmAsm.Evm64.DivMod
- scripts/check-unimported.sh
- scripts/check-file-size.sh
- lake build
- scripts/check-no-warnings.sh /tmp/evm-asm-build.log

Bead: evm-asm-y5j

Note: while working PR3 for issue 61, I found that unconditional limb dispatch is still blocked by missing bounded N1-N3 full-path coverage. Tracked separately as evm-asm-4su.