### PR TITLE
docs(263): document rv64_addr/divmod_addr/exp_addr grindset family

### DIFF
--- a/EvmAsm/Evm64/OPCODE_TEMPLATE.md
+++ b/EvmAsm/Evm64/OPCODE_TEMPLATE.md
@@ -121,6 +121,11 @@ so new concrete offsets are one line and every downstream proof picks them up.
 DivMod had 112 one-off address-equality lemmas before `divmod_addr` was
 introduced (issue #263).
 
+The canonical shape is `EvmAsm/Evm64/Exp/AddrNormAttr.lean` +
+`EvmAsm/Evm64/Exp/AddrNorm.lean` — copy that file pair as the starting
+template. The full grindset family (`rv64_addr`, `divmod_addr`,
+`exp_addr`, `reg_ops`, `byte_alg`) is documented in `TACTICS.md`.
+
 ### 2.6 Validity bundle
 
 If the opcode has any `isValidDwordAccess` side-conditions, bundle them into

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -18,15 +18,37 @@ documented in [`GRIND.md`](GRIND.md):
 
 | Grindset | File | Closes |
 |----------|------|--------|
-| `divmod_addr` | `Evm64/DivMod/AddrNorm.lean`  | DivMod address arithmetic (signExtend12 + shift + toNat) |
-| `rv64_addr`   | `Rv64/AddrNorm.lean`           | Rv64-wide address arithmetic (signExtend13/21 + assoc), subsumes `bv_addr` |
+| `rv64_addr`   | `Rv64/AddrNorm.lean`           | Rv64-wide address arithmetic (signExtend12/13/21 + shift + toNat over numeric literals); subsumes `bv_addr` |
+| `divmod_addr` | `Evm64/DivMod/AddrNorm.lean`   | DivMod-specific atoms layered on top of `rv64_addr` |
+| `exp_addr`    | `Evm64/Exp/AddrNorm.lean`      | Exp-specific atoms (canonical per-opcode example, see #263) |
 | `reg_ops`     | `Rv64/RegOps.lean`             | `MachineState` projection chains (`pc_set<F>`, `getReg_setPC`, etc.) |
 | `byte_alg`    | `Rv64/ByteAlg.lean`            | `extractByte` / `replaceByte` algebra on `Word` |
 
-Each grindset exposes a `by <name>` tactic (`by divmod_addr`, `by rv64_addr`,
-…) that tries `grind` first and falls back to a per-domain `simp only [...]`
-closer. New atomic facts are added as one-line `@[<set>, grind =]` lemmas
-in the set's file; consumers pick them up automatically.
+Each grindset exposes a `by <name>` tactic (`by rv64_addr`, `by divmod_addr`,
+`by exp_addr`, …) that tries `grind` first and falls back to a per-domain
+`simp only [...]` closer. New atomic facts are added as one-line
+`@[<set>, grind =]` lemmas in the set's file; consumers pick them up
+automatically.
+
+### Adding a new opcode-specific address grindset
+
+Each opcode subtree opts into the family by shipping an `AddrNormAttr.lean`
++ `AddrNorm.lean` pair. The canonical shape is `EvmAsm/Evm64/Exp/`:
+
+- `Exp/AddrNormAttr.lean` — single-line `register_simp_attr exp_addr`. Lean
+  forbids using a freshly-registered simp attribute in the same file that
+  declares it, so this *must* be its own module.
+- `Exp/AddrNorm.lean` — atomic equalities tagged
+  `@[exp_addr, grind =]` (and typically `@[rv64_addr, grind =]` so the
+  universal `by rv64_addr` tactic can also close them). Add the new file
+  *after* `AddrNormAttr.lean` in the umbrella import list (`Evm64/Exp.lean`)
+  so the attribute exists when the consumer is elaborated.
+
+Use `by rv64_addr` everywhere by default — it covers `signExtend12 N` and
+`<<<` over numeric literals universally. Reach for `by divmod_addr` /
+`by exp_addr` only when the goal mentions an opcode-specific atom (an
+offset constant defined in that subtree, an opcode-specific scratch-cell
+identity, etc.).
 
 ## runBlock
 


### PR DESCRIPTION
Slice 2 of evm-asm #263 (parent beads task evm-asm-hmip, slice evm-asm-qkip).

Documents the address-normalization grindset family that landed across the DivMod / Exp subtrees:

- **TACTICS.md** — refreshed the grindset table to include `exp_addr` (the canonical per-opcode example) and clarified that `rv64_addr` is the universal default covering `signExtend12` / `<<<` / `toNat` over numeric literals, with `divmod_addr` and `exp_addr` layered on top for opcode-specific atoms. Added a short "Adding a new opcode-specific address grindset" subsection pointing at the `AddrNormAttr.lean` + `AddrNorm.lean` file-pair pattern (Lean forbids using a freshly-registered `register_simp_attr` in the same file that declares it) and the umbrella import-order rule.
- **EvmAsm/Evm64/OPCODE_TEMPLATE.md §2.5** — names `EvmAsm/Evm64/Exp/{AddrNormAttr,AddrNorm}.lean` as the canonical starting template for new opcode subtrees and cross-links the TACTICS.md grindset table.

Slice 1 (evm-asm-ct45, residual one-off audit) was closed as already-satisfied: `rg 'show signExtend12 \(.*by decide' EvmAsm/` returns 0 hits across the whole tree (the only match is a comment inside `Rv64/AddrNorm.lean` itself).

Docs only; no Lean code changed.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).