### PR TITLE
chore(scripts): shake-filter to drop known false positives (#1045)

### DIFF
--- a/scripts/shake-filter.md
+++ b/scripts/shake-filter.md
@@ -1,0 +1,87 @@
+# shake-filter — known false-positive filter for `lake exe shake`
+
+`lake exe shake EvmAsm` produces a long list of "remove this import"
+suggestions. Past slices of #1045 repeatedly hit the same problem: many
+of those suggestions are wrong because shake does not see lemmas /
+notations / spec-database entries that are referenced indirectly via
+attributes or tactic macros.
+
+`scripts/shake-filter.py` post-processes shake's output and drops every
+file block whose source contains a documented false-positive marker
+(custom simp attributes, `runBlock` / `xperm` / `xsimp` / `seqFrame`
+tactic invocations, `@[spec_gen_*]` attribute use, `Word` notation, etc.).
+
+## Usage
+
+```bash
+lake build
+lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py
+```
+
+To inspect what the filter dropped:
+
+```bash
+lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py --show-dropped | less
+```
+
+Filter stats are printed to stderr (`N kept, M dropped`).
+
+## What gets dropped, and why
+
+See the `MARKERS` list at the top of `shake-filter.py` — each marker is
+paired with a one-line reason. The categories are:
+
+1. **Spec-database tactics** — `runBlock`, `xperm` / `xperm_hyp`,
+   `xcancel`, `xsimp`, `seqFrame`, `liftSpec`. These tactics elaborate
+   to `simp` / `grind` calls over an attribute-driven set of lemmas
+   (`@[spec_gen]`, `@[spec_gen_*]`). The imports that *register* those
+   lemmas have no direct reference inside the consumer file, so shake
+   flags them as unused.
+
+2. **`@[spec_gen_*]` declarations** — files that declare specs locally
+   are themselves consumed by attribute, not by direct reference. Shake
+   does not see the downstream attribute lookup.
+
+3. **`*_spec_gen_within` / `*_spec_within` lookup names** — common spec
+   identifiers used in `CallingConvention.lean` and similar files; the
+   backing lemma is loaded via a `simp` / `grind` set.
+
+4. **Custom simp attributes** — `rv64_addr`, `divmod_addr`, `reg_ops`,
+   `byte_alg`. Each is registered in a `*Attr.lean` file and consumed by
+   `simp [attr_name]` elsewhere; shake doesn't track this.
+
+5. **`Word` notation** — `notation "Word" => BitVec 64` lives in
+   `EvmAsm.Rv64.Basic`. Files that only mention `Word` look unrelated
+   to that import.
+
+## Verifying false-positive drops
+
+Past investigations (see `evm-asm-o6y`, `evm-asm-pic`) confirmed that
+the following files produced ZERO genuine shake suggestions despite
+appearing prominently in raw output:
+
+- `EvmAsm/Evm64/CallingConvention.lean`
+- `EvmAsm/Evm64/DivMod/Spec.lean`
+- `EvmAsm/Evm64/DivMod/SpecCall.lean`
+- `EvmAsm/Rv64/SyscallSpecs.lean`
+- `EvmAsm/Rv64/InstructionSpecs.lean`
+
+The filter drops all five. (One survivor — `Evm64/CallingConvention.lean` —
+landed under PR #1481 which removes its single genuinely-unused import.)
+
+## Caveats
+
+The filter is **conservative on the drop side**: it discards any file
+matching a marker, even when shake's suggestion happens to be correct.
+That is the right tradeoff while we still have hundreds of false
+positives — pruning the noise gives slicers a high-signal worklist.
+Expand the audit later by removing markers as we gain confidence that
+shake is correct in their presence.
+
+The filter does **not** modify shake itself; it operates on stdout. To
+re-run shake from scratch:
+
+```bash
+lake clean && lake build && lake exe shake EvmAsm 2>/dev/null \
+    | scripts/shake-filter.py | tee shake-real.txt
+```

--- a/scripts/shake-filter.py
+++ b/scripts/shake-filter.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""
+Filter `lake exe shake EvmAsm` output to drop suggestions in files where
+shake is known to produce false positives.
+
+Background
+----------
+shake's static analysis follows direct constant references but does not see:
+
+  * notations / `notation` declarations exported from an imported module,
+  * tactic registries (e.g. `@[spec_gen_*]`, `@[grindset]`, custom simp attrs)
+    where lemmas are looked up by attribute, not by direct reference,
+  * `runBlock` / `xperm` / `xperm_hyp` / `xcancel` / `xsimp` / `seqFrame`
+    macros that elaborate spec lookups via tactics, and
+  * identifiers introduced through term-elaborator macros referenced only
+    inside proofs.
+
+Whenever a file uses any of these mechanisms, the imports that supply the
+underlying lemma database look unused to shake even though they are not.
+Past attempts (#1045 slices 3, 4, 5, 6) repeatedly hit this — see beads tasks
+evm-asm-o6y, evm-asm-pic and the discussion under #1045.
+
+What this script does
+---------------------
+Reads shake stdout (or a saved capture) on stdin, parses each per-file block,
+and drops the block if the file body contains any of the marker tokens below.
+
+The result is a much smaller list of suggestions, dominated by genuine
+unused imports — a much better starting point than the raw 800+ line output.
+
+Usage
+-----
+    lake build
+    lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py
+
+Or with a saved capture:
+
+    lake exe shake EvmAsm 2>/dev/null > shake.txt
+    scripts/shake-filter.py < shake.txt
+
+Add `--show-dropped` to see what was filtered out and why.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# Marker tokens that indicate a file relies on attribute-driven tactic
+# lookup, custom simp attributes, or notation re-export. Any file whose
+# source text contains one of these will have its shake suggestions dropped.
+#
+# Keep this list short and targeted — each entry should correspond to a
+# documented false-positive class, not just "things that look unusual".
+MARKERS: list[tuple[str, str]] = [
+    # Spec database lookup (attribute-driven). These tactics expand to
+    # `simp` / `grind` calls that pick up lemmas by `@[spec_gen]` /
+    # `@[spec_gen_*]`, so the import that *registers* the lemma looks
+    # unreferenced to shake.
+    ("runBlock",           "tactic looks up @[spec_gen] specs by attribute"),
+    ("xperm",              "AC-perm tactic uses sepConj_* lemmas via simp set"),
+    ("xperm_hyp",          "AC-perm tactic uses sepConj_* lemmas via simp set"),
+    ("xcancel",            "frame-cancel tactic uses sepConj_* lemmas via simp set"),
+    ("xsimp",              "tactic uses xsimp simp set (attribute-driven)"),
+    ("seqFrame",           "tactic uses seqFrame simp set (attribute-driven)"),
+    ("liftSpec",           "tactic uses liftSpec simp set (attribute-driven)"),
+    # spec_gen attribute attached locally — declares lemmas that consumers
+    # of the namespace pick up by attribute, not by direct reference.
+    ("@[spec_gen",         "@[spec_gen_*] declarations are consumed by attribute"),
+    # spec_gen lookup names commonly appearing in CallingConvention etc.
+    ("ld_spec_gen_within", "spec_gen lookup name; backing lemma loaded by attribute"),
+    ("sd_spec_gen_within", "spec_gen lookup name; backing lemma loaded by attribute"),
+    ("addi_spec_gen_same_within",
+                           "spec_gen lookup name; backing lemma loaded by attribute"),
+    ("jal_spec_within",    "spec_gen lookup name; backing lemma loaded by attribute"),
+    ("jalr_spec_within",   "spec_gen lookup name; backing lemma loaded by attribute"),
+    ("jalr_x0_spec_gen_within",
+                           "spec_gen lookup name; backing lemma loaded by attribute"),
+    # Custom simp attribute registries (the `*Attr.lean` files declare these;
+    # consumer files invoke them via `simp [attr]` which shake doesn't track).
+    ("rv64_addr",          "custom simp attribute (rv64_addr)"),
+    ("divmod_addr",        "custom simp attribute (divmod_addr)"),
+    ("reg_ops",            "custom simp attribute (reg_ops)"),
+    ("byte_alg",           "custom simp attribute (byte_alg)"),
+    # Notation use — `notation \"Word\" => BitVec 64` is in Rv64.Basic; files
+    # using `Word` look unrelated to that import.
+    ("notation \"Word\"",  "Word notation defined in Rv64.Basic"),
+]
+
+BLOCK_HEADER = re.compile(r"^/.+\.lean:$")
+
+
+def parse_blocks(text: str) -> list[tuple[str, list[str]]]:
+    """Split shake output into (header_path, body_lines) blocks."""
+    blocks: list[tuple[str, list[str]]] = []
+    current_path: str | None = None
+    current_body: list[str] = []
+    for line in text.splitlines():
+        if BLOCK_HEADER.match(line):
+            if current_path is not None:
+                blocks.append((current_path, current_body))
+            current_path = line[:-1]  # drop trailing ':'
+            current_body = []
+        else:
+            if current_path is None:
+                # Pre-header noise (warnings, etc.) — pass through verbatim
+                # by stashing under a sentinel.
+                blocks.append(("", [line]))
+            else:
+                current_body.append(line)
+    if current_path is not None:
+        blocks.append((current_path, current_body))
+    return blocks
+
+
+def file_markers(path: Path) -> list[tuple[str, str]]:
+    """Return the list of (marker, reason) the file body matches."""
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    hits: list[tuple[str, str]] = []
+    for marker, reason in MARKERS:
+        if marker in text:
+            hits.append((marker, reason))
+    return hits
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(
+        description="Filter `lake exe shake` output to drop known false positives.",
+    )
+    p.add_argument(
+        "--show-dropped",
+        action="store_true",
+        help="Print dropped blocks (commented out) with the marker that triggered them.",
+    )
+    p.add_argument(
+        "--root",
+        default=".",
+        help="Repo root used to resolve relative paths in shake output (default: cwd).",
+    )
+    args = p.parse_args(argv)
+
+    raw = sys.stdin.read()
+    blocks = parse_blocks(raw)
+
+    kept = 0
+    dropped = 0
+    out: list[str] = []
+    for path_str, body in blocks:
+        if path_str == "":
+            # Pre-header noise — pass through.
+            out.extend(body)
+            continue
+        path = Path(path_str)
+        if not path.is_absolute():
+            path = (Path(args.root) / path_str).resolve()
+        hits = file_markers(path)
+        if hits:
+            dropped += 1
+            if args.show_dropped:
+                marker, reason = hits[0]
+                out.append(f"# DROPPED ({marker}): {reason}")
+                out.append(f"# {path_str}:")
+                for line in body:
+                    out.append(f"#   {line}")
+            continue
+        kept += 1
+        out.append(f"{path_str}:")
+        out.extend(body)
+
+    print("\n".join(out))
+    print(
+        f"\n# shake-filter: {kept} block(s) kept, {dropped} dropped as likely false positives.",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds `scripts/shake-filter.py` + docs to post-process `lake exe shake EvmAsm` output, dropping per-file blocks where shake is known to be wrong.

## Why

Past slices of #1045 (3, 4, 5, 6) repeatedly stalled because shake flags imports as unused even when the consumer relies on them indirectly. Categories of false positives, distilled from the audit in beads `evm-asm-o6y` / `evm-asm-pic`:

1. Spec-database tactics (`runBlock`, `xperm`, `xperm_hyp`, `xcancel`, `xsimp`, `seqFrame`, `liftSpec`) — load lemmas via attribute, not direct reference.
2. `@[spec_gen_*]` declarations — same problem from the producer side.
3. `*_spec_gen_within` / `*_spec_within` lookup names (CallingConvention, etc.).
4. Custom simp attributes (`rv64_addr`, `divmod_addr`, `reg_ops`, `byte_alg`).
5. `Word` notation re-export from `EvmAsm.Rv64.Basic`.

## Effect on current tree

Raw output: 822 lines / 236 file blocks.
Filtered:   336 lines /  84 file blocks (152 dropped, 64%).

All five files previously audited as pure noise (CallingConvention, DivMod/Spec, DivMod/SpecCall, SyscallSpecs, InstructionSpecs) are correctly dropped.

## Usage

```
lake build
lake exe shake EvmAsm 2>/dev/null | scripts/shake-filter.py
```

Add `--show-dropped` to see what was filtered out.

## Notes

- Filter is **conservative on the drop side** by design: better to skip a real suggestion than waste a slicer on a false positive. Markers can be tightened later.
- Does not modify shake itself; pure stdout post-processor.
- Pure tooling — no impact on `lake build`.

Refs: #1045 (issue), beads evm-asm-sf0 (this slice), evm-asm-o6y, evm-asm-pic.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).