### PR TITLE
proof(divmod): add N2 bundled full wrapper

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -8,8 +8,9 @@ import EvmAsm.Evm64.DivMod.Spec
 -- which pull in LoopUnifiedN{1,2,3} + LoopComposeN3 + FullPathN{1,2,3}
 -- + FullPathN4Loop → LoopIterN4 → LoopBodyN4 → LoopBody → Compose +
 -- LoopDefs + EvmWordArith.DivN4Overestimate. ModFullPathN{1,3}LoopUnified
--- cover the MOD n=1/n=3 wrappers. FullPathN2Full covers FullPathN2LoopUnified
--- + FullPathN2Cases + FullPath.
+-- cover the MOD n=1/n=3 wrappers. FullPathN2Bundle carries shared N2
+-- irreducible intermediates for later full-wrapper refactors. FullPathN2Full
+-- covers FullPathN2LoopUnified + FullPathN2Cases + FullPath.
 -- SpecCallV4 transitively covers SpecCallAddbackBeq (+ AlgDefs, AlgEuclideans)
 -- and LoopDefs.IterV4InvariantsPhase2 (→ IterV4Invariants). The leaf
 -- NumericalTests / NumericalTestsV4 files are imported explicitly so the
@@ -19,6 +20,7 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 import EvmAsm.Evm64.DivMod.SpecCallV4

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,1 +1,2 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,4 +1,5 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -3,5 +3,6 @@ import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,2 +1,3 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,0 +1,1 @@
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,3 +1,4 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,6 +1,7 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle.lean
@@ -1,5 +1,6 @@
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
@@ -73,7 +73,7 @@ def fullDivN2C3 (bltu_2 bltu_1 bltu_0 : Bool)
   let u := fullDivN2NormU a0 a1 a2 a3 b1
   let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
   if bltu_0 then
-    (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+    (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v.2.1)
       v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
   else
     (mulsubN4 (signExtend12 4095 : Word)
@@ -151,7 +151,7 @@ theorem fullDivN2C3_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     let u := fullDivN2NormU a0 a1 a2 a3 b1
     let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
     if bltu_0 then
-      (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+      (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v.2.1)
         v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
     else
       (mulsubN4 (signExtend12 4095 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
@@ -1,0 +1,162 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+  Irreducible algorithm intermediates for n=2 full-path wrappers.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2LoopUnified
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def fullDivN2Shift (b1 : Word) : Word :=
+  (clzResult b1).1
+
+@[irreducible]
+def fullDivN2AntiShift (b1 : Word) : Word :=
+  signExtend12 (0 : BitVec 12) - fullDivN2Shift b1
+
+@[irreducible]
+def fullDivN2NormV (b0 b1 b2 b3 : Word) : Word × Word × Word × Word :=
+  let shift := fullDivN2Shift b1
+  let antiShift := fullDivN2AntiShift b1
+  (b0 <<< (shift.toNat % 64),
+   (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)),
+   (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)),
+   (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)))
+
+@[irreducible]
+def fullDivN2NormU (a0 a1 a2 a3 b1 : Word) :
+    Word × Word × Word × Word × Word :=
+  let shift := fullDivN2Shift b1
+  let antiShift := fullDivN2AntiShift b1
+  (a0 <<< (shift.toNat % 64),
+   (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)),
+   (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)),
+   (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)),
+   a3 >>> (antiShift.toNat % 64))
+
+@[irreducible]
+def fullDivN2R2 (bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  iterN2 bltu_2 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word)
+
+@[irreducible]
+def fullDivN2R1 (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN2 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+@[irreducible]
+def fullDivN2R0 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN2 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+@[irreducible]
+def fullDivN2C3 (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Word :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  if bltu_0 then
+    (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+  else
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+
+theorem fullDivN2Shift_unfold (b1 : Word) :
+    fullDivN2Shift b1 = (clzResult b1).1 := by
+  delta fullDivN2Shift
+  rfl
+
+theorem fullDivN2AntiShift_unfold (b1 : Word) :
+    fullDivN2AntiShift b1 = signExtend12 (0 : BitVec 12) - fullDivN2Shift b1 := by
+  delta fullDivN2AntiShift
+  rfl
+
+theorem fullDivN2NormV_unfold (b0 b1 b2 b3 : Word) :
+    fullDivN2NormV b0 b1 b2 b3 =
+    let shift := fullDivN2Shift b1
+    let antiShift := fullDivN2AntiShift b1
+    (b0 <<< (shift.toNat % 64),
+     (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)),
+     (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)),
+     (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))) := by
+  delta fullDivN2NormV
+  rfl
+
+theorem fullDivN2NormU_unfold (a0 a1 a2 a3 b1 : Word) :
+    fullDivN2NormU a0 a1 a2 a3 b1 =
+    let shift := fullDivN2Shift b1
+    let antiShift := fullDivN2AntiShift b1
+    (a0 <<< (shift.toNat % 64),
+     (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)),
+     (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)),
+     (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)),
+     a3 >>> (antiShift.toNat % 64)) := by
+  delta fullDivN2NormU
+  rfl
+
+theorem fullDivN2R2_unfold (bltu_2 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    iterN2 bltu_2 v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word) := by
+  delta fullDivN2R2
+  rfl
+
+theorem fullDivN2R1_unfold (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
+  delta fullDivN2R1
+  rfl
+
+theorem fullDivN2R0_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+      r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+  delta fullDivN2R0
+  rfl
+
+theorem fullDivN2C3_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    if bltu_0 then
+      (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+        v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
+    else
+      (mulsubN4 (signExtend12 4095 : Word)
+        v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 := by
+  delta fullDivN2C3
+  rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Branches.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Branches.lean
@@ -91,7 +91,7 @@ theorem fullDivN2C3_true (bltu_2 bltu_1 : Bool)
     let v := fullDivN2NormV b0 b1 b2 b3
     let u := fullDivN2NormU a0 a1 a2 a3 b1
     let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-    (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+    (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v.2.1)
       v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 := by
   delta fullDivN2C3
   rfl

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Branches.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Branches.lean
@@ -1,0 +1,99 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
+
+  Branch-specialized unfold equations for the n=2 full-path intermediates.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem fullDivN2R2_false
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2 false a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    iterN2Max v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word) := by
+  rw [fullDivN2R2_unfold]
+  simp only [iterN2_false]
+
+theorem fullDivN2R2_true
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R2 true a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    iterN2Call v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.2.1 u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word) := by
+  rw [fullDivN2R2_unfold]
+  simp only [iterN2_true]
+
+theorem fullDivN2R1_false (bltu_2 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1 bltu_2 false a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2Max v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
+  rw [fullDivN2R1_unfold]
+  simp only [iterN2_false]
+
+theorem fullDivN2R1_true (bltu_2 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R1 bltu_2 true a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2Call v.1 v.2.1 v.2.2.1 v.2.2.2
+      u.2.1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 := by
+  rw [fullDivN2R1_unfold]
+  simp only [iterN2_true]
+
+theorem fullDivN2R0_false (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R0 bltu_2 bltu_1 false a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2Max v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+      r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+  rw [fullDivN2R0_unfold]
+  simp only [iterN2_false]
+
+theorem fullDivN2R0_true (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2R0 bltu_2 bltu_1 true a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    iterN2Call v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+      r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 := by
+  rw [fullDivN2R0_unfold]
+  simp only [iterN2_true]
+
+theorem fullDivN2C3_false (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2C3 bltu_2 bltu_1 false a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    (mulsubN4 (signExtend12 4095 : Word)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 := by
+  delta fullDivN2C3
+  rfl
+
+theorem fullDivN2C3_true (bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2C3 bltu_2 bltu_1 true a0 a1 a2 a3 b0 b1 b2 b3 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    (mulsubN4 (div128Quot r1.2.1 u.1 v.2.1)
+      v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 := by
+  delta fullDivN2C3
+  rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Bridge.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Bridge.lean
@@ -1,0 +1,43 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge
+
+  Public bridge from the n=2 unified loop postcondition to the bundled denorm
+  precondition and preserved frame.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  cases bltu_2 <;> cases bltu_1 <;> cases bltu_0
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FFF
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FFT
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FTF
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FTT
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TFF
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TFT
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TTF
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+  · exact preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TTT
+      sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/BridgeFalse.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/BridgeFalse.lean
@@ -1,0 +1,194 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse
+
+  False-leading path bridge lemmas from the n=2 unified loop postcondition to
+  the bundled denorm precondition and preserved frame.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FFF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost false false false sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre false false false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame false false false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2MaxPost loopIterPostN2Max at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_false, ite_false, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_false,
+    fullDivN2Scratch1_false, fullDivN2Scratch2_false]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_false, fullDivN2R1_false, fullDivN2R0_false,
+     fullDivN2C3_false, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Max v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Max v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Max v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (signExtend12 4095 : Word)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FFT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost false false true sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre false false true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame false false true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2MaxCallPost loopIterPostN2Call at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_false, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_false, fullDivN2R1_false, fullDivN2R0_true,
+     fullDivN2C3_true, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Max v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Max v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Call v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FTF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost false true false sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre false true false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame false true false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2CallMaxPost loopIterPostN2Max at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_false, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_false,
+    fullDivN2Scratch1_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_false, fullDivN2R1_true, fullDivN2R0_false,
+     fullDivN2C3_false, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Max v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Call v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Max v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (signExtend12 4095 : Word)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_FTT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost false true true sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre false true true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame false true true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2CallCallPost loopIterPostN2Call at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_false, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_false, fullDivN2R1_true, fullDivN2R0_true,
+     fullDivN2C3_true, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Max v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Call v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Call v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/BridgeTrue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/BridgeTrue.lean
@@ -1,0 +1,194 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue
+
+  True-leading path bridge lemmas from the n=2 unified loop postcondition to
+  the bundled denorm precondition and preserved frame.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TFF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost true false false sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre true false false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame true false false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2MaxPost loopIterPostN2Max at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_true, ite_true, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_false,
+    fullDivN2Scratch1_false, fullDivN2Scratch2_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_true, fullDivN2R1_false, fullDivN2R0_false,
+     fullDivN2C3_false, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Call v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Max v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Max v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (signExtend12 4095 : Word)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TFT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost true false true sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre true false true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame true false true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2MaxCallPost loopIterPostN2Call at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_true, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_true, fullDivN2R1_false, fullDivN2R0_true,
+     fullDivN2C3_true, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Call v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Max v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Call v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TTF
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost true true false sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre true true false sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame true true false sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2CallMaxPost loopIterPostN2Max at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_true, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_false,
+    fullDivN2Scratch1_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_true, fullDivN2R1_true, fullDivN2R0_false,
+     fullDivN2C3_false, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Call v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Call v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Max v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (signExtend12 4095 : Word)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+theorem preloopN2UnifiedPost_to_fullDivN2DenormPre_frame_TTT
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (h : PartialState)
+    (hp :
+      preloopN2UnifiedPost true true true sp base a0 a1 a2 a3 b0 b1 b2 b3
+        retMem dMem dloMem scratch_un0 h) :
+    (fullDivN2DenormPre true true true sp a0 a1 a2 a3 b0 b1 b2 b3 **
+     fullDivN2Frame true true true sp base a0 a1 a2 a3 b0 b1 b2 b3
+       retMem dMem dloMem scratch_un0) h := by
+  delta preloopN2UnifiedPost loopN2UnifiedPost at hp
+  simp (config := { decide := true }) only [] at hp
+  delta loopN2Iter10Post loopN2CallCallPost loopIterPostN2Call at hp
+  simp (config := { decide := true }) only
+    [loopExitPostN2_j0_eq, n2_ub2_off4064, n2_qa2, n3_ub1_off4064, n3_qa1,
+      iterN2_true, se12_32, se12_40, se12_48, se12_56] at hp
+  rw [fullDivN2DenormPre_unfold, fullDivN2Frame_unfold,
+    fullDivN2ScratchFinal_unfold, fullDivN2Scratch0_true]
+  simp (config := { decide := true }) only
+    [fullDivN2Shift_unfold, fullDivN2AntiShift_unfold,
+     fullDivN2NormV_unfold, fullDivN2NormU_unfold,
+     fullDivN2R2_true, fullDivN2R1_true, fullDivN2R0_true,
+     fullDivN2C3_true, n2ScratchRet_unfold, n2ScratchD_unfold,
+     n2ScratchDLo_unfold, n2ScratchUn0_unfold,
+     se12_32, se12_40, se12_48, se12_56]
+  set shift := (clzResult b1).1 with hshift
+  set antiShift := (signExtend12 (0 : BitVec 12) - shift) with hantiShift
+  set v0 := b0 <<< (shift.toNat % 64) with hv0
+  set v1 := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64)) with hv1
+  set v2 := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64)) with hv2
+  set v3 := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64)) with hv3
+  set u0 := a0 <<< (shift.toNat % 64) with hu0
+  set u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64)) with hu1
+  set u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64)) with hu2
+  set u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64)) with hu3
+  set u4 := a3 >>> (antiShift.toNat % 64) with hu4
+  set r2 := iterN2Call v0 v1 v2 v3 u2 u3 u4 (0 : Word) (0 : Word) with hr2
+  set r1 := iterN2Call v0 v1 v2 v3 u1 r2.2.1 r2.2.2.1 r2.2.2.2.1
+    r2.2.2.2.2.1 with hr1
+  set r0 := iterN2Call v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1
+    r1.2.2.2.2.1 with hr0
+  set c3 := (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v1)
+    v0 v1 v2 v3 u0 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 with hc3
+  xperm_hyp hp
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Full.lean
@@ -1,0 +1,115 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full
+
+  Compact n=2 DIV full wrapper backed by the bundled denorm postcondition and
+  preserved frame.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.AddrNorm (se12_32 se12_40 se12_48 se12_56)
+
+theorem evm_div_n2_denorm_epilogue_bundled_spec
+    (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hshift_nz : fullDivN2Shift b1 ≠ 0) :
+    cpsTripleWithin (2 + 23 + 10) (base + denormOff) (base + nopOff) (divCode base)
+      (fullDivN2DenormPre bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3)
+      (fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3) := by
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let c3 := fullDivN2C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have h := evm_div_preamble_denorm_epilogue_spec sp base
+    r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1 shift
+    r0.2.2.2.2.1 (0 : Word) (sp + signExtend12 4056) (sp + signExtend12 4088)
+    c3 r0.1 r1.1 r2.1 (0 : Word)
+    v.1 v.2.1 v.2.2.1 v.2.2.2 hshift_nz
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      subst shift; subst v; subst r2; subst r1; subst r0; subst c3
+      delta fullDivN2DenormPre at hp
+      simp only [se12_32, se12_40, se12_48, se12_56] at hp
+      xperm_hyp hp)
+    (fun h hq => by
+      subst shift; subst r2; subst r1; subst r0
+      delta fullDivN2DenormPost
+      xperm_hyp hq)
+    h
+
+theorem evm_div_n2_full_bundled_spec
+    (bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem : Word)
+    (retMem dMem dloMem scratch_un0 : Word)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2z : b2 = 0) (hb1nz : b1 ≠ 0)
+    (hshift_nz : (clzResult b1).1 ≠ 0)
+    (halign : ((base + 516) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + 516)
+    (hbltu_2 : isTrialN2_j2 bltu_2 a3 b0 b1)
+    (hbltu_1 : isTrialN2_j1 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN2_j0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b1).1).toNat % 64))
+      ((b1 <<< (((clzResult b1).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
+      ((b2 <<< (((clzResult b1).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))
+      ((b3 <<< (((clzResult b1).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b1).1).toNat % 64)))) :
+    cpsTripleWithin 744 base (base + nopOff) (divCode base)
+      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ (clzResult b1).2 >>> (63 : Nat)) **
+       (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
+       (.x11 ↦ᵣ v11Old) **
+       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+       ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
+       ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3) **
+       ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
+       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
+       ((sp + signExtend12 4056) ↦ₘ u0Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
+       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
+       ((sp + signExtend12 4024) ↦ₘ u4Old) **
+       ((sp + signExtend12 4016) ↦ₘ u5) ** ((sp + signExtend12 4008) ↦ₘ u6) **
+       ((sp + signExtend12 4000) ↦ₘ u7) ** ((sp + signExtend12 3984) ↦ₘ nMem) **
+       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
+       ((sp + signExtend12 3976) ↦ₘ jMem) **
+       ((sp + signExtend12 3968) ↦ₘ retMem) **
+       ((sp + signExtend12 3960) ↦ₘ dMem) **
+       ((sp + signExtend12 3952) ↦ₘ dloMem) **
+       ((sp + signExtend12 3944) ↦ₘ scratch_un0))
+      (fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 **
+       fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+         retMem dMem dloMem scratch_un0) := by
+  have hshift_nz' : fullDivN2Shift b1 ≠ 0 := by
+    rw [fullDivN2Shift_unfold]
+    exact hshift_nz
+  have hA := evm_div_n2_preloop_loop_unified_spec bltu_2 bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7 nMem shiftMem jMem
+    retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2z hb1nz hshift_nz halign hbltu_2 hbltu_1 hbltu_0 hcarry2
+  have hB := evm_div_n2_denorm_epilogue_bundled_spec bltu_2 bltu_1 bltu_0
+    sp base a0 a1 a2 a3 b0 b1 b2 b3 hshift_nz'
+  have hBF := cpsTripleWithin_frameR
+    (fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0)
+    (by
+      delta fullDivN2Frame fullDivN2ScratchFinal fullDivN2Scratch0 fullDivN2Scratch1
+        fullDivN2Scratch2 n2ScratchRet n2ScratchD n2ScratchDLo n2ScratchUn0
+      pcFree) hB
+  have hFull := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => preloopN2UnifiedPost_to_fullDivN2DenormPre_frame
+      bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 h hp)
+    hA hBF
+  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hq => by xperm_hyp hq)
+    hFull
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean
@@ -1,0 +1,122 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
+
+  One-step irreducible scratch-state transitions for n=2 full-path wrappers.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+def N2ScratchState : Type :=
+  Word × Word × Word × Word
+
+@[irreducible]
+def n2ScratchRet (s : N2ScratchState) : Word :=
+  s.1
+
+@[irreducible]
+def n2ScratchD (s : N2ScratchState) : Word :=
+  s.2.1
+
+@[irreducible]
+def n2ScratchDLo (s : N2ScratchState) : Word :=
+  s.2.2.1
+
+@[irreducible]
+def n2ScratchUn0 (s : N2ScratchState) : Word :=
+  s.2.2.2
+
+@[irreducible]
+def fullDivN2Scratch2 (bltu_2 : Bool) (base v1 u2 retMem dMem dloMem scratch_un0 : Word) :
+    N2ScratchState :=
+  if bltu_2 then
+    (base + 516, v1, div128DLo v1, div128Un0 u2)
+  else
+    (retMem, dMem, dloMem, scratch_un0)
+
+@[irreducible]
+def fullDivN2Scratch1 (bltu_2 bltu_1 : Bool)
+    (base v1 u2 r2_hi retMem dMem dloMem scratch_un0 : Word) :
+    N2ScratchState :=
+  let s2 := fullDivN2Scratch2 bltu_2 base v1 u2 retMem dMem dloMem scratch_un0
+  if bltu_1 then
+    (base + 516, v1, div128DLo v1, div128Un0 r2_hi)
+  else
+    s2
+
+@[irreducible]
+def fullDivN2Scratch0 (bltu_2 bltu_1 bltu_0 : Bool)
+    (base v1 u2 r2_hi r1_hi retMem dMem dloMem scratch_un0 : Word) :
+    N2ScratchState :=
+  let s1 := fullDivN2Scratch1 bltu_2 bltu_1 base v1 u2 r2_hi retMem dMem dloMem scratch_un0
+  if bltu_0 then
+    (base + 516, v1, div128DLo v1, div128Un0 r1_hi)
+  else
+    s1
+
+theorem n2ScratchRet_unfold (s : N2ScratchState) :
+    n2ScratchRet s = s.1 := by
+  delta n2ScratchRet
+  rfl
+
+theorem n2ScratchD_unfold (s : N2ScratchState) :
+    n2ScratchD s = s.2.1 := by
+  delta n2ScratchD
+  rfl
+
+theorem n2ScratchDLo_unfold (s : N2ScratchState) :
+    n2ScratchDLo s = s.2.2.1 := by
+  delta n2ScratchDLo
+  rfl
+
+theorem n2ScratchUn0_unfold (s : N2ScratchState) :
+    n2ScratchUn0 s = s.2.2.2 := by
+  delta n2ScratchUn0
+  rfl
+
+theorem fullDivN2Scratch2_true (base v1 u2 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch2 true base v1 u2 retMem dMem dloMem scratch_un0 =
+      (base + 516, v1, div128DLo v1, div128Un0 u2) := by
+  delta fullDivN2Scratch2
+  rfl
+
+theorem fullDivN2Scratch2_false (base v1 u2 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch2 false base v1 u2 retMem dMem dloMem scratch_un0 =
+      (retMem, dMem, dloMem, scratch_un0) := by
+  delta fullDivN2Scratch2
+  rfl
+
+theorem fullDivN2Scratch1_true (bltu_2 : Bool)
+    (base v1 u2 r2_hi retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch1 bltu_2 true base v1 u2 r2_hi retMem dMem dloMem scratch_un0 =
+      (base + 516, v1, div128DLo v1, div128Un0 r2_hi) := by
+  delta fullDivN2Scratch1
+  rfl
+
+theorem fullDivN2Scratch1_false (bltu_2 : Bool)
+    (base v1 u2 r2_hi retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch1 bltu_2 false base v1 u2 r2_hi retMem dMem dloMem scratch_un0 =
+      fullDivN2Scratch2 bltu_2 base v1 u2 retMem dMem dloMem scratch_un0 := by
+  delta fullDivN2Scratch1
+  rfl
+
+theorem fullDivN2Scratch0_true (bltu_2 bltu_1 : Bool)
+    (base v1 u2 r2_hi r1_hi retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch0 bltu_2 bltu_1 true base v1 u2 r2_hi r1_hi
+        retMem dMem dloMem scratch_un0 =
+      (base + 516, v1, div128DLo v1, div128Un0 r1_hi) := by
+  delta fullDivN2Scratch0
+  rfl
+
+theorem fullDivN2Scratch0_false (bltu_2 bltu_1 : Bool)
+    (base v1 u2 r2_hi r1_hi retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Scratch0 bltu_2 bltu_1 false base v1 u2 r2_hi r1_hi
+        retMem dMem dloMem scratch_un0 =
+      fullDivN2Scratch1 bltu_2 bltu_1 base v1 u2 r2_hi retMem dMem dloMem scratch_un0 := by
+  delta fullDivN2Scratch0
+  rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -48,6 +48,17 @@ def fullDivN2DenormPre (bltu_2 bltu_1 bltu_0 : Bool)
    ((sp + signExtend12 56) ↦ₘ v.2.2.2))
 
 @[irreducible]
+def fullDivN2DenormPost (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+    r0.1 r1.1 r2.1 (0 : Word) **
+  ((sp + signExtend12 3992) ↦ₘ shift)
+
+@[irreducible]
 def fullDivN2Frame (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
     Assertion :=
@@ -109,6 +120,19 @@ theorem fullDivN2DenormPre_unfold (bltu_2 bltu_1 bltu_0 : Bool)
      ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
      ((sp + signExtend12 56) ↦ₘ v.2.2.2)) := by
   delta fullDivN2DenormPre
+  rfl
+
+theorem fullDivN2DenormPost_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    let shift := fullDivN2Shift b1
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
+      r0.1 r1.1 r2.1 (0 : Word) **
+    ((sp + signExtend12 3992) ↦ₘ shift) := by
+  delta fullDivN2DenormPost
   rfl
 
 theorem fullDivN2Frame_unfold (bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -1,0 +1,139 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.State
+
+  Bundled n=2 denorm precondition and preserved frame definitions.
+-/
+
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def fullDivN2ScratchFinal (bltu_2 bltu_1 bltu_0 : Bool)
+    (base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    N2ScratchState :=
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let u := fullDivN2NormU a0 a1 a2 a3 b1
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.1 r2.2.1 r1.2.1
+    retMem dMem dloMem scratch_un0
+
+@[irreducible]
+def fullDivN2DenormPre (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Assertion :=
+  let shift := fullDivN2Shift b1
+  let v := fullDivN2NormV b0 b1 b2 b3
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+   (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+   (.x2 ↦ᵣ r0.2.2.2.2.1) **
+   (.x10 ↦ᵣ fullDivN2C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) **
+   ((sp + signExtend12 3992) ↦ₘ shift) **
+   ((sp + signExtend12 4056) ↦ₘ r0.2.1) **
+   ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+   ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) **
+   ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+   ((sp + signExtend12 4088) ↦ₘ r0.1) **
+   ((sp + signExtend12 4080) ↦ₘ r1.1) **
+   ((sp + signExtend12 4072) ↦ₘ r2.1) **
+   ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+   ((sp + signExtend12 32) ↦ₘ v.1) **
+   ((sp + signExtend12 40) ↦ₘ v.2.1) **
+   ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
+   ((sp + signExtend12 56) ↦ₘ v.2.2.2))
+
+@[irreducible]
+def fullDivN2Frame (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    Assertion :=
+  let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let scratch := fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
+    a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+  ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+  ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+  ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+  ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+  ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+  ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+  (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+  (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+  (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+  (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
+  (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
+  (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
+  (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch)
+
+theorem fullDivN2ScratchFinal_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 =
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let u := fullDivN2NormU a0 a1 a2 a3 b1
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.1 r2.2.1 r1.2.1
+      retMem dMem dloMem scratch_un0 := by
+  delta fullDivN2ScratchFinal
+  rfl
+
+theorem fullDivN2DenormPre_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN2DenormPre bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
+    let shift := fullDivN2Shift b1
+    let v := fullDivN2NormV b0 b1 b2 b3
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ sp + signExtend12 4056) ** (.x0 ↦ᵣ (0 : Word)) **
+     (.x5 ↦ᵣ (0 : Word)) ** (.x7 ↦ᵣ sp + signExtend12 4088) **
+     (.x2 ↦ᵣ r0.2.2.2.2.1) **
+     (.x10 ↦ᵣ fullDivN2C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) **
+     ((sp + signExtend12 3992) ↦ₘ shift) **
+     ((sp + signExtend12 4056) ↦ₘ r0.2.1) **
+     ((sp + signExtend12 4048) ↦ₘ r0.2.2.1) **
+     ((sp + signExtend12 4040) ↦ₘ r0.2.2.2.1) **
+     ((sp + signExtend12 4032) ↦ₘ r0.2.2.2.2.1) **
+     ((sp + signExtend12 4088) ↦ₘ r0.1) **
+     ((sp + signExtend12 4080) ↦ₘ r1.1) **
+     ((sp + signExtend12 4072) ↦ₘ r2.1) **
+     ((sp + signExtend12 4064) ↦ₘ (0 : Word)) **
+     ((sp + signExtend12 32) ↦ₘ v.1) **
+     ((sp + signExtend12 40) ↦ₘ v.2.1) **
+     ((sp + signExtend12 48) ↦ₘ v.2.2.1) **
+     ((sp + signExtend12 56) ↦ₘ v.2.2.2)) := by
+  delta fullDivN2DenormPre
+  rfl
+
+theorem fullDivN2Frame_unfold (bltu_2 bltu_1 bltu_0 : Bool)
+    (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
+    fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3
+      retMem dMem dloMem scratch_un0 =
+    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    let scratch := fullDivN2ScratchFinal bltu_2 bltu_1 bltu_0 base
+      a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+    ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+    ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
+    ((sp + signExtend12 4024) ↦ₘ r0.2.2.2.2.2) **
+    ((sp + signExtend12 4016) ↦ₘ r1.2.2.2.2.2) **
+    ((sp + signExtend12 4008) ↦ₘ r2.2.2.2.2.2) **
+    ((sp + signExtend12 4000) ↦ₘ (0 : Word)) **
+    (sp + signExtend12 3984 ↦ₘ (2 : Word)) **
+    (sp + signExtend12 3976 ↦ₘ (0 : Word)) **
+    (.x1 ↦ᵣ signExtend12 4095) ** (.x11 ↦ᵣ r0.1) **
+    (sp + signExtend12 3968 ↦ₘ n2ScratchRet scratch) **
+    (sp + signExtend12 3960 ↦ₘ n2ScratchD scratch) **
+    (sp + signExtend12 3952 ↦ₘ n2ScratchDLo scratch) **
+    (sp + signExtend12 3944 ↦ₘ n2ScratchUn0 scratch) := by
+  delta fullDivN2Frame
+  rfl
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -18,7 +18,7 @@ def fullDivN2ScratchFinal (bltu_2 bltu_1 bltu_0 : Bool)
   let u := fullDivN2NormU a0 a1 a2 a3 b1
   let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
   let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-  fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.1 r2.2.1 r1.2.1
+  fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.2.1 r2.2.1 r1.2.1
     retMem dMem dloMem scratch_un0
 
 @[irreducible]
@@ -78,7 +78,7 @@ theorem fullDivN2ScratchFinal_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     let u := fullDivN2NormU a0 a1 a2 a3 b1
     let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
     let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-    fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.1 r2.2.1 r1.2.1
+    fullDivN2Scratch0 bltu_2 bltu_1 bltu_0 base v.2.1 u.2.2.2.1 r2.2.1 r1.2.1
       retMem dMem dloMem scratch_un0 := by
   delta fullDivN2ScratchFinal
   rfl


### PR DESCRIPTION
Codex PR for issue 61 / bead evm-asm-7u4.\n\nSummary:\n- add irreducible N2 bundle intermediates, branch folds, scratch state, denorm pre/post, and preserved frame\n- prove false-leading and true-leading bridges from preloopN2UnifiedPost to the bundled denorm pre/frame\n- add evm_div_n2_full_bundled_spec backed by fullDivN2DenormPost ** fullDivN2Frame while leaving existing evm_div_n2_full_unified_spec available\n- fix two N2 bundle wiring issues found by the bridge proofs: final-call C3 quotient operands and j=2 call scratch source\n\nLocal verification:\n- lake build EvmAsm.Evm64.DivMod\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check