### PR TITLE
chore(noshake): suppress LoopBodyN[1-4] LoopBody.* false positives (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -57,4 +57,12 @@
   "EvmAsm.Evm64.Shift.SarCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.DivMod.NormDefs":
-  ["EvmAsm.Rv64.Basic"]}}
+  ["EvmAsm.Rv64.Basic"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN1":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall", "EvmAsm.Evm64.DivMod.LoopBody.TrialMax", "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop", "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq", "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN2":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall", "EvmAsm.Evm64.DivMod.LoopBody.TrialMax", "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop", "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq", "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN3":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall", "EvmAsm.Evm64.DivMod.LoopBody.TrialMax", "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop", "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq", "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN4":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall", "EvmAsm.Evm64.DivMod.LoopBody.TrialMax", "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop", "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq", "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"]}}


### PR DESCRIPTION
Suppress 5 `LoopBody.*` sub-module imports in each of `LoopBodyN1/N2/N3/N4.lean` that `lake exe shake` flags as unused. They are all required: each `LoopBodyNk` file directly references identifiers from those modules (`divK_trial_max_full_spec_within`, `divK_trial_call_full_spec_within`, `divK_mulsub_correction_skip_spec_within`, `divK_store_loop_spec_within`). Verified locally that dropping them breaks the build (`mulsubN4_c3` and friends become unknown).

Drops 15 false-positive lines from `lake exe shake EvmAsm` (878 -> 863), with no source changes.

Refs #1045 (sub-slice of slice 4). beads: `evm-asm-s8q9`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).