### PR TITLE
chore(divmod): name loopControlOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -72,6 +72,12 @@ abbrev addbackBeqOff : Word :=  880
     branch into the next iteration or `divK_denorm`). Sub-offset relative
     to the loopBody block (= loopBodyOff + 436). -/
 abbrev storeLoopOff : Word :=  884
+/-- Offset of the `divK_loop_control` sub-block inside `divK_loopBody`.
+    Entry PC of the 2-instruction loop-control snippet (`ADDI x1, …, 4095`
+    followed by the back-jump BGE) that decides whether to iterate or exit
+    to `divK_denorm`. Sub-offset relative to the loopBody block
+    (= storeLoopOff + 16 = denormOff - 8 = loopBodyOff + 452). -/
+abbrev loopControlOff : Word :=  900
 /-- Offset of `divK_denorm` (denormalize result back to original shift). -/
 abbrev denormOff    : Word :=  908
 /-- Offset of the epilogue (`divK_div_epilogue` for DIV, `divK_mod_epilogue`
@@ -132,6 +138,13 @@ example : addbackBeqOff = loopBodyOff + 432 := by decide
 /-- storeLoopOff = loopBodyOff + 436 (sub-block offset within `divK_loopBody`).
     The `divK_store_qj` snippet starts 109 instructions into the loop body. -/
 example : storeLoopOff = loopBodyOff + 436 := by decide
+/-- loopControlOff = storeLoopOff + 16 (= loopBodyOff + 452 = denormOff - 8,
+    sub-block offset within `divK_loopBody`). The `divK_loop_control` snippet
+    sits 4 instructions past `divK_store_qj` and 2 instructions before the
+    `divK_denorm` block boundary. -/
+example : loopControlOff = storeLoopOff + 16 := by decide
+example : loopControlOff = denormOff - 8 := by decide
+example : loopControlOff = loopBodyOff + 452 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1156,11 +1156,11 @@ theorem lb_bltu_ntaken {base : Word} : (base + 500 : Word) + 4 = base + 504 := b
 -- ============================================================================
 
 -- Address normalization for store_qj and loop control
-theorem lb_sqj {base : Word} : (base + storeLoopOff : Word) + 16 = base + 900 := by bv_addr
+theorem lb_sqj {base : Word} : (base + storeLoopOff : Word) + 16 = base + loopControlOff := by bv_addr
 private theorem lb_lc_taken {base : Word} :
-    (base + 900 : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
+    (base + loopControlOff : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
   rv64_addr
-private theorem lb_lc_exit {base : Word} : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
+private theorem lb_lc_exit {base : Word} : (base + loopControlOff : Word) + 8 = base + denormOff := by bv_addr
 
 private theorem lb_beq_back_ntaken {base : Word} : (base + addbackBeqOff : Word) + 4 = base + storeLoopOff := by bv_addr
 
@@ -1349,14 +1349,14 @@ theorem divK_store_loop_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. Loop control: instrs [113]-[114] at base+900
-  have LC := divK_loop_control_spec_within j (7736 : BitVec 13) (base + 900)
+  have LC := divK_loop_control_spec_within j (7736 : BitVec 13) (base + loopControlOff)
   dsimp only [] at LC
   rw [lb_lc_taken, lb_lc_exit] at LC
   have LCe := cpsBranchWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 113 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 114 _ _ (by decide) (by bv_addr) (by decide))) LC
   -- 3. Add x0 to store_qj via frame, then reshape via consequence
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
@@ -1366,7 +1366,7 @@ theorem divK_store_loop_spec_within
       (fun h hp => by xperm_hyp hp)
       (cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
   -- 4. Frame loop_control with store_qj postcondition atoms, then reshape
-  have LCp : cpsBranchWithin 2 (base + 900) (sharedDivModCode base)
+  have LCp : cpsBranchWithin 2 (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat))
       (base + loopBodyOff)

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -54,8 +54,8 @@ theorem divK_store_loop_j0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at haddi
+  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + 904 from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
@@ -76,7 +76,7 @@ theorem divK_store_loop_j0_spec_within
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
@@ -134,8 +134,8 @@ theorem divK_store_loop_jgt0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + 904 from by bv_addr] at haddi
+  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + 904 from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
@@ -156,7 +156,7 @@ theorem divK_store_loop_jgt0_spec_within
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **


### PR DESCRIPTION
Mirrors PR #1528 (addbackBeqOff = 880) and PR #1534 (loopBackBgeOff = 904).

Introduces `loopControlOff = 900` (= `storeLoopOff + 16` = `denormOff - 8` = `loopBodyOff + 452`) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` for the `divK_loop_control` sub-block — the 2-instruction snippet (`ADDI x1, ., 4095` + back-jump BGE) between `divK_store_qj` and `divK_denorm`. Three drift-check examples tie it to neighbouring offsets.

Mechanical migration of the 12 `base + 900` literals across:
- `EvmAsm/Evm64/DivMod/LoopBody.lean` (6 occurrences)
- `EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean` (6 occurrences)

`lake build` green. No semantic changes.

Refs #301. Beads: evm-asm-p08l (sub-slice of evm-asm-7rk).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).