### PR TITLE
proof(divmod): expose v4 div128 lower bound

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -23,6 +23,7 @@ import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4
+
+  v4 trial-quotient helpers for the n=1 full path.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.V4
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Saturated local quotient digit for an n=1 step.
+
+If the high word is below the divisor top word, this is the exact 128/64
+floor. Otherwise the hardware path uses the max trial digit `2^64 - 1`. -/
+@[irreducible]
+def n1LocalFloorDigit (v0 u0 uTop : Word) : Nat :=
+  if BitVec.ult uTop v0 then
+    (uTop.toNat * 2^64 + u0.toNat) / v0.toNat
+  else
+    2^64 - 1
+
+/-- v4 raw trial quotient bounds the saturated local quotient digit. This is
+    the per-step shape needed by N1 later digits: the call path only needs
+    `uTop < v0`, and the max path is exact by construction. -/
+theorem iterN1_v4_rawTrial_ge_local_digit
+    (bltu : Bool) (v0 u0 uTop : Word)
+    (hv0_ge : v0.toNat ≥ 2^63)
+    (hbranch : bltu = BitVec.ult uTop v0) :
+    let qHat : Word := if bltu then div128Quot_v4 uTop u0 v0 else signExtend12 4095
+    n1LocalFloorDigit v0 u0 uTop ≤ qHat.toNat := by
+  intro qHat
+  subst qHat
+  delta n1LocalFloorDigit
+  cases hult : BitVec.ult uTop v0
+  · have hbltu_false : bltu = false := by
+      simpa [hult] using hbranch
+    rw [hbltu_false]
+    simp only [Bool.false_eq_true, if_false]
+    rw [signExtend12_4095_toNat]
+  · have hbltu_true : bltu = true := by
+      simpa [hult] using hbranch
+    rw [hbltu_true]
+    simp only [if_true]
+    have huTop_lt_v0 : uTop.toNat < v0.toNat := (EvmWord.ult_iff).mp hult
+    exact div128Quot_v4_ge_q_true_normalized_of_lt uTop u0 v0 hv0_ge huTop_lt_v0
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Spec/V4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/V4.lean
@@ -634,8 +634,8 @@ theorem div128Quot_v4_q0''_lt_pow32 (uHi uLo vTop : Word)
   exact div128Quot_v4_phase2_quot_lt_pow32 uHi uLo vTop h_vTop_ge_pow63 h_uHi_lt_vTop
 
 /-- **v4's exact-quotient property**: under standard Knuth-A
-    preconditions (shift-norm + `u4 < b3'` + `u4 < 2^63`), the v4
-    algorithm produces the exact 128/64 quotient.
+    preconditions (`b3'` normalized and `u4 < b3'`), the v4 algorithm
+    produces the exact 128/64 quotient.
 
     Proof composes:
     - `_phase1_perfect` + `_phase2_perfect` (proven in IterV4Invariants*).
@@ -644,11 +644,10 @@ theorem div128Quot_v4_q0''_lt_pow32 (uHi uLo vTop : Word)
       identity).
     - `_combined_arith` (proven; pure-Nat composition).
     - `halfword_combine` (existing lemma; OR-shift to add at toNat). -/
-theorem div128Quot_v4_eq_q_true_normalized
+theorem div128Quot_v4_eq_q_true_normalized_of_lt
     (u4 u3 b3' : Word)
     (h_b3'_ge : b3'.toNat ≥ 2^63)
-    (h_u4_lt_b3' : u4.toNat < b3'.toNat)
-    (_h_u4_lt_pow63 : u4.toNat < 2^63) :
+    (h_u4_lt_b3' : u4.toNat < b3'.toNat) :
     (div128Quot_v4 u4 u3 b3').toNat =
       (u4.toNat * 2^64 + u3.toNat) / b3'.toNat := by
   have h_phase1 := div128Quot_v4_q1''_eq_phase1_perfect u4 u3 b3' h_b3'_ge h_u4_lt_b3'
@@ -693,6 +692,28 @@ theorem div128Quot_v4_eq_q_true_normalized
     ((u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat).toNat
     _ _ _
     h_u3_decomp h_b3'_pos h_phase1' h_un21 h_phase2'
+
+/-- Compatibility wrapper for older call sites that still thread the v1
+    runtime fact `u4 < 2^63`. The v4 proof no longer needs that premise. -/
+theorem div128Quot_v4_eq_q_true_normalized
+    (u4 u3 b3' : Word)
+    (h_b3'_ge : b3'.toNat ≥ 2^63)
+    (h_u4_lt_b3' : u4.toNat < b3'.toNat)
+    (_h_u4_lt_pow63 : u4.toNat < 2^63) :
+    (div128Quot_v4 u4 u3 b3').toNat =
+      (u4.toNat * 2^64 + u3.toNat) / b3'.toNat :=
+  div128Quot_v4_eq_q_true_normalized_of_lt u4 u3 b3' h_b3'_ge h_u4_lt_b3'
+
+/-- Lower-bound corollary of the v4 exact quotient theorem. This is the
+    div128 shape needed by later N1 digits where `uHi < vTop`, but
+    `uHi < 2^63` is not available. -/
+theorem div128Quot_v4_ge_q_true_normalized_of_lt
+    (u4 u3 b3' : Word)
+    (h_b3'_ge : b3'.toNat ≥ 2^63)
+    (h_u4_lt_b3' : u4.toNat < b3'.toNat) :
+    (u4.toNat * 2^64 + u3.toNat) / b3'.toNat ≤
+      (div128Quot_v4 u4 u3 b3').toNat := by
+  rw [div128Quot_v4_eq_q_true_normalized_of_lt u4 u3 b3' h_b3'_ge h_u4_lt_b3']
 
 /-- **`n4CallSkipSemanticHolds_v4` holds unconditionally** under the
     standard call-trial preconditions.

--- a/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq/NumericalTests.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallAddbackBeq/NumericalTests.lean
@@ -469,6 +469,21 @@ theorem div128Quot_v2_buggy_at_unreachable_uHi :
       (uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat := by
   decide
 
+/-- **v1 lower-bound failure at the same unreachable wide-uHi input.**
+    This refutes the all-regime lemma shape
+    `uHi < vTop -> q_true <= div128Quot uHi uLo vTop` for the current v1
+    `div128Quot`. The missing runtime fact is `uHi < 2^63`; without it,
+    the unguarded first D3 correction can undershoot. -/
+theorem div128Quot_v1_lower_bound_false_at_unreachable_uHi :
+    let uHi : Word := BitVec.ofNat 64 (2^64 - 2^32 + 1)
+    let uLo : Word := 0
+    let vTop : Word := BitVec.ofNat 64 (2^64 - 1)
+    vTop.toNat ≥ 2^63 ∧
+    uHi.toNat < vTop.toNat ∧
+    ¬ ((uHi.toNat * 2^64 + uLo.toNat) / vTop.toNat ≤
+        (div128Quot uHi uLo vTop).toNat) := by
+  decide
+
 /-- **u4 bound under runtime preconditions** (numerical evidence):
     On the v1 counterexample, `u4 < 2^63`, confirming the case 0 closure
     plan. Together with `dHi ≥ 2^31`, this gives `q1 < 2^32`, hence


### PR DESCRIPTION
## Summary\n- add a formal v1 div128Quot counterexample showing the all-regime lower-bound route is false\n- split the v4 exact quotient theorem to remove the unused uHi < 2^63 premise\n- add div128Quot_v4_ge_q_true_normalized_of_lt for later N1 digit proofs\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTests EvmAsm.Evm64.DivMod.Spec.V4\n- scripts/check-file-size.sh\n\nCloses evm-asm-n6m.9.4.1