### PR TITLE
feat(exp): exp_loop_back_spec_within (#92 slice 4d)

### DIFF
--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -82,4 +82,65 @@ theorem exp_square_block_spec_within
       CodeReq.singleton base (.JAL .x1 mulOff) from CodeReq.ofProg_singleton]
   exact jal_spec_within .x1 vOld mulOff base (by nofun)
 
+-- ============================================================================
+-- Section 3: exp_loop_back (2 instructions, slice 4d / evm-asm-smfg)
+-- ============================================================================
+--
+-- `exp_loop_back backOff` (defined in `Exp/Program.lean`):
+--
+--     ADDI .x9 .x9 (-1) ;;          -- decrement master iteration counter
+--     single (.BNE .x9 .x0 backOff) -- branch back to loop top while x9 ≠ 0
+--
+-- Tail of the EXP square-and-multiply loop. After the ADDI, the master
+-- counter `x9` is decremented by one. If the post-decrement value is
+-- nonzero, the BNE is taken (PC := (base+4) + signExtend13 backOff,
+-- i.e. branch back to the iteration head); otherwise control falls
+-- through to `base + 8` (loop exit).
+--
+-- Mirrors `signext_cascade_step_spec_within`'s shape (single-register
+-- ADDI feeding into a BNE/BEQ pair). Argument-marshalling and the
+-- surrounding 256-iteration scaffold land in evm-asm-w5mk.
+
+abbrev exp_loop_back_code (backOff : BitVec 13) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (exp_loop_back backOff)
+
+theorem exp_loop_back_spec_within (c : Word) (backOff : BitVec 13)
+    (base target : Word) (htarget : (base + 4) + signExtend13 backOff = target) :
+    let cNew := c + signExtend12 ((-1 : BitVec 12))
+    let code := exp_loop_back_code backOff base
+    cpsBranchWithin 2 base code
+      ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
+      (base + 8) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) := by
+  -- Reshape the two-instruction CodeReq.
+  show cpsBranchWithin 2 base
+    (CodeReq.ofProg base (exp_loop_back backOff)) _ _ _ _ _
+  rw [show CodeReq.ofProg base (exp_loop_back backOff) =
+      (CodeReq.singleton base (.ADDI .x9 .x9 (-1))).union
+        (CodeReq.singleton (base + 4) (.BNE .x9 .x0 backOff)) by
+    show CodeReq.ofProg base
+        (ADDI .x9 .x9 (-1) ;; single (.BNE .x9 .x0 backOff)) = _
+    show CodeReq.ofProg base [.ADDI .x9 .x9 (-1), .BNE .x9 .x0 backOff] = _
+    exact CodeReq.ofProg_pair]
+  have ha1 : (base + 4 : Word) + 4 = base + 8 := by bv_omega
+  have hd : CodeReq.Disjoint
+      (CodeReq.singleton base (.ADDI .x9 .x9 (-1)))
+      (CodeReq.singleton (base + 4) (.BNE .x9 .x0 backOff)) :=
+    CodeReq.Disjoint.singleton (by bv_omega)
+  -- Step 1: ADDI x9 x9 -1 — frame x0 across.
+  have s1_raw := addi_spec_gen_same_within .x9 c (-1) base (by nofun)
+  have s1 : cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.ADDI .x9 .x9 (-1)))
+      ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x9 ↦ᵣ (c + signExtend12 ((-1) : BitVec 12))) **
+        (.x0 ↦ᵣ (0 : Word))) :=
+    cpsTripleWithin_frameR (.x0 ↦ᵣ (0 : Word)) (by pcFree) s1_raw
+  -- Step 2: BNE x9 x0 backOff — taken when x9' ≠ 0.
+  have s2_raw := bne_spec_gen_within .x9 .x0 backOff
+    (c + signExtend12 ((-1) : BitVec 12)) (0 : Word) (base + 4)
+  rw [htarget, ha1] at s2_raw
+  -- Compose ADDI ;; BNE; clean perms.
+  exact cpsTripleWithin_seq_cpsBranchWithin_with_perm hd
+    (fun _ hp => hp) s1 s2_raw
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Sub-slice of #92 (beads evm-asm-smfg, parent evm-asm-mtj3 / slice 4).

Adds `exp_loop_back_spec_within` in `EvmAsm/Evm64/Exp/LimbSpec.lean`:
the cpsBranchWithin 2 spec for the EXP loop tail
`ADDI .x9 .x9 (-1) ;; BNE .x9 .x0 backOff`.

- BNE-taken exit at `(base+4) + signExtend13 backOff` when the
  decremented counter `x9' ≠ 0` (branch back to iteration head).
- BNE fall-through exit at `base + 8` when `x9' = 0` (loop exit).

Mirrors `signext_cascade_step_spec_within`'s ADDI;;BEQ shape but uses
BNE on a single tracked register paired with x0. Bridges via
`cpsTripleWithin_seq_cpsBranchWithin_with_perm`; frame-extends
`addi_spec_gen_same_within` over x0 with `cpsTripleWithin_frameR`.

`lake build` green; 0 sorry.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).