### PR TITLE
chore(CallingConvention): drop unused Evm64.Stack import (#1045)

### DIFF
--- a/EvmAsm/Evm64/CallingConvention.lean
+++ b/EvmAsm/Evm64/CallingConvention.lean
@@ -24,7 +24,6 @@
   Epilogue:                 LD ra, sp, 8 ;; ADDI sp, sp, 16 ;; JALR x0, ra, 0
 -/
 
-import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.ControlFlow
 import EvmAsm.Rv64.Tactics.RunBlock


### PR DESCRIPTION
Re-audit of shake suggestions per beads evm-asm-pic and parent #1045.

Of the 4 imports shake flagged on `EvmAsm/Evm64/CallingConvention.lean` (Evm64.Stack, SyscallSpecs, ControlFlow, Tactics.RunBlock), only **Evm64.Stack** is genuinely unused — `rg` finds no reference to `evmStackIs` / `EvmWord` / `getLimb` in the file. The other three stay:

- `jalr_x0_spec_gen_within` (ControlFlow)
- `addi_spec_gen_same_within`, `ld_spec_gen_within`, `sd_spec_gen_within` (SyscallSpecs)
- `runBlock` + `open EvmAsm.Rv64.Tactics` (Tactics.RunBlock)

shake's suggestion to add `EvmAsm.Rv64.CPSSpec` is unnecessary — CPSSpec arrives transitively via SyscallSpecs.

The other two files in the original beads task (DivMod/Spec.lean, DivMod/SpecCall.lean) no longer appear in `lake exe shake EvmAsm` output — those entries were stale.

`lake build` green (1405 jobs).

Closes evm-asm-pic. Refs #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).