### PR TITLE
feat(exp): exp_bit_test_block_spec_within (#92 slice 4a)

### DIFF
--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -4,9 +4,10 @@
   Per-block / per-limb cpsTriple specs for EXP sub-blocks (square block,
   conditional-multiply block, iter body, loop, prologue, epilogue).
 
-  Skeleton placeholder for GH #92 (beads slice evm-asm-cf2c). Concrete specs
-  will land in the LimbSpec-definition slice (evm-asm-mtj3). Per
-  `OPCODE_TEMPLATE.md`, each sub-block gets exactly one cpsTriple lemma.
+  Slice 4a (beads evm-asm-w5of) lands `exp_bit_test_block_spec_within`.
+  Subsequent slices (evm-asm-mtj3 family) will add `exp_square_block_spec`
+  and `exp_cond_mul_block_spec`. Per `OPCODE_TEMPLATE.md`, each sub-block
+  gets exactly one cpsTriple lemma.
 -/
 
 import EvmAsm.Evm64.Exp.Program
@@ -18,6 +19,36 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
--- Placeholder: per-sub-block specs land in slice 4 (evm-asm-mtj3).
+-- ============================================================================
+-- Section 1: exp_bit_test_block (3 instructions, slice 4a / evm-asm-w5of)
+-- ============================================================================
+--
+-- `exp_bit_test_block` (defined in `Exp/Program.lean`):
+--
+--     ANDI .x10 .x5 1 ;;       -- x10 := x5 &&& 1 (current low bit)
+--     SRLI .x5  .x5 1 ;;       -- x5  := x5 >>> 1 (advance bit cursor)
+--     ADDI .x6  .x6 (-1)       -- x6  := x6 - 1   (decrement remaining bits)
+--
+-- This is the leaf bit-test atom of the square-and-multiply per-iteration
+-- body. The ANDI/SRLI/ADDI triple does NOT touch memory and only depends
+-- on the values currently in x5, x6, x10 (with x0 frame-preserved).
+-- Mirrors the leading triple of `shr_phase_b_spec_within` in
+-- `Evm64/Shift/LimbSpec.lean`.
+
+abbrev exp_bit_test_block_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base exp_bit_test_block
+
+theorem exp_bit_test_block_spec_within
+    (e c v10 : Word) (base : Word) :
+    let code := exp_bit_test_block_code base
+    cpsTripleWithin 3 base (base + 12) code
+      ((.x5 ↦ᵣ e) ** (.x6 ↦ᵣ c) ** (.x10 ↦ᵣ v10))
+      ((.x5 ↦ᵣ (e >>> (1 : BitVec 6).toNat)) **
+       (.x6 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+       (.x10 ↦ᵣ (e &&& signExtend12 (1 : BitVec 12)))) := by
+  have AN := andi_spec_gen_within .x10 .x5 v10 e 1 base (by nofun)
+  have SR := srli_spec_gen_same_within .x5 e 1 (base + 4) (by nofun)
+  have AD := addi_spec_gen_same_within .x6 c (-1) (base + 8) (by nofun)
+  runBlock AN SR AD
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds the leaf bit-test cpsTripleWithin spec for the EXP square-and-multiply iteration body: `ANDI .x10 .x5 1 ;; SRLI .x5 .x5 1 ;; ADDI .x6 .x6 (-1)`.

Mirrors the leading triple of `shr_phase_b_spec_within` in `Evm64/Shift/LimbSpec.lean`:
`andi_spec_gen_within ;; srli_spec_gen_same_within ;; addi_spec_gen_same_within ;; runBlock`.

Lands the first cpsTriple of the LimbSpec slice (#92 slice 4 / evm-asm-mtj3).

Refs: GH #92, beads evm-asm-w5of (slice 4a of evm-asm-mtj3).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).