### PR TITLE
proof(divmod): add N1 MOD denorm helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -15,6 +15,7 @@
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Loop
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3Loop
+import EvmAsm.Evm64.EvmWordArith.CLZLemmas
 
 open EvmAsm.Rv64.Tactics
 
@@ -461,10 +462,55 @@ theorem fullDivN1Shift_unfold (b0 : Word) :
   delta fullDivN1Shift
   rfl
 
+theorem fullDivN1Shift_toNat_pos_of_ne_zero {b0 : Word}
+    (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    0 < (fullDivN1Shift b0).toNat := by
+  rcases Nat.eq_zero_or_pos (fullDivN1Shift b0).toNat with h0 | hpos
+  · exfalso
+    apply hshift_nz
+    exact BitVec.eq_of_toNat_eq h0
+  · exact hpos
+
+theorem fullDivN1Shift_toNat_lt_64 (b0 : Word) :
+    (fullDivN1Shift b0).toNat < 64 := by
+  rw [fullDivN1Shift_unfold]
+  have hle := clzResult_fst_toNat_le b0
+  omega
+
+theorem fullDivN1Shift_toNat_mod_eq (b0 : Word) :
+    (fullDivN1Shift b0).toNat % 64 = (fullDivN1Shift b0).toNat := by
+  exact Nat.mod_eq_of_lt (fullDivN1Shift_toNat_lt_64 b0)
+
 theorem fullDivN1AntiShift_unfold (b0 : Word) :
     fullDivN1AntiShift b0 = signExtend12 (0 : BitVec 12) - fullDivN1Shift b0 := by
   delta fullDivN1AntiShift
   rfl
+
+theorem fullDivN1AntiShift_toNat_mod_eq {b0 : Word}
+    (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    (signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64 =
+      64 - (fullDivN1Shift b0).toNat := by
+  have h1 : 1 ≤ (fullDivN1Shift b0).toNat :=
+    fullDivN1Shift_toNat_pos_of_ne_zero hshift_nz
+  have h63 : (fullDivN1Shift b0).toNat ≤ 63 := by
+    have hlt := fullDivN1Shift_toNat_lt_64 b0
+    omega
+  have h0 : (signExtend12 (0 : BitVec 12) : Word) = 0 := by decide
+  rw [h0]
+  have hshift_toNat : ((0 : Word) - fullDivN1Shift b0).toNat =
+      2^64 - (fullDivN1Shift b0).toNat := by
+    rw [BitVec.toNat_sub]
+    simp
+    omega
+  rw [hshift_toNat]
+  have hsplit : 2^64 - (fullDivN1Shift b0).toNat =
+      (2^64 - 64) + (64 - (fullDivN1Shift b0).toNat) := by
+    omega
+  rw [hsplit, Nat.add_mod]
+  have hmod64 : (2^64 - 64) % 64 = 0 := by decide
+  rw [hmod64]
+  simp
+  omega
 
 theorem fullDivN1NormV_unfold (b0 b1 b2 b3 : Word) :
     fullDivN1NormV b0 b1 b2 b3 =

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipOverestimateBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipOverestimateBridge.lean
@@ -322,6 +322,52 @@ theorem denorm_limbN_eq_mod_of_overestimate
     Useful for the call+addback BEQ MOD adapter's single-addback branch
     (with `X = post1` limbs) — and dual-purpose for any other path that
     establishes the val256 = a%b * 2^s fact at normalized limbs. -/
+theorem denorm_4limb_eq_mod_of_val256_eq_amod_pow_s_of_or_ne_zero
+    {a b : EvmWord} {X1 X2 X3 X4 : Word}
+    {s : Nat} (hs0 : 0 < s) (hs : s < 64)
+    (hbnz : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 ||| b.getLimbN 3 ≠ 0)
+    (h_val_eq : val256 X1 X2 X3 X4 =
+      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) * 2 ^ s) :
+    (EvmWord.mod a b).getLimbN 0 = ((X1 >>> s) ||| (X2 <<< (64 - s))) ∧
+    (EvmWord.mod a b).getLimbN 1 = ((X2 >>> s) ||| (X3 <<< (64 - s))) ∧
+    (EvmWord.mod a b).getLimbN 2 = ((X3 >>> s) ||| (X4 <<< (64 - s))) ∧
+    (EvmWord.mod a b).getLimbN 3 = (X4 >>> s) := by
+  have h_denorm := EvmWord.val256_denormalize hs0 hs X1 X2 X3 X4
+  have hspos : 0 < (2 : Nat) ^ s := Nat.pos_of_ne_zero (by positivity)
+  have h_div : val256 X1 X2 X3 X4 / 2 ^ s =
+      val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := by
+    rw [h_val_eq, Nat.mul_div_cancel _ hspos]
+  rw [h_div] at h_denorm
+  have hr : EvmWord.fromLimbs (fun i : Fin 4 => match i with
+      | 0 => (X1 >>> s) ||| (X2 <<< (64 - s))
+      | 1 => (X2 >>> s) ||| (X3 <<< (64 - s))
+      | 2 => (X3 >>> s) ||| (X4 <<< (64 - s))
+      | 3 => X4 >>> s) =
+      EvmWord.mod
+        (EvmWord.fromLimbs (fun i : Fin 4 => match i with
+          | 0 => a.getLimbN 0 | 1 => a.getLimbN 1
+          | 2 => a.getLimbN 2 | 3 => a.getLimbN 3))
+        (EvmWord.fromLimbs (fun i : Fin 4 => match i with
+          | 0 => b.getLimbN 0 | 1 => b.getLimbN 1
+          | 2 => b.getLimbN 2 | 3 => b.getLimbN 3)) :=
+    EvmWord.mod_of_val256_eq_mod hbnz h_denorm
+  have ha_fold : (EvmWord.fromLimbs (fun i : Fin 4 => match i with
+        | 0 => a.getLimbN 0 | 1 => a.getLimbN 1
+        | 2 => a.getLimbN 2 | 3 => a.getLimbN 3)) = a :=
+    EvmWord.fromLimbs_match_getLimbN_id a
+  have hb_fold : (EvmWord.fromLimbs (fun i : Fin 4 => match i with
+        | 0 => b.getLimbN 0 | 1 => b.getLimbN 1
+        | 2 => b.getLimbN 2 | 3 => b.getLimbN 3)) = b :=
+    EvmWord.fromLimbs_match_getLimbN_id b
+  rw [ha_fold, hb_fold] at hr
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hr]; exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hr]; exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hr]; exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hr]; exact EvmWord.getLimbN_fromLimbs_3
+
 theorem denorm_4limb_eq_mod_of_val256_eq_amod_pow_s
     {a b : EvmWord} {X1 X2 X3 X4 : Word}
     {s : Nat} (hs0 : 0 < s) (hs : s < 64)

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.Base
+import EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 
@@ -749,6 +750,70 @@ theorem fullModN1_denorm_val256_eq_mod_of_limb_eq
       ← EvmWord.getLimb_as_getLimbN_3]
     exact EvmWord.val256_eq_toNat (EvmWord.mod a b)
   rw [hdenorm_toNat, hmod_toNat, ha_val, hb_val]
+
+theorem fullModN1_hmods_of_normalized_val256_eq
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (h_val_eq :
+      EvmWord.val256
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 =
+      EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3 *
+        2 ^ ((fullDivN1Shift b0).toNat % 64)) :
+    (EvmWord.mod a b).getLimbN 0 =
+      (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64)) |||
+        ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 1 =
+      (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64)) |||
+        ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 2 =
+      (((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1 >>>
+          ((fullDivN1Shift b0).toNat % 64)) |||
+        ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 <<<
+          ((signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64))) ∧
+    (EvmWord.mod a b).getLimbN 3 =
+      ((fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 >>>
+        ((fullDivN1Shift b0).toNat % 64)) := by
+  have hbnz' : b.getLimbN 0 ||| b.getLimbN 1 ||| b.getLimbN 2 |||
+      b.getLimbN 3 ≠ 0 := by
+    rw [hb0, hb1, hb2, hb3]
+    exact hbnz
+  have hs0 : 0 < (fullDivN1Shift b0).toNat % 64 := by
+    rw [fullDivN1Shift_toNat_mod_eq]
+    exact fullDivN1Shift_toNat_pos_of_ne_zero hshift_nz
+  have hs : (fullDivN1Shift b0).toNat % 64 < 64 :=
+    Nat.mod_lt _ (by decide)
+  have h_val_eq' : EvmWord.val256
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1 =
+      EvmWord.val256 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3) %
+        EvmWord.val256 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) *
+        2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+    rw [ha0, ha1, ha2, ha3, hb0, hb1, hb2, hb3]
+    exact h_val_eq
+  have hmods :=
+    denorm_4limb_eq_mod_of_val256_eq_amod_pow_s_of_or_ne_zero hs0 hs hbnz' h_val_eq'
+  have hanti_mod :
+      (signExtend12 (0 : BitVec 12) - fullDivN1Shift b0).toNat % 64 =
+        64 - (fullDivN1Shift b0).toNat % 64 := by
+    rw [fullDivN1AntiShift_toNat_mod_eq hshift_nz,
+      fullDivN1Shift_toNat_mod_eq b0]
+  rw [hanti_mod]
+  exact hmods
 
 theorem evm_mod_n1_stack_spec_within
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)


### PR DESCRIPTION
Codex changes:

- Added N1 shift and anti-shift Nat normalization lemmas for fullDivN1Shift.
- Added a generalized denorm-to-MOD limb bridge that only requires the divisor OR to be nonzero.
- Added fullModN1_hmods_of_normalized_val256_eq, reducing the N1 MOD runtime-limb gap to one normalized val256 remainder equation.

Verification:

- lake build EvmAsm.Evm64.DivMod.Spec.Dispatcher