### PR TITLE
chore(noshake): suppress slice-2 opcode Spec false-positives (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -11,4 +11,25 @@
   "EvmAsm.Rv64.Tactics.SeqFrame":
   ["EvmAsm.Rv64.Tactics.PerfTrace"],
   "EvmAsm.Rv64.Tactics.LiftSpec":
-  ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"]}}
+  ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
+  "EvmAsm.Evm64.Pop.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Push0.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Dup.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Swap.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.And.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Or.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Xor.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Not.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Add.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Sub.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Lt.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Gt.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Eq.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.IsZero.Spec":  ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp"]}}


### PR DESCRIPTION
Audited the 17 opcode Program/Spec.lean files flagged by `lake exe shake` for unused `SyscallSpecs` / `GenericSpecs` / `XSimp` / `RunBlock` imports (parent #1045 slice 2, beads `evm-asm-ssb`). For each candidate I removed the import and ran `lake build` — every removal broke the build because the file uses tactics or lemmas registered via those modules:

- `SyscallSpecs` / `RunBlock` provide `addi_spec_gen_same_within`, `ld_spec_gen_within`, etc. via `@[spec_gen_rv64]` and the `runBlock` tactic.
- `Tactics.XSimp` provides the `xperm_hyp` macro (used pervasively in the opcode Spec.lean files even when not textually visible — invoked by other tactics it imports).

So this slice has no source-level removals to land. Instead, mirror the pattern already used for `ByteOps` / `HalfwordOps` / `WordOps` / `RLP.Phase1` and add these 17 entries to `scripts/noshake.json`. Future `lake exe shake EvmAsm` runs will no longer flag them, so reviewers can focus on genuinely actionable hits.

`lake build` remains green (1404 jobs).

Refs #1045, beads `evm-asm-ssb`, `evm-asm-sf0` (the meta task asking for shake false-positive triage before further slicing).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).