### PR TITLE
docs(xperm-partial): revise design note to fix sep-logic flaw (#156)

### DIFF
--- a/EvmAsm/Rv64/Tactics/XPermPartial.lean
+++ b/EvmAsm/Rv64/Tactics/XPermPartial.lean
@@ -1,13 +1,15 @@
 /-
-# `xperm_partial` — design note (slice 1 of #156)
+# `xperm_partial` — design note (slice 1 of #156, REVISED)
 
 Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 
 This file is a DESIGN-ONLY survey + design note. It does NOT yet implement
-anything (slice 2, beads `evm-asm-cy7`, will land the implementation; slice 3,
-`evm-asm-zu8`, will adopt it at call sites).
+anything. The original draft (committed in slice 1, evm-asm-a7k) contained
+a separation-logic flaw flagged in beads `evm-asm-esr`; this revision
+documents the flaw, re-evaluates the design, and recommends scope changes
+for slice 2 (`evm-asm-cy7`) and slice 3 (`evm-asm-zu8`) accordingly.
 
-## Problem
+## Problem (unchanged)
 
 `xperm` (defined in `EvmAsm/Rv64/Tactics/XPerm.lean`) closes a goal
 `⊢ P = Q` where `P` and `Q` are AC-permutations of `sepConj` (`**`) chains
@@ -22,160 +24,172 @@ a single atom, `xperm` errors out (`"could not find atom in LHS"` /
 bugs (forgotten atoms, mis-stated frames, wrong opcode pre/post pairs) that
 a permissive variant would silently paper over.
 
-But there are call sites where the user *knows* an atom is unmatched and
-just wants the residual obligation as a goal so they can dispatch it
-separately. Today those sites either:
+#156 asks for a SIBLING tactic that performs the same atom-matching but,
+instead of failing on unmatched leftovers, leaves the user the residual
+atoms in some form they can dispatch.
 
-* Hand-build a `sepConj_mono_left` / `sepConj_mono_right` tower to manually
-  peel the unmatched atom off the hypothesis, then run `xperm_hyp` on the
-  resource-only tail. See `EvmAsm/Evm64/Shift/ShlCompose.lean:316–322,
-  456–462, 760–767` (5–7-deep `mono_right` towers) and
-  `EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean:107–108` /
-  `…LoopFour.lean:100`.
-* Sidestep the tactic completely with raw
-  `(congrFun (show _ = _ from by xperm) h).mp …` plus a separate
-  `sepConj_pure_right` / `sepConj_mono_right` extraction (see
-  `EvmAsm/Evm64/Byte/Spec.lean:289–299, 407–417, 780–906, 938–944`).
+## The semantic flaw in the original design
 
-The shape of these sites is uniform: hypothesis side has *strictly more*
-atoms than goal side; the user wants `xperm` to consume the goal atoms
-out of the hypothesis and hand back a hypothesis (or sub-goal) for the
-residual.
+The original draft proposed two variants:
 
-## Relationship to existing tactics
+* Variant 1: starting from `h : (R₁ ** … ** Rₙ) s` and goal `Q s` whose
+  atoms are a strict sub-multiset of `h`'s, produce a residual hypothesis
+  `h_resid : <unmatched-atoms> s` "by `sepConj_mono_left` / `_right`
+  monotonicity plus a `sepConjElim_right` projection".
+* Variant 2: reshape the goal into `<unmatched-atoms> s` and close the
+  matched portion automatically.
 
-* **`xperm`** (`Tactics/XPerm.lean`) — strict `LHS = RHS`. Will stay strict.
-* **`xperm_hyp`** (`Tactics/XSimp.lean`) — strict `h : P s ⊢ Q s`. Stays
-  strict.
-* **`xcancel`** (`Tactics/XCancel.lean`) — closes `h : P s ⊢ (Q ** ?Frame) s`,
-  unifying `?Frame` with the residual atoms and *closing the goal*. This is
-  the closest cousin to what #156 asks for, but it requires the goal to
-  *already mention* a `?Frame` metavariable inside the `**` chain. The new
-  tactic targets the case where the goal does NOT mention `?Frame` and the
-  user wants the residual atoms surfaced as a *new sub-goal*, not unified
-  away.
-* **`extract_pure`** (`Tactics/ExtractPure.lean`, #1432) — peels pure leaves
-  (`⌜·⌝`) from a hypothesis. Orthogonal: pure atoms participate in
-  permutation, but unmatched-on-purpose atoms in #156 are typically
-  resource leaves (`↦ᵣ`, `↦ₘ`, `regOwn`, etc.), not propositions.
-* **`xperm_pure`** (#1435, design note in `XPermPure.lean`, slice 2 in
-  `evm-asm-8py`) — composes `extract_pure` with `xperm_hyp`. Also
-  orthogonal: it strips the *pure* asymmetry, not arbitrary atom
-  asymmetry.
+Both are unsound on the raw `Assertion`-application semantics
+(`Assertion := MachineState → Prop`, `(P ** Q) s := ∃ s₁ s₂, …`):
 
-## Proposed shape: `xperm_partial`
+1. **`sepConj_mono_left/right` are monotonicity, not projection.** They
+   accept a pointwise implication `∀ h, P h → P' h` and weaken one factor
+   of an existing `**`-chain on the SAME state. They cannot drop a factor
+   from the chain.
+2. **`sepConjElim_right` does not exist** in `EvmAsm/Rv64/SepLogic.lean`.
+   The existing projection is `holdsFor_sepConj_elim_right`, with type
+   `(P ** Q).holdsFor s → Q.holdsFor s`. Its input/output use
+   `Assertion.holdsFor`, which existentially abstracts over a sub-state
+   that the assertion describes — it does *not* operate on the same `s`
+   that `(P ** Q) s` does. There is no closed-form `(P ** Q) s → Q s` in
+   the library; in general `(P ** Q) s` does not imply `Q s` (it implies
+   `Q` on a sub-heap of `s`).
+3. As a consequence, Variant 1 cannot be implemented as proposed: the
+   step "split via `sepConj_mono_left` to extract `R s`" is not derivable.
+4. Variant 2 has the same flaw in the goal direction: rewriting
+   `⊢ Q s` into `⊢ <residual-atoms> s` and closing the matched portion
+   would require either an `Iff` (which doesn't exist for general
+   asymmetric residuals) or a `holdsFor`-mediated reshape that changes
+   the goal's type.
 
-Two viable surface syntaxes, both targeting "consume goal atoms from
-hypothesis, leave the residual":
+The honest statement is: there is no general tactic that, given
+`h : P s` and goal `Q s` with `Q`'s atoms ⊊ `P`'s atoms, produces a
+plain proof term inhabiting an `Assertion` applied to `s` for the
+unmatched residual.
 
-### Variant 1 — produce a residual hypothesis
+## What IS sound (and what existing tactics cover it)
+
+Three nearby capabilities ARE expressible:
+
+* **In-place weakening** — replace one atom with a strictly weaker atom
+  on the same state. `sepConj_mono_left` / `sepConj_mono_right` already
+  cover this. The "drop ownership" pattern `regIs r v → regOwn r` is the
+  canonical example.
+* **Pure-leaf stripping** — peel a `⌜P⌝` factor from a chain. Provided
+  by `extract_pure` (#1432) and composed in `xperm_pure` (#1435,
+  PR #1483). Pure leaves admit projection `(⌜P⌝ ** Q) s → P ∧ Q s`
+  because pure assertions don't constrain the heap.
+* **Frame-with-meta-residual** — close `h : P s ⊢ (Q ** ?Frame) s`,
+  unifying `?Frame` with the residual atoms. `xcancel`
+  (`Tactics/XCancel.lean`) already does this; it does not surface the
+  residual as a separate goal but instead consumes it via the
+  user-supplied `?Frame` metavariable.
+* **`holdsFor`-mediated projection** — `holdsFor_sepConj_elim_right`
+  gives `(P ** Q).holdsFor s → Q.holdsFor s`. This is sound but its
+  input/output type is `Assertion.holdsFor`, not raw application; it is
+  not a drop-in for sites that work with `(P ** Q) s : Prop` directly.
+
+## Re-survey of the original adopters
+
+The original design listed call sites as "obvious adopters". On
+re-reading them, none of them are `xperm_partial`-shaped:
+
+1. `EvmAsm/Evm64/Shift/ShlCompose.lean` lines 310–322 / 456–462 /
+   755–767 — these are towers of `sepConj_mono_left (regIs_to_regOwn _)`.
+   That is *weakening*, not *dropping*. The total atom count before and
+   after is identical; only the labels change (`regIs` → `regOwn`). A
+   `xperm_partial` that drops atoms would not eliminate this code.
+2. `EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean` lines 100–110 and
+   `…LoopFour.lean` lines 95–105 — these are five-deep `sepConj_mono_*`
+   towers terminating in `((sepConj_pure_right _).1 _).1`. That is
+   *pure-stripping*, which `xperm_pure` (#1435) is the right tool for.
+3. `EvmAsm/Evm64/Byte/Spec.lean` lines 289–299, 407–417, 780–906,
+   938–944 — also pure-stripping, also #1435 territory.
+
+So the slice-1 survey conflated three distinct asymmetries:
+
+* asymmetry-by-weakening (covered by `sepConj_mono_*`),
+* asymmetry-by-pure-leaf (covered by `extract_pure` / `xperm_pure`),
+* asymmetry-by-residual (genuinely unaddressed — the #156 case).
+
+Concrete sites in the codebase exhibit only the first two. There is no
+hand-rolled "drop a resource atom from a chain" pattern in the current
+tree; the closest is `xcancel`, which already handles the case via a
+unified `?Frame`.
+
+## Revised recommendation
+
+**Defer slice 2 (`evm-asm-cy7`) until a real call site appears.** The
+original motivation rested on a survey that conflated weakening and
+pure-stripping with residual-dropping. With those reclassified, the
+expected adoption (slice 3, `evm-asm-zu8`) shrinks from "~30–60 LoC
+removed" to "0 LoC, no current consumer".
+
+If a future call site DOES need to drop a resource atom (i.e. the user
+has a hypothesis they no longer want to track and want to keep just the
+matched portion), the soundest implementation is **via `holdsFor`**,
+not via raw assertion application:
 
 ```
-syntax "xperm_partial" ident " with " ident : tactic
--- xperm_partial h with h_resid
--- semantics:
---   given h : (R₁ ** R₂ ** ... ** Rₙ) s and goal Q s,
---   if Q's atoms are a strict sub-multiset of h's atoms,
---   replace h with h_resid : <unmatched-atoms> s
---   and the original goal stays open (caller dispatches manually).
+syntax "xperm_partial_holdsFor" ident " with " ident : tactic
+-- given h : P.holdsFor s and goal Q.holdsFor s
+-- with Q's atoms a strict sub-multiset of P's,
+-- produce h_resid : <unmatched-atoms>.holdsFor s
+-- by chaining holdsFor_sepConj_elim_right after AC normalisation.
 ```
 
-This matches the most common pattern in the surveyed call sites: the user
-wants the residual as a *fact* they can pass to a downstream tactic
-(`xperm_hyp`, `xcancel`, hand-written term).
+This is sound because `holdsFor_sepConj_elim_right` exists and has the
+right shape (the residual sits on a sub-heap of `s`, which is exactly
+what the user wants when they say "I no longer care about that atom").
+The surface API would mirror `xperm_hyp`'s but operate on
+`Assertion.holdsFor` instead of raw application.
 
-### Variant 2 — produce a residual sub-goal
+Adopting this would require either lifting raw `(P ** Q) s` hypotheses
+into `(P ** Q).holdsFor s` first (most call sites have the raw form;
+the bridge lemma is straightforward but requires `compatibleWith`
+context). This adds enough friction that we should defer until a
+concrete site actually wants the residual rather than weakening or
+pure-stripping.
 
-```
-syntax "xperm_partial" ident : tactic
--- xperm_partial h
--- semantics:
---   given h : P s and goal Q s with Q atoms ⊊ P atoms,
---   reshape goal into <unmatched-atoms> s and close the original
---   matched portion automatically.
-```
+**Action items:**
 
-This is closer to the #156 wording ("leaves a residual goal containing
-the unmatched atoms"). Cleaner when the user wants to feed the residual
-straight into another tactic via `<;>`.
+* Mark `evm-asm-cy7` (slice 2) as blocked-by-design rather than
+  ready-to-implement. Re-open with the `_holdsFor` variant scope above
+  if a call site appears.
+* Mark `evm-asm-zu8` (slice 3) as blocked on `evm-asm-cy7` with the
+  expectation that, if `xperm_partial_holdsFor` does land, the only
+  natural adopters will be future code, not retrofits — the surveyed
+  retrofits are #1435 and `sepConj_mono_*` work, not this.
+* Keep this design file in-tree as the historical record for #156 and
+  to prevent re-doing the same mis-survey.
 
-**Recommendation: implement Variant 1 first.** It composes more cleanly
-with the existing toolbox (`xperm_partial h with h2; xperm_hyp h2`) and
-mirrors the manual `sepConj_mono_right`-tower pattern that the call sites
-already use, so adoption (slice 3) is mechanical. Variant 2 can be added
-later as sugar (`xperm_partial h ≡ xperm_partial h with h; show … s; …`)
-if a need arises.
+## What this revision does NOT propose
 
-## Implementation plan (slice 2, evm-asm-cy7)
+* It does NOT propose closing #156. The user-visible request ("residual
+  goal containing the unmatched atoms") is still meaningful — the
+  conclusion here is just that today's call sites don't exhibit it,
+  and the soundest implementation requires a `holdsFor` lift.
+* It does NOT subsume `xcancel`. `xcancel`'s `?Frame` metavariable
+  shape is already in production (DivMod, EvmWordArith) and remains the
+  right tool when the user wants the residual *consumed* rather than
+  surfaced.
+* It does NOT subsume `xperm_pure` (#1435 / PR #1483) — that handles a
+  different asymmetry (pure leaves) and is independently useful.
 
-Reuse `XPerm.flattenSepConj` + `XCancel.matchGoalAgainstHyp` (already do
-exactly the asymmetric `isDefEq`-matching this needs). The new code:
+## Pointer to existing tactic infrastructure (unchanged from slice 1)
 
-1. Flatten hypothesis and goal sides via `flattenSepConj`.
-2. Match goal atoms against hypothesis atoms (`matchGoalAgainstHyp` from
-   `XCancel.lean`, but adapted: no `?Frame` metavariable expected on the
-   goal side).
-3. Compute `residual := unmatchedAtoms hypAtoms matchedIndices`.
-4. Build the residual assertion `R = a₁ ** … ** aₖ` via
-   `XCancel.buildSepConjChain residual`.
-5. Build a permutation proof `P = (matched-chain) ** R` via
-   `buildPermProof` (using the existing `sepConj_assoc' / _comm' /
-   _left_comm'` machinery).
-6. Use `mkEqMP` + `congrFun` to produce a term of type `(matched ** R) s`,
-   then split via `(sepConj_mono_left _).2.2` (or `sepConjElim_right`)
-   to extract `R s`.
-7. Add it as a hypothesis under the user-supplied name, leave the
-   original goal untouched.
+If/when a `holdsFor`-based `xperm_partial` is implemented:
 
-No new lemmas needed in `SepLogic.lean` — `sepConj_assoc' / _comm' /
-_left_comm' / _emp_left' / _emp_right'` are already enough.
+* `XPerm.flattenSepConj` already produces the atom list.
+* `XCancel.matchGoalAgainstHyp` already does the asymmetric `isDefEq`
+  matching.
+* The AC-normalisation lemmas (`sepConj_assoc'`, `_comm'`,
+  `_left_comm'`, `_emp_left'`, `_emp_right'`) are already enough to
+  build the rearrangement proof.
+* `holdsFor_sepConj_elim_right` provides the projection step that the
+  raw-application variant lacked.
 
-## Failure modes
-
-* **Goal atom not found in hypothesis** → throw `"xperm_partial: goal
-  atom has no match in hypothesis"`. Same fail-fast contract as
-  `xperm` for this direction.
-* **Hypothesis atom count < goal atom count** → throw `"xperm_partial:
-  hypothesis has fewer atoms than goal; use xperm or xcancel"`.
-* **Empty residual** (sizes equal, all atoms matched) → behave like
-  `xperm_hyp`: just bind `h_resid : empAssertion s` and finish. (Or
-  alternatively warn + delegate to `xperm_hyp`. Decide in slice 2.)
-
-## Survey of likely adopters (slice 3, evm-asm-zu8)
-
-Concrete sites that today hand-build a `sepConj_mono_*` tower or an
-explicit `(congrFun (show _ = _ by xperm) _).mp` and would shrink to one
-`xperm_partial h with h'` line:
-
-1. `EvmAsm/Evm64/Shift/ShlCompose.lean:760–767` — 6-deep nested
-   `sepConj_mono_right` chain peeling six atoms before `xperm_hyp`.
-2. `EvmAsm/Evm64/Shift/ShlCompose.lean:316–322, 456–462` — 1-deep
-   `sepConj_mono_left (regIs_to_regOwn …)` plus `xperm_hyp`. Less of a
-   win but still removes one layer.
-3. `EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean:107–108` and
-   `…LoopFour.lean:100` — 5-deep `sepConj_mono_right` chains.
-4. `EvmAsm/Evm64/Byte/Spec.lean:289–299, 407–417, 780–783, 900–906,
-   938–944` — pure asymmetry; better handled by `xperm_pure` (#1435)
-   than `xperm_partial`. Listed for completeness, NOT a target for
-   slice 3 of #156.
-
-Approximate impact on slice 3: ~30–60 LoC removed from Shift and RLP
-files, plus a readability win (a 7-line nested `mono_right` tower
-becomes one line). The Byte/Spec sites belong to #1435, not this
-issue.
-
-## What this design does NOT cover
-
-* **Bidirectional asymmetry** — i.e. *goal* has atoms not in the
-  hypothesis. Symmetric to the case `xperm_partial` handles, but the
-  semantics ("introduce a sub-goal asking the user to prove the missing
-  atom") is meaningfully different. Defer until a real call site
-  appears; today every surveyed asymmetric site has hyp ⊋ goal, never
-  goal ⊋ hyp.
-* **Multi-atom partial unification** — i.e. unification of goal atoms
-  against hypothesis atoms via metavariables. `xcancel` already covers
-  the single-`?Frame` case; multi-mvar matching can be added later
-  via `xperm_partial` if the need ever arises.
-* **Pure atoms** — covered by `xperm_pure` (#1435), not this issue.
+So the implementation cost is moderate; the blocker is genuine demand,
+not infrastructure.
 
 -/


### PR DESCRIPTION
Refs #156. Closes beads evm-asm-esr.

The slice-1 design note in EvmAsm/Rv64/Tactics/XPermPartial.lean
proposed extracting an unmatched residual via sepConj_mono_* +
`sepConjElim_right`. That is unsound:

- `sepConj_mono_left/right` are monotonicity, not projection — they
  weaken one factor of an existing chain on the same state, they cannot
  drop a factor.
- `sepConjElim_right` does not exist in SepLogic.lean. The closest is
  `holdsFor_sepConj_elim_right`, which has signature
  `(P ** Q).holdsFor s → Q.holdsFor s` and operates on a sub-heap, not
  raw assertion application. There is no closed `(P ** Q) s → Q s`.

This revision rewrites the design note to:

1. Document the flaw and why both Variants 1 and 2 are unsound on raw
   assertion application.
2. Re-survey the original 'obvious adopters' and reclassify them:
   - ShlCompose mono_left towers are *weakening* (regIs → regOwn),
     covered by `sepConj_mono_*`.
   - Phase2LongLoop{Three,Four} and Byte/Spec towers are *pure-leaf
     stripping*, covered by `xperm_pure` (#1435 / PR #1483).
   - `xcancel` already covers the residual-consumed-via-?Frame case.
   - No current site exhibits genuine residual-dropping.
3. Recommend deferring slice 2 (`evm-asm-cy7`) until a real call site
   appears; if one does, implement via `Assertion.holdsFor` +
   `holdsFor_sepConj_elim_right` rather than raw application.

Doc-only change. `lake build EvmAsm.Rv64.Tactics.XPermPartial` passes.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).