### PR TITLE
chore(imports): narrow LoopDefs/Bundle to Rv64.SepLogic (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -13,12 +13,10 @@
     * loopN1Iter210Pre / loopN1Iter210PreWithScratch — n=1 three-iteration path
 
   These are plain `Assertion`s (no iter/mulsub computations), so this file
-  depends only on `Compose.Base`.
+  depends only on `Rv64.SepLogic`.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.Base
-
-open EvmAsm.Rv64.Tactics
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Per `lake exe shake`: `EvmAsm.Evm64.DivMod.LoopDefs.Bundle` only uses plain separation-logic primitives (`signExtend12`, `↦ᵣ`, `↦ₘ`, `**`) — the heavy `Compose.Base` import was unused. Drop it in favour of the much smaller `Rv64.SepLogic` import. Also drop the adjacent unused `open EvmAsm.Rv64.Tactics`.

Full `lake build` green; no consumer changes needed.

Refs: #1045, beads slice `evm-asm-jyev` (DivMod loop-body tier shake cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).