### PR TITLE
ci(shake): add markers for documented false-positive classes

### DIFF
--- a/scripts/shake-filter.py
+++ b/scripts/shake-filter.py
@@ -87,6 +87,18 @@ MARKERS: list[tuple[str, str]] = [
     # Notation use — `notation \"Word\" => BitVec 64` is in Rv64.Basic; files
     # using `Word` look unrelated to that import.
     ("notation \"Word\"",  "Word notation defined in Rv64.Basic"),
+    # RLP Phase1 cascade helpers — the *Cascade*.lean files invoke
+    # `rlp_phase1_step_code_disjoint_*` lemmas registered in the
+    # `Phase1Disjoint` import (verified in evm-asm-5et: removing the import
+    # breaks the build). shake doesn't follow the chained-helper-name lookup.
+    ("rlp_phase1_step_code_disjoint",
+                           "Phase1Disjoint helpers used via attribute / chained lookup"),
+    # DivMod compose Offsets uses `divK_phaseA` / `divK_loopBody` etc inside
+    # `example := by decide` blocks; shake misses references inside `example`.
+    ("divK_phaseA",        "DivMod.Program identifiers used in `example` blocks"),
+    # EvmWordArith CallSkipClose uses `div128Quot_le_q_true` from
+    # Div128KB6Composition; shake doesn't follow the underscored compound name.
+    ("div128Quot",         "Div128KB6Composition lemmas referenced via compound names"),
 ]
 
 BLOCK_HEADER = re.compile(r"^/.+\.lean:$")


### PR DESCRIPTION
Extends `scripts/shake-filter.py` with three additional markers identified by the audit in beads task evm-asm-5et:

- `rlp_phase1_step_code_disjoint` — covers the four `EvmAsm/Rv64/RLP/Phase1Cascade*.lean` files (Phase1Disjoint import looks unused but is required).
- `divK_phaseA` — covers `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` (DivMod.Program used inside `example := by decide` blocks).
- `div128Quot` — covers `EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean` (`div128Quot_le_q_true` from Div128KB6Composition).

Each marker is documented inline with the false-positive class it targets. Verified by running synthesized shake blocks through the filter — all three new markers fire on the documented files with the correct reason string. Pure script change; no Lean code touched.

Refs #1045. Beads: evm-asm-5et.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).