### PR TITLE
chore(divmod): name correctionSkipBeqOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -24,6 +24,7 @@
     [copyAUOff    = 396] divK_copyAU        (36 bytes)
     [loopSetupOff = 432] divK_loopSetup     (16 bytes)
     [loopBodyOff  = 448] divK_loopBody     (460 bytes)
+      [correctionSkipBeqOff = 728]  divK_loopBody mulsub-correction-skip BEQ entry (loopBodyOff + 280)
       [storeLoopOff = 884]  divK_store_qj sub-block (loopBodyOff + 436)
     [denormOff    = 908] divK_denorm       (100 bytes)
     [epilogueOff  =1008] divK_{div,mod}_epilogue (40 bytes)
@@ -60,6 +61,12 @@ abbrev copyAUOff    : Word :=  396
 abbrev loopSetupOff : Word :=  432
 /-- Offset of `divK_loopBody` (Knuth Algorithm D main loop body). -/
 abbrev loopBodyOff  : Word :=  448
+/-- Offset of the mulsub correction-skip BEQ entry inside `divK_loopBody`.
+    Entry PC of the BEQ instruction that branches over the addback correction
+    block when the trial-quotient mulsub did not borrow (the "skip" path).
+    Sub-offset relative to the loopBody block (= loopBodyOff + 280, i.e. 70
+    instructions into the loop body). -/
+abbrev correctionSkipBeqOff : Word :=  728
 /-- Offset of the store-quotient sub-block inside `divK_loopBody`.
     Entry PC of the `divK_store_qj` snippet that writes the trial-quotient
     digit `q[j]` to the output buffer (followed by the loop-back / loop-exit
@@ -121,6 +128,10 @@ example : denormOff = loopBodyOff + 4 * (divK_loopBody 560 7736).length := by de
 /-- storeLoopOff = loopBodyOff + 436 (sub-block offset within `divK_loopBody`).
     The `divK_store_qj` snippet starts 109 instructions into the loop body. -/
 example : storeLoopOff = loopBodyOff + 436 := by decide
+/-- correctionSkipBeqOff = loopBodyOff + 280 (sub-block offset within
+    `divK_loopBody`). The mulsub correction-skip BEQ sits 70 instructions
+    into the loop body. -/
+example : correctionSkipBeqOff = loopBodyOff + 280 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean
@@ -24,7 +24,7 @@ open EvmAsm.Rv64
 theorem divK_correction_skip_spec_within
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5Old v2Old : Word) (base : Word) :
-    cpsTripleWithin 1 (base + 728) (base + storeLoopOff) (sharedDivModCode base)
+    cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -39,8 +39,8 @@ theorem divK_correction_skip_spec_within
        ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ u4)) := by
-  -- BEQ x7 x0 156 at base+728 with x7=0, x0=0
-  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + 728)
+  -- BEQ x7 x0 156 at base + correctionSkipBeqOff with x7=0, x0=0
+  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + correctionSkipBeqOff)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 70 _ _ (by decide) (by bv_addr) (by decide)) hbeq
@@ -49,7 +49,7 @@ theorem divK_correction_skip_spec_within
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
     exact hpure rfl)
   -- Strip pure fact from taken postcondition
-  have skip_clean : cpsTripleWithin 1 (base + 728) (base + storeLoopOff) (sharedDivModCode base)
+  have skip_clean : cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode base)
       ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
     cpsTripleWithin_weaken
@@ -78,7 +78,7 @@ theorem divK_correction_skip_spec_within
 theorem divK_correction_skip_v2_spec_within
     (sp uBase qHat v0 v1 v2 v3 u0 u1 u2 u3 u4 : Word)
     (v5Old v2Old : Word) (base : Word) :
-    cpsTripleWithin 1 (base + 728) (base + storeLoopOff) (sharedDivModCode_v2 base)
+    cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode_v2 base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ uBase) ** (.x7 ↦ᵣ (0 : Word)) **
        (.x11 ↦ᵣ qHat) ** (.x5 ↦ᵣ v5Old) ** (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
@@ -93,14 +93,14 @@ theorem divK_correction_skip_v2_spec_within
        ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
        ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
        ((uBase + signExtend12 4064) ↦ₘ u4)) := by
-  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + 728)
+  have hbeq := beq_spec_gen_within .x7 .x0 (156 : BitVec 13) (0 : Word) 0 (base + correctionSkipBeqOff)
   rw [lb_beq_taken, lb_beq_ntaken] at hbeq
   have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub_v2 70 _ _ (by decide) (by bv_addr) (by decide)) hbeq
   have skip := cpsBranchWithin_takenPath hbeq_ext (fun hp hQf => by
     obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQf
     exact hpure rfl)
-  have skip_clean : cpsTripleWithin 1 (base + 728) (base + storeLoopOff) (sharedDivModCode_v2 base)
+  have skip_clean : cpsTripleWithin 1 (base + correctionSkipBeqOff) (base + storeLoopOff) (sharedDivModCode_v2 base)
       ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
       ((.x7 ↦ᵣ (0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
     cpsTripleWithin_weaken


### PR DESCRIPTION
Introduce `correctionSkipBeqOff = 728` (= `loopBodyOff + 280`) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` as the named constant for the mulsub correction-skip BEQ entry inside `divK_loopBody`, with a drift-check example tying it to the symbolic offset.

Mechanically replaces the 6 occurrences of `base + 728` in `EvmAsm/Evm64/DivMod/LoopBody/CorrectionSkip.lean` with `base + correctionSkipBeqOff` (4 spec sites + 2 inside proofs).

Mirrors PR #1510 (`storeLoopOff`) and #1528 (`addbackBeqOff`) patterns.

Tracks #301 (Beads: `evm-asm-4pdc`).

Build: `lake build` green (1428 jobs).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).