### PR TITLE
chore(imports): drop unused Div128KnuthLower import in Div128CallSkipClose (#1045)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV2/QuotientBounds.lean
+++ b/EvmAsm/Evm64/EvmWordArith/CallSkipLowerBoundV2/QuotientBounds.lean
@@ -23,6 +23,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.Algorithm
+import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128CallSkipClose.lean
@@ -23,7 +23,6 @@
 -- Both `Div128KnuthLower` and `Div128FinalAssembly` transitively reach
 -- `Div128QuotientBounds → KnuthTheoremB`, which imports `MaxTrialVacuity`
 -- (→ `Compose.FullPathN4`) and `DivN4Overestimate` (→ `DivMod.LoopSemantic`).
-import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
 import EvmAsm.Evm64.EvmWordArith.Div128FinalAssembly
 import EvmAsm.Evm64.EvmWordArith.Div128KB6Composition
 

--- a/EvmAsm/Evm64/EvmWordArith/Div128Shift0.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Div128Shift0.lean
@@ -21,6 +21,7 @@
 -/
 
 import EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose
+import EvmAsm.Evm64.EvmWordArith.Div128KnuthLower
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Per audit in evm-asm-5et: `Div128CallSkipClose.lean` only mentions `Div128KnuthLower` in a doc comment — no symbol use. Drop the import.

Two transitive consumers (`Div128Shift0`, `CallSkipLowerBoundV2.QuotientBounds`) implicitly relied on `Div128CallSkipClose` to re-export `Div128KnuthLower`; this PR adds the direct import in each so the module graph remains correct (`lake build` green).

Refs #1045 (import-hygiene sweep via `lake exe shake`). Beads: evm-asm-dbe (slice of evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).