### PR TITLE
proof(divmod): aggregate N1 step conservation facts

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -20,6 +20,24 @@ def n1StepConservation
       EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
       out.2.2.2.2.2.toNat * 2^256
 
+@[irreducible]
+def fullDivN1StepsConservation
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.2.1 u.2.2.2.2 0 0 0 r3 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.1
+    r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1 r2 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.1
+    r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 r1 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+
 theorem fullDivN1R3_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
@@ -187,5 +205,29 @@ theorem fullDivN1R0_step_conservation
   rw [fullDivN1R0_eq_iterN1_v3_zero
     bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z]
   exact h
+
+theorem fullDivN1StepsConservation_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2) :
+    fullDivN1StepsConservation bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 := by
+  delta fullDivN1StepsConservation
+  constructor
+  · exact fullDivN1R3_step_conservation
+      bltu_3 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2
+  constructor
+  · exact fullDivN1R2_step_conservation
+      bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2
+  constructor
+  · exact fullDivN1R1_step_conservation
+      bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2
+  · exact fullDivN1R0_step_conservation
+      bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -21,6 +21,30 @@ def n1StepConservation
       out.2.2.2.2.2.toNat * 2^256
 
 @[irreducible]
+def n1StepRemainderVal (out : Word × Word × Word × Word × Word × Word) : Nat :=
+  EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+    out.2.2.2.2.2.toNat * 2^256
+
+theorem n1StepConservation_remainder_le_input
+    (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (out : Word × Word × Word × Word × Word × Word)
+    (h : n1StepConservation v0 v1 v2 u0 u1 u2 u3 uTop out) :
+    n1StepRemainderVal out ≤ EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 := by
+  delta n1StepConservation at h
+  delta n1StepRemainderVal
+  omega
+
+theorem n1StepConservation_remainder_lt_of_input_lt
+    (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (out : Word × Word × Word × Word × Word × Word) {bound : Nat}
+    (h : n1StepConservation v0 v1 v2 u0 u1 u2 u3 uTop out)
+    (hinput : EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 < bound) :
+    n1StepRemainderVal out < bound := by
+  have hle := n1StepConservation_remainder_le_input
+    v0 v1 v2 u0 u1 u2 u3 uTop out h
+  omega
+
+@[irreducible]
 def fullDivN1StepsConservation
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=


### PR DESCRIPTION
Codex PR stacked on #1617.\n\nSummary:\n- Adds fullDivN1StepsConservation as an irreducible aggregate over the four N1 step-conservation facts.\n- Adds fullDivN1StepsConservation_of_runtime to derive the aggregate from the N1 high-zero/nonzero/carry runtime hypotheses.\n- Records the remaining telescope work as bead evm-asm-1hh.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation