### PR TITLE
chore(divmod): name trialCallOff (base + 500) in LoopBody (#301 slice 3)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -24,6 +24,7 @@
     [copyAUOff    = 396] divK_copyAU        (36 bytes)
     [loopSetupOff = 432] divK_loopSetup     (16 bytes)
     [loopBodyOff  = 448] divK_loopBody     (460 bytes)
+      [trialCallOff       = 500]  divK_loopBody BLTU/JAL trial-quotient call entry (loopBodyOff + 52)
       [correctionSkipBeqOff = 728]  divK_loopBody mulsub-correction-skip BEQ entry (loopBodyOff + 280)
       [storeLoopOff = 884]  divK_store_qj sub-block (loopBodyOff + 436)
     [denormOff    = 908] divK_denorm       (100 bytes)
@@ -61,6 +62,13 @@ abbrev copyAUOff    : Word :=  396
 abbrev loopSetupOff : Word :=  432
 /-- Offset of `divK_loopBody` (Knuth Algorithm D main loop body). -/
 abbrev loopBodyOff  : Word :=  448
+/-- Offset of the trial-quotient call sub-block inside `divK_loopBody`.
+    Entry PC of the `BLTU x7, x10, +12` instruction that branches between the
+    div128 call path (uHi < vTop) and the max-trial path (uHi ≥ vTop).
+    Sub-offset relative to the loopBody block (= loopBodyOff + 52, i.e. 13
+    instructions into the loop body, just after the `save j + trial load`
+    prelude). -/
+abbrev trialCallOff : Word :=  500
 /-- Offset of the mulsub correction-skip BEQ entry inside `divK_loopBody`.
     Entry PC of the BEQ instruction that branches over the addback correction
     block when the trial-quotient mulsub did not borrow (the "skip" path).
@@ -143,6 +151,9 @@ example : storeLoopOff = loopBodyOff + 436 := by decide
     `divK_loopBody`). The mulsub correction-skip BEQ sits 70 instructions
     into the loop body. -/
 example : correctionSkipBeqOff = loopBodyOff + 280 := by decide
+/-- trialCallOff = loopBodyOff + 52 (sub-block offset within `divK_loopBody`).
+    The trial-quotient BLTU/JAL pair sits 13 instructions into the loop body. -/
+example : trialCallOff = loopBodyOff + 52 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1080,7 +1080,7 @@ theorem divK_correction_addback_named_spec_within
     v5Old v2Old base hb
 
 private theorem lb_save_j {base : Word} : (base + loopBodyOff : Word) + 4 = base + 452 := by bv_addr
-private theorem lb_trial_load {base : Word} : (base + 452 : Word) + 48 = base + 500 := by bv_addr
+private theorem lb_trial_load {base : Word} : (base + 452 : Word) + 48 = base + trialCallOff := by bv_addr
 
 /-- Save j + trial load: save j to memory, then load uHi, uLo, vTop for trial quotient.
     13 instructions, loop body indices [0]-[12].
@@ -1090,7 +1090,7 @@ theorem divK_save_trial_load_spec_within
     (base : Word) :
     let uAddr := sp + signExtend12 4056 - (j + n) <<< (3 : BitVec 6).toNat
     let vtopBase := sp + (n + signExtend12 4095) <<< (3 : BitVec 6).toNat
-    cpsTripleWithin 13 (base + loopBodyOff) (base + 500) (sharedDivModCode base)
+    cpsTripleWithin 13 (base + loopBodyOff) (base + trialCallOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
        (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) **
@@ -1145,9 +1145,9 @@ theorem divK_save_trial_load_spec_within
     (fun h hq => by xperm_hyp hq)
     SJfTLe
 
-theorem lb_bltu_taken {base : Word} : (base + 500 : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
+theorem lb_bltu_taken {base : Word} : (base + trialCallOff : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
   rv64_addr
-theorem lb_bltu_ntaken {base : Word} : (base + 500 : Word) + 4 = base + 504 := by bv_addr
+theorem lb_bltu_ntaken {base : Word} : (base + trialCallOff : Word) + 4 = base + 504 := by bv_addr
 
 -- ============================================================================
 -- Section 9: Store q[j] + loop control

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCall.lean
@@ -145,7 +145,7 @@ theorem divK_trial_call_full_spec_within
     base
   dsimp only [] at STL
   -- 2. BLTU x7 x10 12 at base+500
-  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + 500)
+  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + trialCallOff)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
@@ -81,7 +81,7 @@ theorem divK_trial_max_full_spec_within
     base
   dsimp only [] at STL
   -- 2. BLTU x7 x10 12 at base+500
-  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + 500)
+  have hbltu_raw := bltu_spec_gen_within .x7 .x10 (12 : BitVec 13) uHi vTop (base + trialCallOff)
   rw [lb_bltu_taken, lb_bltu_ntaken] at hbltu_raw
   have hbltu_ext := cpsBranchWithin_extend_code (hmono :=
     lb_sub 13 _ _ (by decide) (by bv_addr) (by decide)) hbltu_raw


### PR DESCRIPTION
Introduce `trialCallOff = 500` (= loopBodyOff + 52) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` for the BLTU/JAL trial-quotient call sub-block entry inside `divK_loopBody`, with a drift-check example `trialCallOff = loopBodyOff + 52 := by decide` and a layout-table line.

Mechanically migrate all 6 occurrences of `base + 500` under `EvmAsm/Evm64/DivMod/` to `base + trialCallOff`:
- `LoopBody.lean` (4 sites: `lb_trial_load`, `divK_save_trial_load_spec_within` signature, `lb_bltu_taken`, `lb_bltu_ntaken`)
- `LoopBody/TrialCall.lean` (1 site: `bltu_spec_gen_within`)
- `LoopBody/TrialMax.lean` (1 site: `bltu_spec_gen_within`)

After this slice, no `base + 500` literal remains under `EvmAsm/Evm64/DivMod/`. Mirrors PR #1510 (`storeLoopOff`), #1528 (`addbackBeqOff`), #1534 (`loopBackBgeOff`), #1538 (`loopControlOff`).

Closes `evm-asm-5g14`. Tracks #301 / `evm-asm-7rk` / `evm-asm-nqj`.

Local `lake build` green (1428 jobs).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).