### PR TITLE
chore(noshake): flag LoopBodyN[234] LoopBody/* false-positives (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -57,4 +57,22 @@
   "EvmAsm.Evm64.Shift.SarCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.DivMod.NormDefs":
-  ["EvmAsm.Rv64.Basic"]}}
+  ["EvmAsm.Rv64.Basic"],
+ "EvmAsm.Evm64.DivMod.LoopBodyN2":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+ "EvmAsm.Evm64.DivMod.LoopBodyN3":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+ "EvmAsm.Evm64.DivMod.LoopBodyN4":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"]}}


### PR DESCRIPTION
LoopBodyN2/N3/N4.lean each import five LoopBody/* helper modules: TrialCall, TrialMax, StoreLoop, CorrectionAddbackBeq, MulsubCorrectionSkip.

`lake exe shake EvmAsm` flags all five as removable. Verified false-positives — each consumer directly uses at least one decl from each module:

- TrialCall → `divKTrialCallFullPost`, `divK_trial_call_full_spec_within`
- TrialMax → `divK_trial_max_full_spec_within`
- StoreLoop → `divK_store_loop_spec_within` (the wrapper in `LoopBody.lean` depends on the two j-cases elaborated here)
- CorrectionAddbackBeq → `divK_mulsub_correction_addback_beq_spec_within`
- MulsubCorrectionSkip → `divK_mulsub_correction_skip_spec_within`

This patch adds `noshake.json` entries so the slice-4 (DivMod loop-body tier) import-hygiene cleanup can proceed without these distractors.

Verified locally: `lake build` ✅, `lake exe shake EvmAsm` no longer reports LoopBodyN[234].

Refs #1045. Beads: evm-asm-s8q9 (slice of evm-asm-jyev).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).