### PR TITLE
proof(divmod): add dispatcher branch surfaces

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
@@ -48,6 +48,29 @@ theorem sharedDivModCode_sub_modDispatcherCode {base : Word} :
     ∀ a i, (sharedDivModCode base) a = some i → (modDispatcherCode base) a = some i :=
   sharedDivModCode_sub_modCode
 
+abbrev evm_div_spec_within_bzero := evm_div_bzero_spec_within
+abbrev evm_div_spec_within_n1Full := evm_div_n1_full_unified_spec
+abbrev evm_div_spec_within_n2Full := evm_div_n2_full_bundled_spec
+abbrev evm_div_spec_within_n3Full := evm_div_n3_full_unified_spec
+abbrev evm_div_spec_within_n4MaxSkip := evm_div_n4_full_max_skip_spec
+abbrev evm_div_spec_within_n4CallSkip := evm_div_n4_full_call_skip_spec
+abbrev evm_div_spec_within_n4MaxAddbackBeq := evm_div_n4_full_max_addback_beq_spec
+abbrev evm_div_spec_within_n4CallAddbackBeq := evm_div_n4_full_call_addback_beq_spec
+abbrev evm_div_spec_within_n4Shift0CallSkip := evm_div_n4_full_shift0_call_skip_spec
+abbrev evm_div_spec_within_n4Shift0CallAddbackBeq :=
+  evm_div_n4_full_shift0_call_addback_beq_spec
+
+abbrev evm_mod_spec_within_bzero := evm_mod_bzero_spec_within
+abbrev evm_mod_spec_within_n1Full := evm_mod_n1_full_unified_spec
+abbrev evm_mod_spec_within_n2Full := evm_mod_n2_full_unified_spec
+abbrev evm_mod_spec_within_n3Full := evm_mod_n3_full_unified_spec
+abbrev evm_mod_spec_within_n4MaxSkip := evm_mod_n4_full_max_skip_spec_within
+abbrev evm_mod_spec_within_n4CallSkip := evm_mod_n4_full_call_skip_spec_within
+abbrev evm_mod_spec_within_n4CallAddbackBeq := evm_mod_n4_full_call_addback_beq_spec_within
+abbrev evm_mod_spec_within_n4Shift0CallSkip := evm_mod_n4_full_shift0_call_skip_spec
+abbrev evm_mod_spec_within_n4Shift0CallAddbackBeq :=
+  evm_mod_n4_full_shift0_call_addback_beq_spec
+
 inductive DivDispatchBranch where
   | bzero
   | n1Full
@@ -95,5 +118,33 @@ def ModDispatchBranch.bound : ModDispatchBranch → Nat
   | .n4CallAddbackBeq => 340
   | .n4Shift0CallSkip => 208
   | .n4Shift0CallAddbackBeq => 284
+
+/-- Dispatcher registry for bounded limb-level DIV paths. The proof surface is
+    the corresponding path theorem named in each branch comment below. -/
+def evm_div_spec_within : List (DivDispatchBranch × Nat) :=
+  [(.bzero, DivDispatchBranch.bound .bzero),                         -- evm_div_bzero_spec_within
+   (.n1Full, DivDispatchBranch.bound .n1Full),                       -- evm_div_n1_full_unified_spec
+   (.n2Full, DivDispatchBranch.bound .n2Full),                       -- evm_div_n2_full_bundled_spec
+   (.n3Full, DivDispatchBranch.bound .n3Full),                       -- evm_div_n3_full_unified_spec
+   (.n4MaxSkip, DivDispatchBranch.bound .n4MaxSkip),                 -- evm_div_n4_full_max_skip_spec
+   (.n4CallSkip, DivDispatchBranch.bound .n4CallSkip),               -- evm_div_n4_full_call_skip_spec
+   (.n4MaxAddbackBeq, DivDispatchBranch.bound .n4MaxAddbackBeq),     -- evm_div_n4_full_max_addback_beq_spec
+   (.n4CallAddbackBeq, DivDispatchBranch.bound .n4CallAddbackBeq),   -- evm_div_n4_full_call_addback_beq_spec
+   (.n4Shift0CallSkip, DivDispatchBranch.bound .n4Shift0CallSkip),   -- evm_div_n4_full_shift0_call_skip_spec
+   (.n4Shift0CallAddbackBeq, DivDispatchBranch.bound .n4Shift0CallAddbackBeq)]
+                                                                        -- evm_div_n4_full_shift0_call_addback_beq_spec
+
+/-- Dispatcher registry for bounded limb-level MOD paths. -/
+def evm_mod_spec_within : List (ModDispatchBranch × Nat) :=
+  [(.bzero, ModDispatchBranch.bound .bzero),                         -- evm_mod_bzero_spec_within
+   (.n1Full, ModDispatchBranch.bound .n1Full),                       -- evm_mod_n1_full_unified_spec
+   (.n2Full, ModDispatchBranch.bound .n2Full),                       -- evm_mod_n2_full_unified_spec
+   (.n3Full, ModDispatchBranch.bound .n3Full),                       -- evm_mod_n3_full_unified_spec
+   (.n4MaxSkip, ModDispatchBranch.bound .n4MaxSkip),                 -- evm_mod_n4_full_max_skip_spec_within
+   (.n4CallSkip, ModDispatchBranch.bound .n4CallSkip),               -- evm_mod_n4_full_call_skip_spec_within
+   (.n4CallAddbackBeq, ModDispatchBranch.bound .n4CallAddbackBeq),   -- evm_mod_n4_full_call_addback_beq_spec_within
+   (.n4Shift0CallSkip, ModDispatchBranch.bound .n4Shift0CallSkip),   -- evm_mod_n4_full_shift0_call_skip_spec
+   (.n4Shift0CallAddbackBeq, ModDispatchBranch.bound .n4Shift0CallAddbackBeq)]
+                                                                        -- evm_mod_n4_full_shift0_call_addback_beq_spec
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -56,7 +56,7 @@ private theorem d128_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
 /-- Bundled postcondition for `div128_spec_within` (and `mod_div128_spec_within`).
     Hides the 25-let chain that computes Phase 1 / compute-un21 / Phase 2 /
     Phase 2b-guarded / end-combine intermediates so the theorem signature
-    stays a clean `cpsTripleWithin 10000 A B C P (div128SpecPost …)` instead of a
+    stays a clean `cpsTripleWithin n A B C P (div128SpecPost …)` instead of a
     let-chain immediately preceding the triple (anti-pattern, slows
     elaboration). Marked `@[irreducible]` so callers see only the bundled
     assertion; `unfold` to expose the lets when threading downstream.
@@ -612,4 +612,3 @@ theorem div128_v2_spec_shared_within (sp retAddr d uLo uHi : Word) (base : Word)
   cpsTripleWithin_extend_code (hmono := shared_b12_div128_v2_sub)
     (div128_v2_spec_within sp retAddr d uLo uHi base v1Old v6Old v11Old
                      retMem dMem dloMem un0Mem halign)
-

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -201,16 +201,16 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 10000 (base + 916) (base + epilogueOff) (divCode base)
+    cpsTripleWithin 23 (base + 916) (base + epilogueOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u3') ** (.x7 ↦ᵣ (u3 <<< (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
+      (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0') ** ((sp + signExtend12 4048) ↦ₘ u1') **
        ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) :=
-  cpsTripleWithin_mono_nSteps (by decide) (divK_denorm_body_spec_within sp u0 u1 u2 u3 v2 v5 v7 shift base)
+  divK_denorm_body_spec_within sp u0 u1 u2 u3 v2 v5 v7 shift base
 
 -- ============================================================================
 -- Section 10m: DIV Epilogue composition (10 instructions at base+1008)
@@ -277,7 +277,7 @@ theorem divK_div_epilogue_spec_within (sp : Word) (base : Word)
 
 theorem divK_div_epilogue_spec (sp : Word) (base : Word)
     (q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24 : Word) :
-    cpsTripleWithin 10000 (base + epilogueOff) (base + nopOff) (divCode base)
+    cpsTripleWithin 10 (base + epilogueOff) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
@@ -288,7 +288,7 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
        ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
        ((sp + 32) ↦ₘ q0) ** ((sp + 40) ↦ₘ q1) **
        ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (divK_div_epilogue_spec_within sp base q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24)
+  divK_div_epilogue_spec_within sp base q0 q1 q2 q3 v5 v6 v7 v10 m0 m8 m16 m24
 
 -- ============================================================================
 -- Section 11: MOD program code infrastructure
@@ -418,14 +418,14 @@ theorem evm_mod_phaseA_ntaken_spec_within (sp base : Word)
 theorem evm_mod_phaseA_ntaken_spec (sp base : Word)
     (b0 b1 b2 b3 v5 v10 : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
-    cpsTripleWithin 10000 base (base + phaseBOff) (modCode base)
+    cpsTripleWithin 8 base (base + phaseBOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3))
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ (b0 ||| b1 ||| b2 ||| b3)) ** (.x10 ↦ᵣ b3) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
        ((sp + 48) ↦ₘ b2) ** ((sp + 56) ↦ₘ b3)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (evm_mod_phaseA_ntaken_spec_within sp base b0 b1 b2 b3 v5 v10 hbnz)
+  evm_mod_phaseA_ntaken_spec_within sp base b0 b1 b2 b3 v5 v10 hbnz
 
 -- ============================================================================
 -- Section 14: MOD epilogue composition (load u[0..3], store to output)
@@ -488,4 +488,3 @@ theorem divK_mod_epilogue_spec_within (sp : Word) (base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h12
-

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -114,7 +114,7 @@ theorem divK_loop_body_n4_max_skip_j0_divCode
     let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (divCode base)
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -212,7 +212,7 @@ theorem divK_loop_body_n4_max_skip_j0_modCode
     (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4SkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
       (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
@@ -264,7 +264,7 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
     (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -386,7 +386,7 @@ theorem divK_loop_body_n4_call_skip_j0_divCode
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (divCode base)
+    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -460,7 +460,7 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode
     let qHat : Word := signExtend12 4095
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (divCode base)
+    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -580,7 +580,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
     let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (divCode base)
+    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -747,7 +747,7 @@ theorem divK_loop_body_n4_call_skip_j0_modCode
     (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
@@ -817,7 +817,7 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode (sp base : Word)
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
@@ -926,7 +926,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_modCode
     (hborrow : (if BitVec.ult uTop
                   (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
                 then (1 : Word) else 0) ≠ (0 : Word)) :
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
       (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
         v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
       (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
@@ -997,7 +997,7 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode (sp base : Word)
     let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
     (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
      then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 10000 (base + loopBodyOff) (base + denormOff) (modCode base)
+    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -111,12 +111,12 @@ theorem mod_phaseC2_taken_spec_within (sp shift v2 shiftMem : Word) (base : Word
 
 theorem mod_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_z : shift = 0) :
-    cpsTripleWithin 10000 (base + phaseC2Off) (base + copyAUOff) (modCode base)
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (mod_phaseC2_taken_spec_within sp shift v2 shiftMem base hshift_z)
+  mod_phaseC2_taken_spec_within sp shift v2 shiftMem base hshift_z
 
 -- ============================================================================
 -- MOD NormB composition (normalize divisor, 21 instructions)
@@ -253,4 +253,3 @@ theorem mod_normB_full_spec_within (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word)
     (fun h hq => by xperm_hyp hq)
     (cpsTripleWithin_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) h1 h2)
-

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -182,7 +182,7 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    cpsTripleWithin 10000 (base + normAOff) (base + loopSetupOff) (modCode base)
+    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -197,8 +197,8 @@ theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4056) ↦ₘ u0)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (mod_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
-    u0Old u1Old u2Old u3Old u4Old base)
+  mod_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
 
 -- ============================================================================
 -- MOD CopyAU composition (copy a[] to u[], 9 instructions)
@@ -236,7 +236,7 @@ theorem mod_copyAU_full_spec_within (sp : Word)
 
 theorem mod_copyAU_full_spec (sp : Word)
     (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTripleWithin 10000 (base + copyAUOff) (base + loopSetupOff) (modCode base)
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
        ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -249,10 +249,10 @@ theorem mod_copyAU_full_spec (sp : Word)
        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) :=
-  cpsTripleWithin_mono_nSteps (by decide) (mod_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base)
+  mod_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base
 
 -- ============================================================================
--- MOD LoopSetup composition (4 instructions, cpsBranchWithin 10000 at base+432)
+-- MOD LoopSetup composition (4 instructions at base+432)
 -- LD n, ADDI 4, SUB m=4-n, BLT m<0
 -- ============================================================================
 
@@ -338,4 +338,3 @@ theorem mod_loopSetup_taken_spec_within (sp n v1 v5 : Word) (base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h12
-

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -103,12 +103,12 @@ theorem divK_phaseC2_taken_spec_within (sp shift v2 shiftMem : Word) (base : Wor
 
 theorem divK_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
     (hshift_z : shift = 0) :
-    cpsTripleWithin 10000 (base + phaseC2Off) (base + copyAUOff) (divCode base)
+    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 3992) ↦ₘ shiftMem))
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
        (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (divK_phaseC2_taken_spec_within sp shift v2 shiftMem base hshift_z)
+  divK_phaseC2_taken_spec_within sp shift v2 shiftMem base hshift_z
 
 -- ============================================================================
 -- Section 10h: NormB composition (normalize divisor, 21 instructions)
@@ -240,4 +240,3 @@ theorem divK_normB_full_spec_within (sp b0 b1 b2 b3 v5 v7 shift antiShift : Word
     (fun h hq => by xperm_hyp hq)
     (cpsTripleWithin_seq_perm_same_cr
       (fun h hp => by xperm_hyp hp) h1 h2)
-

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -184,7 +184,7 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
     let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
     let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
     let u0 := a0 <<< (shift.toNat % 64)
-    cpsTripleWithin 10000 (base + normAOff) (base + loopSetupOff) (divCode base)
+    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
        ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
@@ -199,8 +199,8 @@ theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
        ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
        ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
        ((sp + signExtend12 4056) ↦ₘ u0)) :=
-  cpsTripleWithin_mono_nSteps (by decide) (divK_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
-    u0Old u1Old u2Old u3Old u4Old base)
+  divK_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
+    u0Old u1Old u2Old u3Old u4Old base
 
 -- ============================================================================
 -- Section 10j: CopyAU composition (copy a[] to u[], 9 instructions)
@@ -237,7 +237,7 @@ theorem divK_copyAU_full_spec_within (sp : Word)
 
 theorem divK_copyAU_full_spec (sp : Word)
     (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTripleWithin 10000 (base + copyAUOff) (base + loopSetupOff) (divCode base)
+    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
        ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
        ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
@@ -250,10 +250,10 @@ theorem divK_copyAU_full_spec (sp : Word)
        ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
        ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
        ((sp + signExtend12 4024) ↦ₘ (0 : Word))) :=
-  cpsTripleWithin_mono_nSteps (by decide) (divK_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base)
+  divK_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base
 
 -- ============================================================================
--- Section 10k: LoopSetup composition (4 instructions, cpsBranchWithin 10000 at base+432)
+-- Section 10k: LoopSetup composition (4 instructions at base+432)
 -- LD n, ADDI 4, SUB m=4-n, BLT m<0
 -- ============================================================================
 
@@ -339,4 +339,3 @@ theorem divK_loopSetup_taken_spec_within (sp n v1 v5 : Word) (base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     h12
-

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -356,7 +356,7 @@ theorem evm_div_phaseAB_n4_spec (sp base : Word)
     (q0 q1 q2 q3 u5 u6 u7 nMem : Word)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
     (hb3nz : b3 ≠ 0) :
-    cpsTripleWithin 10000 base (base + clzOff) (divCode base)
+    cpsTripleWithin (8 + 21) base (base + clzOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
        ((sp + 32) ↦ₘ b0) ** ((sp + 40) ↦ₘ b1) **
@@ -973,4 +973,3 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp)
     (fun h hq => by xperm_hyp hq)
     hphaseB
-


### PR DESCRIPTION
Codex update.

This stacked PR adds the bounded limb dispatcher branch surface on top of #1513:

- adds inferred DIV branch aliases `evm_div_spec_within_bzero`/`n1Full`/`n2Full`/`n3Full`/`n4*` over the existing bounded `cpsTripleWithin` path specs
- adds inferred MOD branch aliases `evm_mod_spec_within_bzero`/`n1Full`/`n2Full`/`n3Full`/`n4*` over the existing bounded `cpsTripleWithin` path specs
- adds `evm_div_spec_within` and `evm_mod_spec_within` branch/bound registries for the dispatcher surface

Verification run locally:

- `#check EvmAsm.Evm64.evm_div_spec_within` and `evm_mod_spec_within` from `EvmAsm.Evm64.DivMod`
- `#check EvmAsm.Evm64.evm_div_spec_within_n4CallAddbackBeq` and `evm_mod_spec_within_n4CallAddbackBeq` from `EvmAsm.Evm64.DivMod`
- `lake build EvmAsm.Evm64.DivMod.Compose.Dispatcher`
- `lake build EvmAsm.Evm64.DivMod`
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- `git diff --check`