### PR TITLE
chore(divmod): name loopBackBgeOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -72,6 +72,13 @@ abbrev addbackBeqOff : Word :=  880
     branch into the next iteration or `divK_denorm`). Sub-offset relative
     to the loopBody block (= loopBodyOff + 436). -/
 abbrev storeLoopOff : Word :=  884
+/-- Offset of the loop-back BGE sub-block inside `divK_loopBody`.
+    Entry PC of the `BGE x1, x0, -...` instruction at the very end of
+    `divK_loopBody` that branches back to `loopBodyOff` for the next
+    iteration when `j ≥ 0`, falling through to `denormOff` otherwise.
+    Sub-offset relative to the loopBody block (= denormOff - 4 =
+    loopBodyOff + 456). -/
+abbrev loopBackBgeOff : Word :=  904
 /-- Offset of `divK_denorm` (denormalize result back to original shift). -/
 abbrev denormOff    : Word :=  908
 /-- Offset of the epilogue (`divK_div_epilogue` for DIV, `divK_mod_epilogue`
@@ -132,6 +139,11 @@ example : addbackBeqOff = loopBodyOff + 432 := by decide
 /-- storeLoopOff = loopBodyOff + 436 (sub-block offset within `divK_loopBody`).
     The `divK_store_qj` snippet starts 109 instructions into the loop body. -/
 example : storeLoopOff = loopBodyOff + 436 := by decide
+/-- loopBackBgeOff = denormOff - 4 (= loopBodyOff + 456, sub-block offset
+    within `divK_loopBody`). The loop-back BGE sits one instruction before
+    `divK_denorm` (it is the very last instruction of the loop body). -/
+example : loopBackBgeOff = denormOff - 4 := by decide
+example : loopBackBgeOff = loopBodyOff + 456 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -55,13 +55,13 @@ theorem divK_store_loop_j0_spec_within
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
   have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at haddi
+  rw [show (base + 900 : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
-  -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
-  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
-      show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
+  -- 3. BGE x1 x0 7736 at base+loopBackBgeOff (instr [114])
+  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
+      show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
     exact lb_sub 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
   -- 4. Eliminate taken branch: j' = -1 < 0, so BGE is not taken
@@ -135,13 +135,13 @@ theorem divK_store_loop_jgt0_spec_within
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
   have haddi := addi_spec_gen_same_within .x1 j 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at haddi
+  rw [show (base + 900 : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
-  -- 3. BGE x1 x0 7736 at base+904 (instr [114])
-  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + 904)
-  rw [show (base + 904 : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
-      show (base + 904 : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
+  -- 3. BGE x1 x0 7736 at base+loopBackBgeOff (instr [114])
+  have hbge_raw := bge_spec_gen_within .x1 .x0 (7736 : BitVec 13) j' (0 : Word) (base + loopBackBgeOff)
+  rw [show (base + loopBackBgeOff : Word) + signExtend13 (7736 : BitVec 13) = base + loopBodyOff from by rv64_addr,
+      show (base + loopBackBgeOff : Word) + 4 = base + denormOff from by bv_addr] at hbge_raw
   have hbge_ext := cpsBranchWithin_extend_code (hmono := by
     exact lb_sub 114 _ _ (by decide) (by bv_addr) (by decide)) hbge_raw
   -- 4. Eliminate not-taken branch: j' = j-1 ≥ 0, so BGE is taken


### PR DESCRIPTION
Sub-slice of evm-asm-7rk (#301 slice 3, parent #301 / evm-asm-nqj).

Mirrors PR #1510 (storeLoopOff) and #1528 (addbackBeqOff): introduce
`loopBackBgeOff = 904` (= `denormOff - 4` = `loopBodyOff + 456`) in
`EvmAsm/Evm64/DivMod/Compose/Offsets.lean` with two drift-check
examples, then mechanically replace the 8 occurrences of `base + 904`
in `EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean`.

This is the entry PC of the `BGE x1, x0, -...` instruction at the
very end of `divK_loopBody` — the loop-back BGE that branches to
`loopBodyOff` for the next iteration when `j ≥ 0`, falling through
to `denormOff` otherwise (i.e. it is the last instruction of the
loop body, immediately before `divK_denorm`).

After this PR no `base + 904` literal remains outside Offsets.lean
(audit comment in the header is unaffected).

Beads: evm-asm-po5e.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
