### PR TITLE
chore(divmod): name addbackBeqOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -60,6 +60,12 @@ abbrev copyAUOff    : Word :=  396
 abbrev loopSetupOff : Word :=  432
 /-- Offset of `divK_loopBody` (Knuth Algorithm D main loop body). -/
 abbrev loopBodyOff  : Word :=  448
+/-- Offset of the addback-skip BEQ sub-block inside `divK_loopBody`.
+    Entry PC of the `BEQ x7, x0, +4` instruction that branches over the
+    addback fixup (executed when the trial-quotient `q̂` did NOT overshoot,
+    so no addback is needed). Sub-offset relative to the loopBody block
+    (= storeLoopOff - 4 = loopBodyOff + 432). -/
+abbrev addbackBeqOff : Word :=  880
 /-- Offset of the store-quotient sub-block inside `divK_loopBody`.
     Entry PC of the `divK_store_qj` snippet that writes the trial-quotient
     digit `q[j]` to the output buffer (followed by the loop-back / loop-exit
@@ -118,6 +124,11 @@ example : loopSetupOff = copyAUOff + 4 * divK_copyAU.length := by decide
 example : loopBodyOff = loopSetupOff + 4 * (divK_loopSetup 464).length := by decide
 /-- denormOff = loopBodyOff + 4 · |divK_loopBody 560 7736|. -/
 example : denormOff = loopBodyOff + 4 * (divK_loopBody 560 7736).length := by decide
+/-- addbackBeqOff = storeLoopOff - 4 (= loopBodyOff + 432, sub-block offset
+    within `divK_loopBody`). The addback-skip BEQ sits one instruction before
+    the `divK_store_qj` entry. -/
+example : addbackBeqOff = storeLoopOff - 4 := by decide
+example : addbackBeqOff = loopBodyOff + 432 := by decide
 /-- storeLoopOff = loopBodyOff + 436 (sub-block offset within `divK_loopBody`).
     The `divK_store_qj` snippet starts 109 instructions into the loop body. -/
 example : storeLoopOff = loopBodyOff + 436 := by decide

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -244,7 +244,7 @@ private theorem lb_ab0_end {base : Word} : (base + 736 : Word) + 32 = base + 768
 private theorem lb_ab1_end {base : Word} : (base + 768 : Word) + 32 = base + 800 := by bv_addr
 private theorem lb_ab2_end {base : Word} : (base + 800 : Word) + 32 = base + 832 := by bv_addr
 private theorem lb_ab3_end {base : Word} : (base + 832 : Word) + 32 = base + 864 := by bv_addr
-private theorem lb_abf_end {base : Word} : (base + 864 : Word) + 16 = base + 880 := by bv_addr
+private theorem lb_abf_end {base : Word} : (base + 864 : Word) + 16 = base + addbackBeqOff := by bv_addr
 
 set_option maxRecDepth 4096 in
 /-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + qHat--.
@@ -281,7 +281,7 @@ theorem divK_addback_full_spec_within
     -- Final: u4 + carry, qHat--
     let aun4 := u4 + aco3
     let qHat' := qHat + signExtend12 4095
-    cpsTripleWithin 37 (base + 732) (base + 880) (sharedDivModCode base)
+    cpsTripleWithin 37 (base + 732) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -779,7 +779,7 @@ theorem divK_addback_full_v2_spec_within
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4 + aco3
     let qHat' := qHat + signExtend12 4095
-    cpsTripleWithin 37 (base + 732) (base + 880) (sharedDivModCode_v2 base)
+    cpsTripleWithin 37 (base + 732) (base + addbackBeqOff) (sharedDivModCode_v2 base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ v7_init) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5_init) ** (.x2 ↦ᵣ v2_init) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -924,7 +924,7 @@ theorem divK_correction_addback_v2_spec_within
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4 + aco3
     let qHat' := qHat + signExtend12 4095
-    cpsTripleWithin 38 (base + 728) (base + 880) (sharedDivModCode_v2 base)
+    cpsTripleWithin 38 (base + 728) (base + addbackBeqOff) (sharedDivModCode_v2 base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -1000,7 +1000,7 @@ theorem divK_correction_addback_spec_within
     let aco3 := ac1_3 ||| ac2_3
     let aun4 := u4 + aco3
     let qHat' := qHat + signExtend12 4095
-    cpsTripleWithin 38 (base + 728) (base + 880) (sharedDivModCode base)
+    cpsTripleWithin 38 (base + 728) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -1060,7 +1060,7 @@ theorem divK_correction_addback_named_spec_within
     (hb : borrow ≠ (0 : Word)) :
     let ab := addbackN4 u0 u1 u2 u3 u4 v0 v1 v2 v3
     let qHat' := qHat + signExtend12 4095
-    cpsTripleWithin 38 (base + 728) (base + 880) (sharedDivModCode base)
+    cpsTripleWithin 38 (base + 728) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ borrow) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -1162,15 +1162,15 @@ private theorem lb_lc_taken {base : Word} :
   rv64_addr
 private theorem lb_lc_exit {base : Word} : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
 
-private theorem lb_beq_back_ntaken {base : Word} : (base + 880 : Word) + 4 = base + storeLoopOff := by bv_addr
+private theorem lb_beq_back_ntaken {base : Word} : (base + addbackBeqOff : Word) + 4 = base + storeLoopOff := by bv_addr
 
 /-- BEQ passthrough at [108]: when carry (x7) ≠ 0, BEQ falls through from base+880 to base+884.
     Used to bridge addback exit (base+880) to store_loop entry (base+884). -/
 theorem divK_beq_passthrough_within {carry : Word} (base : Word) (hne : carry ≠ 0) :
-    cpsTripleWithin 1 (base + 880) (base + storeLoopOff) (sharedDivModCode base)
+    cpsTripleWithin 1 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word))) := by
-  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + 880)
+  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + addbackBeqOff)
   rw [lb_beq_back_ntaken] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
@@ -1184,7 +1184,7 @@ theorem divK_beq_passthrough_within {carry : Word} (base : Word) (hne : carry �
     ntaken
 
 private theorem lb_beq_back_taken {base : Word} :
-    (base + 880 : Word) + signExtend13 (8044 : BitVec 13) = base + 732 := by
+    (base + addbackBeqOff : Word) + signExtend13 (8044 : BitVec 13) = base + 732 := by
   rv64_addr
 
 /-- Double-addback path at [108]: when first addback carry (x7) = 0, BEQ jumps back to [71]
@@ -1219,7 +1219,7 @@ theorem divK_double_addback_beq_spec_within
     let aco3' := ac1_3' ||| ac2_3'
     let aun4' := aun4 + aco3'
     let qHat'' := qHat' + signExtend12 4095
-    cpsTripleWithin 39 (base + 880) (base + storeLoopOff) (sharedDivModCode base)
+    cpsTripleWithin 39 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **
@@ -1237,7 +1237,7 @@ theorem divK_double_addback_beq_spec_within
   intro upc0' ac1_0' aun0' ac2_0' aco0' upc1' ac1_1' aun1' ac2_1' aco1'
         upc2' ac1_2' aun2' ac2_2' aco2' upc3' ac1_3' aun3' ac2_3' aco3' aun4' qHat''
   -- 1. BEQ at [108] taken (carry = 0, x7 = 0 = x0) → base+732
-  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) (0 : Word) 0 (base + 880)
+  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) (0 : Word) 0 (base + addbackBeqOff)
   rw [lb_beq_back_taken, lb_beq_back_ntaken] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
@@ -1300,7 +1300,7 @@ theorem divK_double_addback_beq_named_spec_within
     (hcarry2_nz : addbackN4_carry aun0 aun1 aun2 aun3 v0 v1 v2 v3 ≠ 0) :
     let ab' := addbackN4 aun0 aun1 aun2 aun3 aun4 v0 v1 v2 v3
     let qHat'' := qHat' + signExtend12 4095
-    cpsTripleWithin 39 (base + 880) (base + storeLoopOff) (sharedDivModCode base)
+    cpsTripleWithin 39 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ qHat') ** (.x5 ↦ᵣ aun4) ** (.x2 ↦ᵣ aun3) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ aun0) **

--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
@@ -29,16 +29,17 @@ open EvmAsm.Rv64
 -- Section 10b: Mulsub + correction_addback composition (borrow ≠ 0 path)
 -- ============================================================================
 
-theorem lb_beq_back_ntaken_local {base : Word} : (base + 880 : Word) + 4 = base + storeLoopOff := by
+theorem lb_beq_back_ntaken_local {base : Word} :
+    (base + addbackBeqOff : Word) + 4 = base + storeLoopOff := by
   bv_addr
 
 /-- BEQ passthrough at [108]: when carry (x7) != 0, BEQ falls through from
     base+880 to base+884. -/
 theorem divK_beq_passthrough_spec_within {carry : Word} (base : Word) (hne : carry ≠ 0) :
-    cpsTripleWithin 1 (base + 880) (base + storeLoopOff) (sharedDivModCode base)
+    cpsTripleWithin 1 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word))) := by
-  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + 880)
+  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + addbackBeqOff)
   rw [lb_beq_back_ntaken_local] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
@@ -53,10 +54,10 @@ theorem divK_beq_passthrough_spec_within {carry : Word} (base : Word) (hne : car
 
 /-- v2 mirror of `divK_beq_passthrough_spec_within`. -/
 theorem divK_beq_passthrough_v2_spec_within {carry : Word} (base : Word) (hne : carry ≠ 0) :
-    cpsTripleWithin 1 (base + 880) (base + storeLoopOff) (sharedDivModCode_v2 base)
+    cpsTripleWithin 1 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode_v2 base)
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word))) := by
-  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + 880)
+  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + addbackBeqOff)
   rw [lb_beq_back_ntaken_local] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub_v2 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
@@ -125,7 +126,7 @@ theorem divK_mulsub_correction_addback_880_spec_within
     let qHat' := qHat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 91 (base + div128CallRetOff) (base + 880) (sharedDivModCode base)
+    cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **
@@ -192,7 +193,7 @@ theorem divK_mulsub_correction_addback_named_880_spec_within
     let qHat' := qHat + signExtend12 4095
     -- Hypothesis: borrow ≠ 0
     (if BitVec.ult uTop c3 then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 91 (base + div128CallRetOff) (base + 880) (sharedDivModCode base)
+    cpsTripleWithin 91 (base + div128CallRetOff) (base + addbackBeqOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x1 ↦ᵣ v1Old) ** (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x2 ↦ᵣ v2Old) **


### PR DESCRIPTION
Introduce `addbackBeqOff = 880` (= `storeLoopOff - 4` = `loopBodyOff + 432`) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` with two drift-check examples, then mechanically replace `base + 880` across the loop-body files:

- `LoopBody.lean` (13 occurrences)
- `LoopBody/MulsubCorrectionAddback.lean` (7 occurrences)

This is the entry PC of the addback-skip BEQ instruction inside `divK_loopBody` (the `BEQ x7, x0, +4` that branches over the addback fixup when q̂ did not overshoot, falling through to `storeLoopOff` otherwise). After this PR no `base + 880` literal remains outside `Offsets.lean`.

Mirrors PR #1510 (`storeLoopOff`). Refs #301; sub-slice of beads `evm-asm-7rk` / `evm-asm-8uml` (slice 3 — within-block PC constants in `LoopBody/*` helpers).

Local `lake build` green.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).