### PR TITLE
chore(shake): flag 4 confirmed false-positives in noshake.json (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -7,9 +7,13 @@
   "EvmAsm.Rv64.WordOps":
   ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
   "EvmAsm.Rv64.RLP.Phase1":
-  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp"],
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.ExtractPure"],
+  "EvmAsm.Rv64.RLP.Phase2LongLoad":
+  ["EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.Tactics.XPerm":
+  ["EvmAsm.Rv64.SepLogic"],
   "EvmAsm.Rv64.Tactics.SeqFrame":
-  ["EvmAsm.Rv64.Tactics.PerfTrace"],
+  ["EvmAsm.Rv64.Tactics.PerfTrace", "EvmAsm.Rv64.InstructionSpecs"],
   "EvmAsm.Rv64.Tactics.LiftSpec":
   ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
   "EvmAsm.Evm64.Pop.Spec":


### PR DESCRIPTION
Refs #1045 · evm-asm-mbfi (sub-slice of evm-asm-9tq).

`lake exe shake EvmAsm` reports four import-removal suggestions whose imports are actually required for the file to elaborate. Verified each by attempting the removal locally — every one breaks `lake build` with `Unknown constant` / `unknown tactic` errors. Add them to `scripts/noshake.json` so future shake sweeps don't keep rediscovering them.

| File | Import | Why it's needed |
|---|---|---|
| `EvmAsm.Rv64.Tactics.XPerm` | `EvmAsm.Rv64.SepLogic` | uses `sepConj`, `empAssertion`, `sepConj_assoc'`, `sepConj_emp_right'`, `seps_pick`, `Assertion` at ~20 sites |
| `EvmAsm.Rv64.Tactics.SeqFrame` | `EvmAsm.Rv64.InstructionSpecs` | transitive elaboration dependency during seqFrame |
| `EvmAsm.Rv64.RLP.Phase1` | `EvmAsm.Rv64.Tactics.ExtractPure` | `extract_pure` tactic in two BLTU-branch proofs |
| `EvmAsm.Rv64.RLP.Phase2LongLoad` | `EvmAsm.Rv64.Tactics.XSimp` | `xsimp` in cpsTripleWithin composition |

Test plan: `lake build` green; `lake exe shake EvmAsm` no longer flags any of the four files.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).