### PR TITLE
chore(189): camelCase data params in mulsub_correction_eq

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulSubChain.lean
@@ -93,12 +93,12 @@ theorem mulsub_chain_no_underflow (qNat : Nat)
 /-- After correction (add v back, decrement q), the equation holds.
     If `val256 u + 2^256 = val256 r + q * val256 v` with cb = 1 (underflow),
     then: `val256 u + 2^256 = (val256 r + val256 v) + (q - 1) * val256 v`. -/
-theorem mulsub_correction_eq (u_nat v_nat r_nat qNat : Nat)
-    (hchain : u_nat + 2^256 = r_nat + qNat * v_nat)
+theorem mulsub_correction_eq (uNat vNat rNat qNat : Nat)
+    (hchain : uNat + 2^256 = rNat + qNat * vNat)
     (hq : 0 < qNat) :
-    u_nat + 2^256 = (r_nat + v_nat) + (qNat - 1) * v_nat := by
+    uNat + 2^256 = (rNat + vNat) + (qNat - 1) * vNat := by
   have : qNat = 1 + (qNat - 1) := by omega
-  nlinarith [show qNat * v_nat = v_nat + (qNat - 1) * v_nat by nlinarith]
+  nlinarith [show qNat * vNat = vNat + (qNat - 1) * vNat by nlinarith]
 
 end EvmWord
 


### PR DESCRIPTION
Tiny mechanical batch toward #189 (snake_case → camelCase rename), data parameters only.

## Changes

In `EvmAsm/Evm64/EvmWordArith/MulSubChain.lean`,
`mulsub_correction_eq`:

- `u_nat` → `uNat`
- `v_nat` → `vNat`
- `r_nat` → `rNat`

`qNat` was already camelCase. Hypothesis names (`hchain`, `hq`) stay
snake_case per Mathlib convention (Props/proofs are snake_case — this is
the lesson from PR #1476's review).

The single call site
(`EvmAsm/Evm64/EvmWordArith/DivAddbackLimb.lean:130`,
`mulsub_correction_eq uVal vVal rMsVal qNat h_mulsub hq`) applies
positionally, so the rename is transparent.

## Verification

`lake build` is green locally (1405 jobs, 0 sorries).

Refs #189. Beads: evm-asm-haz.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).