### PR TITLE
docs(#84): document sail-riscv-lean dependency in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,40 @@ lake exec cache get
 lake build
 ```
 
+### Dependencies
+
+Top-level Lake dependencies (declared in [`lakefile.toml`](lakefile.toml)):
+
+- **[Mathlib4](https://github.com/leanprover-community/mathlib4)** — Lean 4
+  mathematics library. Used pervasively for `BitVec`, `Nat` arithmetic, `Fin`,
+  decidability instances, and tactic infrastructure.
+- **[`Lean_RV64D`](https://github.com/dhsorens/sail-riscv-lean)** — fork of
+  [`opencompl/sail-riscv-lean`](https://github.com/opencompl/sail-riscv-lean),
+  itself the Lean export of the official
+  [Sail RISC-V model](https://github.com/riscv/sail-riscv). Pulls in
+  [`lean-sail`](https://github.com/sail-lean/lean-sail) (Sail's Lean monad
+  runtime) transitively.
+
+  Why a fork? The mainline `sail-riscv-lean` lags slightly behind the Lean
+  toolchain we use; the `dhsorens` fork pins a `main` branch that tracks our
+  nightly. Switching back to upstream is the goal once toolchains converge.
+  Pinned to a moving `rev = "main"`; the resolved commit is recorded in
+  [`lake-manifest.json`](lake-manifest.json) and bumped in tandem with
+  Mathlib updates.
+
+The `Lean_RV64D` dependency is the **trust anchor** for our RISC-V semantics:
+hand-written specs in [`EvmAsm/Rv64/Instructions.lean`](EvmAsm/Rv64/Instructions.lean)
+are tied to the Sail-generated decoder/executor via abstraction-relation
+proofs in [`EvmAsm/Rv64/SailEquiv/`](EvmAsm/Rv64/SailEquiv/) (`StateRel.lean`
+plus per-instruction-class `*Proofs.lean`). This is how we discharge the
+"is your hand-written instruction semantics actually RISC-V?" obligation
+against the official Sail model.
+
+Tracking issues: [#84](https://github.com/Verified-zkEVM/evm-asm/issues/84)
+(import sail-riscv-lean as Lake dep — landed),
+[#93](https://github.com/Verified-zkEVM/evm-asm/issues/93) (map hand-written
+`Instr` to SAIL-generated AST).
+
 ### Weekly build benchmark
 
 A scheduled GitHub Actions workflow,


### PR DESCRIPTION
Adds a **Dependencies** subsection under `## Building` in README.md covering both Mathlib and the `Lean_RV64D` Sail dependency.

What it adds:
- One bullet per top-level Lake dependency (Mathlib4, Lean_RV64D fork) with link + role.
- Why the `dhsorens/sail-riscv-lean` fork rather than upstream (toolchain alignment, `rev = "main"` pin tracked via `lake-manifest.json`).
- The trust-anchor framing: `EvmAsm/Rv64/SailEquiv/` ties our hand-written `Rv64/Instructions.lean` to the Sail-generated decoder/executor.
- Tracking issues: #84 (this slice), #93 (Instr ↔ SAIL AST mapping).

Pure docs change — no Lean source touched, `lake build` unaffected.

Closes the doc half of #84 slice 4 (beads `evm-asm-ca57`). The acceptance close-out comment on GH #84 is intentionally left for human review (worker role boundary: no `gh issue close`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).