### PR TITLE
docs(263): document rv64_addr / divmod_addr / exp_addr grindset family

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -332,6 +332,42 @@ Impact: olean sizes drop 50-80% (e.g., LoopBody 16MB → 2.8MB), kernel checking
 
 For closing repetitive proof patterns (e.g., DivMod address-arithmetic equalities via `divmod_addr`), use the registered grind/simp sets rather than inline `simp only [show … from by decide]; bv_omega` chains. See **[GRIND.md](GRIND.md)** for the full conventions, canonical reference implementation (`EvmAsm/Evm64/DivMod/AddrNorm.lean`), layout patterns, empirical justification, and the rollout roadmap.
 
+#### Address-normalization grindset family
+
+Three address grindsets cover all current call-sites; pick the most specific
+that matches the proof's domain:
+
+| Grindset | Scope | File pair |
+|---|---|---|
+| `rv64_addr` | Rv64-wide: `signExtend12/13/21` + `BitVec.add_assoc` + `(N : BitVec 6).toNat` + `(N : Word).toNat` + `BitVec.ofNat 64 (4 * k)`. Subsumes the legacy `bv_addr`. | `EvmAsm/Rv64/AddrNormAttr.lean` + `EvmAsm/Rv64/AddrNorm.lean` |
+| `divmod_addr` | DivMod-specific atoms (Phase-1/Phase-2 offsets, `k <<< 3`, scratch-cell projections). Re-tags the relevant `rv64_addr` atoms so `divmod_addr` is a strict superset within DivMod. | `EvmAsm/Evm64/DivMod/AddrNormAttr.lean` + `EvmAsm/Evm64/DivMod/AddrNorm.lean` |
+| `exp_addr` | EXP opcode-local atoms (skeleton — attribute reserved; populate atoms + add a `by exp_addr` macro once EXP Compose emits concrete address arithmetic). | `EvmAsm/Evm64/Exp/AddrNormAttr.lean` + `EvmAsm/Evm64/Exp/AddrNorm.lean` |
+
+Usage: write `by rv64_addr` (or `by divmod_addr` / `by exp_addr`) to close
+address-arithmetic equalities. Each tactic tries `grind` first and falls back
+to `simp only [<set>, BitVec.add_assoc]; rfl`. New concrete offsets are added
+as one-line `@[<set>, grind =] theorem <name> : … := by decide` lemmas in the
+set's atom file; every downstream proof picks them up.
+
+Opt-in pattern for a new opcode subtree (e.g. `Evm64/Foo/`):
+
+1. Create `Evm64/Foo/AddrNormAttr.lean` with `register_simp_attr foo_addr`.
+2. Create `Evm64/Foo/AddrNorm.lean` that imports `AddrNormAttr`, re-tags
+   relevant `rv64_addr` atoms with `@[foo_addr]` (or adds opcode-specific
+   atoms), and exposes a `foo_addr` macro tactic mirroring `rv64_addr`'s
+   shape.
+3. Wire both into the umbrella import (attr file first — see the
+   `register_simp_attr` rule above).
+
+`EvmAsm/Evm64/Exp/AddrNormAttr.lean` + `EvmAsm/Evm64/Exp/AddrNorm.lean` is the
+canonical minimal shape; `EvmAsm/Evm64/DivMod/AddrNorm.lean` shows the
+mature pattern with re-tagging and per-domain extensions.
+
+**Do not** introduce a new opcode subtree without an `AddrNorm` pair on the
+first commit that adds non-trivial address arithmetic — see
+[`EvmAsm/Evm64/OPCODE_TEMPLATE.md`](EvmAsm/Evm64/OPCODE_TEMPLATE.md) §2.5.
+Retrofitting the grindset later is the tax that issue #263 documents.
+
 ### Parallel file splitting for Compose files
 
 Large composition files (>1000 lines) should be split into independent sub-files under a `Compose/` directory:

--- a/EvmAsm/Evm64/OPCODE_TEMPLATE.md
+++ b/EvmAsm/Evm64/OPCODE_TEMPLATE.md
@@ -121,6 +121,14 @@ so new concrete offsets are one line and every downstream proof picks them up.
 DivMod had 112 one-off address-equality lemmas before `divmod_addr` was
 introduced (issue #263).
 
+The address-grindset family (`rv64_addr`, `divmod_addr`, `exp_addr`) is
+documented in `AGENTS.md` (Build Performance → Named grind/simp sets) and
+`TACTICS.md`. Use the most specific that matches the proof's domain. The
+canonical minimal opt-in shape for a new opcode subtree is
+`EvmAsm/Evm64/Exp/AddrNormAttr.lean` + `EvmAsm/Evm64/Exp/AddrNorm.lean`
+(empty atom file, `<opcode>_addr` macro tactic that defers to `rv64_addr`
+until opcode-specific atoms accrue).
+
 ### 2.6 Validity bundle
 
 If the opcode has any `isValidDwordAccess` side-conditions, bundle them into

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -18,15 +18,22 @@ documented in [`GRIND.md`](GRIND.md):
 
 | Grindset | File | Closes |
 |----------|------|--------|
-| `divmod_addr` | `Evm64/DivMod/AddrNorm.lean`  | DivMod address arithmetic (signExtend12 + shift + toNat) |
-| `rv64_addr`   | `Rv64/AddrNorm.lean`           | Rv64-wide address arithmetic (signExtend13/21 + assoc), subsumes `bv_addr` |
+| `rv64_addr`   | `Rv64/AddrNorm.lean`           | Rv64-wide address arithmetic (signExtend12/13/21 + assoc + `BitVec 6.toNat` + `BitVec.ofNat 64 (4*k)`), subsumes `bv_addr` |
+| `divmod_addr` | `Evm64/DivMod/AddrNorm.lean`   | DivMod address arithmetic (re-tags `rv64_addr` atoms + DivMod-specific Phase-1/Phase-2 offsets) |
+| `exp_addr`    | `Evm64/Exp/AddrNorm.lean`      | EXP opcode-local atoms (skeleton — attribute reserved; populate atoms + add a `by exp_addr` macro once Exp Compose emits concrete address arithmetic) |
 | `reg_ops`     | `Rv64/RegOps.lean`             | `MachineState` projection chains (`pc_set<F>`, `getReg_setPC`, etc.) |
 | `byte_alg`    | `Rv64/ByteAlg.lean`            | `extractByte` / `replaceByte` algebra on `Word` |
 
-Each grindset exposes a `by <name>` tactic (`by divmod_addr`, `by rv64_addr`,
-…) that tries `grind` first and falls back to a per-domain `simp only [...]`
-closer. New atomic facts are added as one-line `@[<set>, grind =]` lemmas
-in the set's file; consumers pick them up automatically.
+Each grindset exposes a `by <name>` tactic (`by rv64_addr`, `by divmod_addr`,
+`by exp_addr`, …) that tries `grind` first and falls back to a per-domain
+`simp only [...]` closer. New atomic facts are added as one-line
+`@[<set>, grind =]` lemmas in the set's file; consumers pick them up
+automatically.
+
+Pick the most specific set that matches the proof's domain. New opcode
+subtrees opt in by adding an `AddrNormAttr.lean` + `AddrNorm.lean` pair —
+see `EvmAsm/Evm64/Exp/AddrNormAttr.lean` for the canonical minimal shape and
+`EvmAsm/Evm64/OPCODE_TEMPLATE.md` §2.5 for the requirement.
 
 ## runBlock
 


### PR DESCRIPTION
Slice 2 of #263 (beads evm-asm-qkip, parent evm-asm-hmip).

Adds a unified description of the address-normalization grindset family
(`rv64_addr` / `divmod_addr` / `exp_addr`) so new opcode subtrees pick
up the convention from day one rather than retrofitting after the fact
(the cost #263 documents).

Changes:
- `AGENTS.md` (Build Performance → Named grind/simp sets): new
  subsection with a scope table, usage pattern, and the canonical
  opt-in shape (`Exp/AddrNorm{Attr}.lean`) for new opcode subtrees.
- `TACTICS.md`: extends the grindset table with broadened `rv64_addr`
  scope, `divmod_addr` (re-tags `rv64_addr`), and `exp_addr` skeleton;
  points at `OPCODE_TEMPLATE` §2.5 for the requirement.
- `EvmAsm/Evm64/OPCODE_TEMPLATE.md` §2.5: cross-link to the new
  AGENTS.md / TACTICS.md sections and name the canonical minimal
  opt-in shape.

Docs-only; no Lean code touched; build unaffected.

Refs #263.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).