### PR TITLE
docs(README): document weekly benchmark workflow (#949 slice 4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ lake exec cache get
 lake build
 ```
 
+### Weekly build benchmark
+
+A scheduled GitHub Actions workflow,
+[`.github/workflows/benchmark.yml`](.github/workflows/benchmark.yml),
+runs `lake build` every Monday at 06:00 UTC and records the wall-clock
+time and peak resident set size in the run's job summary. Raw
+`/usr/bin/time -v` outputs are uploaded as build artifacts
+(`benchmark-<run-id>`) with a 90-day retention so regressions can be
+diff'd against earlier runs.
+
+The workflow is independent of PR CI and does not gate any pull
+request. To trigger an off-schedule run manually, go to **Actions →
+Benchmark → Run workflow** (or `gh workflow run benchmark.yml`).
+History persistence (a long-lived JSON log of timings) is tracked as a
+follow-up under issue #949.
+
 ## Status
 
 This is a **prototype** demonstrating the approach. Current state:


### PR DESCRIPTION
Adds a short README subsection (under Building) describing `.github/workflows/benchmark.yml`:

- Weekly cron (Mondays 06:00 UTC) + `workflow_dispatch` for manual runs.
- Metrics surfaced in the job summary (wall time, peak RSS).
- Raw `/usr/bin/time -v` outputs uploaded as 90-day artifacts.
- Notes that the workflow is independent of PR CI.
- Points at #949 for the open history-persistence follow-up.

Docs-only; no Lean code touched.

Refs #949 (parent), beads evm-asm-xpj.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).