### PR TITLE
proof(divmod): account for N1 telescope carry limbs

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -22,8 +22,18 @@ def n1StepConservation
 
 @[irreducible]
 def n1StepRemainderVal (out : Word × Word × Word × Word × Word × Word) : Nat :=
-  EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
-    out.2.2.2.2.2.toNat * 2^256
+  EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1
+
+@[irreducible]
+def n1StepTopVal (out : Word × Word × Word × Word × Word × Word) : Nat :=
+  out.2.2.2.2.2.toNat
+
+@[irreducible]
+def n1StepsCarryVal
+    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word) : Nat :=
+  let B := 2^64
+  n1StepTopVal r0 * B^4 + n1StepTopVal r1 * B^5 +
+    n1StepTopVal r2 * B^6 + n1StepTopVal r3 * B^7
 
 theorem n1StepConservation_remainder_le_input
     (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
@@ -48,11 +58,13 @@ theorem n1StepConservation_remainder_lt_of_input_lt
 def n1StepsTelescoped
     (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
     (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word) : Prop :=
+  let B := 2^64
   EvmWord.val256 u.1 u.2.1 u.2.2.1 u.2.2.2.1 +
-      u.2.2.2.2.toNat * 2^256 =
-    (r3.1.toNat * 2^192 + r2.1.toNat * 2^128 +
-        r1.1.toNat * 2^64 + r0.1.toNat) *
-      EvmWord.val256 v.1 v.2.1 v.2.2.1 0 + n1StepRemainderVal r0
+      u.2.2.2.2.toNat * B^4 =
+    (r3.1.toNat * B^3 + r2.1.toNat * B^2 +
+        r1.1.toNat * B + r0.1.toNat) *
+      EvmWord.val256 v.1 v.2.1 v.2.2.1 0 + n1StepRemainderVal r0 +
+      n1StepsCarryVal r3 r2 r1 r0
 
 @[irreducible]
 def n1StepsConservation
@@ -67,13 +79,19 @@ def n1StepsConservation
     r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1 r0
 
 theorem n1NatStepConservation_telescope
-    {V q3 q2 q1 q0 rem3 rem2 rem1 rem0 u0 u1 u2 u3 u4 : Nat}
-    (h3 : u3 + u4 * 2^64 = q3 * V + rem3)
-    (h2 : u2 + rem3 * 2^64 = q2 * V + rem2)
-    (h1 : u1 + rem2 * 2^64 = q1 * V + rem1)
-    (h0 : u0 + rem1 * 2^64 = q0 * V + rem0) :
-    u0 + u1 * 2^64 + u2 * 2^128 + u3 * 2^192 + u4 * 2^256 =
-      (q3 * 2^192 + q2 * 2^128 + q1 * 2^64 + q0) * V + rem0 := by
+    {B V q3 q2 q1 q0 rem3 rem2 rem1 rem0 top3 top2 top1 top0
+      u0 u1 u2 u3 u4 : Nat}
+    (h3 : u3 + u4 * B = q3 * V + rem3 + top3 * B^4)
+    (h2 : u2 + rem3 * B = q2 * V + rem2 + top2 * B^4)
+    (h1 : u1 + rem2 * B = q1 * V + rem1 + top1 * B^4)
+    (h0 : u0 + rem1 * B = q0 * V + rem0 + top0 * B^4) :
+    u0 + u1 * B + u2 * B^2 + u3 * B^3 + u4 * B^4 =
+      (q3 * B^3 + q2 * B^2 + q1 * B + q0) * V + rem0 +
+        top0 * B^4 + top1 * B^5 + top2 * B^6 + top3 * B^7 := by
+  have H3 := congrArg (fun x => x * B^3) h3
+  have H2 := congrArg (fun x => x * B^2) h2
+  have H1 := congrArg (fun x => x * B) h1
+  ring_nf at H3 H2 H1 h0 ⊢
   nlinarith
 
 @[irreducible]
@@ -85,14 +103,8 @@ def fullDivN1StepsConservation
   let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
   let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
   let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.2.1 u.2.2.2.2 0 0 0 r3 ∧
-  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.1
-    r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1 r2 ∧
-  n1StepConservation v.1 v.2.1 v.2.2.1 u.2.1
-    r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1 r1 ∧
-  n1StepConservation v.1 v.2.1 v.2.2.1 u.1
-    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
-    (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  n1StepsConservation v u r3 r2 r1 r0
 
 @[irreducible]
 def fullDivN1StepsTelescoped
@@ -286,6 +298,7 @@ theorem fullDivN1StepsConservation_of_runtime
     fullDivN1StepsConservation bltu_3 bltu_2 bltu_1 bltu_0
       a0 a1 a2 a3 b0 b1 b2 b3 := by
   delta fullDivN1StepsConservation
+  delta n1StepsConservation
   constructor
   · exact fullDivN1R3_step_conservation
       bltu_3 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -35,6 +35,25 @@ def n1StepsCarryVal
   n1StepTopVal r0 * B^4 + n1StepTopVal r1 * B^5 +
     n1StepTopVal r2 * B^6 + n1StepTopVal r3 * B^7
 
+theorem n1StepRemainderVal_mul_base
+    (out : Word × Word × Word × Word × Word × Word) :
+    let B := 2^64
+    n1StepRemainderVal out * B =
+      out.2.1.toNat * B + out.2.2.1.toNat * B^2 +
+        out.2.2.2.1.toNat * B^3 + out.2.2.2.2.1.toNat * B^4 := by
+  intro B
+  delta n1StepRemainderVal
+  unfold EvmWord.val256
+  ring
+
+theorem n1StepTopVal_mul_base4
+    (out : Word × Word × Word × Word × Word × Word) :
+    let B := 2^64
+    n1StepTopVal out * B^4 = out.2.2.2.2.2.toNat * 2^256 := by
+  intro B
+  delta n1StepTopVal
+  norm_num
+
 theorem n1StepConservation_remainder_le_input
     (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
     (out : Word × Word × Word × Word × Word × Word)


### PR DESCRIPTION
Codex PR.\n\nChanges:\n- Corrects the N1 telescope target so shifted top-limb carry terms are preserved instead of dropped.\n- Rewrites the pure Nat telescope around a base B to avoid huge-power normalization.\n- Adds projection helpers for the next tuple bridge step.\n\nBeads:\n- Progresses evm-asm-cwv.\n- Creates and progresses evm-asm-x8d for the remaining tuple bridge normalization blocker.\n\nVerification:\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation