### PR TITLE
proof(divmod): split double-addback conservation premises

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivN4DoubleAddback.lean
@@ -107,6 +107,94 @@ theorem hq_over_from_second_carry_one (q : Word) {v0 v1 v2 v3 u0 u1 u2 u3 : Word
     exact Nat.le_div_iff_mul_le hv_pos |>.mpr (by linarith [Nat.mul_comm (q.toNat - 2) (val256 v0 v1 v2 v3)])
   omega
 
+theorem iterWithDoubleAddback_val256_conservation_of_carry2
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| v3 ≠ 0)
+    (hc3_one_of_borrow :
+      BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 →
+        (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2 = 1)
+    (hcarry2 : isAddbackCarry2Nz q v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
+    let out := iterWithDoubleAddback q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 v3 +
+        EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2^256 := by
+  intro out
+  subst out
+  by_cases hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  · have hout := iterWithDoubleAddback_borrow (qHat := q) (v0 := v0) (v1 := v1)
+      (v2 := v2) (v3 := v3) (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+      (uTop := uTop) hb
+    simp only [] at hout
+    rw [hout]
+    let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+    let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+    by_cases hcarry_zero : carry = 0
+    · rw [if_pos hcarry_zero]
+      have hc3_one : ms.2.2.2.2 = 1 := by
+        subst ms
+        exact hc3_one_of_borrow hb
+      have hcarry2_nz :
+          let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+            (uTop - ms.2.2.2.2) v0 v1 v2 v3
+          addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3 ≠ 0 := by
+        subst carry
+        exact hcarry2 hcarry_zero
+      have hcarry2_one :
+          let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 0 v0 v1 v2 v3
+          (addbackN4_carry ab.1 ab.2.1 ab.2.2.1 ab.2.2.2.1 v0 v1 v2 v3).toNat = 1 := by
+        simp only [] at hcarry2_nz ⊢
+        have h_indep := addbackN4_fst4_u4_indep ms.1 ms.2.1 ms.2.2.1
+          ms.2.2.2.1 (uTop - ms.2.2.2.2) 0 v0 v1 v2 v3
+        rcases h_indep with ⟨h0, h1, h2, h3⟩
+        rw [← h0, ← h1, ← h2, ← h3]
+        have hcarry_eq :=
+          addbackN4_carry_eq_one_of_ne_zero _ _ _ _ _ _ _ _ hcarry2_nz
+        rw [hcarry_eq]
+        decide
+      have hq_over := hq_over_from_second_carry_one q hbnz hc3_one hcarry_zero hcarry2_one
+      have hq_ge_2 :=
+        q_ge_two_of_mulsub_borrow_and_addback_carry_zero
+          q v0 v1 v2 v3 u0 u1 u2 u3 hc3_one hcarry_zero
+      have hbranch : iterDoubleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+        subst ms
+        subst carry
+        exact iterDoubleAddbackBranch_of q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+          hb (hc3_one_of_borrow hb) hcarry_zero hbnz hq_over hq_ge_2
+      have h := iterDoubleAddbackBranch_val256_conservation
+        q v0 v1 v2 v3 u0 u1 u2 u3 uTop hbranch
+      simp only [] at h
+      exact h
+    · rw [if_neg hcarry_zero]
+      have hcarry_one : carry = 1 := by
+        subst ms
+        subst carry
+        exact addbackN4_carry_eq_one_of_ne_zero
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.1
+          (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.1
+          v0 v1 v2 v3 hcarry_zero
+      have hq_pos := q_pos_of_mulsub_borrow q v0 v1 v2 v3 u0 u1 u2 u3 (by
+        subst ms
+        exact hc3_one_of_borrow hb)
+      have hbranch : iterSingleAddbackBranch q v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+        subst ms
+        subst carry
+        exact iterSingleAddbackBranch_of q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+          hb (hc3_one_of_borrow hb) hcarry_one hq_pos
+      have h := iterSingleAddbackBranch_val256_conservation
+        q v0 v1 v2 v3 u0 u1 u2 u3 uTop hbranch
+      simp only [] at h
+      exact h
+  · have hout := iterWithDoubleAddback_no_borrow (qHat := q) (v0 := v0) (v1 := v1)
+      (v2 := v2) (v3 := v3) (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+      (uTop := uTop) hb
+    simp only [] at hout
+    rw [hout]
+    exact iterWithDoubleAddback_no_borrow_val256_conservation
+      q v0 v1 v2 v3 u0 u1 u2 u3 uTop hb
+
 -- ============================================================================
 -- Double-addback correctness: n=4 max trial, c3=1, carry1=0, carry2=1
 -- ============================================================================


### PR DESCRIPTION
Codex changes:

- Added iterWithDoubleAddback_val256_conservation_of_carry2.
- The new wrapper avoids a global q_over premise and derives the double-addback q_over from Carry2Nz progress.
- This closes bead evm-asm-utz and unblocks the N1 iteration bound pack from forcing false max-path overestimates.

Stacking:

- Stacked on PR #1584.

Verification:

- lake build EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback