### PR TITLE
fix(divmod): drop dead ValidMemRange hypotheses (#338 slice 4)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Beq.lean
@@ -170,14 +170,17 @@ def isAddbackCarry2NzN4MaxAb (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 
     After #720 dropped the unused \`hv_*\` params from the inner
     \`divK_loop_body_n4_max_addback_j0_beq_norm\`, the 18 corresponding
-    validity hypotheses here also became unused and are removed. -/
+    validity hypotheses here also became unused and are removed.
+
+    GH #338: the outer \`hvalid : ValidMemRange sp 8\` and the four
+    derived \`have hv_v0..hv_v3\` are also dead — the inner spec no
+    longer consumes them. Removed. -/
 theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
@@ -214,10 +217,6 @@ theorem evm_div_n4_preloop_max_addback_beq_spec (sp base : Word)
   let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
-  have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
-  have hv_v2 : isValidDwordAccess (sp + 48) = true := hvalid 6 (by omega)
-  have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
@@ -329,13 +328,16 @@ def isAddbackCarry2NzN4CallAb_v2 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
 
     After #720 dropped the unused \`hv_*\` params from the inner
     \`divK_loop_body_n4_call_addback_j0_beq_norm\`, the 22 corresponding
-    validity hypotheses here also became unused and are removed. -/
+    validity hypotheses here also became unused and are removed.
+
+    GH #338: the outer \`hvalid : ValidMemRange sp 8\` and the four
+    derived \`have hv_v0..hv_v3\` are also dead — removed. -/
 theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
     (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
     (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
@@ -371,10 +373,6 @@ theorem evm_div_n4_preloop_call_addback_beq_spec (sp base : Word)
   let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
   let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
   let u0 := a0 <<< (shift.toNat % 64)
-  have hv_v0 : isValidDwordAccess (sp + 32) = true := hvalid 4 (by omega)
-  have hv_v1 : isValidDwordAccess (sp + 40) = true := hvalid 5 (by omega)
-  have hv_v2 : isValidDwordAccess (sp + 48) = true := hvalid 6 (by omega)
-  have hv_v3 : isValidDwordAccess (sp + 56) = true := hvalid 7 (by omega)
   have hPre := evm_div_n4_to_loopSetup_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem
@@ -559,7 +557,6 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0)
     (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (hbltu : isMaxTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAb a0 a1 a2 a3 b0 b1 b2 b3)
     (hborrow : isAddbackBorrowN4Max a0 a1 a2 a3 b0 b1 b2 b3) :
@@ -609,7 +606,7 @@ theorem evm_div_n4_full_max_addback_beq_spec (sp base : Word)
   have hA := evm_div_n4_preloop_max_addback_beq_spec sp base
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
-    hbnz hb3nz hshift_nz hvalid
+    hbnz hb3nz hshift_nz
     hbltu hcarry2_nz hborrow
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
     un0Out un1Out un2Out un3Out shift
@@ -750,7 +747,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
     (retMem dMem dloMem scratch_un0 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0) (hvalid : ValidMemRange sp 8)
+    (hshift_nz : (clzResult b3).1 ≠ 0)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4 a3 b2 b3)
     (hcarry2_nz : isAddbackCarry2NzN4CallAb a0 a1 a2 a3 b0 b1 b2 b3)
@@ -804,7 +801,7 @@ theorem evm_div_n4_full_call_addback_beq_spec (sp base : Word)
     a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
     retMem dMem dloMem scratch_un0
-    hbnz hb3nz hshift_nz hvalid
+    hbnz hb3nz hshift_nz
     halign hbltu hcarry2_nz hborrow
   have hB := evm_div_preamble_denorm_epilogue_spec sp base
     un0Out un1Out un2Out un3Out shift

--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -822,10 +822,8 @@ theorem evm_div_n4_full_max_skip_stack_pre_spec_bundled (sp base : Word)
 
 /-- EvmWord-level wrapper over `evm_div_n4_full_max_addback_beq_spec`: same
     shape as `evm_div_n4_full_max_skip_stack_pre_spec` but for the
-    max+addback BEQ sub-path (double-addback included). The extra
-    `hvalid : ValidMemRange sp 8` hypothesis is threaded through, along
-    with all 20 individual `hv_*` access hypotheses and `hbltu`,
-    `hcarry2_nz`, `hborrow`. The postcondition is the concrete
+    max+addback BEQ sub-path (double-addback included).
+    The postcondition is the concrete
     `fullDivN4MaxAddbackBeqPost` — turning that into a stack post
     requires the semantic-correctness bridge (single-addback or
     double-addback) threaded separately in the final stack spec. -/
@@ -836,7 +834,6 @@ theorem evm_div_n4_full_max_addback_beq_stack_pre_spec (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (hbltu : isMaxTrialN4Evm a b)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAbEvm a b)
     (hborrow : isAddbackBorrowN4MaxEvm a b) :
@@ -861,7 +858,7 @@ theorem evm_div_n4_full_max_addback_beq_stack_pre_spec (sp base : Word)
     v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem
-    hbnz' hb3nz hshift_nz hvalid
+    hbnz' hb3nz hshift_nz
     hbltu hcarry2_nz hborrow
   exact cpsTripleWithin_weaken
     (fun h hp => by
@@ -883,7 +880,6 @@ theorem evm_div_n4_full_max_addback_beq_stack_pre_spec_bundled (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (hbltu : isMaxTrialN4Evm a b)
     (hcarry2_nz : isAddbackCarry2NzN4MaxAbEvm a b)
     (hborrow : isAddbackBorrowN4MaxEvm a b) :
@@ -896,7 +892,7 @@ theorem evm_div_n4_full_max_addback_beq_stack_pre_spec_bundled (sp base : Word)
         (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)) := by
   have h := evm_div_n4_full_max_addback_beq_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-    nMem shiftMem jMem hbnz hb3nz hshift_nz hvalid
+    nMem shiftMem jMem hbnz hb3nz hshift_nz
     hbltu hcarry2_nz hborrow
   exact cpsTripleWithin_weaken
     (fun _ hp => by rw [divN4StackPre_unfold] at hp; exact hp)

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -3607,7 +3607,6 @@ theorem evm_div_n4_call_addback_beq_stack_spec (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4Evm a b)
     (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
@@ -3621,7 +3620,7 @@ theorem evm_div_n4_call_addback_beq_stack_spec (sp base : Word)
   have h_pre := evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0
-    hbnz hb3nz hshift_nz hvalid halign hbltu hcarry2_nz hborrow
+    hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
   obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
     n4_call_addback_beq_div_mod_getLimbN a b hbnz hsem
   refine cpsTripleWithin_weaken (fun _ hp => hp) ?_ h_pre
@@ -5263,7 +5262,6 @@ theorem evm_div_n4_call_stack_spec (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4Evm a b)
     (hcarry2_nz_addback :
@@ -5284,7 +5282,7 @@ theorem evm_div_n4_call_stack_spec (sp base : Word)
   · exact evm_div_n4_call_addback_beq_stack_spec sp base a b
       v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
       nMem shiftMem jMem retMem dMem dloMem scratch_un0
-      hbnz hb3nz hshift_nz hvalid halign hbltu
+      hbnz hb3nz hshift_nz halign hbltu
       (hcarry2_nz_addback haddback) haddback (hsem_addback haddback)
 
 /-- **n=4 shift_nz MOD top-level dispatcher** — mirror of

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkip.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkip.lean
@@ -405,7 +405,6 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4Evm a b)
     (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
@@ -431,7 +430,7 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec (sp base : Word)
     v5 v6 v7 v10 v11Old
     q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0
-    hbnz' hb3nz hshift_nz hvalid halign hbltu hcarry2_nz hborrow
+    hbnz' hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
   exact cpsTripleWithin_weaken
     (fun h hp => by
       rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ rfl rfl rfl rfl,
@@ -453,7 +452,6 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
     (hbnz : b ≠ 0)
     (hb3nz : b.getLimbN 3 ≠ 0)
     (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0)
-    (hvalid : ValidMemRange sp 8)
     (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
     (hbltu : isCallTrialN4Evm a b)
     (hcarry2_nz : isAddbackCarry2NzN4CallEvm a b)
@@ -469,7 +467,7 @@ theorem evm_div_n4_full_call_addback_beq_stack_pre_spec_bundled (sp base : Word)
   have h := evm_div_n4_full_call_addback_beq_stack_pre_spec sp base a b
     v5 v6 v7 v10 v11 q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
     nMem shiftMem jMem retMem dMem dloMem scratch_un0
-    hbnz hb3nz hshift_nz hvalid halign hbltu hcarry2_nz hborrow
+    hbnz hb3nz hshift_nz halign hbltu hcarry2_nz hborrow
   exact cpsTripleWithin_weaken
     (fun _ hp => by rw [divN4StackPreCall_unfold] at hp; exact hp)
     (fun _ hq => hq)


### PR DESCRIPTION
Removes the redundant `hvalid : ValidMemRange sp 8` parameter and the four derived `have hv_v0..hv_v3` lines from the n=4 addback-BEQ DIV path:

- `evm_div_n4_preloop_max_addback_beq_spec`
- `evm_div_n4_preloop_call_addback_beq_spec`
- `evm_div_n4_full_max_addback_beq_spec` (cascade)
- `evm_div_n4_full_call_addback_beq_spec` (cascade)
- `evm_div_n4_full_max_addback_beq_stack_pre_spec` (+ bundled)
- `evm_div_n4_full_call_addback_beq_stack_pre_spec` (+ bundled)
- `evm_div_n4_call_addback_beq_stack_spec`
- `evm_div_n4_call_stack_spec` (top-level n=4 shift_nz dispatcher)

After #720 the inner `divK_loop_body_*_addback_j0_beq_norm` specs no longer consume `isValidDwordAccess` hypotheses, so the four `have hv_v0..hv_v3 := hvalid _ ..` lines in each preloop spec became dead bindings, and the outer `hvalid : ValidMemRange sp 8` parameter that fed them is unused. The slice-1 survey on GH #338 ([issuecomment-4354505594](https://github.com/Verified-zkEVM/evm-asm/issues/338)) classified these as class (d) — already dead.

Proof bodies are otherwise unchanged: only the four `have` lines and the matching argument positions at call sites are dropped. Step counts, postconditions, and code requirements are unchanged. `lake build` green, zero new sorries.

Closes evm-asm-7d7. Part of #338 (evm-asm-cm6).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).