### PR TITLE
feat(memory): track high-water mark for MSIZE / memory expansion (slice 2 of #99)

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -5,9 +5,14 @@
   dynamically expandable) stored in RV64IM doubleword-aligned memory cells.
 
   Slice 1 (issue #99): defines the core `evmMemIs` assertion at dword-cell
-  granularity plus the zero-initialized form `evmMemZero`. Subsequent slices
-  add high-water-mark / expansion tracking (slice 2), MLOAD/MSTORE/MSTORE8
-  specs (slices 3-5) and MSIZE (slice 6).
+  granularity plus the zero-initialized form `evmMemZero`.
+
+  Slice 2 (issue #99): tracks the EVM memory high-water mark in a single
+  scratch dword cell via `evmMemSizeIs`, and provides the pure expansion
+  helper `evmMemExpand` that computes the new byte-size after an access of
+  `(offset, length)`, rounded up to a 32-byte-word boundary as the EVM-spec
+  requires. Subsequent slices wire this into MLOAD/MSTORE/MSTORE8 (slices
+  3-5) and MSIZE (slice 6).
 
   Design choices (kept minimal for this slice):
 
@@ -84,5 +89,110 @@ instance (base : Word) (n : Nat) (contents : Nat → Word) :
 
 instance (base : Word) (n : Nat) : Assertion.PCFree (evmMemZero base n) :=
   ⟨pcFree_evmMemZero⟩
+
+/-! ## High-water mark / EVM memory expansion (slice 2)
+
+  The EVM tracks a single dynamic byte-size for memory (MSIZE), which only
+  grows: any access to byte range `[offset, offset + length)` expands the
+  active memory to the smallest multiple of 32 that covers the access, and
+  the new size is the max of the old size and that bound.
+
+  We model the size as a single 64-bit cell held at a caller-chosen scratch
+  location `sizeLoc`, owning the assertion that the cell holds the current
+  byte-size. The pure helper `evmMemExpand` computes the new byte-size; the
+  separation-logic specs in later slices (MLOAD/MSTORE/MSTORE8/MSIZE) will
+  read this cell, replace it, and reason about the contents update via
+  `evmMemSizeIs`. -/
+
+/-- The EVM memory size cell: an 8-byte cell at `sizeLoc` holding the current
+    byte-size of EVM memory. The size is the high-water mark — bytes
+    `[0, sizeBytes)` may be accessed; reads of unwritten bytes within that
+    range still return zero (modelled by `evmMemZero`). -/
+def evmMemSizeIs (sizeLoc : Word) (sizeBytes : Nat) : Assertion :=
+  sizeLoc ↦ₘ BitVec.ofNat 64 sizeBytes
+
+theorem evmMemSizeIs_unfold {sizeLoc : Word} {sizeBytes : Nat} :
+    evmMemSizeIs sizeLoc sizeBytes = (sizeLoc ↦ₘ BitVec.ofNat 64 sizeBytes) := rfl
+
+theorem pcFree_evmMemSizeIs {sizeLoc : Word} {sizeBytes : Nat} :
+    (evmMemSizeIs sizeLoc sizeBytes).pcFree := by
+  unfold evmMemSizeIs; exact pcFree_memIs
+
+instance (sizeLoc : Word) (sizeBytes : Nat) :
+    Assertion.PCFree (evmMemSizeIs sizeLoc sizeBytes) := ⟨pcFree_evmMemSizeIs⟩
+
+/-- Round a byte count up to the next multiple of 32 (the EVM word size).
+    `roundUpTo32 n = ((n + 31) / 32) * 32`. -/
+def roundUpTo32 (n : Nat) : Nat := ((n + 31) / 32) * 32
+
+theorem roundUpTo32_zero : roundUpTo32 0 = 0 := by decide
+
+theorem roundUpTo32_le (n : Nat) : n ≤ roundUpTo32 n := by
+  unfold roundUpTo32
+  have h : n ≤ (n + 31) / 32 * 32 := by
+    have := Nat.div_mul_le_self (n + 31) 32
+    omega
+  exact h
+
+theorem roundUpTo32_dvd (n : Nat) : 32 ∣ roundUpTo32 n := by
+  unfold roundUpTo32; exact ⟨(n + 31) / 32, (Nat.mul_comm _ _)⟩
+
+theorem roundUpTo32_idempotent (n : Nat) : roundUpTo32 (roundUpTo32 n) = roundUpTo32 n := by
+  unfold roundUpTo32
+  -- (n+31)/32 * 32 is already a multiple of 32, so adding 31 and dividing
+  -- by 32 yields the same quotient. omega handles Nat div/mod.
+  omega
+
+/-- The pure EVM memory-expansion update: given the current high-water
+    `sizeBytes` and an access `(offset, length)`, compute the new
+    high-water mark.
+
+    Per the EVM yellow paper, an access of zero length never expands memory.
+    Otherwise the active memory grows to cover `[offset, offset + length)`,
+    rounded up to a 32-byte boundary, and the new size is the max of the old
+    size and that bound. -/
+def evmMemExpand (sizeBytes offset length : Nat) : Nat :=
+  if length = 0 then sizeBytes else max sizeBytes (roundUpTo32 (offset + length))
+
+/-- Zero-length accesses do not expand EVM memory. -/
+@[simp] theorem evmMemExpand_zero_length (sizeBytes offset : Nat) :
+    evmMemExpand sizeBytes offset 0 = sizeBytes := by
+  unfold evmMemExpand; simp
+
+theorem evmMemExpand_ge_old (sizeBytes offset length : Nat) :
+    sizeBytes ≤ evmMemExpand sizeBytes offset length := by
+  unfold evmMemExpand
+  by_cases h : length = 0
+  · simp [h]
+  · simp [h]; exact Nat.le_max_left _ _
+
+theorem evmMemExpand_ge_access (sizeBytes offset length : Nat) (hlen : length ≠ 0) :
+    offset + length ≤ evmMemExpand sizeBytes offset length := by
+  unfold evmMemExpand
+  simp [hlen]
+  exact Nat.le_trans (roundUpTo32_le _) (Nat.le_max_right _ _)
+
+/-- The new high-water mark is always a multiple of 32 (when nonzero) — i.e.
+    if the old size was 32-aligned, the new one is too. -/
+theorem evmMemExpand_dvd_of_old_dvd (sizeBytes offset length : Nat)
+    (h_old : 32 ∣ sizeBytes) :
+    32 ∣ evmMemExpand sizeBytes offset length := by
+  unfold evmMemExpand
+  by_cases hlen : length = 0
+  · simp [hlen]; exact h_old
+  · simp [hlen]
+    -- max of two multiples-of-32 is a multiple of 32
+    rcases Nat.le_total sizeBytes (roundUpTo32 (offset + length)) with hle | hle
+    · rw [Nat.max_eq_right hle]; exact roundUpTo32_dvd _
+    · rw [Nat.max_eq_left hle]; exact h_old
+
+/-- Idempotence: re-expanding for the same access does not grow further. -/
+theorem evmMemExpand_idempotent (sizeBytes offset length : Nat) :
+    evmMemExpand (evmMemExpand sizeBytes offset length) offset length =
+    evmMemExpand sizeBytes offset length := by
+  unfold evmMemExpand
+  by_cases hlen : length = 0
+  · simp [hlen]
+  · simp only [hlen, if_false, Nat.max_assoc, Nat.max_self]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds the EVM-memory size cell assertion (`evmMemSizeIs`) and the pure expansion helper (`evmMemExpand`) that drives MLOAD/MSTORE/MSTORE8 in subsequent slices.

## What's added (Evm64/Memory.lean)
- `evmMemSizeIs sizeLoc sizeBytes` — owns a single 8-byte scratch cell holding the current EVM-memory byte-size (the high-water mark MSIZE reads). Comes with `pcFree` lemma and `PCFree` instance.
- `roundUpTo32 n = ((n+31)/32)*32` plus zero / le / dvd / idempotence lemmas.
- `evmMemExpand sizeBytes offset length` — the EVM yellow-paper update: zero-length is a no-op; otherwise new size is `max(old, roundUpTo32(offset + length))`. Lemmas: `evmMemExpand_zero_length` (`@[simp]`), `evmMemExpand_ge_old`, `evmMemExpand_ge_access`, `evmMemExpand_dvd_of_old_dvd`, `evmMemExpand_idempotent`.

Pure data + lemmas only — no separation-logic specs are wired yet; slices 3-5 (MLOAD/MSTORE/MSTORE8) and slice 6 (MSIZE) consume these.

## Verification
- `lake build` green (1440/1440 targets).
- No new file added → no umbrella import wiring needed.
- No `maxHeartbeats` / `maxRecDepth` adjustments.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs #99
beads: evm-asm-2ko1