### PR TITLE
feat(mstore8): add evm_mstore8_kernel_spec_within (slice 5 of #99)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -49,6 +49,7 @@ import EvmAsm.Evm64.SignExtend
 
 -- Multiply
 import EvmAsm.Evm64.Multiply
+import EvmAsm.Evm64.MStore8
 
 -- Exp (skeleton — GH #92, square-and-multiply over 256-bit exponent)
 import EvmAsm.Evm64.Exp

--- a/EvmAsm/Evm64/MStore8.lean
+++ b/EvmAsm/Evm64/MStore8.lean
@@ -1,0 +1,2 @@
+import EvmAsm.Evm64.MStore8.Program
+import EvmAsm.Evm64.MStore8.Spec

--- a/EvmAsm/Evm64/MStore8/Program.lean
+++ b/EvmAsm/Evm64/MStore8/Program.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Evm64.MStore8.Program
+
+  256-bit EVM MSTORE8: write the LOW byte of a 256-bit value to a single
+  byte of EVM memory at a caller-prepared byte address.
+
+  The slice 5 issue body (issue #99) calls this a "single SB spec", so we
+  expose just the SB kernel here (one instruction). Full EVM-level MSTORE8
+  also pops `(offset, value)` from the EVM stack and updates the MSIZE
+  high-water mark; those layers compose on top of this kernel in later
+  slices and are intentionally out of scope for this slice. The pure
+  helper `evmMemExpand_one_byte` in `Evm64/Memory.lean` consumers can use
+  to discharge the size update is provided in `Spec.lean`.
+
+  Implementation (1 instruction = 4 bytes):
+
+    SB addrReg dataReg 0    -- write low byte of `dataReg` at addr `addrReg`
+
+  `addrReg` holds the byte address (already the EVM memory base + offset)
+  and `dataReg` holds the 256-bit EVM word whose low byte is the byte to
+  write. (The EVM yellow paper specifies that MSTORE8 writes only the
+  least significant byte of the popped 256-bit operand, which on RV64
+  matches taking the low 8 bits of the low limb.)
+
+  Slice 5 of issue #99. Authored by @pirapira; implemented by Hermes-bot
+  (evm-hermes).
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- 256-bit EVM MSTORE8 byte-write kernel: a single SB at offset 0.
+
+    `addrReg` carries the EVM memory byte address (caller has already
+    computed `memBase + offset`); `dataReg` carries the 256-bit EVM word
+    whose low byte is written. Caller is responsible for stack pop and
+    memory-expansion bookkeeping; this kernel only performs the byte
+    write itself. -/
+def evm_mstore8_kernel (addrReg dataReg : Reg) : Program :=
+  SB addrReg dataReg 0
+
+abbrev evm_mstore8_kernel_code (addrReg dataReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_mstore8_kernel addrReg dataReg)
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore8/Spec.lean
+++ b/EvmAsm/Evm64/MStore8/Spec.lean
@@ -1,0 +1,76 @@
+/-
+  EvmAsm.Evm64.MStore8.Spec
+
+  Slice 5 of issue #99 — MSTORE8 spec.
+
+  MSTORE8 in the EVM writes the LOW byte of a 256-bit operand to a single
+  byte of EVM memory. The slice 5 plan asks for a "single SB spec"; this
+  file provides exactly that, packaged at the EVM-memory layer:
+
+  * `evm_mstore8_kernel_spec_within` — a thin wrapper around the generic
+    `sb_spec_gen_within` that carries the byte address in a register and
+    leaves the dword cell holding the byte exposed as a raw `↦ₘ`. Lifting
+    to `evmMemIs` (which views memory as a sequence of dword cells) is
+    deferred to consumer slices that frame in/out the relevant cell.
+
+  Memory-expansion bookkeeping is a pure-Nat update on the high-water
+  mark; a one-byte access at offset `o` expands the size to
+  `max sizeBytes (roundUpTo32 (o + 1))`. The lemma
+  `evmMemExpand_one_byte_eq` exposes this fact for the consumer slices
+  that want to thread `evmMemSizeIs` through the spec.
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+-/
+
+import EvmAsm.Evm64.MStore8.Program
+import EvmAsm.Evm64.Memory
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- MSTORE8 byte-write kernel spec: composes `sb_spec_gen_within` for the
+    one SB instruction. The dword cell containing the target byte is
+    threaded through as a raw `↦ₘ`; consumer slices frame it in/out of
+    `evmMemIs` as needed. -/
+theorem evm_mstore8_kernel_spec_within
+    (addrReg dataReg : Reg) (v_addr v_data : Word)
+    (base : Word) (dwordAddr wordOld : Word)
+    (halign : alignToDword v_addr = dwordAddr)
+    (hvalid : isValidByteAccess v_addr = true) :
+    let code := evm_mstore8_kernel_code addrReg dataReg base
+    cpsTripleWithin 1 base (base + 4) code
+      ((addrReg ↦ᵣ v_addr) ** (dataReg ↦ᵣ v_data) ** (dwordAddr ↦ₘ wordOld))
+      ((addrReg ↦ᵣ v_addr) ** (dataReg ↦ᵣ v_data) **
+       (dwordAddr ↦ₘ replaceByte wordOld (byteOffset v_addr) (v_data.truncate 8))) := by
+  -- The SB offset is 0, so `v_addr + signExtend12 0 = v_addr`. Rewrite the
+  -- generic spec hypotheses to match.
+  have h_off : signExtend12 (0 : BitVec 12) = (0 : Word) := by decide
+  have halign' : alignToDword (v_addr + signExtend12 (0 : BitVec 12)) = dwordAddr := by
+    rw [h_off]; simpa using halign
+  have hvalid' : isValidByteAccess (v_addr + signExtend12 (0 : BitVec 12)) = true := by
+    rw [h_off]; simpa using hvalid
+  have hSB := sb_spec_gen_within addrReg dataReg v_addr v_data
+                (0 : BitVec 12) base dwordAddr wordOld halign' hvalid'
+  -- Rewrite the byte-offset in the post via h_off.
+  have hbo : byteOffset (v_addr + signExtend12 (0 : BitVec 12)) = byteOffset v_addr := by
+    rw [h_off]; simp
+  rw [hbo] at hSB
+  exact hSB
+
+/-! ## EVM memory expansion for a one-byte access
+
+  MSTORE8 writes one byte at offset `o`, so the access is `(o, 1)` and
+  the high-water-mark update is `max sizeBytes (roundUpTo32 (o + 1))`.
+  This lemma is the pure-Nat helper the consumer slice will use to
+  discharge the size update next to `evm_mstore8_kernel_spec_within`. -/
+
+theorem evmMemExpand_one_byte_eq (sizeBytes offset : Nat) :
+    evmMemExpand sizeBytes offset 1 = max sizeBytes (roundUpTo32 (offset + 1)) := by
+  unfold evmMemExpand; simp
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Slice 5 of #99 — MSTORE8 byte-write kernel spec.

MSTORE8 in the EVM writes the LOW byte of a 256-bit operand to a
single byte of EVM memory. This PR adds:

- `evm_mstore8_kernel` (Program): a single SB at offset 0, parameterized
  over the address and data registers.
- `evm_mstore8_kernel_spec_within` (Spec): a thin wrapper around the
  generic `sb_spec_gen_within` that carries the byte address in a
  register and exposes the dword cell holding the target byte as a raw
  `↦ₘ`. Lifting to `evmMemIs` (dword-cell view) is deferred to consumer
  slices that frame in/out the relevant cell.
- `evmMemExpand_one_byte_eq`: pure-Nat helper exposing the expansion
  rule for a one-byte access — `max sizeBytes (roundUpTo32 (o + 1))`.

The new module is wired into `EvmAsm/Evm64.lean` so it is transitively
reachable from `EvmAsm.lean` (issues #1209 / #1440 — unimported-file
CI check is green: `388 modules, 388 reachable, 0 orphans`).

## Acceptance

- [x] MSTORE8 single-byte spec proved (no `sorry`)
- [x] `lake build` green (full repo)
- [x] `scripts/check-unimported.sh` green
- [x] No `set_option maxHeartbeats` / `maxRecDepth` bumps

## Tracking

- Closes beads `evm-asm-mwnn` (#99 slice 5)
- Parent: #99 (EVM memory model — Memory.lean)
- Builds on:
  - #1561 (slice 1 — `evmMemIs`)
  - #1583 (slice 2 — high-water mark)
  - existing `Rv64.ByteOps.sb_spec_gen_within`

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).