### PR TITLE
chore(divmod): name addback per-limb sub-block offsets (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -108,6 +108,30 @@ abbrev correctionAddbackOff : Word :=  712
     instructions into the loop body). Sub-offset relative to the loopBody
     block (= correctionSkipBeqOff + 4 = loopBodyOff + 284). -/
 abbrev addbackInitOff : Word :=  732
+/-- Offset of the limb-0 addback step inside `divK_loopBody`.
+    Entry PC of the `divK_addback_step` snippet for `q[j] · b[0]` (the first
+    per-limb addback fixup, run only when the trial quotient overshoots).
+    Sub-offset relative to the loopBody block
+    (= addbackInitOff + 4 = loopBodyOff + 288). -/
+abbrev addbackLimb0Off : Word :=  736
+/-- Offset of the limb-1 addback step inside `divK_loopBody`.
+    Sub-offset relative to the loopBody block
+    (= addbackLimb0Off + 32 = loopBodyOff + 320). -/
+abbrev addbackLimb1Off : Word :=  768
+/-- Offset of the limb-2 addback step inside `divK_loopBody`.
+    Sub-offset relative to the loopBody block
+    (= addbackLimb1Off + 32 = loopBodyOff + 352). -/
+abbrev addbackLimb2Off : Word :=  800
+/-- Offset of the limb-3 addback step inside `divK_loopBody`.
+    Sub-offset relative to the loopBody block
+    (= addbackLimb2Off + 32 = loopBodyOff + 384). -/
+abbrev addbackLimb3Off : Word :=  832
+/-- Offset of the final addback fixup (`divK_addback_final`) inside
+    `divK_loopBody`. The 4-instruction snippet that propagates the final
+    addback carry into the high limb, immediately before the addback-skip
+    BEQ. Sub-offset relative to the loopBody block
+    (= addbackLimb3Off + 32 = addbackBeqOff - 16 = loopBodyOff + 416). -/
+abbrev addbackFinalOff : Word :=  864
 /-- Offset of the addback-skip BEQ sub-block inside `divK_loopBody`.
     Entry PC of the `BEQ x7, x0, +4` instruction that branches over the
     addback fixup (executed when the trial-quotient `q̂` did NOT overshoot,
@@ -223,6 +247,18 @@ example : addbackInitOff = loopBodyOff + 284 := by decide
     `divK_loopBody`). The correction-addback path (sub-carry snippet entry)
     sits 66 instructions into the loop body. -/
 example : correctionAddbackOff = loopBodyOff + 264 := by decide
+/-- addbackLimb{0..3}Off and addbackFinalOff are evenly spaced 32 bytes (8
+    instructions) apart starting at `addbackInitOff + 4`, ending at
+    `addbackBeqOff - 16` (the 4-instruction `divK_addback_final` fixup before
+    the addback-skip BEQ). -/
+example : addbackLimb0Off = addbackInitOff + 4 := by decide
+example : addbackLimb1Off = addbackLimb0Off + 32 := by decide
+example : addbackLimb2Off = addbackLimb1Off + 32 := by decide
+example : addbackLimb3Off = addbackLimb2Off + 32 := by decide
+example : addbackFinalOff = addbackLimb3Off + 32 := by decide
+example : addbackFinalOff + 16 = addbackBeqOff := by decide
+example : addbackLimb0Off = loopBodyOff + 288 := by decide
+example : addbackFinalOff = loopBodyOff + 416 := by decide
 /-- trialCallOff = loopBodyOff + 52 (sub-block offset within `divK_loopBody`).
     The trial-divide call-site sits 13 instructions into the loop body. -/
 example : trialCallOff = loopBodyOff + 52 := by decide

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -239,12 +239,12 @@ theorem divK_mulsub_4limbs_spec_within
     (fun h hq => by xperm_hyp hq)
     L0fL1eL2eL3e
 
-private theorem lb_ab0 {base : Word} : (base + addbackInitOff : Word) + 4 = base + 736 := by bv_addr
-private theorem lb_ab0_end {base : Word} : (base + 736 : Word) + 32 = base + 768 := by bv_addr
-private theorem lb_ab1_end {base : Word} : (base + 768 : Word) + 32 = base + 800 := by bv_addr
-private theorem lb_ab2_end {base : Word} : (base + 800 : Word) + 32 = base + 832 := by bv_addr
-private theorem lb_ab3_end {base : Word} : (base + 832 : Word) + 32 = base + 864 := by bv_addr
-private theorem lb_abf_end {base : Word} : (base + 864 : Word) + 16 = base + addbackBeqOff := by bv_addr
+private theorem lb_ab0 {base : Word} : (base + addbackInitOff : Word) + 4 = base + addbackLimb0Off := by bv_addr
+private theorem lb_ab0_end {base : Word} : (base + addbackLimb0Off : Word) + 32 = base + addbackLimb1Off := by bv_addr
+private theorem lb_ab1_end {base : Word} : (base + addbackLimb1Off : Word) + 32 = base + addbackLimb2Off := by bv_addr
+private theorem lb_ab2_end {base : Word} : (base + addbackLimb2Off : Word) + 32 = base + addbackLimb3Off := by bv_addr
+private theorem lb_ab3_end {base : Word} : (base + addbackLimb3Off : Word) + 32 = base + addbackFinalOff := by bv_addr
+private theorem lb_abf_end {base : Word} : (base + addbackFinalOff : Word) + 16 = base + addbackBeqOff := by bv_addr
 
 set_option maxRecDepth 4096 in
 /-- Full add-back correction: init carry + 4 limb corrections + final u[j+4] adjust + qHat--.
@@ -316,9 +316,9 @@ theorem divK_addback_full_spec_within
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
      ((uBase + signExtend12 4064) ↦ₘ u4))
     (by pcFree) Ie
-  -- Limb 0: instrs [72]-[79] at base+736
+  -- Limb 0: instrs [72]-[79] at base+addbackLimb0Off
   have A0 := divK_addback_limb_spec_within sp uBase (signExtend12 0 : Word)
-    v5_init v2_init v0 u0 32 0 (base + 736)
+    v5_init v2_init v0 u0 32 0 (base + addbackLimb0Off)
   rw [lb_ab0_end] at A0
   have A0e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 72 _ _ (by decide) (by bv_addr) (by decide))
@@ -332,9 +332,9 @@ theorem divK_addback_full_spec_within
     A0
   -- Compose init + limb 0
   seqFrame If A0e
-  -- Limb 1: instrs [80]-[87] at base+768
+  -- Limb 1: instrs [80]-[87] at base+addbackLimb1Off
   have A1 := divK_addback_limb_spec_within sp uBase aco0
-    ac2_0 aun0 v1 u1 40 4088 (base + 768)
+    ac2_0 aun0 v1 u1 40 4088 (base + addbackLimb1Off)
   rw [lb_ab1_end] at A1
   have A1e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 80 _ _ (by decide) (by bv_addr) (by decide))
@@ -347,9 +347,9 @@ theorem divK_addback_full_spec_within
       (lb_sub 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A1
   seqFrame IfA0e A1e
-  -- Limb 2: instrs [88]-[95] at base+800
+  -- Limb 2: instrs [88]-[95] at base+addbackLimb2Off
   have A2 := divK_addback_limb_spec_within sp uBase aco1
-    ac2_1 aun1 v2 u2 48 4080 (base + 800)
+    ac2_1 aun1 v2 u2 48 4080 (base + addbackLimb2Off)
   rw [lb_ab2_end] at A2
   have A2e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 88 _ _ (by decide) (by bv_addr) (by decide))
@@ -362,9 +362,9 @@ theorem divK_addback_full_spec_within
       (lb_sub 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A2
   seqFrame IfA0eA1e A2e
-  -- Limb 3: instrs [96]-[103] at base+832
+  -- Limb 3: instrs [96]-[103] at base+addbackLimb3Off
   have A3 := divK_addback_limb_spec_within sp uBase aco2
-    ac2_2 aun2 v3 u3 56 4072 (base + 832)
+    ac2_2 aun2 v3 u3 56 4072 (base + addbackLimb3Off)
   rw [lb_ab3_end] at A3
   have A3e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 96 _ _ (by decide) (by bv_addr) (by decide))
@@ -377,8 +377,8 @@ theorem divK_addback_full_spec_within
       (lb_sub 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A3
   seqFrame IfA0eA1eA2e A3e
-  -- Final: instrs [104]-[107] at base+864
-  have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + 864)
+  -- Final: instrs [104]-[107] at base+addbackFinalOff
+  have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + addbackFinalOff)
   rw [lb_abf_end] at AF
   have AFe := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub 104 _ _ (by decide) (by bv_addr) (by decide))
@@ -813,9 +813,9 @@ theorem divK_addback_full_v2_spec_within
      ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
      ((uBase + signExtend12 4064) ↦ₘ u4))
     (by pcFree) Ie
-  -- Limb 0: instrs [72]-[79] at base+736
+  -- Limb 0: instrs [72]-[79] at base+addbackLimb0Off
   have A0 := divK_addback_limb_spec_within sp uBase (signExtend12 0 : Word)
-    v5_init v2_init v0 u0 32 0 (base + 736)
+    v5_init v2_init v0 u0 32 0 (base + addbackLimb0Off)
   rw [lb_ab0_end] at A0
   have A0e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub_v2 72 _ _ (by decide) (by bv_addr) (by decide))
@@ -828,9 +828,9 @@ theorem divK_addback_full_v2_spec_within
       (lb_sub_v2 79 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A0
   seqFrame If A0e
-  -- Limb 1: instrs [80]-[87] at base+768
+  -- Limb 1: instrs [80]-[87] at base+addbackLimb1Off
   have A1 := divK_addback_limb_spec_within sp uBase aco0
-    ac2_0 aun0 v1 u1 40 4088 (base + 768)
+    ac2_0 aun0 v1 u1 40 4088 (base + addbackLimb1Off)
   rw [lb_ab1_end] at A1
   have A1e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub_v2 80 _ _ (by decide) (by bv_addr) (by decide))
@@ -843,9 +843,9 @@ theorem divK_addback_full_v2_spec_within
       (lb_sub_v2 87 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A1
   seqFrame IfA0e A1e
-  -- Limb 2: instrs [88]-[95] at base+800
+  -- Limb 2: instrs [88]-[95] at base+addbackLimb2Off
   have A2 := divK_addback_limb_spec_within sp uBase aco1
-    ac2_1 aun1 v2 u2 48 4080 (base + 800)
+    ac2_1 aun1 v2 u2 48 4080 (base + addbackLimb2Off)
   rw [lb_ab2_end] at A2
   have A2e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub_v2 88 _ _ (by decide) (by bv_addr) (by decide))
@@ -858,9 +858,9 @@ theorem divK_addback_full_v2_spec_within
       (lb_sub_v2 95 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A2
   seqFrame IfA0eA1e A2e
-  -- Limb 3: instrs [96]-[103] at base+832
+  -- Limb 3: instrs [96]-[103] at base+addbackLimb3Off
   have A3 := divK_addback_limb_spec_within sp uBase aco2
-    ac2_2 aun2 v3 u3 56 4072 (base + 832)
+    ac2_2 aun2 v3 u3 56 4072 (base + addbackLimb3Off)
   rw [lb_ab3_end] at A3
   have A3e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub_v2 96 _ _ (by decide) (by bv_addr) (by decide))
@@ -873,8 +873,8 @@ theorem divK_addback_full_v2_spec_within
       (lb_sub_v2 103 _ _ (by decide) (by bv_addr) (by decide)))))))))
     A3
   seqFrame IfA0eA1eA2e A3e
-  -- Final: instrs [104]-[107] at base+864
-  have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + 864)
+  -- Final: instrs [104]-[107] at base+addbackFinalOff
+  have AF := divK_addback_final_spec_within uBase aco3 qHat ac2_3 u4 4064 (base + addbackFinalOff)
   rw [lb_abf_end] at AF
   have AFe := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (lb_sub_v2 104 _ _ (by decide) (by bv_addr) (by decide))


### PR DESCRIPTION
Slice of #301 (beads evm-asm-mtes, parent evm-asm-nqj).

Introduce 5 named offsets in `Compose/Offsets.lean` for the per-limb
addback fixup sub-blocks inside `divK_loopBody`:

| Offset | Value | Relation |
| ------ | ----- | -------- |
| `addbackLimb0Off` | 736 | = `addbackInitOff + 4` = `loopBodyOff + 288` |
| `addbackLimb1Off` | 768 | = `addbackLimb0Off + 32` |
| `addbackLimb2Off` | 800 | = `addbackLimb1Off + 32` |
| `addbackLimb3Off` | 832 | = `addbackLimb2Off + 32` |
| `addbackFinalOff` | 864 | = `addbackLimb3Off + 32` = `addbackBeqOff - 16` |

Migrate the 16 `base + NNN` literals in `EvmAsm/Evm64/DivMod/LoopBody.lean`
that referred to these PCs (5 `lb_ab*` PC-step lemmas + 5×2 call-site
occurrences in the two top-level loop-body theorems, plus matching block
comments).

Add structural drift `example`s (32-byte spacing,
`addbackFinalOff + 16 = addbackBeqOff`) so any future change to the
addback chain length fails loudly at the canonical constants rather
than silently propagating through stale `base + NNN` literals.

No proof-content change. `lake build` green; no new heartbeat overrides.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).