### PR TITLE
chore(shake): flag confirmed shake false-positives in noshake.json

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -8,6 +8,10 @@
   ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
   "EvmAsm.Rv64.RLP.Phase1":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.ExtractPure"],
+  "EvmAsm.Rv64.RLP.Phase1CascadePrefixE2": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
+  "EvmAsm.Rv64.RLP.Phase1CascadePrefixE3": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
+  "EvmAsm.Rv64.RLP.Phase1CascadePrefixE4": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
+  "EvmAsm.Rv64.RLP.Phase1CascadePrefixE5": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase2LongLoad":
   ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.XPerm":
@@ -16,6 +20,7 @@
   ["EvmAsm.Rv64.Tactics.PerfTrace", "EvmAsm.Rv64.InstructionSpecs"],
   "EvmAsm.Rv64.Tactics.LiftSpec":
   ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
+  "EvmAsm.Rv64.AddrNorm": ["EvmAsm.Rv64.AddrNormAttr"],
   "EvmAsm.Evm64.Pop.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Push0.Spec":
@@ -36,4 +41,18 @@
   "EvmAsm.Evm64.IsZero.Spec":  ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
-  "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp"]}}
+  "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.EvmWordArith.MulCorrect"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2":
+  ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2":
+  ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp", "EvmAsm.Evm64.DivMod.LimbSpec.Div128Tail"],
+  "EvmAsm.Evm64.DivMod.Compose.Offsets":
+  ["EvmAsm.Evm64.DivMod.Program"],
+  "EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose":
+  ["EvmAsm.Evm64.EvmWordArith.Div128KB6Composition"],
+  "EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds":
+  ["EvmAsm.Evm64.EvmWordArith.Div128KnuthLower"],
+  "EvmAsm.Evm64.Shift.ShlCompose":
+  ["EvmAsm.Evm64.Shift.ComposeBase"],
+  "EvmAsm.Evm64.Shift.SarCompose":
+  ["EvmAsm.Evm64.Shift.ComposeBase"]}}


### PR DESCRIPTION
Refs #1045 (Import hygiene sweep via lake exe shake), beads evm-asm-rg27.

## Summary

Tested 16 `remove #[...]` suggestions from the latest `lake exe shake EvmAsm` run by removing each import and running `lake build`. Every one broke the build — shake does not track attribute / macro / tactic dependencies, so these are confirmed false-positives. Adding them to `scripts/noshake.json` so they stop appearing in future shake reports.

## Newly flagged modules

| Module | Falsely-flagged import | Real reason it's needed |
|---|---|---|
| `EvmAsm.Rv64.RLP.Phase1CascadePrefixE{2,3,4,5}` | `Phase1Disjoint` | provides `rlp_phase1_step_code_disjoint_*` lemmas used in the proofs |
| `EvmAsm.Rv64.AddrNorm` | `AddrNormAttr` | provides the `@[rv64_addr]` attribute |
| `EvmAsm.Evm64.Multiply.Spec` | `EvmWordArith.MulCorrect` | provides `EvmWord.mul_correct` |
| `EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2` | `Div128Step1` | underlying step-1 spec |
| `EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2` | `Div128Clamp`, `Div128Tail` | composed step-2 inputs |
| `EvmAsm.Evm64.DivMod.Compose.Offsets` | `DivMod.Program` | drift-check examples |
| `EvmAsm.Evm64.EvmWordArith.Div128CallSkipClose` | `Div128KB6Composition` | composed bound |
| `EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.QuotientBounds` | `Div128KnuthLower` | `div128Quot_rhatc_lt_pow32_of_uHi_lt_dHi_mul_pow32` |
| `EvmAsm.Evm64.Shift.{ShlCompose,SarCompose}` | `Shift.ComposeBase` | composition base |

## Verification

- `lake build` succeeds: 1428/1428 jobs.
- `lake exe shake EvmAsm` output drops from 879 → 853 lines (the entries above are now ignored).
- Each removal was tested individually or in a small group and confirmed to break the build before adding the noshake entry.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).