### PR TITLE
chore(divmod): name trialJalOff sub-block offset (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -76,6 +76,14 @@ abbrev trialCallOff : Word :=  500
     Sub-offset relative to the loopBody block (= trialCallOff + 4
     = loopBodyOff + 56, i.e. 14 instructions into the loop body). -/
 abbrev trialMaxOff : Word :=  504
+/-- Offset of the trial-divide JAL-to-`divK_div128` call site inside `divK_loopBody`.
+    Entry PC of the BLTU-taken target / JAL instruction that calls into the
+    `divK_div128` long-division subroutine to compute the trial quotient.
+    Sub-offset relative to the loopBody block (= trialCallOff + 12
+    = trialMaxOff + 8 = loopBodyOff + 64, i.e. 16 instructions into the loop
+    body — past the trial-divide entry, immediately before the div128
+    call-return PC `divCallRetOff = loopBodyOff + 68`). -/
+abbrev trialJalOff : Word :=  512
 /-- Offset of the `divK_mulsub_correction` sub-block inside `divK_loopBody`.
     Entry PC of the mulsub-correction snippet that computes
     `u[j..j+n] := u[j..j+n] − q̂ · v` (the trial-quotient subtract step in
@@ -267,6 +275,13 @@ example : trialCallOff = loopBodyOff + 52 := by decide
     instruction past `trialCallOff`. -/
 example : trialMaxOff = trialCallOff + 4 := by decide
 example : trialMaxOff = loopBodyOff + 56 := by decide
+/-- trialJalOff = trialCallOff + 12 (= loopBodyOff + 64, sub-block offset within
+    `divK_loopBody`). The JAL-to-`divK_div128` call site sits 16 instructions
+    into the loop body, immediately before the div128 call-return PC
+    `divCallRetOff = loopBodyOff + 68`. -/
+example : trialJalOff = trialCallOff + 12 := by decide
+example : trialJalOff = loopBodyOff + 64 := by decide
+example : trialJalOff + 4 = div128CallRetOff := by decide
 /-- mulsubOff = loopBodyOff + 88 (sub-block offset within `divK_loopBody`).
     The `divK_mulsub_correction` snippet starts 22 instructions into the loop
     body, after the trial-divide entry (~13 instructions) and the div128 call

--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1147,7 +1147,7 @@ theorem divK_save_trial_load_spec_within
     (fun h hq => by xperm_hyp hq)
     SJfTLe
 
-theorem lb_bltu_taken {base : Word} : (base + trialCallOff : Word) + signExtend13 (12 : BitVec 13) = base + 512 := by
+theorem lb_bltu_taken {base : Word} : (base + trialCallOff : Word) + signExtend13 (12 : BitVec 13) = base + trialJalOff := by
   rv64_addr
 theorem lb_bltu_ntaken {base : Word} : (base + trialCallOff : Word) + 4 = base + trialMaxOff := by bv_addr
 

--- a/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean
@@ -34,9 +34,9 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
-private theorem lb_jal_target {base : Word} : (base + 512 : Word) + signExtend21 (560 : BitVec 21) = base + div128Off := by
+private theorem lb_jal_target {base : Word} : (base + trialJalOff : Word) + signExtend21 (560 : BitVec 21) = base + div128Off := by
   rv64_addr
-private theorem lb_jal_ret {base : Word} : (base + 512 : Word) + 4 = base + div128CallRetOff := by bv_addr
+private theorem lb_jal_ret {base : Word} : (base + trialJalOff : Word) + 4 = base + div128CallRetOff := by bv_addr
 
 /-- Trial call path: JAL x2 560 (instr [16]) + div128 subroutine.
     Entry: base+512, Exit: base+516, CodeReq: sharedDivModCode base.
@@ -46,7 +46,7 @@ theorem divK_trial_call_path_spec_within
     (v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
-    cpsTripleWithin 52 (base + 512) (base + div128CallRetOff) (sharedDivModCode base)
+    cpsTripleWithin 52 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
@@ -91,7 +91,7 @@ theorem divK_trial_call_path_spec_within
   let x1Exit := if rhat2cHi = 0 then rhat2Un0 else rhat2cHi
   let q := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
   -- 1. JAL x2 560 at base+512: x2 ← base+516, PC → base+1072
-  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + 512) (by nofun)
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
   have Je := cpsTripleWithin_extend_code (hmono :=
     lb_sub 16 _ _ (by decide) (by bv_addr) (by decide)) J
@@ -125,7 +125,7 @@ theorem divK_trial_call_path_v2_spec_within
     (v2Old v11Old : Word)
     (retMem dMem dloMem un0Mem : Word)
     (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff) :
-    cpsTripleWithin 62 (base + 512) (base + div128CallRetOff) (sharedDivModCode_v2 base)
+    cpsTripleWithin 62 (base + trialJalOff) (base + div128CallRetOff) (sharedDivModCode_v2 base)
       ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ j) **
        (.x5 ↦ᵣ uLo) ** (.x6 ↦ᵣ vtopBase) **
        (.x7 ↦ᵣ uHi) ** (.x10 ↦ᵣ vTop) **
@@ -137,7 +137,7 @@ theorem divK_trial_call_path_v2_spec_within
       (div128V2SpecPost sp (base + div128CallRetOff) vTop uLo uHi) := by
   unfold div128V2SpecPost
   -- 1. JAL x2 560 at base+512.
-  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + 512) (by nofun)
+  have J := jal_spec_within .x2 v2Old (560 : BitVec 21) (base + trialJalOff) (by nofun)
   rw [lb_jal_target, lb_jal_ret] at J
   have Je := cpsTripleWithin_extend_code (hmono :=
     lb_sub_v2 16 _ _ (by decide) (by bv_addr) (by decide)) J

--- a/docs/divmod-offset-audit.md
+++ b/docs/divmod-offset-audit.md
@@ -125,7 +125,7 @@ structured as:
 | base + 452 | loopBodyOff + 4     | within trial-divide entry          |
 | base + 500 | loopBodyOff + 52    | `trialCallOff   = loopBodyOff + 52`|
 | base + 504 | loopBodyOff + 56    | within trial-call                  |
-| base + 512 | loopBodyOff + 64    | within trial-call                  |
+| base + 512 | loopBodyOff + 64    | `trialJalOff    = loopBodyOff + 64`|
 | base + 516 | loopBodyOff + 68    | **`divCallRetOff`** (slice 1, PR #1503) |
 | base + 536 | loopBodyOff + 88    | `mulsubOff      = loopBodyOff + 88`|
 | base + 580 | loopBodyOff + 132   | within mulsub                      |


### PR DESCRIPTION
Slice of #301 (named offset constants for DivMod hardcoded addresses).

Introduce a top-level offset `trialJalOff : Word := 512` (= `loopBodyOff + 64` = `trialCallOff + 12`) for the trial-divide JAL-to-`divK_div128` call site inside `divK_loopBody`, with three `drift_check_*` examples anchoring it to `trialCallOff + 12`, `loopBodyOff + 64`, and `divCallRetOff - 4`.

Migrate the 7 remaining `base + 512` literals to the named constant:
- `EvmAsm/Evm64/DivMod/LoopBody.lean`: 1 occurrence (RHS of `lb_bltu_taken`).
- `EvmAsm/Evm64/DivMod/LoopBody/TrialCallPath.lean`: 6 occurrences across both v1 and v2 trial-call-path specs and the `lb_jal_target` / `lb_jal_ret` address helpers.

Also update `docs/divmod-offset-audit.md` to reflect the new name.

After this slice, the only remaining `base + 512` references in the DivMod tree are the 4 inside `Compose/Offsets.lean` itself (the new abbrev + drift-checks).

`lake build`: green.

beads: `evm-asm-o5ti`
Refs: #301

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).