### PR TITLE
proof(divmod): add iteration branch constructors

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -604,6 +604,60 @@ theorem fullModN1RemainderWord_toNat
   rw [EvmWord.fromLimbs_toNat]
   rfl
 
+theorem fullModN1RemainderWord_toNat_eq_mod_toNat_of_val256_eq
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hrem :
+      EvmWord.val256
+        (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64)))
+        (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64)))
+        (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+            ((fullDivN1Shift b0).toNat % 64)) |||
+          ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+            ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64)))
+        ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64)) =
+      EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3) :
+    (fullModN1RemainderWord bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.mod a b).toNat := by
+  have ha_val : EvmWord.val256 a0 a1 a2 a3 = a.toNat := by
+    rw [← ha0, ← ha1, ← ha2, ← ha3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : EvmWord.val256 b0 b1 b2 b3 = b.toNat := by
+    rw [← hb0, ← hb1, ← hb2, ← hb3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  have hb_pos : 0 < b.toNat := by
+    rw [← hb_val]
+    exact EvmWord.val256_pos_of_or_ne_zero hbnz
+  have hb_ne : b ≠ 0 := by
+    intro hb_zero
+    have hb_toNat_zero : b.toNat = 0 := by simp [hb_zero]
+    omega
+  have hmod_toNat : (EvmWord.mod a b).toNat = a.toNat % b.toNat := by
+    unfold EvmWord.mod
+    rw [if_neg hb_ne]
+    exact BitVec.toNat_umod
+  rw [fullModN1RemainderWord_toNat, hrem, ha_val, hb_val, hmod_toNat]
+
 theorem evm_mod_n1_stack_spec_within
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)
     (a b : EvmWord)

--- a/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean
@@ -168,6 +168,22 @@ def iterSingleAddbackConservation (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop
       EvmWord.val256 ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 +
       ab.2.2.2.2.toNat * 2^256
 
+theorem iterSingleAddbackBranch_of
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    (hc3_one : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry_one : addbackN4_carry
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+      v0 v1 v2 v3 = 1)
+    (hq_pos : 1 ≤ q.toNat) :
+    iterSingleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta iterSingleAddbackBranch
+  simp only []
+  exact ⟨hb, hc3_one, hcarry_one, hq_pos⟩
+
 theorem iterSingleAddbackBranch_uTop_toNat_eq_zero
     (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (hbranch : iterSingleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
@@ -567,6 +583,24 @@ def iterDoubleAddbackBranch (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
     v0 ||| v1 ||| v2 ||| v3 ≠ 0 ∧
     q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2 ∧
     2 ≤ q.toNat
+
+theorem iterDoubleAddbackBranch_of
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2)
+    (hc3_one : (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry_zero : addbackN4_carry
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+      (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+      v0 v1 v2 v3 = 0)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hq_over : q.toNat ≤ val256 u0 u1 u2 u3 / val256 v0 v1 v2 v3 + 2)
+    (hq_ge_2 : 2 ≤ q.toNat) :
+    iterDoubleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  delta iterDoubleAddbackBranch
+  simp only []
+  exact ⟨hb, hc3_one, hcarry_zero, hbnz, hq_over, hq_ge_2⟩
 
 theorem iterDoubleAddbackBranch_uTop_toNat_eq_zero
     (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)


### PR DESCRIPTION
Codex adds constructor adapters for the DivMod iteration branch predicates.\n\nSummary:\n- add iterSingleAddbackBranch_of from raw borrow/carry/q facts\n- add iterDoubleAddbackBranch_of from raw borrow/carry/nonzero/overestimate/q facts\n- keep later generic conservation proofs from repeatedly unfolding predicate definitions\n\nValidation:\n- lake build EvmAsm.Evm64.EvmWordArith.DivN4Overestimate\n- scripts/check-file-size.sh\n- scripts/check-unimported.sh\n- git diff --check