### PR TITLE
chore(shake): noshake LoopBody.{TrialCall,TrialMax,StoreLoop,CorrectionAddbackBeq,MulsubCorrectionSkip} in LoopBodyN[1234]

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -57,4 +57,28 @@
   "EvmAsm.Evm64.Shift.SarCompose":
   ["EvmAsm.Evm64.Shift.ComposeBase"],
   "EvmAsm.Evm64.DivMod.NormDefs":
-  ["EvmAsm.Rv64.Basic"]}}
+  ["EvmAsm.Rv64.Basic"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN1":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN2":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN3":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+  "EvmAsm.Evm64.DivMod.LoopBodyN4":
+  ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
+   "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
+   "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
+   "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"]}}


### PR DESCRIPTION
Adds noshake.json entries for five LoopBody/* imports in LoopBodyN1/N2/N3/N4.lean that lake exe shake flags as unused but are in fact required by the loop-body composition proofs:

- LoopBody.TrialCall — divK_trial_call_full_spec_within, divKTrialCallFullPost
- LoopBody.TrialMax — divK_trial_max_full_spec_within
- LoopBody.StoreLoop — divK_store_loop_spec_within
- LoopBody.CorrectionAddbackBeq — divK_mulsub_correction_addback_beq_spec_within
- LoopBody.MulsubCorrectionSkip — divK_mulsub_correction_skip_spec(_within)

Verified by:
- `lake build` green.
- `lake exe shake EvmAsm | rg 'LoopBodyN[1-4]\.lean'` no longer reports the five LoopBody/* removals on those four files.

Closes the noshake portion of #1045 slice 4. Tracked by beads evm-asm-s8q9.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).