### PR TITLE
chore(divmod): name loopControlOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -107,6 +107,11 @@ abbrev addbackBeqOff : Word :=  880
     branch into the next iteration or `divK_denorm`). Sub-offset relative
     to the loopBody block (= loopBodyOff + 436). -/
 abbrev storeLoopOff : Word :=  884
+/-- Offset of the `divK_loop_control` sub-block inside `divK_loopBody`.
+    Entry PC of the loop-control snippet that decrements `j` and prepares the
+    next iteration. Sub-offset relative to the loopBody block
+    (= storeLoopOff + 16 = loopBackBgeOff - 4 = loopBodyOff + 452). -/
+abbrev loopControlOff : Word :=  900
 /-- Offset of the loop-back BGE sub-block inside `divK_loopBody`.
     Entry PC of the `BGE x1, x0, -...` instruction at the end of the loop
     body that branches back to `loopBodyOff` for the next iteration when
@@ -173,6 +178,12 @@ example : addbackBeqOff = loopBodyOff + 432 := by decide
 /-- storeLoopOff = loopBodyOff + 436 (sub-block offset within `divK_loopBody`).
     The `divK_store_qj` snippet starts 109 instructions into the loop body. -/
 example : storeLoopOff = loopBodyOff + 436 := by decide
+/-- loopControlOff = storeLoopOff + 16 (= loopBodyOff + 452, sub-block offset
+    within `divK_loopBody`). The `divK_loop_control` snippet sits 4 instructions
+    after the `divK_store_qj` entry. -/
+example : loopControlOff = storeLoopOff + 16 := by decide
+example : loopControlOff = loopBodyOff + 452 := by decide
+example : loopControlOff = loopBackBgeOff - 4 := by decide
 /-- loopBackBgeOff = denormOff - 4 (= loopBodyOff + 456, sub-block offset
     within `divK_loopBody`). The loop-back BGE sits one instruction before
     the `divK_denorm` block. -/

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1156,11 +1156,11 @@ theorem lb_bltu_ntaken {base : Word} : (base + trialCallOff : Word) + 4 = base +
 -- ============================================================================
 
 -- Address normalization for store_qj and loop control
-theorem lb_sqj {base : Word} : (base + storeLoopOff : Word) + 16 = base + 900 := by bv_addr
+theorem lb_sqj {base : Word} : (base + storeLoopOff : Word) + 16 = base + loopControlOff := by bv_addr
 private theorem lb_lc_taken {base : Word} :
-    (base + 900 : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
+    (base + loopControlOff : Word) + 4 + signExtend13 (7736 : BitVec 13) = base + loopBodyOff := by
   rv64_addr
-private theorem lb_lc_exit {base : Word} : (base + 900 : Word) + 8 = base + denormOff := by bv_addr
+private theorem lb_lc_exit {base : Word} : (base + loopControlOff : Word) + 8 = base + denormOff := by bv_addr
 
 private theorem lb_beq_back_ntaken {base : Word} : (base + addbackBeqOff : Word) + 4 = base + storeLoopOff := by bv_addr
 
@@ -1349,14 +1349,14 @@ theorem divK_store_loop_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. Loop control: instrs [113]-[114] at base+900
-  have LC := divK_loop_control_spec_within j (7736 : BitVec 13) (base + 900)
+  have LC := divK_loop_control_spec_within j (7736 : BitVec 13) (base + loopControlOff)
   dsimp only [] at LC
   rw [lb_lc_taken, lb_lc_exit] at LC
   have LCe := cpsBranchWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 113 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 114 _ _ (by decide) (by bv_addr) (by decide))) LC
   -- 3. Add x0 to store_qj via frame, then reshape via consequence
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
@@ -1366,7 +1366,7 @@ theorem divK_store_loop_spec_within
       (fun h hp => by xperm_hyp hp)
       (cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) SQe)
   -- 4. Frame loop_control with store_qj postcondition atoms, then reshape
-  have LCp : cpsBranchWithin 2 (base + 900) (sharedDivModCode base)
+  have LCp : cpsBranchWithin 2 (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ jX8) ** (.x7 ↦ᵣ qAddr) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qHat))
       (base + loopBodyOff)

--- a/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/StoreLoop.lean
@@ -54,8 +54,8 @@ theorem divK_store_loop_j0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
+  have haddi := addi_spec_gen_same_within .x1 (0 : Word) 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
@@ -76,7 +76,7 @@ theorem divK_store_loop_j0_spec_within
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ (0 : Word)) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
@@ -134,8 +134,8 @@ theorem divK_store_loop_jgt0_spec_within
      (CodeReq.union_sub (lb_sub 111 _ _ (by decide) (by bv_addr) (by decide))
       (lb_sub 112 _ _ (by decide) (by bv_addr) (by decide))))) SQ
   -- 2. ADDI x1 x1 4095 at base+900 (instr [113])
-  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + 900) (by nofun)
-  rw [show (base + 900 : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
+  have haddi := addi_spec_gen_same_within .x1 j 4095 (base + loopControlOff) (by nofun)
+  rw [show (base + loopControlOff : Word) + 4 = base + loopBackBgeOff from by bv_addr] at haddi
   have haddi_e := cpsTripleWithin_extend_code (hmono := by
     exact lb_sub 113 _ _ (by decide) (by bv_addr) (by decide)) haddi
   -- 3. BGE x1 x0 7736 at base+904 (instr [114])
@@ -156,7 +156,7 @@ theorem divK_store_loop_jgt0_spec_within
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     hbge_exit_raw
   -- 5. Build store_qj + x0 frame → base+900
-  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + 900) (sharedDivModCode base)
+  have SQx0 : cpsTripleWithin 4 (base + storeLoopOff) (base + loopControlOff) (sharedDivModCode base)
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **
        (.x5 ↦ᵣ v5Old) ** (.x7 ↦ᵣ v7Old) ** (.x0 ↦ᵣ (0 : Word)) ** (qAddr ↦ₘ qOld))
       ((.x1 ↦ᵣ j) ** (.x12 ↦ᵣ sp) ** (.x11 ↦ᵣ qHat) **


### PR DESCRIPTION
Introduce `loopControlOff = 900` (= `storeLoopOff + 16` = `loopBackBgeOff - 4` = `loopBodyOff + 452`, `divK_loop_control` sub-block entry) in `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` with drift-check examples, then mechanically replace the 12 occurrences of `base + 900` across `LoopBody.lean` and `LoopBody/StoreLoop.lean`.

Mirrors prior sub-slice migrations (storeLoopOff #1510, addbackBeqOff #1528, loopBackBgeOff #1580, trialCallOff #1545).

Acceptance: `lake build` green locally; no `base + 900` literal remains in `LoopBody/`.

Refs: #301 (parent), beads evm-asm-p08l. Replaces closed PR #1538 (closed due to merge conflict) — same diff rebased on current main.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).