### PR TITLE
chore(shake): noshake entries for *Attr files (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -21,6 +21,9 @@
   "EvmAsm.Rv64.Tactics.LiftSpec":
   ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
   "EvmAsm.Rv64.AddrNorm": ["EvmAsm.Rv64.AddrNormAttr"],
+  "EvmAsm.Rv64.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Rv64.RegOpsAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Rv64.ByteAlgAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.Pop.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Push0.Spec":


### PR DESCRIPTION
Suppresses three `lake exe shake EvmAsm` false positives on:

- `EvmAsm/Rv64/AddrNormAttr.lean`
- `EvmAsm/Rv64/RegOpsAttr.lean`
- `EvmAsm/Rv64/ByteAlgAttr.lean`

`shake` proposes replacing `import Lean.Meta.Tactic.Simp.RegisterCommand` with `import Lean.Meta.Tactic.Simp.Attr`. The replacement breaks the build because `register_simp_attr` (used in each file) is the macro defined in `RegisterCommand`, not `Attr`. Swapping yields `unexpected identifier; expected '#guard_msgs', ...`.

Verified locally:
- `jq . scripts/noshake.json` — valid JSON.
- `lake exe shake EvmAsm` — three suggestions are gone, no other regressions.

Refs evm-asm-8vj9 (slice of evm-asm-jyev / GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).