### PR TITLE
chore(imports): drop unused Mathlib.Tactic.Set from Evm64/Basic.lean

### DIFF
--- a/EvmAsm/Evm64/Basic.lean
+++ b/EvmAsm/Evm64/Basic.lean
@@ -7,7 +7,6 @@
 
 import EvmAsm.Rv64.Basic
 import Std.Tactic.BVDecide
-import Mathlib.Tactic.Set
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Slice 1 of #1045 import-hygiene sweep (beads evm-asm-jxq, parent evm-asm-9tq).

Per `lake exe shake EvmAsm`, `EvmAsm/Evm64/Basic.lean` does not use any tactic from `Mathlib.Tactic.Set`. Drop the unused import.

### Note on the rest of the slice description

The parent beads task listed Common/Arithmetic/ByteOps/MultiLimb/Comparison/Properties as additional candidates. I tried each: shake's `remove` suggestions are spurious there because those files use `linarith`, `ring`, `norm_num`, `positivity`, `nlinarith` — `lake build` fails when applied. Only the `Evm64/Basic.lean` removal is safe in the current tree.

This is the only `import Mathlib.Tactic.X` removal currently flagged by shake that is actually applicable; subsequent shake-output entries (`Common.lean: remove Mathlib.Tactic.Linarith`, etc.) all break the build.

### Verification

`lake build` succeeds (1404 jobs).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).