### PR TITLE
chore(imports): drop 3 confirmed unused imports + noshake NormDefs (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
@@ -17,7 +17,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
-import EvmAsm.Evm64.EvmWordArith.DivCorrect
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Environment/Layout.lean
+++ b/EvmAsm/Evm64/Environment/Layout.lean
@@ -47,8 +47,6 @@
   ```
 -/
 
-import EvmAsm.Evm64.Environment
-
 namespace EvmAsm.Evm64
 namespace EvmEnv
 

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -31,7 +31,6 @@
     matches how `evmStackIs` uses a `List EvmWord`.
 -/
 
-import EvmAsm.Evm64.Basic
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -55,4 +55,6 @@
   "EvmAsm.Evm64.Shift.ShlCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.Shift.SarCompose":
-  ["EvmAsm.Evm64.Shift.ComposeBase"]}}
+  ["EvmAsm.Evm64.Shift.ComposeBase"],
+  "EvmAsm.Evm64.DivMod.NormDefs":
+  ["EvmAsm.Rv64.Basic"]}}


### PR DESCRIPTION
Slice of #1045 import-hygiene sweep.

`lake exe shake EvmAsm | scripts/shake-filter.py` produced 4 pure-remove
blocks (no replacement imports needed). Verified each with `lake build`:

- `EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean` — drop unused
  `EvmAsm.Evm64.EvmWordArith.DivCorrect`.
- `EvmAsm/Evm64/Environment/Layout.lean` — drop unused
  `EvmAsm.Evm64.Environment` (file only declares offset `Nat` constants
  and `% 32 = 0` decidable facts).
- `EvmAsm/Evm64/Memory.lean` — drop unused `EvmAsm.Evm64.Basic`
  (file uses `Word`/`Assertion` from `Rv64.SepLogic`, no `EvmWord`).

`EvmAsm/Evm64/DivMod/NormDefs.lean`: shake's 4th suggestion was a false
positive — `Rv64.Basic` exports the `Word` notation (`notation "Word"
=> BitVec 64`) which shake's static analysis doesn't see. Flagged in
`scripts/noshake.json` instead, matching the existing pattern for other
notation-driven imports.

`lake build` succeeds (1443 jobs, 0 errors, 0 sorries).

Beads: `evm-asm-9tq` (parent #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).