### PR TITLE
chore(shake): flag LoopBodyN{1,2,3} false-positives in LoopIterN1/* and LoopIterN{2,3} (#1045)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -91,4 +91,16 @@
  "EvmAsm.Evm64.DivMod.LoopComposeN3":
   ["EvmAsm.Evm64.DivMod.LoopIterN3"],
  "EvmAsm.Evm64.DivMod.Compose.FullPathN4Loop":
-  ["EvmAsm.Evm64.DivMod.LoopIterN4"]}}
+  ["EvmAsm.Evm64.DivMod.LoopIterN4"],
+ "EvmAsm.Evm64.DivMod.LoopIterN1.Max":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN1"],
+ "EvmAsm.Evm64.DivMod.LoopIterN1.Call":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN1"],
+ "EvmAsm.Evm64.DivMod.LoopIterN1.MaxBeq":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN1"],
+ "EvmAsm.Evm64.DivMod.LoopIterN1.CallBeq":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN1"],
+ "EvmAsm.Evm64.DivMod.LoopIterN2":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN2"],
+ "EvmAsm.Evm64.DivMod.LoopIterN3":
+  ["EvmAsm.Evm64.DivMod.LoopBodyN3"]}}


### PR DESCRIPTION
Shake (`lake exe shake EvmAsm`) reports `LoopBodyN1` as unused in:
- `EvmAsm/Evm64/DivMod/LoopIterN1/Max.lean`
- `EvmAsm/Evm64/DivMod/LoopIterN1/Call.lean`
- `EvmAsm/Evm64/DivMod/LoopIterN1/MaxBeq.lean`
- `EvmAsm/Evm64/DivMod/LoopIterN1/CallBeq.lean`

and similarly `LoopBodyN2` / `LoopBodyN3` in `LoopIterN2.lean` / `LoopIterN3.lean`.

Verified false-positive: removing the import breaks the build with
`unexpected token '↦'` parse errors — the import transitively brings in
the `↦ᵣ` / `↦ₘ` notation expansions and spec dependencies that shake's
olean dependency tracking misses. Same pattern as the existing
`LoopBodyN4` noshake entry already used by `LoopIterN4.lean`.

Slice of evm-asm-jyev (GH #1045). Six `scripts/noshake.json` entries added.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).