### PR TITLE
chore(noshake): flag 4 LoopUnified/Compose/FullPath shake false-positives (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -83,4 +83,12 @@
    "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",
    "EvmAsm.Evm64.DivMod.LoopBody.StoreLoop",
    "EvmAsm.Evm64.DivMod.LoopBody.CorrectionAddbackBeq",
-   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"]}}
+   "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
+ "EvmAsm.Evm64.DivMod.LoopUnifiedN3":
+  ["EvmAsm.Evm64.DivMod.LoopComposeN3"],
+ "EvmAsm.Evm64.DivMod.LoopUnifiedN2":
+  ["EvmAsm.Evm64.DivMod.LoopComposeN2"],
+ "EvmAsm.Evm64.DivMod.LoopComposeN3":
+  ["EvmAsm.Evm64.DivMod.LoopIterN3"],
+ "EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop":
+  ["EvmAsm.Evm64.DivMod.LoopIterN4"]}}


### PR DESCRIPTION
Sub-slice of #1045 slice 4 (evm-asm-jyev / evm-asm-1uo7).

Add 4 `noshake.json` entries for shake suggestions verified locally to break the build:

| Importer | Suppressed import | Why |
|---|---|---|
| `LoopUnifiedN3` | `LoopComposeN3` | provides `iterN3_true`/`iterN3_false` simp lemmas used at line 48 |
| `LoopUnifiedN2` | `LoopComposeN2` | provides `iterN2_true`/`iterN2_false` simp lemmas used at line 300 |
| `LoopComposeN3` | `LoopIterN3` | provides `loopBodyPre` / `cpsTripleWithin` via the `@[spec_gen]` registry |
| `Compose/FullPathN4Loop` | `LoopIterN4` | `BitVec.ult` unification + `@[spec_gen]`-registered theorems |

Each removal was tested individually with `lake build` on this branch and produced compilation errors (Unknown identifier / cpsTripleWithin / loopBodyPre / BitVec.ult unification). Restored, then suppressed via `scripts/noshake.json`.

`lake build` green locally on this branch.

Refs: #1045, evm-asm-1uo7.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).