### PR TITLE
chore(divmod): name trialMaxOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -25,6 +25,7 @@
     [loopSetupOff = 432] divK_loopSetup     (16 bytes)
     [loopBodyOff  = 448] divK_loopBody     (460 bytes)
       [trialCallOff = 500]  divK_loopBody trial-quotient BLTU sub-block entry (loopBodyOff + 52)
+      [trialMaxOff  = 504]  divK_loopBody divK_trial_max sub-block (trialCallOff + 4)
       [correctionSkipBeqOff = 728]  divK_loopBody mulsub-correction-skip BEQ entry (loopBodyOff + 280)
       [storeLoopOff = 884]  divK_store_qj sub-block (loopBodyOff + 436)
     [denormOff    = 908] divK_denorm       (100 bytes)
@@ -69,6 +70,13 @@ abbrev loopBodyOff  : Word :=  448
     invokes `divK_div128`. Sub-offset relative to the loopBody block
     (= loopBodyOff + 52, i.e. 13 instructions into the loop body). -/
 abbrev trialCallOff : Word :=  500
+/-- Offset of the trial-quotient `divK_trial_max` sub-block inside `divK_loopBody`.
+    Entry PC of the BLT-fall-through into the "max" trial-quotient `divK_trial_max`
+    snippet (`q̂ = 2^64 - 1`) — the BLTU instruction at `trialCallOff` falls
+    through here when the high limb does NOT equal the divisor's top limb.
+    Sub-offset relative to the loopBody block (= trialCallOff + 4
+    = loopBodyOff + 56, i.e. 14 instructions into the loop body). -/
+abbrev trialMaxOff : Word :=  504
 /-- Offset of the mulsub correction-skip BEQ entry inside `divK_loopBody`.
     Entry PC of the BEQ instruction that branches over the addback correction
     block when the trial-quotient mulsub did not borrow (the "skip" path).
@@ -154,6 +162,11 @@ example : correctionSkipBeqOff = loopBodyOff + 280 := by decide
 /-- trialCallOff = loopBodyOff + 52 (sub-block offset within `divK_loopBody`).
     The trial-quotient BLTU sits 13 instructions into the loop body. -/
 example : trialCallOff = loopBodyOff + 52 := by decide
+/-- trialMaxOff = trialCallOff + 4 (= loopBodyOff + 56, sub-block offset within
+    `divK_loopBody`). The `divK_trial_max` snippet is the BLT fall-through one
+    instruction past `trialCallOff`. -/
+example : trialMaxOff = trialCallOff + 4 := by decide
+example : trialMaxOff = loopBodyOff + 56 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1147,7 +1147,7 @@ theorem divK_save_trial_load_spec_within
 
 theorem lb_bltu_taken {base : Word} : (base + trialCallOff : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
   rv64_addr
-theorem lb_bltu_ntaken {base : Word} : (base + trialCallOff : Word) + 4 = base + 504 := by bv_addr
+theorem lb_bltu_ntaken {base : Word} : (base + trialCallOff : Word) + 4 = base + trialMaxOff := by bv_addr
 
 -- ============================================================================
 -- Section 9: Store q[j] + loop control

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean
@@ -26,7 +26,7 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 
 private theorem lb_trial_max_end {base : Word} :
-    (base + 504 : Word) + 12 = base + div128CallRetOff := by bv_addr
+    (base + trialMaxOff : Word) + 12 = base + div128CallRetOff := by bv_addr
 -- ============================================================================
 -- Trial quotient MAX path (Section 8a) — extended to sharedDivModCode
 -- Used only by `divK_trial_max_full_spec_within` below.
@@ -35,10 +35,10 @@ private theorem lb_trial_max_end {base : Word} :
 /-- Trial quotient MAX path: qHat = MAX64, skip div128 call.
     2 instructions at base+504. Entry: base+504, Exit: base+516. -/
 private theorem divK_trial_max_extended (v11Old : Word) (base : Word) :
-    cpsTripleWithin 2 (base + 504) (base + div128CallRetOff) (sharedDivModCode base)
+    cpsTripleWithin 2 (base + trialMaxOff) (base + div128CallRetOff) (sharedDivModCode base)
       ((.x11 ↦ᵣ v11Old) ** (.x0 ↦ᵣ 0))
       ((.x11 ↦ᵣ signExtend12 4095) ** (.x0 ↦ᵣ 0)) := by
-  have TM := divK_trial_max_spec_within v11Old (base + 504)
+  have TM := divK_trial_max_spec_within v11Old (base + trialMaxOff)
   dsimp only [] at TM
   rw [lb_trial_max_end] at TM
   exact cpsTripleWithin_extend_code (hmono := by


### PR DESCRIPTION
Stacks on #1545 (trialCallOff).

Introduce `trialMaxOff = 504` (= `trialCallOff + 4` = `loopBodyOff + 56`) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` as the named constant for the `divK_trial_max` sub-block entry — the BLT fall-through PC reached when the BLTU at `trialCallOff` does NOT branch into the call path.

Mechanically replaces the 3 occurrences of `base + 504` in `EvmAsm/Evm64/DivMod/LoopBody/TrialMax.lean` (`lb_trial_max_end`, `divK_trial_max_extended` `cpsTripleWithin` entry, and the `divK_trial_max_spec_within` instantiation) plus the `lb_bltu_ntaken` RHS in `EvmAsm/Evm64/DivMod/LoopBody.lean`.

Adds drift-check `example`s tying `trialMaxOff` to `trialCallOff + 4` and `loopBodyOff + 56`.

Mirrors PR #1510 (`storeLoopOff`), #1528 (`addbackBeqOff`), 7aad9e55 (`correctionSkipBeqOff`) patterns.

Tracks #301 (Beads: evm-asm-qhh8).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).