### PR TITLE
feat(exp): EXP opcode directory skeleton (#92)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -49,6 +49,9 @@ import EvmAsm.Evm64.SignExtend
 -- Multiply
 import EvmAsm.Evm64.Multiply
 
+-- Exp (skeleton — GH #92, square-and-multiply over 256-bit exponent)
+import EvmAsm.Evm64.Exp
+
 -- DivMod (Knuth Algorithm D)
 import EvmAsm.Evm64.DivMod
 

--- a/EvmAsm/Evm64/Exp.lean
+++ b/EvmAsm/Evm64/Exp.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.Exp
+
+  Umbrella for the EXP opcode subtree (GH #92). Re-exports the top-level
+  spec; downstream consumers should `import EvmAsm.Evm64.Exp` and not
+  reach into sub-modules directly.
+
+  AddrNormAttr is imported first (per AGENTS.md `register_simp_attr`
+  ordering rule) so the `exp_addr` attribute exists when later modules
+  attach lemmas to it.
+-/
+
+import EvmAsm.Evm64.Exp.AddrNormAttr
+import EvmAsm.Evm64.Exp.Program
+import EvmAsm.Evm64.Exp.LimbSpec
+import EvmAsm.Evm64.Exp.AddrNorm
+import EvmAsm.Evm64.Exp.Compose.Base
+import EvmAsm.Evm64.Exp.Spec

--- a/EvmAsm/Evm64/Exp/AddrNorm.lean
+++ b/EvmAsm/Evm64/Exp/AddrNorm.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.Exp.AddrNorm
+
+  Address-normalization simp set for EXP composition proofs.
+
+  Skeleton placeholder (GH #92, beads slice evm-asm-cf2c). The
+  `@[exp_addr, grind =]`-tagged atomic facts will be added once the
+  Compose layer (Exp/Compose/Loop.lean) starts emitting concrete address
+  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
+  base and the attribute declaration so downstream files can already
+  open the namespace.
+-/
+
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Evm64.Exp.AddrNormAttr
+
+namespace EvmAsm.Evm64.Exp.AddrNorm
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.Exp.AddrNorm

--- a/EvmAsm/Evm64/Exp/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/Exp/AddrNormAttr.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.Exp.AddrNormAttr
+
+  Declares the `exp_addr` simp attribute used by `Exp/AddrNorm.lean`.
+
+  Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code should
+  import `Exp/AddrNorm.lean` (which imports this file) — not this file directly.
+
+  Skeleton placeholder for GH #92 (EXP opcode). No tagged lemmas yet.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for EXP address arithmetic. Will collect atomic evaluations of
+    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+    in EXP composition proofs. -/
+register_simp_attr exp_addr

--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -1,0 +1,22 @@
+/-
+  EvmAsm.Evm64.Exp.Compose.Base
+
+  Shared composition infrastructure for EXP: `expCode` (the union of all
+  sub-block `CodeReq`s), subsumption helpers tying sub-block codes back to
+  `expCode`, and shared length lemmas.
+
+  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). Concrete
+  definitions will be added in the loop-composition slice (evm-asm-w5mk).
+-/
+
+import EvmAsm.Evm64.Exp.LimbSpec
+import EvmAsm.Evm64.Exp.AddrNorm
+
+namespace EvmAsm.Evm64.Exp.Compose
+
+open EvmAsm.Rv64
+
+-- Placeholder: `expCode` and subsumption lemmas land alongside the
+-- iter / loop composition (evm-asm-w5mk).
+
+end EvmAsm.Evm64.Exp.Compose

--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.Exp.LimbSpec
+
+  Per-block / per-limb cpsTriple specs for EXP sub-blocks (square block,
+  conditional-multiply block, iter body, loop, prologue, epilogue).
+
+  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). Concrete specs
+  will land in the LimbSpec-definition slice (evm-asm-mtj3). Per
+  `OPCODE_TEMPLATE.md`, each sub-block gets exactly one cpsTriple lemma.
+-/
+
+import EvmAsm.Evm64.Exp.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: per-sub-block specs land in slice 4 (evm-asm-mtj3).
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -1,0 +1,30 @@
+/-
+  EvmAsm.Evm64.Exp.Program
+
+  256-bit EVM EXP opcode (`EXP(a, b) = a^b mod 2^256`) as a 64-bit RISC-V
+  program.
+
+  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c).
+
+  The actual Program will be defined in the Program-definition slice
+  (evm-asm-ahaz). Per `docs/92-exp-survey.md` the algorithm is binary
+  square-and-multiply over 256 bits of exponent, invoking `evm_mul`
+  (made callable via a `cc_ret` shim) once per squaring and conditionally
+  once per set bit. The full bytecode will be assembled from sub-blocks
+  `exp_prologue`, `exp_square_block`, `exp_cond_mul_block`, `exp_iter_body`,
+  `exp_loop`, `exp_epilogue`.
+
+  This file currently has no `evm_exp` definition; later slices will add
+  it without breaking the umbrella import graph.
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_exp : Program` lands in slice 3 (evm-asm-ahaz).
+-- See `docs/92-exp-survey.md` for the algorithm and reuse points.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.Exp.Spec
+
+  Top-level (semantic / stack-level) cpsTriple spec for `evm_exp`,
+  bridging the limb-level loop composition to a single `evmWordIs`
+  pre/post pair.
+
+  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). The actual
+  `evm_exp_stack_spec` / `evm_exp_stack_spec_within` theorem lands in the
+  semantic slice (evm-asm-6snn).
+-/
+
+import EvmAsm.Evm64.Exp.Compose.Base
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_exp_stack_spec_within` lands in slice 6 (evm-asm-6snn).
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds the empty `Evm64/Exp/` subtree per `OPCODE_TEMPLATE.md`, wired into the `Evm64` umbrella so future EXP slices can land without further plumbing:

```
EvmAsm/Evm64/Exp.lean              -- umbrella, AddrNormAttr first
EvmAsm/Evm64/Exp/AddrNormAttr.lean -- declares @[exp_addr] simp set
EvmAsm/Evm64/Exp/AddrNorm.lean     -- (placeholder) tagged address facts
EvmAsm/Evm64/Exp/Program.lean      -- (placeholder) evm_exp Program
EvmAsm/Evm64/Exp/LimbSpec.lean     -- (placeholder) per-block specs
EvmAsm/Evm64/Exp/Compose/Base.lean -- (placeholder) expCode + subsumption
EvmAsm/Evm64/Exp/Spec.lean         -- (placeholder) evm_exp_stack_spec
```

All files compile sorry-free; `lake build` is green locally. No semantic content yet — concrete definitions land in subsequent slices per `docs/92-exp-survey.md` §5:

- evm-asm-ahaz — slice 3: define `evm_exp` Program
- evm-asm-mtj3 — slice 4: limb-level specs for square + conditional-multiply
- evm-asm-w5mk — slice 5: full-loop composition (256-bit exponent loop)
- evm-asm-6snn — slice 6: semantic `evm_exp_stack_spec` via `evmWordIs` + edge-case tests

The skeleton follows the OPCODE_TEMPLATE convention of registering `AddrNormAttr` in its own file (Lean 4 forbids using a `register_simp_attr` in the same file that declares it) and importing it first from the umbrella.

Tracks #92 (Beads: evm-asm-cf2c, slice 2 of evm-asm-20z6).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).