### PR TITLE
chore: strip 2 spurious parens in Multiply/Spec (#1075 slice 7)

### DIFF
--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -74,8 +74,8 @@ private theorem mul_stack_weaken (sp : Word) (a b : EvmWord)
   delta evmMulStackPost
   refine sepConj_mono_right ?_ h hp
   iterate 5 apply sepConj_mono (regIs_implies_regOwn _)
-  iterate 3 apply sepConj_mono (memIs_implies_memOwn)
-  exact sepConj_mono_left (memIs_implies_memOwn)
+  iterate 3 apply sepConj_mono memIs_implies_memOwn
+  exact sepConj_mono_left memIs_implies_memOwn
 
 -- ============================================================================
 -- Stack-level MUL spec


### PR DESCRIPTION
Removes parens around the bare identifier `memIs_implies_memOwn` passed to `sepConj_mono` / `sepConj_mono_left` in `EvmAsm/Evm64/Multiply/Spec.lean` (lines 77-78).

After this slice, an EvmAsm-tree scan shows no remaining spurious parens around single bare identifiers outside intentional `Tactics/SeqFrame.lean` macro `$(...)` splices and `Tactics/RunBlock.lean` trace strings — effectively closing out the parent cleanup sweep.

Pure syntactic cleanup; `lake build` is green.

Refs #1075. Slice 7 (beads `evm-asm-gpv`) of the parens-cleanup sweep tracked by parent `evm-asm-u7r`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).