### PR TITLE
chore(shake): drop unused DivCorrect import in Spec/N2RemainderWord (#1045)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2RemainderWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2RemainderWord.lean
@@ -28,7 +28,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
-import EvmAsm.Evm64.EvmWordArith.DivCorrect
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
`lake exe shake EvmAsm` flags `EvmAsm.Evm64.EvmWordArith.DivCorrect` as unused in `EvmAsm/Evm64/DivMod/Spec/N2RemainderWord.lean`. Verified real — the file contains no references to `DivCorrect`, `div_correct`, or `mod_correct`, so this is not a tactic-registry / instance false-positive. `lake build` green locally after the drop.

Refs beads evm-asm-0txh (sub-slice of evm-asm-9tq / GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).