### PR TITLE
refactor(rlp): adopt xperm_pure at long-loop closure call sites (#1435)

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopBody.lean
@@ -28,6 +28,7 @@
 
 import EvmAsm.Rv64.RLP.Phase2LongIter
 import EvmAsm.Rv64.Tactics.ExtractPure
+import EvmAsm.Rv64.Tactics.XPermPure
 
 namespace EvmAsm.Rv64.RLP
 

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
@@ -113,12 +113,9 @@ theorem rlp_phase2_long_loop_eight_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iters 2-8: seven-byte closure at base with (ptr+1, cnt=7).
   have seven_byte := rlp_phase2_long_loop_seven_byte_spec_within ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean
@@ -98,12 +98,9 @@ theorem rlp_phase2_long_loop_five_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iters 2-5: four-byte closure at base with (ptr+1, cnt=4).
   have four_byte := rlp_phase2_long_loop_four_byte_spec_within ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean
@@ -95,12 +95,9 @@ theorem rlp_phase2_long_loop_four_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iters 2-4: three-byte closure at base with (ptr+1, cnt=3).
   have three_byte := rlp_phase2_long_loop_three_byte_spec_within ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean
@@ -92,12 +92,9 @@ theorem rlp_phase2_long_loop_one_byte_spec_within
   -- reaching the innermost `F ** ⌜P⌝`).
   exact cpsTripleWithin_weaken
     (fun _ hp => hp)
-    (fun h hp => by
+    (fun _ hp => by
       simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-      refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-        (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-      intro h' hp'
-      exact ((sepConj_pure_right _).1 hp').1)
+      open EvmAsm.Rv64.Tactics in xperm_pure hp)
     tri
 
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
@@ -106,12 +106,9 @@ theorem rlp_phase2_long_loop_seven_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iters 2-7: six-byte closure at base with (ptr+1, cnt=6).
   have six_byte := rlp_phase2_long_loop_six_byte_spec_within ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
@@ -101,12 +101,9 @@ theorem rlp_phase2_long_loop_six_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iters 2-6: five-byte closure at base with (ptr+1, cnt=5).
   have five_byte := rlp_phase2_long_loop_five_byte_spec_within ((len <<< 8) + byte1)

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean
@@ -102,12 +102,9 @@ theorem rlp_phase2_long_loop_three_byte_spec_within
        (.x0 ↦ᵣ (0 : Word)) ** (dwordAddr ↦ₘ wordVal)) :=
     cpsTripleWithin_weaken
       (fun _ hp => hp)
-      (fun h hp => by
+      (fun _ hp => by
         simp only [rlp_phase2_long_loop_body_post_unfold] at hp
-        refine sepConj_mono_right (sepConj_mono_right (sepConj_mono_right
-          (sepConj_mono_right (sepConj_mono_right ?_)))) h hp
-        intro h' hp'
-        exact ((sepConj_pure_right _).1 hp').1)
+        open EvmAsm.Rv64.Tactics in xperm_pure hp)
       tri1
   -- Iter 2+3: two-byte closure starting at base with ptr+1, cnt = 2.
   have two_byte := rlp_phase2_long_loop_two_byte_spec_within ((len <<< 8) + byte1)


### PR DESCRIPTION
Closes evm-asm-ag3 (#1435 slice 3 — adopt pure-aware xperm at representative call sites).

The eight `Phase2LongLoop_*_byte_spec_within` proofs each carried an identical 5-deep `sepConj_mono_right` tower terminating in `((sepConj_pure_right _).1 _).1` to weaken the loop-body post by stripping its trailing pure atom. This is exactly the asymmetry-by-pure-leaf shape that `xperm_pure` (#1483, slice 2 of #1435) was built for.

This PR replaces the manual towers with a single `xperm_pure hp` call in each adopter, dropping ~5 lines per site (35 lines total) and removing the index-fragile `sepConj_mono_right` depth that previously broke whenever the underlying post was reshaped.

**Sites adopted (7 files, 7 weakenings):**
- `EvmAsm/Rv64/RLP/Phase2LongLoopOne.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopThree.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopFour.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopFive.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean`
- `EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean`

Bridge: `import EvmAsm.Rv64.Tactics.XPermPure` added to `Phase2LongLoopBody.lean` (the umbrella transitively imported by all seven downstream files).

`lake build` green; no proof skipped, no `set_option maxHeartbeats`, no `sorry`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).