### PR TITLE
feat(divmod): fullDivN3QuotientWord helpers + evm_div_n3_stack_spec_within_word (#61)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -21,3 +21,5 @@ import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N2ModBridge
 import EvmAsm.Evm64.DivMod.Spec.N2ModStackSpec
 import EvmAsm.Evm64.DivMod.Spec.N3ModBridge
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
+import EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec

--- a/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3DivStackSpec.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3DivStackSpec
+
+  EvmWord-level n=3 DIV stack-spec wrapper. The per-limb form
+  `evm_div_n3_stack_spec_within` already exists in
+  `Spec/Dispatcher.lean`; this file adds the `_word` variant that takes a
+  single `EvmWord`-valued equality `fullDivN3QuotientWord ... = EvmWord.div a b`
+  and projects it into the four per-limb hypotheses via
+  `fullDivN3_hdivs_of_word_eq`.
+
+  Mirrors `evm_div_n2_stack_spec_within_word`.
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+
+  See beads `evm-asm-pwvj`, parent `evm-asm-pb40` (#61).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- `_word` form of `evm_div_n3_stack_spec_within`: takes a single
+    `EvmWord`-valued equality `fullDivN3QuotientWord ... = EvmWord.div a b`
+    rather than the four per-limb equalities. -/
+theorem evm_div_n3_stack_spec_within_word
+    (bltu_1 bltu_0 : Bool) (sp base : Word)
+    (a b : EvmWord)
+    (a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old : Word)
+    (q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+     nMem shiftMem jMem retMem dMem dloMem scratch_un0 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hb3z : b3 = 0) (hb2nz : b2 ≠ 0)
+    (hshift_nz : (clzResult b2).1 ≠ 0)
+    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
+    (hbltu_1 : isTrialN3_j1 bltu_1 a3 b1 b2)
+    (hbltu_0 : isTrialN3_j0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hcarry2 : Carry2NzAll (b0 <<< (((clzResult b2).1).toNat % 64))
+      ((b1 <<< (((clzResult b2).1).toNat % 64)) ||| (b0 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b2 <<< (((clzResult b2).1).toNat % 64)) ||| (b1 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64)))
+      ((b3 <<< (((clzResult b2).1).toNat % 64)) ||| (b2 >>> ((signExtend12 (0 : BitVec 12) - (clzResult b2).1).toNat % 64))))
+    (hdivWord : fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    cpsTripleWithin 542 base (base + nopOff) (divCode base)
+      (divModStackDispatchPre sp a b
+        (signExtend12 (4 : BitVec 12) - (4 : Word))
+        ((clzResult b2).2 >>> (63 : Nat))
+        v5 v6 v7 v10 v11Old
+        q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+        shiftMem nMem jMem retMem dMem dloMem scratch_un0)
+      (divStackDispatchPost sp a b) := by
+  obtain ⟨hdiv0, hdiv1, hdiv2, hdiv3⟩ :=
+    fullDivN3_hdivs_of_word_eq bltu_1 bltu_0
+      a b a0 a1 a2 a3 b0 b1 b2 b3 hdivWord
+  exact evm_div_n3_stack_spec_within bltu_1 bltu_0
+    sp base a b
+    a0 a1 a2 a3 b0 b1 b2 b3 v5 v6 v7 v10 v11Old
+    q0 q1 q2 q3 u0Old u1Old u2Old u3Old u4Old u5 u6 u7
+    nMem shiftMem jMem retMem dMem dloMem scratch_un0
+    ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hbnz hb3z hb2nz
+    hshift_nz halign hbltu_1 hbltu_0 hcarry2
+    hdiv0 hdiv1 hdiv2 hdiv3
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
@@ -1,0 +1,141 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N3QuotientWord
+
+  Quotient-word helper for the n=3 DIV path. Mirrors `Spec.N2QuotientWord`
+  for n=3: packages the two non-zero per-limb results from
+  `fullDivN3R{0,1}` (with `q2 = q3 = 0` because n=3 means `b3 = 0 ∧ b2 ≠ 0`,
+  so `a / b < 2^128`) into a single `EvmWord`, and provides the standard
+  structural lemmas (per-limb extraction, `BitVec.eq_of_toNat_eq` bridge,
+  `toNat`-as-`val256`, and a `val256`-equality bridge to `EvmWord.div`).
+
+  Consumed by `evm_div_n3_stack_spec_within_word` (mirror of
+  `evm_div_n2_stack_spec_within_word`).
+
+  Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
+
+  See beads `evm-asm-pwvj`, parent `evm-asm-pb40` (#61).
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Pack the four per-limb DIV results from the n=3 path into a single
+    `EvmWord`. The top two limbs are `0` because n=3 means `b3 = 0` with
+    `b2 ≠ 0`, so the quotient cannot exceed 128 bits. -/
+@[irreducible]
+def fullDivN3QuotientWord (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (0 : Word)
+    | 3 => (0 : Word))
+
+/-- If `fullDivN3QuotientWord ... = EvmWord.div a b`, then each limb of
+    `EvmWord.div a b` matches the corresponding `fullDivN3R{0,1}` result
+    (and limbs 2, 3 are zero). -/
+theorem fullDivN3_hdivs_of_word_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 = (0 : Word) ∧
+    (EvmWord.div a b).getLimbN 3 = (0 : Word) := by
+  refine ⟨?_, ?_, ?_, ?_⟩
+  · rw [← hdiv]
+    delta fullDivN3QuotientWord
+    exact EvmWord.getLimbN_fromLimbs_0
+  · rw [← hdiv]
+    delta fullDivN3QuotientWord
+    exact EvmWord.getLimbN_fromLimbs_1
+  · rw [← hdiv]
+    delta fullDivN3QuotientWord
+    exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]
+    delta fullDivN3QuotientWord
+    exact EvmWord.getLimbN_fromLimbs_3
+
+/-- BitVec extensionality bridge: a `toNat` equality lifts to an `EvmWord`
+    equality. -/
+theorem fullDivN3QuotientWord_eq_div_of_toNat_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv_toNat :
+      (fullDivN3QuotientWord bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat) :
+    fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b :=
+  BitVec.eq_of_toNat_eq hdiv_toNat
+
+/-- The `toNat` of the packed quotient word equals the four-limb
+    `EvmWord.val256` of the per-limb results (with top two limbs zero). -/
+theorem fullDivN3QuotientWord_toNat
+    (bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat =
+    EvmWord.val256
+      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (0 : Word) (0 : Word) := by
+  delta fullDivN3QuotientWord
+  rw [EvmWord.fromLimbs_toNat]
+  rfl
+
+/-- `val256`-equality bridge: if the `EvmWord.val256` of the four per-limb
+    results equals `a.toNat / b.toNat` (computed via `EvmWord.val256` of the
+    inputs), then the `toNat` of the quotient word equals
+    `(EvmWord.div a b).toNat`. Mirrors
+    `fullDivN2QuotientWord_toNat_eq_div_toNat_of_val256_eq`. -/
+theorem fullDivN3QuotientWord_toNat_eq_div_toNat_of_val256_eq
+    (bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hquot :
+      EvmWord.val256
+        (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+        (0 : Word) (0 : Word) =
+      EvmWord.val256 a0 a1 a2 a3 / EvmWord.val256 b0 b1 b2 b3) :
+    (fullDivN3QuotientWord bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat := by
+  have ha_val : EvmWord.val256 a0 a1 a2 a3 = a.toNat := by
+    rw [← ha0, ← ha1, ← ha2, ← ha3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : EvmWord.val256 b0 b1 b2 b3 = b.toNat := by
+    rw [← hb0, ← hb1, ← hb2, ← hb3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  have hb_pos : 0 < b.toNat := by
+    rw [← hb_val]
+    exact EvmWord.val256_pos_of_or_ne_zero hbnz
+  have hb_ne : b ≠ 0 := by
+    intro hb_zero
+    have hb_toNat_zero : b.toNat = 0 := by simp [hb_zero]
+    omega
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div
+    rw [if_neg hb_ne]
+    exact BitVec.toNat_udiv
+  rw [fullDivN3QuotientWord_toNat, hquot, ha_val, hb_val, hdiv_toNat]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Mirrors the n=2 EvmWord-level DIV stack-spec infrastructure (`Spec/N2QuotientWord.lean`, `Spec/N2DivStackSpec.lean`) for n=3, closing the n=2 / n=3 asymmetry noted at the close of slice 2 (PR #1658).

## What

* `Spec/N3QuotientWord.lean` — `fullDivN3QuotientWord` packs the two non-zero per-limb DIV results (`q0`, `q1`) into a single `EvmWord` with `q2 = q3 = 0` (n=3 ⇒ `b3 = 0 ∧ b2 ≠ 0` ⇒ `a/b < 2^128`), plus the four standard structural helpers:
  - `fullDivN3_hdivs_of_word_eq`
  - `fullDivN3QuotientWord_eq_div_of_toNat_eq`
  - `fullDivN3QuotientWord_toNat`
  - `fullDivN3QuotientWord_toNat_eq_div_toNat_of_val256_eq`
* `Spec/N3DivStackSpec.lean` — `evm_div_n3_stack_spec_within_word`: thin wrapper of the existing `evm_div_n3_stack_spec_within` (Dispatcher.lean:1162) that consumes a single `EvmWord`-valued equality `fullDivN3QuotientWord ... = EvmWord.div a b` rather than the four per-limb hypotheses.

Wired into `EvmAsm/Evm64/DivMod/Spec.lean` umbrella.

## Why

After PR #1658 added `evm_div_n2_stack_spec_within_word`, the dispatcher surface was asymmetric: n=2 had both per-limb and `_word` forms, while n=3 had only the per-limb `evm_div_n3_stack_spec_within`. The unified `evm_div_stack_spec` planned in slice 3 (`evm-asm-4keh`) needs a uniform `_word` surface across n ∈ {1,2,3,4}; this PR closes the n=3 gap mechanically.

## Verification

`lake build` green (1466/1466 jobs); 0 sorry.

## Refs

* GH #61
* beads `evm-asm-pwvj`, parent `evm-asm-pb40`

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).