### PR TITLE
chore(divmod): migrate base + 452 in LoopBody to loopBodyOff + 4 (#301)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody.lean
@@ -1081,8 +1081,11 @@ theorem divK_correction_addback_named_spec_within
   exact divK_correction_addback_spec_within sp uBase borrow qHat v0 v1 v2 v3 u0 u1 u2 u3 u4
     v5Old v2Old base hb
 
-private theorem lb_save_j {base : Word} : (base + loopBodyOff : Word) + 4 = base + 452 := by bv_addr
-private theorem lb_trial_load {base : Word} : (base + 452 : Word) + 48 = base + trialCallOff := by bv_addr
+private theorem lb_save_j {base : Word} :
+    (base + loopBodyOff : Word) + 4 = base + (loopBodyOff + 4) := by
+  simp [BitVec.add_assoc]
+private theorem lb_trial_load {base : Word} :
+    (base + (loopBodyOff + 4) : Word) + 48 = base + trialCallOff := by bv_addr
 
 /-- Save j + trial load: save j to memory, then load uHi, uLo, vTop for trial quotient.
     13 instructions, loop body indices [0]-[12].
@@ -1123,7 +1126,7 @@ theorem divK_save_trial_load_spec_within
     (by pcFree) SJe
   -- 2. Trial load: instrs [1]-[12] at base+452
   have TL := divK_trial_load_spec_within sp j n v5Old v6Old v7Old v10Old uHi uLo vTop
-    (base + 452)
+    (base + (loopBodyOff + 4))
   dsimp only [] at TL
   rw [lb_trial_load] at TL
   have TLe := cpsTripleWithin_extend_code (hmono := by


### PR DESCRIPTION
Migrate the 3 residual occurrences of literal `base + 452` in `EvmAsm/Evm64/DivMod/LoopBody.lean` to `(loopBodyOff + 4)` form.

Per the audit recommendation in `docs/divmod-offset-audit.md` ('name boundaries, not interior steps'), 452 is the interior PC for instr [1] of `divK_loopBody` — it sits between `loopBodyOff = 448` (save j) and `trialCallOff = 500` (trial-call entry), so it does not deserve its own top-level named offset.

Sites:
- `lb_save_j` RHS
- `lb_trial_load` LHS
- `divK_save_trial_load_spec_within` trial-load call `(base + 452)`

After this slice, no `base + 452` literal remains under `EvmAsm/Evm64/DivMod/`.

Local `lake build` green (1463 jobs).

Tracks #301 / evm-asm-nqj. Closes evm-asm-jds6.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).