### PR TITLE
docs(agents): clarify Mathlib naming — hypotheses snake_case, values camelCase

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,11 @@ When adding or modifying proofs:
 
 ## Critical Rules
 
+- **Naming convention (Mathlib-aligned):**
+  - **camelCase** for *value* identifiers: `let`-bound locals, theorem/lemma parameters, function arguments, definitions (e.g. `let qAddr := ...`, `theorem foo (carryNat : Nat)`).
+  - **snake_case** for *hypothesis* names — proof bindings introduced by `have h_… : Prop`, `obtain ⟨h_lt, h_eq⟩`, `intro h_pos`, etc. Mathlib keeps these snake_case (e.g. `h_pos`, `h_le`, `h_zero`, `h_eq`). Do **NOT** rename `h_*`-style hypothesis names to camelCase as part of #189 cleanup — that's the wrong direction. PR #1497 made this mistake.
+  - When in doubt: if it names a `Prop`-typed term used in a proof, leave snake_case; if it names data (a `Nat`, `Word`, `BitVec`, etc.), use camelCase.
+
 - **Do NOT add `set_option maxHeartbeats` to any file** unless you are in `Evm64/Shift/` composition files (Compose, ShlCompose, SarCompose) for body/path composition proofs. Heartbeat limits are configured globally in `lakefile.toml`.
 - **Do NOT add `set_option maxRecDepth` to any file.** Recursion depth is configured globally in `lakefile.toml`.
 - If a proof times out or hits recursion limits, restructure the proof (e.g., split into smaller lemmas, use intermediate `have` bindings) rather than increasing limits. Increasing `maxRecDepth`/`maxHeartbeats` is almost always a waste of time — the real issue is typically a unification mismatch, wrong argument order, or missing address canonicalization.


### PR DESCRIPTION
Adds a Critical Rules entry to AGENTS.md distinguishing:

- **camelCase** for value identifiers: `let`-locals, theorem/lemma parameters, function arguments, definitions.
- **snake_case** for hypothesis names: `have h_eq`, `obtain ⟨h_lt, h_pos⟩`, `intro h_pos` — Mathlib keeps these snake_case.

Motivation: PR #1497 renamed `have ha_fold/hc3_lt/...` to camelCase, which goes against Mathlib convention. This rule prevents future #189 slices from making the same mistake.

Beads parent task evm-asm-8ug also updated with the same clarification, and the misguided child task evm-asm-drm closed.

Refs #189.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).