### PR TITLE
proof(divmod): add N1 step telescope scaffold

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -45,6 +45,38 @@ theorem n1StepConservation_remainder_lt_of_input_lt
   omega
 
 @[irreducible]
+def n1StepsTelescoped
+    (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
+    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word) : Prop :=
+  EvmWord.val256 u.1 u.2.1 u.2.2.1 u.2.2.2.1 +
+      u.2.2.2.2.toNat * 2^256 =
+    (r3.1.toNat * 2^192 + r2.1.toNat * 2^128 +
+        r1.1.toNat * 2^64 + r0.1.toNat) *
+      EvmWord.val256 v.1 v.2.1 v.2.2.1 0 + n1StepRemainderVal r0
+
+@[irreducible]
+def n1StepsConservation
+    (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
+    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word) : Prop :=
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.2.1 u.2.2.2.2 0 0 0 r3 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.1
+    r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1 r2 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.1
+    r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 r1 ∧
+  n1StepConservation v.1 v.2.1 v.2.2.1 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 r0
+
+theorem n1NatStepConservation_telescope
+    {V q3 q2 q1 q0 rem3 rem2 rem1 rem0 u0 u1 u2 u3 u4 : Nat}
+    (h3 : u3 + u4 * 2^64 = q3 * V + rem3)
+    (h2 : u2 + rem3 * 2^64 = q2 * V + rem2)
+    (h1 : u1 + rem2 * 2^64 = q1 * V + rem1)
+    (h0 : u0 + rem1 * 2^64 = q0 * V + rem0) :
+    u0 + u1 * 2^64 + u2 * 2^128 + u3 * 2^192 + u4 * 2^256 =
+      (q3 * 2^192 + q2 * 2^128 + q1 * 2^64 + q0) * V + rem0 := by
+  nlinarith
+
+@[irreducible]
 def fullDivN1StepsConservation
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
@@ -61,6 +93,18 @@ def fullDivN1StepsConservation
   n1StepConservation v.1 v.2.1 v.2.2.1 u.1
     r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
     (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+
+@[irreducible]
+def fullDivN1StepsTelescoped
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  n1StepsTelescoped v u r3 r2 r1 r0
 
 theorem fullDivN1R3_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)


### PR DESCRIPTION
Codex PR.\n\nSummary:\n- Adds compact N1 telescope propositions: n1StepsConservation, n1StepsTelescoped, and fullDivN1StepsTelescoped.\n- Adds pure Nat telescope theorem n1NatStepConservation_telescope for composing four N1 step equations.\n- Records the remaining full-path wrapper WHNF timeout as bead evm-asm-cwv.\n\nBeads:\n- Advances evm-asm-1hh.\n- Adds follow-up evm-asm-cwv.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation