### PR TITLE
refactor(divmod): move 2 pure-Nat post1 lemmas to CallAddbackPureNat (#1078)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -3749,59 +3749,6 @@ theorem algCallAddbackBeqMsC3_eq_u4_plus_one_of_single_addback
   exact c3_n_eq_u4_plus_one_of_single_addback a b hb3nz hshift_nz hborrow hsem hcarry_nz
 
 
-/-- **Sub-stub: post1 = a%b * 2^s from c3 = u4 + 1 (pure Nat).**
-
-    Given the closed Nat lemmas + `c3_n_eq_u4_plus_one_of_single_addback`'s
-    output, this directly gives val256(post1_low4) = a%b * 2^s.
-
-    Composition of:
-    - `val256_post1_low4_eq_mod_times_pow_s_plus_c3_minus_one_minus_u4` (closed).
-    - `c3 = u4 + 1` (substituted in).
-
-    Result: post1_val + 0*2^256 = a%b * 2^s + 0, i.e., post1_val = a%b * 2^s. -/
-theorem post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one
-    (post1_val ms_val a_val b_val s u4 c3 : Nat)
-    (h_mulsub : c3 * 2^256 + (a_val * 2^s - u4 * 2^256) = ms_val + (a_val / b_val + 1) * (b_val * 2^s))
-    (h_addback : post1_val + 2^256 = ms_val + b_val * 2^s)
-    (h_u4_le : u4 * 2^256 ≤ a_val * 2^s)
-    (h_c3_eq : c3 = u4 + 1) :
-    post1_val = a_val % b_val * 2^s := by
-  have h_id := val256_post1_low4_eq_mod_times_pow_s_plus_c3_minus_one_minus_u4
-    post1_val ms_val a_val b_val s u4 c3 h_mulsub h_addback h_u4_le
-  -- h_id: post1_val + (u4 + 1) * 2^256 = a%b * 2^s + c3 * 2^256
-  -- h_c3_eq: c3 = u4 + 1
-  rw [h_c3_eq] at h_id
-  omega
-
-/-- **Pure-Nat: post1_val = a%b * 2^s from mulsub+addback Euclidean + bounds.**
-
-    Packaged single-shot sub-stub for the call+addback BEQ MOD adapter's
-    single-addback branch (PR #1253). Combines:
-    - `c3_eq_u4_plus_one_from_mulsub_addback_bounds` (yields c3 = u4 + 1).
-    - `post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one` (val256-level result).
-
-    Avoids exposing the intermediate `c3 = u4 + 1` step at the call site.
-    Once the Word-level bridge to the parent's let-chain is figured out, the
-    parent can apply this directly to skip an entire chained `c3` derivation.
-
-    The hypotheses are exactly the 6 preconditions for the c3-pinning lemma:
-    `h_mulsub` already encodes `qHat = a/b + 1` via the `(a_val / b_val + 1)`
-    factor on its RHS. -/
-theorem post1_val_eq_amod_pow_s_pure_nat
-    (post1_val ms_val a_val b_val s u4 c3 : Nat)
-    (h_mulsub : c3 * 2^256 + (a_val * 2^s - u4 * 2^256) = ms_val + (a_val / b_val + 1) * (b_val * 2^s))
-    (h_addback : post1_val + 2^256 = ms_val + b_val * 2^s)
-    (h_u4_le : u4 * 2^256 ≤ a_val * 2^s)
-    (h_post1_lt : post1_val < 2^256)
-    (h_amod_pow_lt : a_val % b_val * 2^s < 2^256)
-    (h_u4_lt_c3 : u4 < c3) :
-    post1_val = a_val % b_val * 2^s := by
-  have h_c3_eq := c3_eq_u4_plus_one_from_mulsub_addback_bounds
-    post1_val ms_val a_val b_val s u4 c3
-    h_mulsub h_addback h_u4_le h_post1_lt h_amod_pow_lt h_u4_lt_c3
-  exact post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one
-    post1_val ms_val a_val b_val s u4 c3 h_mulsub h_addback h_u4_le h_c3_eq
-
 /-- **Wrapper: post1Val = a%b * 2^s in single-addback (irreducible-form)** (CLOSED).
 
     Given the algorithm's invariants in single-addback (carry ≠ 0), the val256

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
@@ -256,4 +256,57 @@ theorem case_2_dHi_2pow32_le_arith
     DHi ≤ U - QdHi := by
   omega
 
+/-- **Sub-stub: post1 = a%b * 2^s from c3 = u4 + 1 (pure Nat).**
+
+    Given the closed Nat lemmas + `c3_n_eq_u4_plus_one_of_single_addback`'s
+    output, this directly gives val256(post1_low4) = a%b * 2^s.
+
+    Composition of:
+    - `val256_post1_low4_eq_mod_times_pow_s_plus_c3_minus_one_minus_u4` (closed).
+    - `c3 = u4 + 1` (substituted in).
+
+    Result: post1_val + 0*2^256 = a%b * 2^s + 0, i.e., post1_val = a%b * 2^s. -/
+theorem post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one
+    (post1_val ms_val a_val b_val s u4 c3 : Nat)
+    (h_mulsub : c3 * 2^256 + (a_val * 2^s - u4 * 2^256) = ms_val + (a_val / b_val + 1) * (b_val * 2^s))
+    (h_addback : post1_val + 2^256 = ms_val + b_val * 2^s)
+    (h_u4_le : u4 * 2^256 ≤ a_val * 2^s)
+    (h_c3_eq : c3 = u4 + 1) :
+    post1_val = a_val % b_val * 2^s := by
+  have h_id := val256_post1_low4_eq_mod_times_pow_s_plus_c3_minus_one_minus_u4
+    post1_val ms_val a_val b_val s u4 c3 h_mulsub h_addback h_u4_le
+  -- h_id: post1_val + (u4 + 1) * 2^256 = a%b * 2^s + c3 * 2^256
+  -- h_c3_eq: c3 = u4 + 1
+  rw [h_c3_eq] at h_id
+  omega
+
+/-- **Pure-Nat: post1_val = a%b * 2^s from mulsub+addback Euclidean + bounds.**
+
+    Packaged single-shot sub-stub for the call+addback BEQ MOD adapter's
+    single-addback branch (PR #1253). Combines:
+    - `c3_eq_u4_plus_one_from_mulsub_addback_bounds` (yields c3 = u4 + 1).
+    - `post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one` (val256-level result).
+
+    Avoids exposing the intermediate `c3 = u4 + 1` step at the call site.
+    Once the Word-level bridge to the parent's let-chain is figured out, the
+    parent can apply this directly to skip an entire chained `c3` derivation.
+
+    The hypotheses are exactly the 6 preconditions for the c3-pinning lemma:
+    `h_mulsub` already encodes `qHat = a/b + 1` via the `(a_val / b_val + 1)`
+    factor on its RHS. -/
+theorem post1_val_eq_amod_pow_s_pure_nat
+    (post1_val ms_val a_val b_val s u4 c3 : Nat)
+    (h_mulsub : c3 * 2^256 + (a_val * 2^s - u4 * 2^256) = ms_val + (a_val / b_val + 1) * (b_val * 2^s))
+    (h_addback : post1_val + 2^256 = ms_val + b_val * 2^s)
+    (h_u4_le : u4 * 2^256 ≤ a_val * 2^s)
+    (h_post1_lt : post1_val < 2^256)
+    (h_amod_pow_lt : a_val % b_val * 2^s < 2^256)
+    (h_u4_lt_c3 : u4 < c3) :
+    post1_val = a_val % b_val * 2^s := by
+  have h_c3_eq := c3_eq_u4_plus_one_from_mulsub_addback_bounds
+    post1_val ms_val a_val b_val s u4 c3
+    h_mulsub h_addback h_u4_le h_post1_lt h_amod_pow_lt h_u4_lt_c3
+  exact post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one
+    post1_val ms_val a_val b_val s u4 c3 h_mulsub h_addback h_u4_le h_c3_eq
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Sub-slice of #1078 slice 4 (beads evm-asm-30s). Continues PR #1507's pattern by relocating two pure-Nat helpers from `EvmAsm/Evm64/DivMod/Spec/CallAddback.lean` to `Spec/CallAddbackPureNat.lean`:

- `post1_eq_mod_times_pow_s_of_c3_eq_u4_plus_one`
- `post1_val_eq_amod_pow_s_pure_nat`

Both are pure-Nat helpers whose only dependencies (`val256_post1_low4_eq_mod_times_pow_s_plus_c3_minus_one_minus_u4` and `c3_eq_u4_plus_one_from_mulsub_addback_bounds`) already live in `CallAddbackPureNat.lean`, so the move is fully internal to that pure-Nat surface — no new imports required.

The Word-level wrapper `algCallAddbackBeqPost1Val_eq_amod_pow_s_of_single_addback` keeps importing them transitively via the existing `import EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat`.

Trims `CallAddback.lean` by 53 lines (3850 → 3797 LOC).
`lake build` green locally.

Refs #1078.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).