### PR TITLE
proof(divmod): add v4 N1 local digit bound

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -23,6 +23,7 @@ import EvmAsm.Evm64.DivMod.N4StackSpec
 import EvmAsm.Evm64.DivMod.Compose.SharedLoopPost
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -1,0 +1,50 @@
+/-
+  EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4
+
+  v4 trial-quotient helpers for the n=1 full path.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.V4
+import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Saturated local quotient digit for an n=1 step.
+
+If the high word is below the divisor top word, this is the exact 128/64
+floor. Otherwise the hardware path uses the max trial digit `2^64 - 1`. -/
+@[irreducible]
+def n1LocalFloorDigit (v0 u0 uTop : Word) : Nat :=
+  if BitVec.ult uTop v0 then
+    (uTop.toNat * 2^64 + u0.toNat) / v0.toNat
+  else
+    2^64 - 1
+
+/-- v4 raw trial quotient bounds the saturated local quotient digit. This is
+    the per-step shape needed by N1 later digits: the call path only needs
+    `uTop < v0`, and the max path is exact by construction. -/
+theorem iterN1_v4_rawTrial_ge_local_digit
+    (bltu : Bool) (v0 u0 uTop : Word)
+    (hv0_ge : v0.toNat ≥ 2^63)
+    (hbranch : bltu = BitVec.ult uTop v0) :
+    let qHat : Word := if bltu then div128Quot_v4 uTop u0 v0 else signExtend12 4095
+    n1LocalFloorDigit v0 u0 uTop ≤ qHat.toNat := by
+  intro qHat
+  subst qHat
+  delta n1LocalFloorDigit
+  cases hult : BitVec.ult uTop v0
+  · have hbltu_false : bltu = false := by
+      simpa [hult] using hbranch
+    rw [hbltu_false]
+    simp only [Bool.false_eq_true, if_false]
+    rw [signExtend12_4095_toNat]
+  · have hbltu_true : bltu = true := by
+      simpa [hult] using hbranch
+    rw [hbltu_true]
+    simp only [if_true]
+    have huTop_lt_v0 : uTop.toNat < v0.toNat := (EvmWord.ult_iff).mp hult
+    exact div128Quot_v4_ge_q_true_normalized_of_lt uTop u0 v0 hv0_ge huTop_lt_v0
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary\n- add FullPathN1ConservationV4 for v4 N1 trial-quotient helpers\n- define the saturated local quotient digit used by N1 max-trial paths\n- prove the v4 raw trial quotient bounds that saturated digit\n- import the new helper through the DivMod umbrella\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4 EvmAsm.Evm64.DivMod\n- scripts/check-file-size.sh\n\nStacked on #1675.\n\nCloses evm-asm-n6m.9.4.2