### PR TITLE
refactor: make CodeReq.union_mono_left arguments implicit (#331)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -181,31 +181,31 @@ abbrev sharedDivModCode_v4 (base : Word) : CodeReq :=
 -- Per-block subsumption: each shared block ⊆ divCode.
 -- Blocks 0-9 are at the same union positions; blocks 10-12 (shared) = blocks 11-13 (divCode).
 private theorem shared_b0_div {b : Word} : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
 private theorem shared_b1_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b2_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b3_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b4_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b5_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b6_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b7_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b8_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b9_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b10_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b11_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b12_div {b : Word} : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (divCode b) a = some i := by
-  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold divCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 
 /-- sharedDivModCode ⊆ divCode: every shared block is also in divCode. -/
 theorem sharedDivModCode_sub_divCode {base : Word} :
@@ -229,31 +229,31 @@ theorem sharedDivModCode_sub_divCode {base : Word} :
 -- Per-block subsumption for modCode. Same pattern as shared_b*_div — the
 -- shared blocks occupy the same union positions in modCode as in divCode.
 private theorem shared_b0_mod {b : Word} : ∀ a i, (CodeReq.ofProg b (divK_phaseA 1020)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; exact CodeReq.union_mono_left
 private theorem shared_b1_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseBOff) divK_phaseB) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b2_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + clzOff) divK_clz) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b3_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + phaseC2Off) (divK_phaseC2 172)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b4_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + normBOff) divK_normB) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b5_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + normAOff) (divK_normA 40)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b6_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + copyAUOff) divK_copyAU) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b7_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopSetupOff) (divK_loopSetup 464)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b8_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + loopBodyOff) (divK_loopBody 560 7736)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b9_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + denormOff) divK_denorm) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b10_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + zeroPathOff) divK_zeroPath) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b11_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + nopOff) (ADDI .x0 .x0 0 : Program)) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 private theorem shared_b12_mod {b : Word} : ∀ a i, (CodeReq.ofProg (b + div128Off) divK_div128) a = some i → (modCode b) a = some i := by
-  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left _ _
+  unfold modCode; simp only [CodeReq.unionAll_cons]; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; exact CodeReq.union_mono_left
 
 /-- sharedDivModCode ⊆ modCode: every shared block is also in modCode.
     Mirror of `sharedDivModCode_sub_divCode`. -/
@@ -284,7 +284,7 @@ theorem shared_b12_div128_v2_sub {b : Word} :
   unfold sharedDivModCode_v2; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- v4 mirror of `shared_b12_div128_v2_sub`: block 12 (`divK_div128_v4`)
     is included in `sharedDivModCode_v4 base`. Used by `div128_v4_spec_shared`
@@ -295,7 +295,7 @@ theorem shared_b12_div128_v4_sub {b : Word} :
   unfold sharedDivModCode_v4; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- ============================================================================
 -- Postcondition bundle for loopSetup (shift ≠ 0) path

--- a/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/CLZ.lean
@@ -25,7 +25,7 @@ private theorem divK_clz_code_sub_divCode {base : Word} :
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Helper: CLZ stage at instruction index k is subsumed by divCode.
     The stage has 4 instructions starting at index k of divK_clz. -/

--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -27,7 +27,7 @@ private theorem divK_div128_ofProg_sub_sharedCode {base : Word} :
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Helper: combine two subsumption proofs over a union.
 -- `CodeReq.union_sub` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).

--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -25,7 +25,7 @@ private theorem divK_denorm_code_sub_divCode {base : Word} :
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Denorm preamble for shift≠0: LD shift from memory + BEQ not taken.
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
@@ -224,7 +224,7 @@ private theorem divK_divEpilogue_code_sub_divCode {base : Word} :
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Full DIV epilogue: load q[0..3] from scratch, advance sp, store to output, JAL to NOP.
     base+1008 → base+1068 (10 instructions). -/
@@ -302,21 +302,21 @@ theorem divK_div_epilogue_spec (sp : Word) (base : Word)
 private theorem divK_phaseA_code_sub_modCode {base : Word} :
     ∀ a i, (divK_phaseA_code base) a = some i → (modCode base) a = some i := by
   unfold modCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 private theorem divK_zeroPath_code_sub_modCode {base : Word} :
     ∀ a i, (divK_zeroPath_code (base + zeroPathOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_zeroPath_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 private theorem beq_singleton_sub_modCode {base : Word} :
     ∀ a i, (CodeReq.singleton (base + 28) (.BEQ .x5 .x0 1020)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  exact CodeReq.union_mono_left _ _ a i
+  exact CodeReq.union_mono_left a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
       (by decide) (by decide)) a i h)
 
@@ -437,7 +437,7 @@ private theorem divK_modEpilogue_code_sub_modCode {base : Word} :
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Full MOD epilogue: load u[0..3] (denormalized remainder), advance sp, store to output, JAL to NOP.
     base+1008 → base+1068 (10 instructions). -/

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -555,7 +555,7 @@ private theorem divK_denorm_code_sub_modCode' (base : Word) :
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Denorm preamble for shift≠0 with modCode: LD shift from memory + BEQ not taken.
     base+908 → base+916. -/
@@ -668,7 +668,7 @@ private theorem divK_denorm_code_sub_divCode' (base : Word) :
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- ============================================================================
 -- DIV shift=0 post-loop: Preamble (LD+BEQ taken) → DIV Epilogue (base+908 → base+1068)

--- a/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModCLZ.lean
@@ -24,7 +24,7 @@ private theorem divK_clz_code_sub_modCode {base : Word} :
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Helper: CLZ stage at instruction index k is subsumed by modCode. -/
 private theorem clz_stage_sub_mod {base : Word}

--- a/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModDiv128.lean
@@ -29,7 +29,7 @@ private theorem divK_div128_ofProg_sub_modCode {base : Word} :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Helper: combine two subsumption proofs over a union.
 -- `CodeReq.union_sub` — use `CodeReq.union_sub` from `Rv64/SepLogic.lean` (shared).

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -25,7 +25,7 @@ private theorem divK_denorm_code_sub_modCode {base : Word} :
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Full Denorm (shift body only) for modCode: denormalize u[0..3] by right-shifting.
     base+904+16 → base+904+100 (21 instructions: ADDI+SUB + 3×merge + last).

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -28,7 +28,7 @@ private theorem divK_denorm_code_sub_modCode_n4 (base : Word) :
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Bounded denorm preamble for shift≠0 with `modCode`: LD shift from memory
     followed by a not-taken BEQ. -/

--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -25,7 +25,7 @@ private theorem divK_phaseC2_code_sub_modCode {base : Word} :
     ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- BEQ x6 x0 172 singleton at base+224 (index 3 of phaseC2) is subsumed by modCode. -/
 private theorem beq_shift_sub_modCode {base : Word} :
@@ -128,7 +128,7 @@ private theorem divK_normB_code_sub_modCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Reuse se12_32/40/48/56 from Compose.Base (no private shadows needed).
 

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -25,7 +25,7 @@ private theorem divK_normA_code_sub_modCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- signExtend12 for src/dst offsets used by normA specs
 -- `mod_se12_{0,8,16,24}` removed: use `signExtend12_{0,8,16,24}` from Rv64/Instructions.lean.
@@ -210,7 +210,7 @@ private theorem divK_copyAU_code_sub_modCode {base : Word} :
     ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Full CopyAU for modCode: copy a[0..3] to u[0..3], set u[4]=0.
     base+396 -> base+432 (9 instructions).
@@ -261,7 +261,7 @@ private theorem divK_loopSetup_code_sub_modCode {base : Word} :
     ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i → (modCode base) a = some i := by
   unfold modCode divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- BLT singleton at base+444 (index 3 of loopSetup) is subsumed by modCode. -/
 private theorem blt_loopSetup_sub_modCode {base : Word} :

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -37,7 +37,7 @@ private theorem sub_modCode_of_phaseB_left {base : Word} {rest : CodeReq} :
     (CodeReq.ofProg_disjoint_range
       (fun k1 k2 hk1 hk2 => by
         simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _)
+    (CodeReq.union_mono_left)
 
 theorem divK_phaseB_init1_code_sub_modCode {base : Word} :
     ∀ a i, (divK_phaseB_init1_code (base + phaseBOff)) a = some i → (modCode base) a = some i := by

--- a/EvmAsm/Evm64/DivMod/Compose/Norm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Norm.lean
@@ -19,7 +19,7 @@ private theorem divK_phaseC2_code_sub_divCode {base : Word} :
     ∀ a i, (divK_phaseC2_code 172 (base + phaseC2Off)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_phaseC2_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- BEQ x6 x0 172 singleton at base+224 (index 3 of phaseC2) is subsumed by divCode. -/
 private theorem beq_shift_sub_divCode {base : Word} :
@@ -120,7 +120,7 @@ private theorem divK_normB_code_sub_divCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + normBOff) divK_normB) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- se12_32, se12_40, se12_48, se12_56 are in Base.lean
 

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -23,7 +23,7 @@ private theorem divK_normA_code_sub_divCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + normAOff) (divK_normA 40)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- signExtend12 rewrites pulled from the divmod_addr global set (AddrNorm.lean).
 open EvmAsm.Evm64.DivMod.AddrNorm (se12_0 se12_8 se12_16 se12_24)
@@ -212,7 +212,7 @@ private theorem divK_copyAU_code_sub_divCode {base : Word} :
     ∀ a i, (divK_copyAU_code (base + copyAUOff)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_copyAU_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Full CopyAU: copy a[0..3] to u[0..3], set u[4]=0.
     base+396 → base+432 (9 instructions). -/
@@ -262,7 +262,7 @@ private theorem divK_loopSetup_code_sub_divCode {base : Word} :
     ∀ a i, (divK_loopSetup_code 464 (base + loopSetupOff)) a = some i → (divCode base) a = some i := by
   unfold divCode divK_loopSetup_code; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- BLT singleton at base+444 (index 3 of loopSetup) is subsumed by divCode. -/
 private theorem blt_loopSetup_sub_divCode {base : Word} :

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -36,13 +36,13 @@ private theorem sub_divCode_of_phaseB_left {base : Word} {rest : CodeReq} :
     (CodeReq.ofProg_disjoint_range
       (fun k1 k2 hk1 hk2 => by
         simp only [divK_phaseA_len, divK_phaseB_len] at hk1 hk2; bv_omega))
-    (CodeReq.union_mono_left _ _)
+    (CodeReq.union_mono_left)
 
 /-- Phase A code (8 instructions, block 0) is subsumed by divCode. -/
 private theorem divK_phaseA_code_sub_divCode {base : Word} :
     ∀ a i, (divK_phaseA_code base) a = some i → (divCode base) a = some i := by
   unfold divCode divK_phaseA_code; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Zero path code (5 instructions, block 11) is subsumed by divCode. -/
 private theorem divK_zeroPath_code_sub_divCode {base : Word} :
@@ -51,7 +51,7 @@ private theorem divK_zeroPath_code_sub_divCode {base : Word} :
   -- Skip blocks 0-10, then match block 11
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- BEQ singleton at base+28 is subsumed by divCode (part of block 0: phaseA). -/
 private theorem beq_singleton_sub_divCode {base : Word} :
@@ -59,7 +59,7 @@ private theorem beq_singleton_sub_divCode {base : Word} :
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  exact CodeReq.union_mono_left _ _ a i
+  exact CodeReq.union_mono_left a i
     (CodeReq.singleton_mono (CodeReq.ofProg_lookup base (divK_phaseA 1020) 7
       (by decide) (by decide)) a i h)
 

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1.lean
@@ -93,7 +93,7 @@ theorem divK_div128_step1_spec_within
     runBlock I0 I1 I2
   have h1 : cpsTripleWithin 3 base (base + 12) cr _ _ :=
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
-      rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))
+      rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left)))
   have h1f := cpsTripleWithin_frameR
     ((.x11 ↦ᵣ un1) ** (.x1 ↦ᵣ v1Old) ** (.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (sp + signExtend12 3952 ↦ₘ dlo))

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean
@@ -277,7 +277,7 @@ theorem divK_div128_step1_v2_branch_merged_spec_within
         (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
         (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
         (CodeReq.union_mono_tail (CodeReq.union_mono_tail
-        (CodeReq.union_mono_left _ _)))))))))))))))
+        (CodeReq.union_mono_left)))))))))))))))
   -- h2: prodcheck1b_merged_spec's cr is the 10-suffix of merged_cr.
   have h2_raw := divK_div128_prodcheck1b_merged_spec_within sp q1' rhat' dHi un1
     rhatUn1 qDlo1 dlo (base + 60)

--- a/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
+++ b/EvmAsm/Evm64/DivMod/LimbSpec/Div128Step2.lean
@@ -71,7 +71,7 @@ theorem divK_div128_step2_upto_guard_spec_within
   have h1 : cpsTripleWithin 3 base (base + 12) cr _ _ :=
     cpsTripleWithin_extend_code (h := h1_raw) (hmono := by
       rw [hcr_eq]; exact CodeReq.union_mono_tail (CodeReq.union_mono_tail
-        (CodeReq.union_mono_left _ _)))
+        (CodeReq.union_mono_left)))
   have h1f := cpsTripleWithin_frameR
     ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ 0) **
      (sp + signExtend12 3952 ↦ₘ dlo) ** (sp + signExtend12 3944 ↦ₘ un0))
@@ -166,7 +166,7 @@ theorem divK_div128_step2_thru_guard_spec_within
       rw [hcr_eq]
       exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
         (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
-        (CodeReq.union_mono_left _ _)))))))
+        (CodeReq.union_mono_left)))))))
   -- h2 = phase2b_guard_spec at base+28 (2-singleton cr).
   have h2_raw := divK_div128_phase2b_guard_spec_within sp rhat2c hi (base + 28) (36 : BitVec 13)
   have ha_bne : (base + 28 : Word) + 4 = base + 32 := by bv_addr
@@ -273,7 +273,7 @@ theorem divK_div128_step2_branch_merged_spec_within
       rw [hcr_eq]
       exact CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
         (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_tail
-        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left _ _)))))))))
+        (CodeReq.union_mono_tail (CodeReq.union_mono_tail (CodeReq.union_mono_left)))))))))
   -- h2 = prodcheck2_merged_spec at base+36 (8-singleton cr, positions 9-16
   -- of the 17-cr). Use split+simp pattern (8 levels deep but each level is
   -- cheap — heads don't match the prodcheck2 cr's head).

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -30,7 +30,7 @@ private theorem divK_loopBody_ofProg_sub_sharedCode {base : Word} :
   unfold sharedDivModCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Helper: singleton at index k of divK_loopBody ⊆ sharedDivModCode base. -/
 theorem lb_sub {base : Word} (k : Nat) (addr : Word) (instr : Instr)
@@ -51,7 +51,7 @@ private theorem divK_loopBody_ofProg_sub_sharedCode_v2 {base : Word} :
   unfold sharedDivModCode_v2; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- v2 mirror of `lb_sub`: singleton at index k of divK_loopBody ⊆ sharedDivModCode_v2 base. -/
 theorem lb_sub_v2 {base : Word} (k : Nat) (addr : Word) (instr : Instr)

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -71,7 +71,7 @@ private theorem phase_b_sub_shrCode {base : Word} :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shrCode base a = some i := by
   unfold shr_phase_b_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Phase C union-chain ⊆ ofProg bridge (`shr_phase_c_code_sub_ofProg`) is shared
 -- and lives in `ComposeBase`.
@@ -81,7 +81,7 @@ private theorem ofProg_phase_c_sub_shrCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shrCode base a = some i := by
   unfold shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Phase C code (union chain, 5 instrs at +64) is subsumed by shrCode (block 2). -/
 private theorem phase_c_sub_shrCode {base : Word} :
@@ -94,35 +94,35 @@ private theorem body_3_sub_shrCode {base : Word} :
     ∀ a i, shr_body_3_code 252 (base + 84) a = some i → shrCode base a = some i := by
   unfold shr_body_3_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Body 2 code (ofProg, 13 instrs at +112) is subsumed by shrCode (block 4). -/
 private theorem body_2_sub_shrCode {base : Word} :
     ∀ a i, shr_body_2_code 200 (base + 112) a = some i → shrCode base a = some i := by
   unfold shr_body_2_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Body 1 code (ofProg, 19 instrs at +164) is subsumed by shrCode (block 5). -/
 private theorem body_1_sub_shrCode {base : Word} :
     ∀ a i, shr_body_1_code 124 (base + 164) a = some i → shrCode base a = some i := by
   unfold shr_body_1_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Body 0 code (ofProg, 25 instrs at +240) is subsumed by shrCode (block 6). -/
 private theorem body_0_sub_shrCode {base : Word} :
     ∀ a i, shr_body_0_code 24 (base + 240) a = some i → shrCode base a = some i := by
   unfold shr_body_0_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shrCode (block 7). -/
 private theorem zero_path_sub_shrCode {base : Word} :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shrCode base a = some i := by
   unfold shr_zero_path_code shrCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
 -- Each bridges singleton → ofProg shr_phase_a (9-element) → shrCode block 0
@@ -134,7 +134,7 @@ private theorem ld_s1_sub_shrCode {base : Word} :
   have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- LD/OR acc at base+4 (2 instrs) is subsumed by shrCode. -/
 private theorem ld_or_16_sub_shrCode {base : Word} :
@@ -143,7 +143,7 @@ private theorem ld_or_16_sub_shrCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- LD/OR acc at base+12 (2 instrs) is subsumed by shrCode. -/
 private theorem ld_or_24_sub_shrCode {base : Word} :
@@ -152,7 +152,7 @@ private theorem ld_or_24_sub_shrCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- BNE singleton at base+20 is subsumed by shrCode. -/
 private theorem bne_sub_shrCode {base : Word} :
@@ -161,7 +161,7 @@ private theorem bne_sub_shrCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- LD x5 x12 0 singleton at base+24 is subsumed by shrCode. -/
 private theorem ld_s0_sub_shrCode {base : Word} :
@@ -170,7 +170,7 @@ private theorem ld_s0_sub_shrCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- SLTIU singleton at base+28 is subsumed by shrCode. -/
 private theorem sltiu_sub_shrCode {base : Word} :
@@ -179,7 +179,7 @@ private theorem sltiu_sub_shrCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- BEQ singleton at base+32 is subsumed by shrCode. -/
 private theorem beq_sub_shrCode {base : Word} :
@@ -188,7 +188,7 @@ private theorem beq_sub_shrCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shrCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 -- ============================================================================
 -- Section 3: Address normalization lemmas

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -73,7 +73,7 @@ private theorem ld_s1_sub_sarCode {base : Word} :
   have h1 := singleton_sub_ofProg base base sar_phase_a (.LD .x5 .x12 8) 0
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_or_16_sub_sarCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → sarCode base a = some i := by
@@ -81,7 +81,7 @@ private theorem ld_or_16_sub_sarCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) sar_phase_a (shr_ld_or_acc_prog 16) 1
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_or_24_sub_sarCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → sarCode base a = some i := by
@@ -89,7 +89,7 @@ private theorem ld_or_24_sub_sarCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) sar_phase_a (shr_ld_or_acc_prog 24) 3
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem bne_sub_sarCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 332) a = some i → sarCode base a = some i := by
@@ -97,7 +97,7 @@ private theorem bne_sub_sarCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 20) sar_phase_a (.BNE .x5 .x0 332) 5
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_s0_sub_sarCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → sarCode base a = some i := by
@@ -105,7 +105,7 @@ private theorem ld_s0_sub_sarCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 24) sar_phase_a (.LD .x5 .x12 0) 6
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem sltiu_sub_sarCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → sarCode base a = some i := by
@@ -113,7 +113,7 @@ private theorem sltiu_sub_sarCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 28) sar_phase_a (.SLTIU .x10 .x5 256) 7
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem beq_sub_sarCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 320) a = some i → sarCode base a = some i := by
@@ -121,14 +121,14 @@ private theorem beq_sub_sarCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 32) sar_phase_a (.BEQ .x10 .x0 320) 8
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold sarCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 /-- Phase B code (ofProg, 7 instrs at +36) is subsumed by sarCode (block 1). -/
 private theorem phase_b_sub_sarCode {base : Word} :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → sarCode base a = some i := by
   unfold shr_phase_b_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Phase C subsumption (SAR-specific offsets)
 
@@ -156,7 +156,7 @@ private theorem ofProg_phase_c_sub_sarCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + 64) sar_phase_c) a = some i → sarCode base a = some i := by
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SAR Phase C code is subsumed by sarCode (block 2). -/
 private theorem sar_phase_c_sub_sarCode {base : Word} :
@@ -171,28 +171,28 @@ private theorem sar_body_3_sub_sarCode {base : Word} :
     ∀ a i, sar_body_3_code (base + 84) 268 a = some i → sarCode base a = some i := by
   unfold sar_body_3_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SAR Body 2 code (14 instrs at +116) is subsumed by sarCode (block 4). -/
 private theorem sar_body_2_sub_sarCode {base : Word} :
     ∀ a i, sar_body_2_code (base + 116) 212 a = some i → sarCode base a = some i := by
   unfold sar_body_2_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SAR Body 1 code (20 instrs at +172) is subsumed by sarCode (block 5). -/
 private theorem sar_body_1_sub_sarCode {base : Word} :
     ∀ a i, sar_body_1_code (base + 172) 132 a = some i → sarCode base a = some i := by
   unfold sar_body_1_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SAR Body 0 code (25 instrs at +252) is subsumed by sarCode (block 6). -/
 private theorem sar_body_0_sub_sarCode {base : Word} :
     ∀ a i, sar_body_0_code (base + 252) 32 a = some i → sarCode base a = some i := by
   unfold sar_body_0_code sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Bridge: sar_sign_fill_path_code (union chain) ⊆ ofProg sar_sign_fill_path (7-element list)
 private theorem sign_fill_code_sub_ofProg {base : Word} :
@@ -224,7 +224,7 @@ private theorem ofProg_sign_fill_sub_sarCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + 352) sar_sign_fill_path) a = some i → sarCode base a = some i := by
   unfold sarCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Sign-fill path code (7 instrs at +352) is subsumed by sarCode (block 7). -/
 private theorem sign_fill_sub_sarCode {base : Word} :

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -70,7 +70,7 @@ private theorem phase_b_sub_shlCode {base : Word} :
     ∀ a i, shr_phase_b_code (base + 36) a = some i → shlCode base a = some i := by
   unfold shr_phase_b_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Phase C union-chain ⊆ ofProg bridge (`shr_phase_c_code_sub_ofProg`) is shared
 -- and lives in `ComposeBase`.
@@ -79,7 +79,7 @@ private theorem ofProg_phase_c_sub_shlCode {base : Word} :
     ∀ a i, (CodeReq.ofProg (base + 64) shr_phase_c) a = some i → shlCode base a = some i := by
   unfold shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Phase C code (union chain, 5 instrs at +64) is subsumed by shlCode (block 2). -/
 private theorem phase_c_sub_shlCode {base : Word} :
@@ -92,35 +92,35 @@ private theorem shl_body_3_sub_shlCode {base : Word} :
     ∀ a i, shl_body_3_code (base + 84) 252 a = some i → shlCode base a = some i := by
   unfold shl_body_3_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SHL Body 2 code (13 instrs at +112) is subsumed by shlCode (block 4). -/
 private theorem shl_body_2_sub_shlCode {base : Word} :
     ∀ a i, shl_body_2_code (base + 112) 200 a = some i → shlCode base a = some i := by
   unfold shl_body_2_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SHL Body 1 code (19 instrs at +164) is subsumed by shlCode (block 5). -/
 private theorem shl_body_1_sub_shlCode {base : Word} :
     ∀ a i, shl_body_1_code (base + 164) 124 a = some i → shlCode base a = some i := by
   unfold shl_body_1_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- SHL Body 0 code (25 instrs at +240) is subsumed by shlCode (block 6). -/
 private theorem shl_body_0_sub_shlCode {base : Word} :
     ∀ a i, shl_body_0_code (base + 240) 24 a = some i → shlCode base a = some i := by
   unfold shl_body_0_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 /-- Zero path code (ofProg, 5 instrs at +340) is subsumed by shlCode (block 7). -/
 private theorem zero_path_sub_shlCode {base : Word} :
     ∀ a i, shr_zero_path_code (base + 340) a = some i → shlCode base a = some i := by
   unfold shr_zero_path_code shlCode; simp only [CodeReq.unionAll_cons]
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
-  exact CodeReq.union_mono_left _ _
+  exact CodeReq.union_mono_left
 
 -- Individual instruction subsumption helpers (for phase A raw composition)
 
@@ -130,7 +130,7 @@ private theorem ld_s1_sub_shlCode {base : Word} :
   have h1 := singleton_sub_ofProg base base shr_phase_a (.LD .x5 .x12 8) 0
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_or_16_sub_shlCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 16 (base + 4) a = some i → shlCode base a = some i := by
@@ -138,7 +138,7 @@ private theorem ld_or_16_sub_shlCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 4) shr_phase_a (shr_ld_or_acc_prog 16) 1
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_or_24_sub_shlCode {base : Word} :
     ∀ a i, shr_ld_or_acc_code 24 (base + 12) a = some i → shlCode base a = some i := by
@@ -146,7 +146,7 @@ private theorem ld_or_24_sub_shlCode {base : Word} :
   have h1 := CodeReq.ofProg_mono_sub base (base + 12) shr_phase_a (shr_ld_or_acc_prog 24) 3
     (by bv_omega) (by decide) (by decide) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem bne_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 20) (.BNE .x5 .x0 320) a = some i → shlCode base a = some i := by
@@ -154,7 +154,7 @@ private theorem bne_sub_shlCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 20) shr_phase_a (.BNE .x5 .x0 320) 5
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem ld_s0_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 24) (.LD .x5 .x12 0) a = some i → shlCode base a = some i := by
@@ -162,7 +162,7 @@ private theorem ld_s0_sub_shlCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 24) shr_phase_a (.LD .x5 .x12 0) 6
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem sltiu_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 28) (.SLTIU .x10 .x5 256) a = some i → shlCode base a = some i := by
@@ -170,7 +170,7 @@ private theorem sltiu_sub_shlCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 28) shr_phase_a (.SLTIU .x10 .x5 256) 7
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 private theorem beq_sub_shlCode {base : Word} :
     ∀ a i, CodeReq.singleton (base + 32) (.BEQ .x10 .x0 308) a = some i → shlCode base a = some i := by
@@ -178,7 +178,7 @@ private theorem beq_sub_shlCode {base : Word} :
   have h1 := singleton_sub_ofProg base (base + 32) shr_phase_a (.BEQ .x10 .x0 308) 8
     (by decide) (by decide) (by bv_omega) (by decide) a i h
   unfold shlCode; simp only [CodeReq.unionAll_cons]
-  exact CodeReq.union_mono_left _ _ a i h1
+  exact CodeReq.union_mono_left a i h1
 
 -- ============================================================================
 -- Section 3: Address normalization lemmas

--- a/EvmAsm/Rv64/SepLogic.lean
+++ b/EvmAsm/Rv64/SepLogic.lean
@@ -2229,7 +2229,7 @@ theorem CodeReq.union_none_left {head tail : CodeReq} {a : Word}
   simp [CodeReq.union, h]
 
 /-- Left child of a union is subsumed (unconditionally true, union is left-biased). -/
-theorem CodeReq.union_mono_left (cr1 cr2 : CodeReq) :
+theorem CodeReq.union_mono_left {cr1 cr2 : CodeReq} :
     ∀ a i, cr1 a = some i → (cr1.union cr2) a = some i := by
   intro a i h; simp [CodeReq.union, h]
 
@@ -2452,7 +2452,7 @@ theorem CodeReq.ofProg_disjoint_range_len (base1 : Word) (prog1 : List Instr) (n
 theorem CodeReq.ofProg_mono_append_left (base : Word) (p1 p2 : List Instr) :
     ∀ a i, (CodeReq.ofProg base p1) a = some i →
            (CodeReq.ofProg base (p1 ++ p2)) a = some i := by
-  rw [CodeReq.ofProg_append]; exact CodeReq.union_mono_left _ _
+  rw [CodeReq.ofProg_append]; exact CodeReq.union_mono_left
 
 /-- Right (suffix) of a program append is subsumed by the full program.
     Requires bound to ensure non-overlapping address ranges. -/
@@ -2541,7 +2541,7 @@ theorem CodeReq.mono_unionAll (crs : List CodeReq) (k : Nat) (hk : k < crs.lengt
     cases k with
     | zero =>
       simp only [List.get, CodeReq.unionAll_cons]
-      exact CodeReq.union_mono_left _ _
+      exact CodeReq.union_mono_left
     | succ k' =>
       simp only [List.get, CodeReq.unionAll_cons]
       exact CodeReq.mono_union_right
@@ -2563,7 +2563,7 @@ theorem CodeReq.mono_sub_unionAll (sub_cr : CodeReq) (crs : List CodeReq)
     cases k with
     | zero =>
       simp only [CodeReq.unionAll_cons]
-      intro a i h; exact CodeReq.union_mono_left _ _ a i (h_sub a i h)
+      intro a i h; exact CodeReq.union_mono_left a i (h_sub a i h)
     | succ k' =>
       simp only [CodeReq.unionAll_cons]
       exact CodeReq.mono_union_right

--- a/EvmAsm/Rv64/Tactics/SeqFrame.lean
+++ b/EvmAsm/Rv64/Tactics/SeqFrame.lean
@@ -819,14 +819,14 @@ partial def buildMonoProof (oldCr newCr : Expr) : MetaM Expr :=
     let tail := newCrW.getAppArgs[1]!
     -- Left match: oldCr ≡ head (pre-whnfR, preserving abbrev identity)
     if oldCr == head then
-      return ← mkAppM ``EvmAsm.Rv64.CodeReq.union_mono_left #[head, tail]
+      return ← mkAppOptM ``EvmAsm.Rv64.CodeReq.union_mono_left #[some head, some tail]
     if ← withoutModifyingState (withReducible (isDefEq oldCr head)) then
-      return ← mkAppM ``EvmAsm.Rv64.CodeReq.union_mono_left #[head, tail]
+      return ← mkAppOptM ``EvmAsm.Rv64.CodeReq.union_mono_left #[some head, some tail]
     -- Also check whnfR'd form (handles case where oldCr was already expanded)
     if oldCrW == head then
-      return ← mkAppM ``EvmAsm.Rv64.CodeReq.union_mono_left #[head, tail]
+      return ← mkAppOptM ``EvmAsm.Rv64.CodeReq.union_mono_left #[some head, some tail]
     if ← withoutModifyingState (withReducible (isDefEq oldCrW head)) then
-      return ← mkAppM ``EvmAsm.Rv64.CodeReq.union_mono_left #[head, tail]
+      return ← mkAppOptM ``EvmAsm.Rv64.CodeReq.union_mono_left #[some head, some tail]
     -- No head match. Try skip (prove head.Disjoint oldCr, recurse on tail) first,
     -- then fall back to splitting oldCr. The skip-first order is essential when oldCr
     -- is an opaque abbrev that will match a LATER head in newCr's chain — splitting


### PR DESCRIPTION
Slice 2 of #331 (beads evm-asm-m6h). Slice-1 survey identified `CodeReq.union_mono_left` as the only combinator with >80% `_`-rate per positional argument (94% on `cr1`, 94% on `cr2` across 116 call sites, 218 total `_` args). Both args are reliably inferable from the conclusion type `(cr1.union cr2) a = some i`.

## Changes
- Flip `(cr1 cr2 : CodeReq)` → `{cr1 cr2 : CodeReq}` in `EvmAsm/Rv64/SepLogic.lean`.
- Drop the now-redundant `_ _` args at all 116 call sites (DivMod, Shift, etc.).
- Update `SeqFrame.lean`'s term-mode auto-discharger to use `mkAppOptM` so the elaborator can still pass the (now-implicit) cr1/cr2 explicitly.

Diff: 24 files, 114 insertions / 114 deletions — pure visual de-noise, no behavioural change.

## Verification
`lake build` succeeds locally with 0 errors and 0 sorries.

## Followups
After this lands, slice 1's survey suggests there are no other combinators worth converting (the `cps*` family already uses implicit args appropriately). Slices 3+4 of #331 likely collapse into a single close-out comment on the issue.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs: #331, beads evm-asm-m6h