### PR TITLE
chore(noshake): flag ModFullPathN4 as needed by ModFullPathN1LoopUnified (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -76,7 +76,9 @@
    "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
    "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
    "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
-  "EvmAsm.Evm64.DivMod.LoopBodyN4":
+  "EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified":
+ ["EvmAsm.Evm64.DivMod.Compose.ModFullPathN4"],
+ "EvmAsm.Evm64.DivMod.LoopBodyN4":
   ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
    "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
    "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",


### PR DESCRIPTION
Shake reports `EvmAsm.Evm64.DivMod.Compose.ModFullPathN4` as an unused import in `EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified`, but removing it breaks the build — the file uses `evm_mod_preamble_denorm_epilogue_spec_within`, which is declared in ModFullPathN4. Verified locally:

- After dropping the import, `lake build EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified` fails with `Unknown identifier evm_mod_preamble_denorm_epilogue_spec_within`.
- With the import restored and the noshake entry added, `lake exe shake EvmAsm` no longer flags it.

Adds a narrow noshake entry suppressing this single false positive.

Refs: evm-asm-5h34, parent evm-asm-jyev (#1045 slice 4).
Authored by @pirapira; implemented by Hermes-bot (evm-hermes).