### PR TITLE
chore(divmod): migrate denorm block literals to denormOff + k (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -31,7 +31,7 @@ private theorem divK_denorm_code_sub_divCode {base : Word} :
     base+908 → base+916. Bridges the gap between loop body exit and denorm body. -/
 theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTripleWithin 2 (base + denormOff) (base + 916) (divCode base)
+    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -40,20 +40,19 @@ theorem divK_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
   have hbeq_exit := cpsBranchWithin_ntakenPath hbeqe
@@ -88,7 +87,7 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + 916) (base + epilogueOff) (divCode base)
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -99,11 +98,11 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
        ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
   intro antiShift u0' u1' u2' u3'
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
-  have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + 916) (by nofun)
-  rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
+  have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + denormOff + 8) (by nofun)
+  rw [show (base + denormOff + 8 : Word) + 4 = base + denormOff + 12 from by bv_addr] at haddi
   have haddie := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 916) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 8) divK_denorm
         [.ADDI .x2 .x0 0] 2
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) haddi
   -- Frame ADDI with x12, x5, x7, x6, and all memory
@@ -113,15 +112,14 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) haddie
   have hsub := sub_spec_gen_rd_eq_rs1_within .x2 .x6
-    (signExtend12 (0 : BitVec 12)) shift (base + 920) (by nofun)
-  rw [show (base + 920 : Word) + 4 = base + 924 from by bv_addr] at hsub
+    (signExtend12 (0 : BitVec 12)) shift (base + denormOff + 12) (by nofun)
+  rw [show (base + denormOff + 12 : Word) + 4 = base + denormOff + 16 from by bv_addr] at hsub
   have hsube := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [bv64_4mul_3,
-            show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
+        rw [bv64_4mul_3] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTripleWithin_frameR
@@ -132,11 +130,11 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
   have h_anti := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
-  have hm0 := divK_denorm_merge_spec_within 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + 924)
-  rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
+  have hm0 := divK_denorm_merge_spec_within 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + denormOff + 16)
+  rw [show (base + denormOff + 16 : Word) + 24 = base + denormOff + 40 from by bv_addr] at hm0
   have hm0e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 924) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 16) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm0
   have hm0ef := cpsTripleWithin_frameR
@@ -147,11 +145,11 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec_within 4048 4040 sp u1 u2
-    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + 948)
-  rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
+    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 40)
+  rw [show (base + denormOff + 40 : Word) + 24 = base + denormOff + 64 from by bv_addr] at hm1
   have hm1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 948) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 40) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   have hm1ef := cpsTripleWithin_frameR
@@ -162,11 +160,11 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec_within 4040 4032 sp u2 u3
-    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + 972)
-  rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
+    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 64)
+  rw [show (base + denormOff + 64 : Word) + 24 = base + denormOff + 88 from by bv_addr] at hm2
   have hm2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 972) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 64) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTripleWithin_frameR
@@ -176,11 +174,11 @@ theorem divK_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (bas
   have h_m2 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
-  have hl := divK_denorm_last_spec_within 4032 sp u3 u2' shift (base + 996)
-  rw [show (base + 996 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
+  have hl := divK_denorm_last_spec_within 4032 sp u3 u2' shift (base + denormOff + 88)
+  rw [show (base + denormOff + 88 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
   have hle := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_divCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 996) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 88) divK_denorm
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTripleWithin_frameR
@@ -201,7 +199,7 @@ theorem divK_denorm_body_spec (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base : Wor
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + 916) (base + epilogueOff) (divCode base)
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **

--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -397,7 +397,7 @@ theorem evm_div_n4_shift0_to_loopSetup_spec (sp base : Word)
 theorem evm_div_denorm_epilogue_spec (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (q0 q1 q2 q3 m0 m8 m16 m24 : Word) :
-    cpsTripleWithin (23 + 10) (base + 916) (base + nopOff) (divCode base)
+    cpsTripleWithin (23 + 10) (base + denormOff + 8) (base + nopOff) (divCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -453,7 +453,7 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
 private theorem fullPath_mod_denorm_epilogue_spec_within (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (m0 m8 m16 m24 : Word) :
-    cpsTripleWithin 33 (base + 916) (base + nopOff) (modCode base)
+    cpsTripleWithin 33 (base + denormOff + 8) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -561,7 +561,7 @@ private theorem divK_denorm_code_sub_modCode' (base : Word) :
     base+908 → base+916. -/
 private theorem fullPath_mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTripleWithin 2 (base + denormOff) (base + 916) (modCode base)
+    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -570,20 +570,19 @@ private theorem fullPath_mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
   have hbeq_exit := cpsBranchWithin_ntakenPath hbeqe
@@ -698,20 +697,19 @@ theorem evm_div_shift0_epilogue_spec_within (sp base : Word)
        ((sp + 48) ↦ₘ q2) ** ((sp + 56) ↦ₘ q3)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode' base a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_divCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝
@@ -776,20 +774,19 @@ theorem evm_mod_shift0_epilogue_spec_within (sp base : Word)
        ((sp + 48) ↦ₘ u2) ** ((sp + 56) ↦ₘ u3)) := by
   -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
   -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   -- 3. Eliminate not-taken branch: shift = 0 means BEQ taken
   --    BEQ not-taken postcondition: (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ 0) ** ⌜shift ≠ 0⌝

--- a/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean
@@ -37,7 +37,7 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
     let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
     let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
     let u3' := u3 >>> (shift.toNat % 64)
-    cpsTripleWithin 23 (base + 916) (base + epilogueOff) (modCode base)
+    cpsTripleWithin 23 (base + denormOff + 8) (base + epilogueOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) **
        (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
@@ -48,11 +48,11 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
        ((sp + signExtend12 4040) ↦ₘ u2') ** ((sp + signExtend12 4032) ↦ₘ u3')) := by
   intro antiShift u0' u1' u2' u3'
   -- ADDI x2 x0 0 + SUB x2 x2 x6 (base+916 → base+924): compute antiShift
-  have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + 916) (by nofun)
-  rw [show (base + 916 : Word) + 4 = base + 920 from by bv_addr] at haddi
+  have haddi := addi_x0_spec_gen_within .x2 v2 0 (base + denormOff + 8) (by nofun)
+  rw [show (base + denormOff + 8 : Word) + 4 = base + denormOff + 12 from by bv_addr] at haddi
   have haddie := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 916) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 8) divK_denorm
         [.ADDI .x2 .x0 0] 2
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) haddi
   -- Frame ADDI with x12, x5, x7, x6, and all memory
@@ -62,15 +62,14 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3))
     (by pcFree) haddie
   have hsub := sub_spec_gen_rd_eq_rs1_within .x2 .x6
-    (signExtend12 (0 : BitVec 12)) shift (base + 920) (by nofun)
-  rw [show (base + 920 : Word) + 4 = base + 924 from by bv_addr] at hsub
+    (signExtend12 (0 : BitVec 12)) shift (base + denormOff + 12) (by nofun)
+  rw [show (base + denormOff + 12 : Word) + 4 = base + denormOff + 16 from by bv_addr] at hsub
   have hsube := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
       (CodeReq.singleton_mono (by
         have hlookup := CodeReq.ofProg_lookup (base + denormOff) divK_denorm 3
           (by decide) (by decide)
-        rw [bv64_4mul_3,
-            show (base + denormOff : Word) + 12 = base + 920 from by bv_addr] at hlookup
+        rw [bv64_4mul_3] at hlookup
         exact hlookup) a i h)) hsub
   -- Frame SUB with x12, x5, x7, x0, and all memory
   have hsubf := cpsTripleWithin_frameR
@@ -81,11 +80,11 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
   have h_anti := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) haddief hsubf
   -- Merge u[0] with u[1] (base+924 → base+948)
-  have hm0 := divK_denorm_merge_spec_within 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + 924)
-  rw [show (base + 924 : Word) + 24 = base + 948 from by bv_addr] at hm0
+  have hm0 := divK_denorm_merge_spec_within 4056 4048 sp u0 u1 v5 v7 shift antiShift (base + denormOff + 16)
+  rw [show (base + denormOff + 16 : Word) + 24 = base + denormOff + 40 from by bv_addr] at hm0
   have hm0e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 924) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 16) divK_denorm
         (divK_denorm_merge_prog 4056 4048) 4
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm0
   have hm0ef := cpsTripleWithin_frameR
@@ -96,11 +95,11 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
     (fun h hp => by xperm_hyp hp) h_anti hm0ef
   -- Merge u[1] with u[2] (base+948 → base+972)
   have hm1 := divK_denorm_merge_spec_within 4048 4040 sp u1 u2
-    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + 948)
-  rw [show (base + 948 : Word) + 24 = base + 972 from by bv_addr] at hm1
+    u0' (u1 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 40)
+  rw [show (base + denormOff + 40 : Word) + 24 = base + denormOff + 64 from by bv_addr] at hm1
   have hm1e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 948) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 40) divK_denorm
         (divK_denorm_merge_prog 4048 4040) 10
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm1
   have hm1ef := cpsTripleWithin_frameR
@@ -111,11 +110,11 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
     (fun h hp => by xperm_hyp hp) h_m0 hm1ef
   -- Merge u[2] with u[3] (base+972 → base+996)
   have hm2 := divK_denorm_merge_spec_within 4040 4032 sp u2 u3
-    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + 972)
-  rw [show (base + 972 : Word) + 24 = base + 996 from by bv_addr] at hm2
+    u1' (u2 <<< (antiShift.toNat % 64)) shift antiShift (base + denormOff + 64)
+  rw [show (base + denormOff + 64 : Word) + 24 = base + denormOff + 88 from by bv_addr] at hm2
   have hm2e := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 972) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 64) divK_denorm
         (divK_denorm_merge_prog 4040 4032) 16
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hm2
   have hm2ef := cpsTripleWithin_frameR
@@ -125,11 +124,11 @@ theorem mod_denorm_body_spec_within (sp u0 u1 u2 u3 v2 v5 v7 shift : Word) (base
   have h_m2 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h_m1 hm2ef
   -- Last u[3] (base+996 → base+1008)
-  have hl := divK_denorm_last_spec_within 4032 sp u3 u2' shift (base + 996)
-  rw [show (base + 996 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
+  have hl := divK_denorm_last_spec_within 4032 sp u3 u2' shift (base + denormOff + 88)
+  rw [show (base + denormOff + 88 : Word) + 12 = base + epilogueOff from by bv_addr] at hl
   have hle := cpsTripleWithin_extend_code (hmono := fun a i h =>
     divK_denorm_code_sub_modCode a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 996) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 88) divK_denorm
         (divK_denorm_last_prog 4032) 22
         (by bv_addr) (by decide) (by decide) (by decide) a i h)) hl
   have hlef := cpsTripleWithin_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean
@@ -34,7 +34,7 @@ private theorem divK_denorm_code_sub_modCode_n4 (base : Word) :
     followed by a not-taken BEQ. -/
 theorem mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
     (hshift_nz : shift ≠ 0) :
-    cpsTripleWithin 2 (base + denormOff) (base + 916) (modCode base)
+    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift))
@@ -42,19 +42,18 @@ theorem mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base 
        (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 3992) ↦ₘ shift)) := by
   have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  rw [show (base + denormOff : Word) + 4 = base + 912 from by bv_addr] at hld
   have hlde := cpsTripleWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode_n4 base a i
       (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
         [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + 912)
-  rw [show (base + 912 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + 912 : Word) + 4 = base + 916 from by bv_addr] at hbeq
+  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
+  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
+      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
   have hbeqe := cpsBranchWithin_extend_code (hmono := by
     intro a i h
     exact divK_denorm_code_sub_modCode_n4 base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + 912) divK_denorm
+      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
         [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
   have hbeq_exit := cpsBranchWithin_ntakenPath hbeqe
     (fun hp hQt => by
@@ -84,7 +83,7 @@ theorem mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base 
 theorem evm_mod_denorm_epilogue_spec_within (sp base : Word)
     (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
     (m0 m8 m16 m24 : Word) :
-    cpsTripleWithin 33 (base + 916) (base + nopOff) (modCode base)
+    cpsTripleWithin 33 (base + denormOff + 8) (base + nopOff) (modCode base)
       ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
        (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
        ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **


### PR DESCRIPTION
Sub-slice of evm-asm-7rk (#301 slice 3, parent #301 / evm-asm-nqj).

Mechanical replacement of `base + 912/916/920/924/948/972/996` literals in DivMod denorm composition files with `base + denormOff + k` (where k = literal − 908). No new abbreviations introduced — uses the existing `denormOff = 908` constant, so this is a pure naming migration.

Files touched:
- `EvmAsm/Evm64/DivMod/Compose/Epilogue.lean` (32 → 0)
- `EvmAsm/Evm64/DivMod/Compose/ModEpilogue.lean` (24 → 0)
- `EvmAsm/Evm64/DivMod/Compose/FullPath.lean` (21 → 0)
- `EvmAsm/Evm64/DivMod/Compose/ModFullPathN4.lean` (8 → 0)

Removed five identity `show` rewrites that became reflexive after the substitution (`rw [show (base + denormOff : Word) + 4 = base + denormOff + 4 from by bv_addr]` and one nested in an `rw [bv64_4mul_3, show ...] at hlookup` pair).

`lake build` green. No semantic changes.

Refs #301. Beads: evm-asm-tc8p.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).