### PR TITLE
feat(ci): persist benchmark history to benchmark-history branch (#949 slice 3)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -23,6 +23,9 @@ concurrency:
   group: benchmark
   cancel-in-progress: false
 
+permissions:
+  contents: write
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest
@@ -112,6 +115,104 @@ jobs:
               echo "| status        | build failed (see log) |"
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Persist record to benchmark-history branch
+        if: steps.metrics.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WALL_RAW: ${{ steps.metrics.outputs.wall_raw }}
+          WALL_SECONDS: ${{ steps.metrics.outputs.wall_seconds }}
+          PEAK_RSS_KB: ${{ steps.metrics.outputs.peak_rss_kb }}
+        run: |
+          set -euo pipefail
+          # Clone a fresh copy of the repo at a temp path and check out (or
+          # initialize) the long-lived `benchmark-history` orphan branch.
+          # Keeping this in its own working tree means we don't disturb the
+          # checkout used for the build above.
+          tmpdir=$(mktemp -d)
+          git -c protocol.version=2 clone --no-checkout --filter=blob:none \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$tmpdir/history"
+          cd "$tmpdir/history"
+          git config user.name  'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          if git ls-remote --exit-code --heads origin benchmark-history >/dev/null 2>&1; then
+            git fetch --depth=1 origin benchmark-history
+            git checkout benchmark-history
+          else
+            # Initialize a fresh orphan branch with a README and an empty log.
+            git checkout --orphan benchmark-history
+            git rm -rf --quiet . 2>/dev/null || true
+            printf '%s\n' \
+              '# benchmark-history' \
+              '' \
+              'Append-only record of weekly `lake build` benchmark runs from' \
+              '`.github/workflows/benchmark.yml` (issue #949 slice 3).' \
+              '' \
+              'One JSON object per line in `history.jsonl`:' \
+              '' \
+              '- `commit`        : full SHA of the commit benchmarked' \
+              '- `ref`           : the branch / ref that triggered the run' \
+              '- `timestamp`     : ISO 8601 UTC timestamp of when the record was appended' \
+              '- `trigger`       : GitHub event name (`schedule` or `workflow_dispatch`)' \
+              '- `run_id`        : GitHub Actions run ID (link target)' \
+              '- `wall_seconds`  : `lake build` wall-clock time, integer seconds' \
+              '- `wall_raw`      : raw `Elapsed (wall clock) time` string from `/usr/bin/time -v`' \
+              '- `peak_rss_kb`   : peak resident set size in kilobytes' \
+              '- `runner_os`     : `uname -s` of the runner' \
+              '- `runner_cores`  : `nproc` on the runner' \
+              > README.md
+            : > history.jsonl
+          fi
+          # Build a single JSONL record for this run via a tempfile script
+          # (avoids Python's strictness about leading whitespace in `-c`).
+          export TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          export RUNNER_OS_NAME="$(uname -s)"
+          export RUNNER_CORES="$(nproc)"
+          script="$tmpdir/append_record.py"
+          {
+            echo 'import json, os'
+            echo 'rec = {'
+            echo '  "commit":       os.environ["GITHUB_SHA"],'
+            echo '  "ref":          os.environ["GITHUB_REF"],'
+            echo '  "timestamp":    os.environ["TIMESTAMP"],'
+            echo '  "trigger":      os.environ["GITHUB_EVENT_NAME"],'
+            echo '  "run_id":       os.environ["GITHUB_RUN_ID"],'
+            echo '  "wall_raw":     os.environ["WALL_RAW"],'
+            echo '  "wall_seconds": int(os.environ["WALL_SECONDS"]),'
+            echo '  "peak_rss_kb":  int(os.environ["PEAK_RSS_KB"]),'
+            echo '  "runner_os":    os.environ["RUNNER_OS_NAME"],'
+            echo '  "runner_cores": int(os.environ["RUNNER_CORES"]),'
+            echo '}'
+            echo 'with open("history.jsonl", "a") as f:'
+            echo '  f.write(json.dumps(rec, sort_keys=True) + "\n")'
+          } > "$script"
+          python3 "$script"
+          git add history.jsonl README.md
+          # `--allow-empty` keeps the run idempotent if an immediate re-run
+          # on the same commit produced identical metrics (extremely unlikely
+          # but defensive).
+          git commit -m "benchmark: ${GITHUB_SHA::12} wall=${WALL_SECONDS}s rss=${PEAK_RSS_KB}KB" \
+            --allow-empty
+          # Push with retries: the `benchmark` concurrency group should
+          # serialize runs, but a manual workflow_dispatch could still race
+          # against the cron run. On rejection, re-fetch the remote branch,
+          # re-append our record, amend the commit, and try again. We avoid
+          # `git rebase` per the project's no-rebase policy.
+          for attempt in 1 2 3; do
+            if git push origin benchmark-history; then
+              echo "history push: ok on attempt $attempt"
+              break
+            fi
+            echo "history push: attempt $attempt failed, refetching + re-applying" >&2
+            git fetch origin benchmark-history
+            git reset --hard origin/benchmark-history
+            python3 "$script"
+            git add history.jsonl README.md
+            git commit -m "benchmark: ${GITHUB_SHA::12} wall=${WALL_SECONDS}s rss=${PEAK_RSS_KB}KB" \
+              --allow-empty
+            sleep 5
+          done
 
       - name: Upload raw timing artifacts
         if: always()


### PR DESCRIPTION
Slice 3 of #949 (beads `evm-asm-alg`): persist a per-run JSONL record to a long-lived `benchmark-history` orphan branch so we can track lake-build wall time and peak RSS across weekly runs.

## What this adds

A new step in `.github/workflows/benchmark.yml`, **Persist record to benchmark-history branch**, that runs only on a successful metrics extraction. It:

1. Clones the repo into a tempdir (does not touch the build checkout).
2. Either checks out the existing `benchmark-history` branch or, on the first run, initializes it as an orphan branch with a README + empty `history.jsonl`.
3. Appends one JSON object per run to `history.jsonl` (one record per line) with: `commit`, `ref`, `timestamp`, `trigger`, `run_id`, `wall_raw`, `wall_seconds`, `peak_rss_kb`, `runner_os`, `runner_cores`.
4. Commits as `github-actions[bot]` and pushes with up to 3 retries.

## Design choices

- **Branch over artifact** (per slice 1 design comment on #949): artifacts expire after 90 days, a long-lived branch persists indefinitely and is human-browsable. The `benchmark-history` branch is orphan / disjoint from `main`'s history so it doesn't pollute `git log` on `main`.
- **No rebase on push rejection**: per the project's no-rebase policy (`AGENTS.md`), the retry loop re-fetches `benchmark-history`, hard-resets to it, re-appends the JSONL record, and re-commits, then re-pushes. The benchmark workflow already has a `concurrency: benchmark` group serializing runs, so collisions should be rare.
- **`contents: write` permission**: scoped to this workflow file only.
- **Bot identity**: commits authored by `github-actions[bot]` (the standard `GITHUB_TOKEN` identity), not @pirapira.
- **Idempotent**: the JSONL append + `--allow-empty` commit is a no-op on identical re-runs.

## Why JSONL

One self-contained record per line, append-friendly, trivially parseable for downstream plotting / CSV export. No structural change needed when fields are added — just extend the dict.

## Out of scope (future slices)

- Auto-rendered timeseries plot or sparkline (could be a separate workflow that reads `history.jsonl` from `benchmark-history` and writes a PNG to `gh-pages`).
- Regression alerting (open an issue if `wall_seconds` regresses by N% over the trailing K runs).
- PR-comment integration.

## Validation

I cannot exercise the workflow before merge (it only triggers on `schedule` or `workflow_dispatch` against the default branch). After merge, kicking it off via the Actions UI's "Run workflow" button on `main` will validate end-to-end:

1. First run: creates `benchmark-history` branch with `README.md` + `history.jsonl` containing one record.
2. Subsequent runs: append a new line.

YAML syntax was validated locally with `yaml.safe_load`. The new shell script avoids heredocs (which break under YAML 4-space indentation) and uses a tempfile-based Python script to avoid `python3 -c` whitespace pitfalls.

Closes beads `evm-asm-alg`. Parent: `evm-asm-wgr` (#949). Sibling slice 4: `evm-asm-xpj` (#1484, README docs — will need a follow-up to mention this branch once both land).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).