### PR TITLE
feat(memory): define evm_mstore8 Program (slice 5a of #99)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -66,3 +66,4 @@ import EvmAsm.Evm64.Environment.Layout
 -- EVM memory model (issue #99)
 import EvmAsm.Evm64.Memory
 import EvmAsm.Evm64.MSize
+import EvmAsm.Evm64.MStore8

--- a/EvmAsm/Evm64/MStore8.lean
+++ b/EvmAsm/Evm64/MStore8.lean
@@ -1,0 +1,1 @@
+import EvmAsm.Evm64.MStore8.Program

--- a/EvmAsm/Evm64/MStore8/Program.lean
+++ b/EvmAsm/Evm64/MStore8/Program.lean
@@ -1,0 +1,67 @@
+/-
+  EvmAsm.Evm64.MStore8.Program
+
+  256-bit EVM MSTORE8: pop two 32-byte words from the EVM stack — offset
+  (top, at `sp`) and value (next, at `sp + 32`) — and write the LOW byte
+  of `value` to EVM memory at byte-address `offset`.
+
+  Memory is byte-addressable but lives inside the dword-keyed RV64 memory
+  via the `extractByte` / `replaceByte` algebra in `Rv64/ByteOps.lean`.
+  The RISC-V `SB` instruction handles the byte-level write through that
+  layer; this slice just assembles the addressing and the pop.
+
+  Per the EVM yellow paper §H.1, MSTORE8 reads only the low 8 bits of the
+  value word and triggers a 1-byte memory expansion at byte `offset`.
+
+  Implementation (5 instructions = 20 bytes):
+
+    LD   offReg   x12   0     -- low limb of offset (full 64-bit byte addr)
+    LD   valReg   x12   32    -- low limb of value (low byte is the relevant one)
+    ADD  addrReg  memBaseReg offReg
+                              -- target byte address inside the EVM memory buf
+    SB   addrReg  valReg 0    -- write the low byte of valReg
+    ADDI .x12     .x12  64    -- pop both 32-byte words
+
+  Slice 5a of issue #99 (sub-slice of evm-asm-mwnn). Program-only — the
+  spec proof lands in a follow-up slice.
+
+  All scratch registers (`offReg`, `valReg`, `addrReg`, `memBaseReg`) are
+  caller-chosen; the spec slice will pin down the disjointness side
+  conditions (must differ from `.x0`, `.x12`, and from each other where
+  required for SD/LD non-aliasing).
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- 256-bit EVM MSTORE8 program parameterized over the registers used as
+    scratch and the register holding the EVM memory base address.
+
+    * `offReg` — scratch reg, receives the low 64 bits of the popped
+      offset; together with `memBaseReg` it forms the target byte
+      address.
+    * `valReg` — scratch reg, receives the low 64 bits of the popped
+      value (only the low 8 bits matter for `SB`).
+    * `addrReg` — scratch reg, holds `memBaseReg + offReg` (the actual
+      byte address fed to `SB`).
+    * `memBaseReg` — caller-chosen register holding the base address of
+      the EVM memory buffer.
+
+    5 instructions = 20 bytes. -/
+def evm_mstore8 (offReg valReg addrReg memBaseReg : Reg) : Program :=
+  LD offReg .x12 0 ;;
+  LD valReg .x12 32 ;;
+  ADD addrReg memBaseReg offReg ;;
+  SB addrReg valReg 0 ;;
+  ADDI .x12 .x12 64
+
+/-- `CodeReq` for `evm_mstore8` placed at `base`. -/
+abbrev evm_mstore8_code (offReg valReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_mstore8 offReg valReg addrReg memBaseReg)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Introduces `EvmAsm/Evm64/MStore8/Program.lean` with the `evm_mstore8` program (5 RISC-V instructions = 20 bytes):

```
LD   offReg   x12 0
LD   valReg   x12 32
ADD  addrReg  memBaseReg offReg
SB   addrReg  valReg 0
ADDI x12      x12 64
```

Pops two 32-byte stack words (offset on top, value beneath), writes the LOW byte of value to EVM memory at byte address `memBaseReg + offset`, advances the EVM stack pointer by 64.

Wires `EvmAsm/Evm64/MStore8.lean` (umbrella) into `EvmAsm/Evm64.lean`.

Program-only step mirroring how MSIZE was split (program slice → spec slice → stack-form lift, see PRs #1561/#1583/#1594/#1599). The single-byte spec proof (against `generic_sb_spec_within` from `Rv64/ByteOps.lean`) and the high-water mark expansion side condition land in follow-up slices on top of `evmMemSizeIs` / `evmMemExpand` from PR #1583.

`lake build` green (1449 jobs).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs: #99 (slice 5), beads evm-asm-xduc / evm-asm-mwnn.