### PR TITLE
feat(divmod): wire evm_div_n3_stack_spec_within in Dispatcher (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.DivMod.Spec.Base
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 
 namespace EvmAsm.Evm64
 
@@ -863,5 +864,135 @@ theorem evm_mod_n1_stack_spec_within_word
     ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2z hb1z
     hshift_nz halign hbltu_3 hbltu_2 hbltu_1 hbltu_0 hcarry2
     hmod0 hmod1 hmod2 hmod3
+
+/- ============================================================================
+   N=3 DIV stack-dispatch wrapper (slice 2b of #61).
+   Mirrors `evm_div_n1_stack_spec_within` using `evm_div_n3_full_unified_spec`.
+   ============================================================================ -/
+
+/-- Bridge from the `fullDivN3UnifiedPost` postcondition (raw memory atoms +
+    frame) to the value-agnostic `divStackDispatchPost`. Mirror of
+    `fullDivN1UnifiedPost_to_divStackDispatchPost`; the only structural
+    differences are that `q2`/`q3` are statically `0` at n=3, and there is no
+    `b3`/`b2/b1` zero-limb conditional in the call paths. -/
+theorem fullDivN3UnifiedPost_to_divStackDispatchPost
+    (bltu_1 bltu_0 : Bool)
+    (sp base : Word) (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    ∀ h,
+      fullDivN3UnifiedPost bltu_1 bltu_0 sp base
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 h →
+      divStackDispatchPost sp a b h := by
+  intro h hq
+  let shift := fullDivN3Shift b2
+  let antiShift := signExtend12 (0 : BitVec 12) - shift
+  let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let u0' := (r0.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.1 <<< (antiShift.toNat % 64))
+  let u1' := (r0.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u2' := (r0.2.2.2.1 >>> (shift.toNat % 64)) ||| (r0.2.2.2.2.1 <<< (antiShift.toNat % 64))
+  let u3' := r0.2.2.2.2.1 >>> (shift.toNat % 64)
+  let v := fullDivN3NormV b0 b1 b2 b3
+  let u := fullDivN3NormU a0 a1 a2 a3 b2
+  let scratch_ret1 := if bltu_1 then (base + 516) else retMem
+  let scratch_d1 := if bltu_1 then v.2.2.1 else dMem
+  let scratch_dlo1 := if bltu_1 then div128DLo v.2.2.1 else dloMem
+  let scratch_un01 := if bltu_1 then div128Un0 u.2.2.2.1 else scratch_un0
+  refine divStackDispatchPost_weaken (sp := sp) (a := a) (b := b)
+    (v1 := signExtend12 4095) (v2 := antiShift)
+    (v5 := r0.1) (v6 := r1.1) (v7 := (0 : Word))
+    (v10 := (0 : Word)) (v11 := r0.1)
+    (q0 := r0.1) (q1 := r1.1) (q2 := (0 : Word)) (q3 := (0 : Word))
+    (u0 := u0') (u1 := u1') (u2 := u2') (u3 := u3')
+    (u4 := r0.2.2.2.2.2) (u5 := r1.2.2.2.2.2)
+    (u6 := (0 : Word)) (u7 := (0 : Word))
+    (shiftMem := shift) (nMem := 3) (jMem := 0)
+    (retMem := if bltu_0 then (base + 516) else scratch_ret1)
+    (dMem := if bltu_0 then v.2.2.1 else scratch_d1)
+    (dloMem := if bltu_0 then div128DLo v.2.2.1 else scratch_dlo1)
+    (scratch_un0 := if bltu_0 then div128Un0 r1.2.2.1 else scratch_un01) h ?_
+  delta fullDivN3UnifiedPost fullDivN3DenormPost fullDivN3Frame fullDivN3Scratch at hq
+  simp only [denormDivPost_unfold] at hq
+  rw [show evmWordIs sp a =
+      ((sp ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
+       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3))
+      from by rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3]]
+  rw [show evmWordIs (sp + 32) (EvmWord.div a b) =
+      (((sp + 32) ↦ₘ
+          (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1) **
+       ((sp + 40) ↦ₘ
+          (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1) **
+       ((sp + 48) ↦ₘ (0 : Word)) **
+       ((sp + 56) ↦ₘ (0 : Word)))
+      from by
+        rw [evmWordIs_sp32_limbs_eq sp (EvmWord.div a b) _ _ _ _
+          hdiv0 hdiv1 hdiv2 hdiv3]]
+  rw [divScratchValuesCall_unfold, divScratchValues_unfold]
+  rw [word_add_zero] at hq
+  xperm_hyp hq
+
+/-- N=3 DIV stack-level entry point: mirrors `evm_div_n1_stack_spec_within`. -/
+theorem evm_div_n3_stack_spec_within
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hdiv0 : (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv1 : (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1)
+    (hdiv2 : (EvmWord.div a b).getLimbN 2 = (0 : Word))
+    (hdiv3 : (EvmWord.div a b).getLimbN 3 = (0 : Word)) :
+    cpsTripleWithin 542 base (base + nopOff) (divCode base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  have hFull := evm_div_n3_full_unified_spec
+    bltu_1 bltu_0 sp base
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    hbnz hb3z hb2nz hshift_nz halign hbltu_1 hbltu_0 hcarry2
+  exact cpsTripleWithin_weaken
+    (fun h hp => by
+      delta divModStackDispatchPre at hp
+      rw [evmWordIs_sp_limbs_eq sp a _ _ _ _ ha0 ha1 ha2 ha3,
+          evmWordIs_sp32_limbs_eq sp b _ _ _ _ hb0 hb1 hb2 hb3,
+          divScratchValuesCall_unfold, divScratchValues_unfold] at hp
+      rw [word_add_zero]
+      xperm_hyp hp)
+    (fun h hq =>
+      fullDivN3UnifiedPost_to_divStackDispatchPost
+        bltu_1 bltu_0 sp base a b
+        a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0
+        ha0 ha1 ha2 ha3 hdiv0 hdiv1 hdiv2 hdiv3 h hq)
+    hFull
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Mirrors `evm_div_n1_stack_spec_within` for n=3 by composing `evm_div_n3_full_unified_spec` with a new `fullDivN3UnifiedPost_to_divStackDispatchPost` bridge.

The bridge structurally parallels `fullDivN1UnifiedPost_to_divStackDispatchPost`; the differences are:
- `q2`/`q3` are statically `0` at n=3 (only the bottom two quotient limbs are non-trivial), so `hdiv2` / `hdiv3` collapse to `= 0`.
- The call-trial scratch `if bltu_…` chain has only two levels (`bltu_1`/`bltu_0`) instead of four.
- `scratch_un01` uses `u.2.2.2.1` (the 4th limb of the n=3 `fullDivN3NormU`) and `scratch_un0` uses `r1.2.2.1`.
- `nMem := 3`, `shift` derived from `b2` (not `b0`).
- Halt budget is `542` (vs. `946` at n=1), inherited from `evm_div_n3_full_unified_spec`.

Closes the n=3 DIV gap of slice 2 of the unified DIV/MOD stack-spec parent task. The remaining sub-slices wire n=2 DIV (in flight: evm-asm-qqn4) and n=2/n=3 MOD.

`lake build` green (1440 jobs, no sorries, no heartbeat overrides).

Refs #61. Beads slice: evm-asm-u4wa.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).