### PR TITLE
chore(divmod): name base + 1300/1356 div128 v2/v4 offsets (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Div128.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128.lean
@@ -527,7 +527,7 @@ theorem div128_v2_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
   have hst2 := divK_div128_step2_spec_within sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     (base + 1232)
   unfold divKDiv128Step2Code divKDiv128Step2Post at hst2
-  rw [show (base + 1232 : Word) + 68 = base + 1300 from by bv_addr] at hst2
+  rw [show (base + 1232 : Word) + 68 = base + (div128Off + 228) from by bv_addr] at hst2
   have hst2e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v2_sub 40 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v2_sub 41 _ _ (by decide) (by bv_addr) (by decide))
@@ -572,7 +572,7 @@ theorem div128_v2_spec_within (sp retAddr d uLo uHi : Word) (base : Word)
   let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let x11Exit := if rhat2cHi = 0 then un0 else rhat2c
   have hend := divK_div128_end_spec_within sp q1'' q0' retAddr x11Exit retAddr
-    (base + 1300) _halign
+    (base + (div128Off + 228)) _halign
   have hende := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v2_sub 57 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v2_sub 58 _ _ (by decide) (by bv_addr) (by decide))

--- a/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Div128V4.lean
@@ -271,7 +271,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
   have hst2 := divK_div128_step2_v4_spec sp un21 dHi cu_q1_dlo cu_rhat_un1 un1 dLo un0
     scratchMem (base + 1232)
   unfold divKDiv128Step2V4Code divKDiv128Step2V4Post at hst2
-  rw [show (base + 1232 : Word) + 124 = base + 1356 from by bv_addr] at hst2
+  rw [show (base + 1232 : Word) + 124 = base + (div128Off + 284) from by bv_addr] at hst2
   have hst2e := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.ofProg_mono_sub (base + div128Off) (base + 1232)
       divK_div128_v4 divKDiv128Step2V4Instrs 40
@@ -313,7 +313,7 @@ theorem div128_v4_spec (sp retAddr d uLo uHi : Word) (base : Word)
                        else un0
   let mem3936Exit := if rhat2cHi ≠ 0 then scratchMem else rhat2c
   have hend := divK_div128_end_spec_within sp q1'' q0'' retAddr x11Exit_step2 retAddr
-    (base + 1356) _halign
+    (base + (div128Off + 284)) _halign
   have hende := cpsTripleWithin_extend_code (hmono := by
     exact CodeReq.union_sub (d128_v4_sub 71 _ _ (by decide) (by bv_addr) (by decide))
      (CodeReq.union_sub (d128_v4_sub 72 _ _ (by decide) (by bv_addr) (by decide))


### PR DESCRIPTION
Migrate the four remaining numeric `base + 1300` / `base + 1356` literals in `Compose/Div128.lean` and `Compose/Div128V4.lean` to `base + (div128Off + k)` form, mirroring evm-asm-fv3k for the canonical div128 block.

These offsets sit past `div128Off + 196` (end of `divK_div128`) and live in the v2/v4 extended div128 paths. Per `docs/divmod-offset-audit.md` recommendation #3, whether to introduce dedicated `div128V2Off`/`div128V4Off` constants can be revisited later — for now `div128Off + k` keeps the literals consistent with the rest of the #301 migration.

`lake build` green locally.

Refs GH #301; beads evm-asm-to5z.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).