### PR TITLE
chore(divmod): name mulsubOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -61,6 +61,13 @@ abbrev copyAUOff    : Word :=  396
 abbrev loopSetupOff : Word :=  432
 /-- Offset of `divK_loopBody` (Knuth Algorithm D main loop body). -/
 abbrev loopBodyOff  : Word :=  448
+/-- Offset of the `divK_mulsub_correction` sub-block inside `divK_loopBody`.
+    Entry PC of the mulsub-correction snippet that computes
+    `u[j..j+n] := u[j..j+n] − q̂ · v` (the trial-quotient subtract step in
+    Knuth Algorithm D). Sub-offset relative to the loopBody block
+    (= loopBodyOff + 88, i.e. 22 instructions into the loop body — past
+    the trial-divide entry and div128 call site). -/
+abbrev mulsubOff : Word :=  536
 /-- Offset of the mulsub correction-skip BEQ entry inside `divK_loopBody`.
     Entry PC of the BEQ instruction that branches over the addback correction
     block when the trial-quotient mulsub did not borrow (the "skip" path).
@@ -143,6 +150,11 @@ example : storeLoopOff = loopBodyOff + 436 := by decide
     `divK_loopBody`). The mulsub correction-skip BEQ sits 70 instructions
     into the loop body. -/
 example : correctionSkipBeqOff = loopBodyOff + 280 := by decide
+/-- mulsubOff = loopBodyOff + 88 (sub-block offset within `divK_loopBody`).
+    The `divK_mulsub_correction` snippet starts 22 instructions into the loop
+    body, after the trial-divide entry (~13 instructions) and the div128 call
+    site (~9 instructions including the JAL+JALR ABI dance). -/
+example : mulsubOff = loopBodyOff + 88 := by decide
 /-- epilogueOff = denormOff + 4 · |divK_denorm|. -/
 example : epilogueOff = denormOff + 4 * divK_denorm.length := by decide
 /-- zeroPathOff = epilogueOff + 4 · |divK_div_epilogue 24|

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -76,7 +76,7 @@ theorem lb_sub_v2 {base : Word} (k : Nat) (addr : Word) (instr : Instr)
 -- ============================================================================
 
 -- Mulsub limb base addresses (instrs [22]-[65])
-private theorem lb_ms1 {base : Word} : (base + 536 : Word) + 44 = base + 580 := by bv_addr
+private theorem lb_ms1 {base : Word} : (base + mulsubOff : Word) + 44 = base + 580 := by bv_addr
 private theorem lb_ms2 {base : Word} : (base + 580 : Word) + 44 = base + 624 := by bv_addr
 private theorem lb_ms3 {base : Word} : (base + 624 : Word) + 44 = base + 668 := by bv_addr
 private theorem lb_ms_end {base : Word} : (base + 668 : Word) + 44 = base + 712 := by bv_addr
@@ -130,7 +130,7 @@ theorem divK_mulsub_4limbs_spec_within
     let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
     let un3 := u3 - fs3
     let c3 := pc3 + bs3
-    cpsTripleWithin 44 (base + 536) (base + 712) (sharedDivModCode base)
+    cpsTripleWithin 44 (base + mulsubOff) (base + 712) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ (signExtend12 0 : Word)) **
        (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ v5_init) ** (.x7 ↦ᵣ v7_init) **
        (.x2 ↦ᵣ v2_init) **
@@ -151,7 +151,7 @@ theorem divK_mulsub_4limbs_spec_within
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3
   -- Limb 0: instrs [22]-[32] at base+536
   have L0 := divK_mulsub_limb_spec_within sp uBase qHat (signExtend12 0 : Word)
-    v5_init v7_init v2_init v0 u0 32 0 (base + 536)
+    v5_init v7_init v2_init v0 u0 32 0 (base + mulsubOff)
 
   rw [lb_ms1] at L0
   have L0e := cpsTripleWithin_extend_code (hmono := by
@@ -393,7 +393,7 @@ theorem divK_addback_full_spec_within
     (fun h hq => by xperm_hyp hq)
     IfA0eA1eA2eA3eAFe
 
-private theorem lb_ms_setup {base : Word} : (base + div128CallRetOff : Word) + 20 = base + 536 := by bv_addr
+private theorem lb_ms_setup {base : Word} : (base + div128CallRetOff : Word) + 20 = base + mulsubOff := by bv_addr
 
 -- Address normalization for sub_carry
 private theorem lb_sc {base : Word} : (base + 712 : Word) + 16 = base + 728 := by bv_addr
@@ -546,7 +546,7 @@ theorem divK_mulsub_4limbs_v2_spec_within
     let bs3 := if BitVec.ult u3 fs3 then (1 : Word) else 0
     let un3 := u3 - fs3
     let c3 := pc3 + bs3
-    cpsTripleWithin 44 (base + 536) (base + 712) (sharedDivModCode_v2 base)
+    cpsTripleWithin 44 (base + mulsubOff) (base + 712) (sharedDivModCode_v2 base)
       ((.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) ** (.x10 ↦ᵣ (signExtend12 0 : Word)) **
        (.x6 ↦ᵣ uBase) ** (.x5 ↦ᵣ v5_init) ** (.x7 ↦ᵣ v7_init) **
        (.x2 ↦ᵣ v2_init) **
@@ -567,7 +567,7 @@ theorem divK_mulsub_4limbs_v2_spec_within
         p3_lo p3_hi fs3 ba3 pc3 bs3 un3 c3
   -- Limb 0: instrs [22]-[32] at base+536
   have L0 := divK_mulsub_limb_spec_within sp uBase qHat (signExtend12 0 : Word)
-    v5_init v7_init v2_init v0 u0 32 0 (base + 536)
+    v5_init v7_init v2_init v0 u0 32 0 (base + mulsubOff)
 
   rw [lb_ms1] at L0
   have L0e := cpsTripleWithin_extend_code (hmono := by


### PR DESCRIPTION
Sub-slice of #301 (named offset constants for DivMod hardcoded addresses). Mirrors PR #1545 (trialCallOff) / #1549 (trialMaxOff) / #1528 (addbackBeqOff).

## What

- Introduces `mulsubOff = 536` (= `loopBodyOff + 88`) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` with a drift-check `example`.
- Migrates the 6 occurrences of `base + 536` in `EvmAsm/Evm64/DivMod/LoopBody.lean` to `base + mulsubOff`.

The offset names the entry PC of the `divK_mulsub_correction` sub-block (trial-quotient subtract step in Knuth Algorithm D), 22 instructions into the loop body — past the trial-divide entry and div128 call site.

## Acceptance

- `lake build` green (1428 jobs, 0 errors).
- No `base + 536` literal remains outside `docs/divmod-offset-audit.md` (which references it as the audit input).

From the slice 2 audit (`docs/divmod-offset-audit.md`), mulsub block recommendation. Beads: evm-asm-7rk / evm-asm-xgdr.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).