### PR TITLE
ci(benchmark): surface regressions via benchmark-tracking issue (#949 slice 4)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -25,6 +25,7 @@ concurrency:
 
 permissions:
   contents: write
+  issues: write
 
 jobs:
   benchmark:
@@ -226,3 +227,63 @@ jobs:
             cache_get.log
           if-no-files-found: warn
           retention-days: 90
+
+      # Regression surfacing (#949 slice 4 / evm-asm-9o8v).
+      #
+      # After the new record is on `benchmark-history`, compare the most
+      # recent two records in `history.jsonl`, compute wall-clock and peak-RSS
+      # deltas, and post / update a single tracking issue (label
+      # `benchmark-tracking`, fixed title `Weekly benchmark report`) with the
+      # latest snapshot plus the diff. No CI gate, no email, no PR comment —
+      # design doc `docs/benchmark-workflow-design.md` (c) explicitly defers
+      # thresholds. We only surface a soft ⚠️ marker when wall time grows by
+      # more than `REGRESSION_PCT` percent over the previous run; the user
+      # decides whether the regression is real before acting.
+      - name: Update benchmark tracking issue
+        if: steps.metrics.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WALL_RAW: ${{ steps.metrics.outputs.wall_raw }}
+          WALL_SECONDS: ${{ steps.metrics.outputs.wall_seconds }}
+          PEAK_RSS_KB: ${{ steps.metrics.outputs.peak_rss_kb }}
+          REGRESSION_PCT: '10'
+          ISSUE_LABEL: benchmark-tracking
+          ISSUE_TITLE: Weekly benchmark report
+        run: |
+          set -euo pipefail
+          # Fetch the just-pushed history.jsonl. The previous step pushed at
+          # least one new line; if this is the very first run, history.jsonl
+          # has a single entry and we skip the diff.
+          tmpdir=$(mktemp -d)
+          git -c protocol.version=2 clone --no-checkout --depth=2 --filter=blob:none \
+            --branch benchmark-history \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$tmpdir/history"
+          (cd "$tmpdir/history" && git checkout benchmark-history -- history.jsonl)
+          cp "$tmpdir/history/history.jsonl" history.jsonl
+
+          # Build the report markdown via the checked-in helper. We avoid
+          # inlining Python in the YAML (heredoc + indented `run:` blocks
+          # are notoriously fragile).
+          python3 "${GITHUB_WORKSPACE}/scripts/benchmark-report.py"
+          echo "::group::report.md"
+          cat report.md
+          echo "::endgroup::"
+
+          # Find an existing tracking issue, or open a new one.
+          issue_number=$(gh issue list --label "$ISSUE_LABEL" --state open \
+            --json number,title --jq \
+            '[.[] | select(.title == env.ISSUE_TITLE)][0].number // empty')
+          if [ -n "$issue_number" ]; then
+            echo "Updating tracking issue #$issue_number"
+            gh issue edit "$issue_number" --body-file report.md
+          else
+            # Ensure label exists (idempotent — gh returns 422 if it already
+            # exists, which we tolerate).
+            gh label create "$ISSUE_LABEL" \
+              --description "Auto-updated weekly benchmark report (issue #949)" \
+              --color FBCA04 2>/dev/null || true
+            echo "Opening new tracking issue"
+            gh issue create --label "$ISSUE_LABEL" --title "$ISSUE_TITLE" \
+              --body-file report.md
+          fi

--- a/scripts/benchmark-report.py
+++ b/scripts/benchmark-report.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Build the weekly benchmark tracking-issue body.
+
+Reads ``history.jsonl`` (current dir) — one JSON object per run, as written
+by ``.github/workflows/benchmark.yml`` to the ``benchmark-history`` branch
+— and writes ``report.md`` with the latest snapshot plus a Δ table against
+the previous run.
+
+Used by ``.github/workflows/benchmark.yml`` (#949 slice 4 / evm-asm-9o8v).
+
+Inputs (env):
+- ``GITHUB_REPOSITORY``   — ``owner/repo``, used for hyperlinks.
+- ``REGRESSION_PCT``      — soft regression threshold (percent, float).
+
+Output:
+- writes ``report.md`` (markdown, suitable for ``gh issue create/edit``).
+- exits 0 on success.
+
+The threshold is informational only — the workflow does NOT fail on
+regression. See ``docs/benchmark-workflow-design.md`` (c) for rationale.
+"""
+
+import json
+import os
+
+
+def fmt_delta(c, p, pct_thr):
+    if p is None or p == 0:
+        return "n/a", False
+    delta = c - p
+    pct = 100.0 * delta / p
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta} ({sign}{pct:.1f}%)", (pct > pct_thr)
+
+
+def main():
+    repo = os.environ["GITHUB_REPOSITORY"]
+    pct_thr = float(os.environ["REGRESSION_PCT"])
+
+    with open("history.jsonl") as f:
+        lines = [l for l in f if l.strip()]
+    cur = json.loads(lines[-1])
+    prev = json.loads(lines[-2]) if len(lines) >= 2 else None
+
+    if prev:
+        wall_str, wall_regress = fmt_delta(
+            cur["wall_seconds"], prev["wall_seconds"], pct_thr
+        )
+        rss_str, rss_regress = fmt_delta(
+            cur["peak_rss_kb"], prev["peak_rss_kb"], pct_thr
+        )
+    else:
+        wall_str, wall_regress = "first run", False
+        rss_str, rss_regress = "first run", False
+    regress = wall_regress or rss_regress
+    badge = "\u26a0\ufe0f regression" if regress else "\u2705 within tolerance"
+
+    commit = cur["commit"]
+    commit_short = commit[:12]
+    commit_url = f"https://github.com/{repo}/commit/{commit}"
+    run_url = f"https://github.com/{repo}/actions/runs/{cur['run_id']}"
+    history_url = (
+        f"https://github.com/{repo}/blob/benchmark-history/history.jsonl"
+    )
+
+    prev_wall_raw = prev["wall_raw"] if prev else "n/a"
+    prev_wall_sec = prev["wall_seconds"] if prev else "n/a"
+    prev_rss_kb = prev["peak_rss_kb"] if prev else "n/a"
+
+    out = [
+        f"## Weekly benchmark report \u2014 {cur['timestamp']}",
+        "",
+        f"Status: **{badge}** (threshold: +{int(pct_thr)}% on wall or RSS)",
+        "",
+        "| metric        | current | previous | \u0394 |",
+        "|---------------|---------|----------|---|",
+        f"| wall (raw)    | `{cur['wall_raw']}` | `{prev_wall_raw}` | \u2014 |",
+        f"| wall seconds  | {cur['wall_seconds']} | {prev_wall_sec} | {wall_str} |",
+        f"| peak RSS (KB) | {cur['peak_rss_kb']} | {prev_rss_kb} | {rss_str} |",
+        "",
+        f"- commit: [`{commit_short}`]({commit_url})",
+        f"- ref: `{cur['ref']}`",
+        f"- trigger: `{cur['trigger']}`",
+        f"- runner: `{cur['runner_os']}`, {cur['runner_cores']} cores",
+        f"- run: [{cur['run_id']}]({run_url})",
+        "",
+        f"Full history on the [`benchmark-history`]({history_url}) branch "
+        "(one JSON object per run).",
+        "",
+        "<!-- benchmark-tracking-managed: this issue body is rewritten by "
+        ".github/workflows/benchmark.yml on every Monday cron. Comments are "
+        "preserved; the body is not. -->",
+    ]
+    with open("report.md", "w") as f:
+        f.write("\n".join(out) + "\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements #949 slice 4 (beads evm-asm-9o8v). After the weekly benchmark workflow appends a new record to the `benchmark-history` branch, this PR adds a final step that:

- fetches the latest two records from `benchmark-history`;
- computes wall-clock and peak-RSS deltas via `scripts/benchmark-report.py`;
- posts or updates a single GitHub issue (label `benchmark-tracking`, title `Weekly benchmark report`) with the snapshot plus diff and a soft warning marker when growth exceeds `REGRESSION_PCT` (default 10%).

Per `docs/benchmark-workflow-design.md` (c) this is informational only — there is no CI gate on regression. The user reads the weekly report and decides whether the regression is real.

The Python helper is checked-in (rather than inlined into the YAML `run:` block) because indented heredocs are notoriously fragile. Smoke-tested locally on synthetic two-row and one-row `history.jsonl` inputs (regression and first-run paths).

The workflow already had `permissions: contents: write`; this PR adds `issues: write` so the cron run can create/edit the tracking issue.

Refs: #949 / beads `evm-asm-9o8v`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
