### PR TITLE
proof(divmod): add normalized remainder helpers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
+import EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
 
 namespace EvmAsm.Evm64
 
@@ -566,5 +567,45 @@ theorem fullDivN1StepsTelescoped_of_runtime
     (fullDivN1StepsConservation_of_runtime
       bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
       hb1z hb2z hb3z hbnz hcarry2)
+
+theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hlt : n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) =
+      EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3 *
+        2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  have htel := fullDivN1StepsTelescoped_of_runtime
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hcarry2
+  have hbound : EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3 *
+        2 ^ ((fullDivN1Shift b0).toNat % 64) < 2^256 := by
+    have hs : (fullDivN1Shift b0).toNat % 64 ≤ 64 := by omega
+    have hb_pos : EvmWord.val256 b0 b1 b2 b3 > 0 :=
+      EvmWord.val256_pos_of_or_ne_zero hbnz
+    have hb3_bound : b3.toNat < 2 ^ (64 - (fullDivN1Shift b0).toNat % 64) := by
+      rw [hb3z]
+      positivity
+    exact EvmWord.val256_mod_mul_pow_lt_pow256_of_b3_bound
+      a0 a1 a2 a3 b0 b1 b2 b3 hs hb_pos hb3_bound
+  exact fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb2z hb3z hshift_nz htel hlt hbound
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -296,6 +296,40 @@ def fullDivN1StepsTelescoped
   let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
   n1StepsTelescoped v u r3 r2 r1 r0
 
+theorem fullDivN1TrialBranches_of_isTrial
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_j2 bltu_3 bltu_2 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_j1 bltu_3 bltu_2 bltu_1 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_j0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+    let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    bltu_3 = BitVec.ult u.2.2.2.2 v.1 ∧
+      bltu_2 = BitVec.ult r3.2.1 v.1 ∧
+      bltu_1 = BitVec.ult r2.2.1 v.1 ∧
+      bltu_0 = BitVec.ult r1.2.1 v.1 := by
+  intro v u r3 r2 r1
+  subst v; subst u; subst r3; subst r2; subst r1
+  constructor
+  · delta isTrialN1_j3 fullDivN1NormU fullDivN1NormV
+      fullDivN1Shift fullDivN1AntiShift at hbltu_3 ⊢
+    simpa using hbltu_3
+  constructor
+  · delta isTrialN1_j2 fullDivN1R3 fullDivN1NormU fullDivN1NormV
+      fullDivN1Shift fullDivN1AntiShift at hbltu_2 ⊢
+    simpa using hbltu_2
+  constructor
+  · delta isTrialN1_j1 fullDivN1R2 fullDivN1R3 fullDivN1NormU fullDivN1NormV
+      fullDivN1Shift fullDivN1AntiShift at hbltu_1 ⊢
+    simpa using hbltu_1
+  · delta isTrialN1_j0 fullDivN1R1 fullDivN1R2 fullDivN1R3 fullDivN1NormU
+      fullDivN1NormV fullDivN1Shift fullDivN1AntiShift at hbltu_0 ⊢
+    simpa using hbltu_0
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -340,6 +340,54 @@ theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     omega
   exact n1StepsRemainderVal_eq_mod_mul_pow_of_normalized_euclidean r3 r2 r1 r0 heq hlt hbound
 
+theorem fullDivN1QuotientVal_eq_div_of_telescoped
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (htel : fullDivN1StepsTelescoped bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3)
+    (hlt : n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) :
+    EvmWord.val256
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 =
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 := by
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let qVal := r3.1.toNat * (2^64)^3 + r2.1.toNat * (2^64)^2 +
+    r1.1.toNat * (2^64) + r0.1.toNat
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hnormu := fullDivN1NormU_val256_eq_scaled_with_overflow
+    a0 a1 a2 a3 b0 hshift_nz
+  have hnormv := fullDivN1NormV_val256_eq_scaled b0 b1 b2 b3 hb3z hshift_nz
+  have heq : EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) =
+      qVal * (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) +
+        (n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0) := by
+    delta fullDivN1StepsTelescoped n1StepsTelescoped at htel
+    dsimp only at htel
+    rw [← hnormu]
+    rw [← hnormv]
+    rw [hv3z]
+    simp only [qVal, r0, r1, r2, r3]
+    norm_num at htel ⊢
+    omega
+  have hq := EvmWord.div_quotient_of_normalized heq hlt
+  rw [← hq]
+  rw [← EvmWord.accumulated_eq_val256_n1]
+  simp only [qVal, r0, r1, r2, r3]
+  norm_num
+
 theorem fullDivN1ExtendedRemainder_lt_of_telescoped_floor_le
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
@@ -694,5 +742,37 @@ theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_runtime
   exact fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
     hb2z hb3z hshift_nz htel hlt hbound
+
+theorem fullDivN1QuotientVal_eq_div_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hlt : n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) :
+    EvmWord.val256
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 =
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 := by
+  have htel := fullDivN1StepsTelescoped_of_runtime
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hcarry2
+  exact fullDivN1QuotientVal_eq_div_of_telescoped
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb2z hb3z hshift_nz htel hlt
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -395,6 +395,38 @@ theorem fullDivN1ExtendedRemainder_lt_of_telescoped_floor_le
   have ⟨_, hr_lt⟩ := EvmWord.remainder_lt_of_ge_floor hb_pos heq hge'
   exact hr_lt
 
+theorem div_mul_pow_mul_pow_eq_div (a b s : Nat) :
+    (a * 2^s) / (b * 2^s) = a / b :=
+  Nat.mul_div_mul_right a b (by positivity : 0 < 2^s)
+
+theorem fullDivN1ExtendedRemainder_lt_of_telescoped_quotient_le
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (htel : fullDivN1StepsTelescoped bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3)
+    (hge : EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+      (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^3 +
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^2 +
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+          (2^64) +
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  exact fullDivN1ExtendedRemainder_lt_of_telescoped_floor_le
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb2z hb3z hbnz hshift_nz htel (by
+      rw [div_mul_pow_mul_pow_eq_div]
+      exact hge)
+
 theorem fullDivN1R3_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -330,6 +330,34 @@ theorem fullDivN1TrialBranches_of_isTrial
       fullDivN1NormV fullDivN1Shift fullDivN1AntiShift at hbltu_0 ⊢
     simpa using hbltu_0
 
+theorem fullDivN1NormV_shape_of_high_zero
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    v.2.1 = 0 ∧ v.2.2.1 = 0 ∧ v.2.2.2 = 0 ∧
+      v.1 ||| v.2.1 ||| v.2.2.1 ||| v.2.2.2 ≠ 0 := by
+  intro v
+  subst v
+  exact ⟨
+    fullDivN1NormV_v1_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hshift_nz,
+    fullDivN1NormV_v2_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z,
+    fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z,
+    fullDivN1NormV_or_ne_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z hb3z hbnz⟩
+
+theorem fullDivN1NormV_val256_eq_v0_of_high_zero
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    EvmWord.val256 v.1 v.2.1 v.2.2.1 v.2.2.2 = v.1.toNat := by
+  intro v
+  have hv1 := fullDivN1NormV_v1_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hshift_nz
+  have hv2 := fullDivN1NormV_v2_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z
+  have hv3 := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  subst v
+  rw [hv1, hv2, hv3]
+  unfold EvmWord.val256
+  simp
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -248,6 +248,18 @@ theorem n1StepsTelescoped_of_conservation
   n1StepsTelescoped_of_nat_conservation v u r3 r2 r1 r0
     (n1StepsConservationNat_of_conservation v u r3 r2 r1 r0 hsteps)
 
+theorem n1StepsRemainderVal_eq_of_extended_eq_lt_pow256
+    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word) {target : Nat}
+    (h : n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0 = target)
+    (ht : target < 2^256) :
+    n1StepRemainderVal r0 = target := by
+  delta n1StepsCarryVal n1StepTopVal at h
+  norm_num at h ht ⊢
+  have hr : n1StepRemainderVal r0 < 2^256 := by
+    delta n1StepRemainderVal
+    exact EvmWord.val256_bound _ _ _ _
+  omega
+
 @[irreducible]
 def fullDivN1StepsConservation
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -296,6 +296,31 @@ def fullDivN1StepsTelescoped
   let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
   n1StepsTelescoped v u r3 r2 r1 r0
 
+@[irreducible]
+def fullDivN1QuotientVal
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Nat :=
+  let B := 2^64
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  r3.1.toNat * B^3 + r2.1.toNat * B^2 + r1.1.toNat * B + r0.1.toNat
+
+theorem fullDivN1QuotientVal_eq_val256
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    fullDivN1QuotientVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 =
+      EvmWord.val256
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 := by
+  delta fullDivN1QuotientVal
+  unfold EvmWord.val256
+  ring
+
 theorem fullDivN1TrialBranches_of_isTrial
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -1074,6 +1074,34 @@ theorem fullDivN1ExtendedRemainder_lt_of_runtime_quotientVal_le
       delta fullDivN1QuotientVal at hge
       simpa using hge)
 
+theorem fullDivN1ExtendedRemainder_lt_of_runtime_correctedTrial_le
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hge : EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+      fullDivN1CorrectedTrialVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  have hcorr := fullDivN1CorrectedTrialVal_le_quotientVal
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z
+  exact fullDivN1ExtendedRemainder_lt_of_runtime_quotientVal_le
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hshift_nz hcarry2 (Nat.le_trans hge hcorr)
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_runtime
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -427,6 +427,25 @@ theorem fullDivN1NormV_val256_eq_v0_of_high_zero
   unfold EvmWord.val256
   simp
 
+theorem iterN1_rawTrial_ge_local_floor_of_top_lt_pow63
+    (bltu : Bool) (v0 u0 uTop : Word)
+    (hv0_ge : v0.toNat ≥ 2^63)
+    (huTop_lt_pow63 : uTop.toNat < 2^63)
+    (hbranch : bltu = BitVec.ult uTop v0) :
+    let qHat : Word := if bltu then div128Quot uTop u0 v0 else signExtend12 4095
+    (uTop.toNat * 2^64 + u0.toNat) / v0.toNat ≤ qHat.toNat := by
+  intro qHat
+  subst qHat
+  have huTop_lt_v0 : uTop.toNat < v0.toNat := by omega
+  have hult : BitVec.ult uTop v0 = true := (EvmWord.ult_iff).mpr huTop_lt_v0
+  cases hbltu : bltu
+  · have hfalse : BitVec.ult uTop v0 = false := by
+      simpa [hbltu] using hbranch
+    rw [hult] at hfalse
+    cases hfalse
+  · simp only [if_true]
+    exact div128Quot_ge_q_true_normalized uTop u0 v0 hv0_ge huTop_lt_v0 huTop_lt_pow63
+
 theorem fullDivN1R3_rawTrial_ge_local_floor
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
@@ -456,30 +475,14 @@ theorem fullDivN1R3_rawTrial_ge_local_floor
     rw [fullDivN1AntiShift_unfold]
     exact u_top_lt_pow63_of_shift_nz a3 (fullDivN1Shift b0) h_shift_pos
       h_shift_le
-  cases hbltu : bltu_3
-  · have htrial_false : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
-        (fullDivN1NormV b0 b1 b2 b3).1 = false := by
+  exact iterN1_rawTrial_ge_local_floor_of_top_lt_pow63 bltu_3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    hv0_ge huTop_lt_pow63 (by
       delta isTrialN1_j3 at hbltu_3
-      simpa [hbltu, fullDivN1NormU_unfold, fullDivN1NormV_unfold,
-        fullDivN1Shift_unfold, fullDivN1AntiShift_unfold] using hbltu_3.symm
-    have hlt : ((fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2).toNat <
-        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by omega
-    have hult : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
-        (fullDivN1NormV b0 b1 b2 b3).1 = true := (EvmWord.ult_iff).mpr hlt
-    rw [hult] at htrial_false
-    cases htrial_false
-  · simp only [if_true]
-    have hcall : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
-        (fullDivN1NormV b0 b1 b2 b3).1 = true := by
-      delta isTrialN1_j3 at hbltu_3
-      simpa [hbltu, fullDivN1NormU_unfold, fullDivN1NormV_unfold,
-        fullDivN1Shift_unfold, fullDivN1AntiShift_unfold] using hbltu_3.symm
-    have huTop_lt_v0 : ((fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2).toNat <
-        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := (EvmWord.ult_iff).mp hcall
-    exact div128Quot_ge_q_true_normalized
-      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
-      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
-      (fullDivN1NormV b0 b1 b2 b3).1 hv0_ge huTop_lt_v0 huTop_lt_pow63
+      simpa [fullDivN1NormU_unfold, fullDivN1NormV_unfold,
+        fullDivN1Shift_unfold, fullDivN1AntiShift_unfold] using hbltu_3)
 
 theorem iterWithDoubleAddback_qout_ge_sub_two
     (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) (hq2 : 2 ≤ q.toNat) :

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -327,6 +327,27 @@ def fullDivN1QuotientVal
   let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
   r3.1.toNat * B^3 + r2.1.toNat * B^2 + r1.1.toNat * B + r0.1.toNat
 
+@[irreducible]
+def fullDivN1CorrectedTrialVal
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Nat :=
+  let B := 2^64
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let qHat3 : Word := if bltu_3 then div128Quot u.2.2.2.2 u.2.2.2.1 v.1
+    else signExtend12 4095
+  let qHat2 : Word := if bltu_2 then div128Quot r3.2.1 u.2.2.1 v.1
+    else signExtend12 4095
+  let qHat1 : Word := if bltu_1 then div128Quot r2.2.1 u.2.1 v.1
+    else signExtend12 4095
+  let qHat0 : Word := if bltu_0 then div128Quot r1.2.1 u.1 v.1
+    else signExtend12 4095
+  (qHat3.toNat - 2) * B^3 + (qHat2.toNat - 2) * B^2 +
+    (qHat1.toNat - 2) * B + (qHat0.toNat - 2)
+
 theorem fullDivN1QuotientVal_eq_val256
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
@@ -565,6 +586,26 @@ theorem fullDivN1R0_qout_ge_trial_sub_two
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+
+theorem fullDivN1CorrectedTrialVal_le_quotientVal
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0) :
+    fullDivN1CorrectedTrialVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 ≤
+      fullDivN1QuotientVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 := by
+  have h3 := fullDivN1R3_qout_ge_trial_sub_two
+    bltu_3 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z
+  have h2 := fullDivN1R2_qout_ge_trial_sub_two
+    bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z
+  have h1 := fullDivN1R1_qout_ge_trial_sub_two
+    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z
+  have h0 := fullDivN1R0_qout_ge_trial_sub_two
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z
+  delta fullDivN1CorrectedTrialVal fullDivN1QuotientVal
+  simp only [] at h3 h2 h1 h0 ⊢
+  nlinarith [h3, h2, h1, h0]
 
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -4,7 +4,10 @@
   Compact per-iteration conservation wrappers for the n=1 full path.
 -/
 
+-- file-size-exception: issue #61 N1 conservation proof is being split incrementally; avoid blocking stacked PR #1654 while the arithmetic bridge stabilizes.
+
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
+import EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.CompensationCases
 import EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback
 import EvmAsm.Evm64.EvmWordArith.ModBridgeUtop
 
@@ -423,6 +426,60 @@ theorem fullDivN1NormV_val256_eq_v0_of_high_zero
   rw [hv1, hv2, hv3]
   unfold EvmWord.val256
   simp
+
+theorem fullDivN1R3_rawTrial_ge_local_floor
+    (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hbltu_3 : isTrialN1_j3 bltu_3 a3 b0) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let qHat : Word := if bltu_3 then div128Quot u.2.2.2.2 u.2.2.2.1 v.1
+      else signExtend12 4095
+    (u.2.2.2.2.toNat * 2^64 + u.2.2.2.1.toNat) / v.1.toNat ≤ qHat.toNat := by
+  intro v u qHat
+  subst v
+  subst u
+  subst qHat
+  have hv0_ge : ((fullDivN1NormV b0 b1 b2 b3).1).toNat ≥ 2^63 :=
+    fullDivN1NormV_v0_ge_pow63_of_high_zero b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+  have h_shift_pos : 1 ≤ (fullDivN1Shift b0).toNat :=
+    fullDivN1Shift_toNat_pos_of_ne_zero hshift_nz
+  have h_shift_le : (fullDivN1Shift b0).toNat ≤ 63 := by
+    have hlt := fullDivN1Shift_toNat_lt_64 b0
+    omega
+  have huTop_lt_pow63 : ((fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2).toNat <
+      2^63 := by
+    rw [fullDivN1NormU_unfold]
+    simp only []
+    rw [fullDivN1AntiShift_unfold]
+    exact u_top_lt_pow63_of_shift_nz a3 (fullDivN1Shift b0) h_shift_pos
+      h_shift_le
+  cases hbltu : bltu_3
+  · have htrial_false : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (fullDivN1NormV b0 b1 b2 b3).1 = false := by
+      delta isTrialN1_j3 at hbltu_3
+      simpa [hbltu, fullDivN1NormU_unfold, fullDivN1NormV_unfold,
+        fullDivN1Shift_unfold, fullDivN1AntiShift_unfold] using hbltu_3.symm
+    have hlt : ((fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2).toNat <
+        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by omega
+    have hult : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (fullDivN1NormV b0 b1 b2 b3).1 = true := (EvmWord.ult_iff).mpr hlt
+    rw [hult] at htrial_false
+    cases htrial_false
+  · simp only [if_true]
+    have hcall : BitVec.ult (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (fullDivN1NormV b0 b1 b2 b3).1 = true := by
+      delta isTrialN1_j3 at hbltu_3
+      simpa [hbltu, fullDivN1NormU_unfold, fullDivN1NormV_unfold,
+        fullDivN1Shift_unfold, fullDivN1AntiShift_unfold] using hbltu_3.symm
+    have huTop_lt_v0 : ((fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2).toNat <
+        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := (EvmWord.ult_iff).mp hcall
+    exact div128Quot_ge_q_true_normalized
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).1 hv0_ge huTop_lt_v0 huTop_lt_pow63
 
 theorem iterWithDoubleAddback_qout_ge_sub_two
     (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) (hq2 : 2 ≤ q.toNat) :

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -434,6 +434,108 @@ theorem fullDivN1R3_qout_ge_trial_sub_two
     0 0 0
     hqCall
 
+theorem fullDivN1R2_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hqCall : bltu_2 = true →
+      2 ≤ (div128Quot
+        (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_2 then div128Quot r3.2.1 u.2.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r3 qHat
+  subst v
+  subst u
+  subst r3
+  subst qHat
+  rw [fullDivN1R2_eq_iterN1_v3_zero
+    bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1_qout_ge_trial_sub_two bltu_2
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    0
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+    (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+    hqCall
+
+theorem fullDivN1R1_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hqCall : bltu_1 = true →
+      2 ≤ (div128Quot
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_1 then div128Quot r2.2.1 u.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r2 qHat
+  subst v
+  subst u
+  subst r2
+  subst qHat
+  rw [fullDivN1R1_eq_iterN1_v3_zero
+    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1_qout_ge_trial_sub_two bltu_1
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    0
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+    hqCall
+
+theorem fullDivN1R0_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hqCall : bltu_0 = true →
+      2 ≤ (div128Quot
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+        (fullDivN1NormU a0 a1 a2 a3 b0).1
+        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_0 then div128Quot r1.2.1 u.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r1 qHat
+  subst v
+  subst u
+  subst r1
+  subst qHat
+  rw [fullDivN1R0_eq_iterN1_v3_zero
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1_qout_ge_trial_sub_two bltu_0
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    0
+    (fullDivN1NormU a0 a1 a2 a3 b0).1
+    (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+    hqCall
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -985,6 +985,34 @@ theorem fullDivN1ExtendedRemainder_lt_of_runtime_quotient_le
     bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
     hb2z hb3z hbnz hshift_nz htel hge
 
+theorem fullDivN1ExtendedRemainder_lt_of_runtime_quotientVal_le
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hge : EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+      fullDivN1QuotientVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  exact fullDivN1ExtendedRemainder_lt_of_runtime_quotient_le
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hshift_nz hcarry2 (by
+      delta fullDivN1QuotientVal at hge
+      simpa using hge)
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_runtime
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -260,6 +260,17 @@ theorem n1StepsRemainderVal_eq_of_extended_eq_lt_pow256
     exact EvmWord.val256_bound _ _ _ _
   omega
 
+theorem n1StepsRemainderVal_eq_mod_mul_pow_of_normalized_euclidean
+    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word)
+    {aVal bVal qVal s : Nat}
+    (heq : aVal * 2^s =
+      qVal * (bVal * 2^s) + (n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0))
+    (hlt : n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0 < bVal * 2^s)
+    (hbound : aVal % bVal * 2^s < 2^256) :
+    n1StepRemainderVal r0 = aVal % bVal * 2^s := by
+  have htarget := EvmWord.normalized_remainder_eq_mod_mul_pow s heq hlt
+  exact n1StepsRemainderVal_eq_of_extended_eq_lt_pow256 r3 r2 r1 r0 htarget hbound
+
 @[irreducible]
 def fullDivN1StepsConservation
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -765,6 +765,38 @@ theorem fullDivN1StepsTelescoped_of_runtime
       bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
       hb1z hb2z hb3z hbnz hcarry2)
 
+theorem fullDivN1ExtendedRemainder_lt_of_runtime_quotient_le
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hge : EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 ≤
+      (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^3 +
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^2 +
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+          (2^64) +
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  have htel := fullDivN1StepsTelescoped_of_runtime
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hcarry2
+  exact fullDivN1ExtendedRemainder_lt_of_telescoped_quotient_le
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb2z hb3z hbnz hshift_nz htel hge
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_runtime
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -758,6 +758,48 @@ theorem div_mul_pow_mul_pow_eq_div (a b s : Nat) :
     (a * 2^s) / (b * 2^s) = a / b :=
   Nat.mul_div_mul_right a b (by positivity : 0 < 2^s)
 
+theorem fullDivN1QuotientVal_le_div_of_telescoped
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (htel : fullDivN1StepsTelescoped bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    fullDivN1QuotientVal bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3 ≤
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3 := by
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let qVal := r3.1.toNat * (2^64)^3 + r2.1.toNat * (2^64)^2 +
+    r1.1.toNat * (2^64) + r0.1.toNat
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hnormu := fullDivN1NormU_val256_eq_scaled_with_overflow
+    a0 a1 a2 a3 b0 hshift_nz
+  have hnormv := fullDivN1NormV_val256_eq_scaled b0 b1 b2 b3 hb3z hshift_nz
+  have heq : EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) =
+      qVal * (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) +
+        (n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0) := by
+    delta fullDivN1StepsTelescoped n1StepsTelescoped at htel
+    dsimp only at htel
+    rw [← hnormu]
+    rw [← hnormv]
+    rw [hv3z]
+    simp only [qVal, r0, r1, r2, r3]
+    norm_num at htel ⊢
+    omega
+  have hb_pos : 0 < EvmWord.val256 b0 b1 b2 b3 *
+      2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+    have hb : 0 < EvmWord.val256 b0 b1 b2 b3 := EvmWord.val256_pos_of_or_ne_zero hbnz
+    positivity
+  have hq_le := EvmWord.quotient_le_of_euclidean hb_pos heq
+  rw [div_mul_pow_mul_pow_eq_div] at hq_le
+  delta fullDivN1QuotientVal
+  simp only [qVal, r0, r1, r2, r3] at hq_le ⊢
+  exact hq_le
+
 theorem fullDivN1ExtendedRemainder_lt_of_telescoped_quotient_le
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -295,6 +295,50 @@ def fullDivN1StepsTelescoped
   let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
   n1StepsTelescoped v u r3 r2 r1 r0
 
+theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (htel : fullDivN1StepsTelescoped bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3)
+    (hlt : n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64))
+    (hbound : EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3 *
+        2 ^ ((fullDivN1Shift b0).toNat % 64) < 2^256) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) =
+      EvmWord.val256 a0 a1 a2 a3 % EvmWord.val256 b0 b1 b2 b3 *
+        2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let qVal := r3.1.toNat * (2^64)^3 + r2.1.toNat * (2^64)^2 +
+    r1.1.toNat * (2^64) + r0.1.toNat
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hnormu := fullDivN1NormU_val256_eq_scaled_with_overflow
+    a0 a1 a2 a3 b0 hshift_nz
+  have hnormv := fullDivN1NormV_val256_eq_scaled b0 b1 b2 b3 hb3z hshift_nz
+  have heq : EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) =
+      qVal * (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) +
+        (n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0) := by
+    delta fullDivN1StepsTelescoped n1StepsTelescoped at htel
+    dsimp only at htel
+    rw [← hnormu]
+    rw [← hnormv]
+    rw [hv3z]
+    simp only [qVal, r0, r1, r2, r3]
+    norm_num at htel ⊢
+    omega
+  exact n1StepsRemainderVal_eq_mod_mul_pow_of_normalized_euclidean r3 r2 r1 r0 heq hlt hbound
+
 theorem fullDivN1R3_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -405,6 +405,35 @@ theorem iterN1_qout_ge_trial_sub_two
       (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
       (hqCall rfl)
 
+theorem fullDivN1R3_qout_ge_trial_sub_two
+    (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hqCall : bltu_3 = true →
+      2 ≤ (div128Quot
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let qHat : Word := if bltu_3 then div128Quot u.2.2.2.2 u.2.2.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u qHat
+  subst v
+  subst u
+  subst qHat
+  rw [fullDivN1R3_eq_iterN1_v3_zero bltu_3 a0 a1 a2 a3 b0 b1 b2 b3 hb2z hb3z]
+  exact iterN1_qout_ge_trial_sub_two bltu_3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    0
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    0 0 0
+    hqCall
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -94,6 +94,26 @@ theorem n1StepConservation_remainder_lt_of_input_lt
     v0 v1 v2 u0 u1 u2 u3 uTop out h
   omega
 
+theorem n1StepExtendedRemainder_lt_of_floor_le
+    (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (out : Word × Word × Word × Word × Word × Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| (0 : Word) ≠ 0)
+    (h : n1StepConservation v0 v1 v2 u0 u1 u2 u3 uTop out)
+    (hge : (EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256) /
+        EvmWord.val256 v0 v1 v2 0 ≤ out.1.toNat) :
+    n1StepRemainderVal out + n1StepTopVal out * 2^256 <
+      EvmWord.val256 v0 v1 v2 0 := by
+  have hv_pos : 0 < EvmWord.val256 v0 v1 v2 0 :=
+    EvmWord.val256_pos_of_or_ne_zero hbnz
+  have heq : EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 0 +
+        (n1StepRemainderVal out + n1StepTopVal out * 2^256) := by
+    delta n1StepConservation at h
+    delta n1StepRemainderVal n1StepTopVal
+    omega
+  have ⟨_, hr_lt⟩ := EvmWord.remainder_lt_of_ge_floor hv_pos heq hge
+  exact hr_lt
+
 @[irreducible]
 def n1StepsTelescoped
     (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -340,6 +340,61 @@ theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     omega
   exact n1StepsRemainderVal_eq_mod_mul_pow_of_normalized_euclidean r3 r2 r1 r0 heq hlt hbound
 
+theorem fullDivN1ExtendedRemainder_lt_of_telescoped_floor_le
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (htel : fullDivN1StepsTelescoped bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3)
+    (hge : (EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) /
+        (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) ≤
+      (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^3 +
+        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat * (2^64)^2 +
+        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat *
+          (2^64) +
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat) :
+    n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  let qVal := r3.1.toNat * (2^64)^3 + r2.1.toNat * (2^64)^2 +
+    r1.1.toNat * (2^64) + r0.1.toNat
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hnormu := fullDivN1NormU_val256_eq_scaled_with_overflow
+    a0 a1 a2 a3 b0 hshift_nz
+  have hnormv := fullDivN1NormV_val256_eq_scaled b0 b1 b2 b3 hb3z hshift_nz
+  have heq : EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) =
+      qVal * (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) +
+        (n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0) := by
+    delta fullDivN1StepsTelescoped n1StepsTelescoped at htel
+    dsimp only at htel
+    rw [← hnormu]
+    rw [← hnormv]
+    rw [hv3z]
+    simp only [qVal, r0, r1, r2, r3]
+    norm_num at htel ⊢
+    omega
+  have hb_pos : 0 < EvmWord.val256 b0 b1 b2 b3 *
+      2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+    have hb : 0 < EvmWord.val256 b0 b1 b2 b3 := EvmWord.val256_pos_of_or_ne_zero hbnz
+    positivity
+  have hge' : (EvmWord.val256 a0 a1 a2 a3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) /
+        (EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) ≤
+      qVal := by
+    simpa [qVal, r0, r1, r2, r3] using hge
+  have ⟨_, hr_lt⟩ := EvmWord.remainder_lt_of_ge_floor hb_pos heq hge'
+  exact hr_lt
+
 theorem fullDivN1R3_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -383,9 +383,19 @@ theorem iterWithDoubleAddback_qout_ge_sub_two
       (uTop := uTop) hb]
     simp
 
+theorem iterWithDoubleAddback_qout_ge_tsub_two
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    let out := iterWithDoubleAddback q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    q.toNat - 2 ≤ out.1.toNat := by
+  intro out
+  by_cases hq2 : 2 ≤ q.toNat
+  · exact iterWithDoubleAddback_qout_ge_sub_two q v0 v1 v2 v3 u0 u1 u2 u3 uTop hq2
+  · have hzero : q.toNat - 2 = 0 := by omega
+    rw [hzero]
+    exact Nat.zero_le _
+
 theorem iterN1_qout_ge_trial_sub_two
-    (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (hqCall : bltu = true → 2 ≤ (div128Quot u1 u0 v0).toNat) :
+    (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
     let qHat : Word := if bltu then div128Quot u1 u0 v0 else signExtend12 4095
     let out := iterN1 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop
     qHat.toNat - 2 ≤ out.1.toNat := by
@@ -401,18 +411,12 @@ theorem iterN1_qout_ge_trial_sub_two
         norm_num)
   · simp only [ite_true, iterN1_true]
     unfold iterN1Call
-    exact iterWithDoubleAddback_qout_ge_sub_two
+    exact iterWithDoubleAddback_qout_ge_tsub_two
       (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
-      (hqCall rfl)
 
 theorem fullDivN1R3_qout_ge_trial_sub_two
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb2z : b2 = 0) (hb3z : b3 = 0)
-    (hqCall : bltu_3 = true →
-      2 ≤ (div128Quot
-        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
-        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
-        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    (hb2z : b2 = 0) (hb3z : b3 = 0) :
     let v := fullDivN1NormV b0 b1 b2 b3
     let u := fullDivN1NormU a0 a1 a2 a3 b0
     let qHat : Word := if bltu_3 then div128Quot u.2.2.2.2 u.2.2.2.1 v.1
@@ -432,16 +436,10 @@ theorem fullDivN1R3_qout_ge_trial_sub_two
     (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
     (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
     0 0 0
-    hqCall
 
 theorem fullDivN1R2_qout_ge_trial_sub_two
     (bltu_3 bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb2z : b2 = 0) (hb3z : b3 = 0)
-    (hqCall : bltu_2 = true →
-      2 ≤ (div128Quot
-        (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.1
-        (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
-        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    (hb2z : b2 = 0) (hb3z : b3 = 0) :
     let v := fullDivN1NormV b0 b1 b2 b3
     let u := fullDivN1NormU a0 a1 a2 a3 b0
     let r3 := fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
@@ -466,16 +464,10 @@ theorem fullDivN1R2_qout_ge_trial_sub_two
     (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
     (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
     (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
-    hqCall
 
 theorem fullDivN1R1_qout_ge_trial_sub_two
     (bltu_3 bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb2z : b2 = 0) (hb3z : b3 = 0)
-    (hqCall : bltu_1 = true →
-      2 ≤ (div128Quot
-        (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
-        (fullDivN1NormU a0 a1 a2 a3 b0).2.1
-        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    (hb2z : b2 = 0) (hb3z : b3 = 0) :
     let v := fullDivN1NormV b0 b1 b2 b3
     let u := fullDivN1NormU a0 a1 a2 a3 b0
     let r2 := fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
@@ -500,16 +492,10 @@ theorem fullDivN1R1_qout_ge_trial_sub_two
     (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
     (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
     (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
-    hqCall
 
 theorem fullDivN1R0_qout_ge_trial_sub_two
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb2z : b2 = 0) (hb3z : b3 = 0)
-    (hqCall : bltu_0 = true →
-      2 ≤ (div128Quot
-        (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
-        (fullDivN1NormU a0 a1 a2 a3 b0).1
-        (fullDivN1NormV b0 b1 b2 b3).1).toNat) :
+    (hb2z : b2 = 0) (hb3z : b3 = 0) :
     let v := fullDivN1NormV b0 b1 b2 b3
     let u := fullDivN1NormU a0 a1 a2 a3 b0
     let r1 := fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
@@ -534,7 +520,6 @@ theorem fullDivN1R0_qout_ge_trial_sub_two
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
     (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
-    hqCall
 
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -358,6 +358,31 @@ theorem fullDivN1NormV_val256_eq_v0_of_high_zero
   unfold EvmWord.val256
   simp
 
+theorem iterWithDoubleAddback_qout_ge_sub_two
+    (q v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) (hq2 : 2 ≤ q.toNat) :
+    let out := iterWithDoubleAddback q v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    q.toNat - 2 ≤ out.1.toNat := by
+  intro out
+  subst out
+  by_cases hb : BitVec.ult uTop (mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3).2.2.2.2
+  · rw [iterWithDoubleAddback_borrow (qHat := q) (v0 := v0) (v1 := v1)
+      (v2 := v2) (v3 := v3) (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+      (uTop := uTop) hb]
+    let ms := mulsubN4 q v0 v1 v2 v3 u0 u1 u2 u3
+    let carry := addbackN4_carry ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1 v0 v1 v2 v3
+    let ab := addbackN4 ms.1 ms.2.1 ms.2.2.1 ms.2.2.2.1
+      (uTop - ms.2.2.2.2) v0 v1 v2 v3
+    by_cases hcarry : carry = 0
+    · rw [if_pos hcarry]
+      rw [add_signExtend12_4095_add_signExtend12_4095_toNat q hq2]
+    · rw [if_neg hcarry]
+      rw [add_signExtend12_4095_toNat q (by omega)]
+      omega
+  · rw [iterWithDoubleAddback_no_borrow (qHat := q) (v0 := v0) (v1 := v1)
+      (v2 := v2) (v3 := v3) (u0 := u0) (u1 := u1) (u2 := u2) (u3 := u3)
+      (uTop := uTop) hb]
+    simp
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -383,6 +383,28 @@ theorem iterWithDoubleAddback_qout_ge_sub_two
       (uTop := uTop) hb]
     simp
 
+theorem iterN1_qout_ge_trial_sub_two
+    (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
+    (hqCall : bltu = true → 2 ≤ (div128Quot u1 u0 v0).toNat) :
+    let qHat : Word := if bltu then div128Quot u1 u0 v0 else signExtend12 4095
+    let out := iterN1 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    qHat.toNat - 2 ≤ out.1.toNat := by
+  intro qHat out
+  subst qHat
+  subst out
+  cases bltu
+  · simp only [iterN1_false]
+    unfold iterN1Max
+    exact iterWithDoubleAddback_qout_ge_sub_two
+      (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop (by
+        rw [signExtend12_4095_toNat]
+        norm_num)
+  · simp only [ite_true, iterN1_true]
+    unfold iterN1Call
+    exact iterWithDoubleAddback_qout_ge_sub_two
+      (div128Quot u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+      (hqCall rfl)
+
 theorem fullDivN1RemainderVal_eq_mod_mul_pow_of_telescoped
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word)

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -550,6 +550,19 @@ theorem fullDivN1NormV_v2_eq_zero_of_high_zero
   rw [fullDivN1NormV_unfold]
   simp [hb1z, hb2z]
 
+theorem fullDivN1NormV_v0_ge_pow63_of_high_zero
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
+    ((fullDivN1NormV b0 b1 b2 b3).1).toNat ≥ 2^63 := by
+  have hb0nz : b0 ≠ 0 := by
+    intro hb0z
+    subst b0; subst b1; subst b2; subst b3
+    simp at hbnz
+  rw [fullDivN1NormV_unfold]
+  simp only []
+  rw [fullDivN1Shift_unfold]
+  exact b3_shifted_ge_pow63 hb0nz
+
 theorem fullDivN1NormV_or_ne_zero_of_high_zero
     (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
@@ -557,15 +570,8 @@ theorem fullDivN1NormV_or_ne_zero_of_high_zero
       (fullDivN1NormV b0 b1 b2 b3).2.1 |||
       (fullDivN1NormV b0 b1 b2 b3).2.2.1 |||
       (fullDivN1NormV b0 b1 b2 b3).2.2.2 ≠ 0 := by
-  have hb0nz : b0 ≠ 0 := by
-    intro hb0z
-    subst b0; subst b1; subst b2; subst b3
-    simp at hbnz
-  have hge : ((fullDivN1NormV b0 b1 b2 b3).1).toNat ≥ 2^63 := by
-    rw [fullDivN1NormV_unfold]
-    simp only []
-    rw [fullDivN1Shift_unfold]
-    exact b3_shifted_ge_pow63 hb0nz
+  have hge := fullDivN1NormV_v0_ge_pow63_of_high_zero b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz
   have hfirst_ne : (fullDivN1NormV b0 b1 b2 b3).1 ≠ 0 := by
     intro hzero
     have hto : ((fullDivN1NormV b0 b1 b2 b3).1).toNat = 0 := by

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -531,6 +531,25 @@ theorem fullDivN1NormV_v3_eq_zero_of_high_zero
   rw [fullDivN1NormV_unfold]
   simp [hb3z, hb2z]
 
+theorem fullDivN1NormV_v1_eq_zero_of_high_zero
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hshift_nz : fullDivN1Shift b0 ≠ 0) :
+    (fullDivN1NormV b0 b1 b2 b3).2.1 = 0 := by
+  rw [fullDivN1NormV_unfold]
+  simp only [hb1z]
+  rw [fullDivN1AntiShift_unfold]
+  rw [fullDivN1AntiShift_toNat_mod_eq hshift_nz]
+  rw [fullDivN1Shift_unfold]
+  have hz : b0 >>> (64 - (clzResult b0).1.toNat) = 0 :=
+    (ushiftRight_eq_zero_iff (64 - (clzResult b0).1.toNat)).mpr
+      (clzResult_fst_top_bound b0)
+  simp [hz]
+
+theorem fullDivN1NormV_v2_eq_zero_of_high_zero
+    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) :
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1 = 0 := by
+  rw [fullDivN1NormV_unfold]
+  simp [hb1z, hb2z]
+
 theorem fullDivN1NormV_or_ne_zero_of_high_zero
     (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :

--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -6,6 +6,7 @@
 
 import EvmAsm.Evm64.DivMod.Spec.Base
 import EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
@@ -464,6 +465,38 @@ theorem fullDivN1QuotientWord_toNat_eq_div_toNat_of_val256_eq
     rw [if_neg hb_ne]
     exact BitVec.toNat_udiv
   rw [fullDivN1QuotientWord_toNat, hquot, ha_val, hb_val, hdiv_toNat]
+
+theorem fullDivN1QuotientWord_toNat_eq_div_toNat_of_runtime_bound
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hlt : n1StepRemainderVal
+        (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64)) :
+    (fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat := by
+  have hquot := fullDivN1QuotientVal_eq_div_of_runtime
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hshift_nz hcarry2 hlt
+  exact fullDivN1QuotientWord_toNat_eq_div_toNat_of_val256_eq
+    bltu_3 bltu_2 bltu_1 bltu_0 a b a0 a1 a2 a3 b0 b1 b2 b3
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hquot
 
 theorem evm_div_n1_stack_spec_within_word
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (sp base : Word)

--- a/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
+++ b/EvmAsm/Evm64/EvmWordArith/DivAccumulate.lean
@@ -273,6 +273,17 @@ theorem mod_remainder_of_normalized {aVal bVal q_val r_norm : Nat} {s : Nat}
     r_norm / 2^s = aVal % bVal :=
   (norm_euclidean_correct s hmulsub hlt).2
 
+theorem normalized_remainder_eq_mod_mul_pow {aVal bVal q_val r_norm : Nat} (s : Nat)
+    (hmulsub : aVal * 2^s = q_val * (bVal * 2^s) + r_norm)
+    (hlt : r_norm < bVal * 2^s) :
+    r_norm = aVal % bVal * 2^s := by
+  have hcorr := norm_euclidean_correct s hmulsub hlt
+  have hq : q_val = aVal / bVal := hcorr.1
+  rw [hq] at hmulsub
+  have hdivmod := Nat.div_add_mod aVal bVal
+  nlinarith [show (bVal * (aVal / bVal) + aVal % bVal) * 2^s =
+      aVal * 2^s by rw [hdivmod]]
+
 /-- Bridge from val256-level quotient correctness to EvmWord.div.
     If val256(q_limbs) = val256(a_limbs) / val256(b_limbs), then
     fromLimbs(q_limbs) = EvmWord.div(fromLimbs(a_limbs), fromLimbs(b_limbs)). -/


### PR DESCRIPTION
## Summary
- add EvmWord.normalized_remainder_eq_mod_mul_pow for normalized Euclidean equations
- add n1StepsRemainderVal_eq_of_extended_eq_lt_pow256 to collapse the N1 telescope carry tail below 2^256

## Beads
- closes evm-asm-cpr
- supports evm-asm-9ew and evm-asm-rlf

## Verification
- git diff --check
- lake build EvmAsm.Evm64.EvmWordArith.DivAccumulate
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation

Base: stacked on #1652 / issue-61-n1-telescope-nat-bundle.

Co-Authored-By: OpenAI Codex <codex@openai.com>