### PR TITLE
proof(divmod): add v4 N1 iter output bound

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -92,4 +92,141 @@ theorem iterN1_v4_qout_ge_trial_sub_two
     exact iterWithDoubleAddback_qout_ge_tsub_two
       (div128Quot_v4 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
+@[irreducible]
+def fullDivN1R3_v4 (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  iterN1_v4 bltu_3 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.2.2.1 u.2.2.2.2 (0 : Word) (0 : Word) (0 : Word)
+
+@[irreducible]
+def fullDivN1R2_v4 (bltu_3 bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r3 := fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN1_v4 bltu_2 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.2.1 r3.2.1 r3.2.2.1 r3.2.2.2.1 r3.2.2.2.2.1
+
+@[irreducible]
+def fullDivN1R1_v4 (bltu_3 bltu_2 bltu_1 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r2 := fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN1_v4 bltu_1 v.1 v.2.1 v.2.2.1 v.2.2.2
+    u.2.1 r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+
+@[irreducible]
+def fullDivN1R0_v4 (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  let v := fullDivN1NormV b0 b1 b2 b3
+  let u := fullDivN1NormU a0 a1 a2 a3 b0
+  let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  iterN1_v4 bltu_0 v.1 v.2.1 v.2.2.1 v.2.2.2 u.1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+
+theorem fullDivN1R3_v4_qout_ge_trial_sub_two
+    (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let qHat : Word := if bltu_3 then div128Quot_v4 u.2.2.2.2 u.2.2.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u qHat
+  subst v
+  subst u
+  subst qHat
+  delta fullDivN1R3_v4
+  exact iterN1_v4_qout_ge_trial_sub_two bltu_3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    0 0 0
+
+theorem fullDivN1R2_v4_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r3 := fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_2 then div128Quot_v4 r3.2.1 u.2.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r3 qHat
+  subst v
+  subst u
+  subst r3
+  subst qHat
+  delta fullDivN1R2_v4
+  exact iterN1_v4_qout_ge_trial_sub_two bltu_2
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.1
+    (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+
+theorem fullDivN1R1_v4_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r2 := fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_1 then div128Quot_v4 r2.2.1 u.2.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r2 qHat
+  subst v
+  subst u
+  subst r2
+  subst qHat
+  delta fullDivN1R1_v4
+  exact iterN1_v4_qout_ge_trial_sub_two bltu_1
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+
+theorem fullDivN1R0_v4_qout_ge_trial_sub_two
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    let qHat : Word := if bltu_0 then div128Quot_v4 r1.2.1 u.1 v.1
+      else signExtend12 4095
+    qHat.toNat - 2 ≤
+      (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+  intro v u r1 qHat
+  subst v
+  subst u
+  subst r1
+  subst qHat
+  delta fullDivN1R0_v4
+  exact iterN1_v4_qout_ge_trial_sub_two bltu_0
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.2
+    (fullDivN1NormU a0 a1 a2 a3 b0).1
+    (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.1
+    (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.1
+    (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.1
+    (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).2.2.2.2.1
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -4,6 +4,7 @@
   v4 trial-quotient helpers for the n=1 full path.
 -/
 
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation
 import EvmAsm.Evm64.DivMod.Spec.V4
 import EvmAsm.Evm64.EvmWordArith.DivN4Overestimate
 
@@ -46,5 +47,49 @@ theorem iterN1_v4_rawTrial_ge_local_digit
     simp only [if_true]
     have huTop_lt_v0 : uTop.toNat < v0.toNat := (EvmWord.ult_iff).mp hult
     exact div128Quot_v4_ge_q_true_normalized_of_lt uTop u0 v0 hv0_ge huTop_lt_v0
+
+@[irreducible]
+def iterN1Call_v4 (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  iterWithDoubleAddback (div128Quot_v4 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+/-- v4 per-iteration computation for n=1. The max path is unchanged; the call
+    path uses the fully corrected `div128Quot_v4`. -/
+def iterN1_v4 (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    Word × Word × Word × Word × Word × Word :=
+  if bltu then iterN1Call_v4 v0 v1 v2 v3 u0 u1 u2 u3 uTop
+  else iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop
+
+@[simp]
+theorem iterN1_v4_true {v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    iterN1_v4 true v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN1Call_v4 v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp [iterN1_v4]
+
+@[simp]
+theorem iterN1_v4_false {v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word} :
+    iterN1_v4 false v0 v1 v2 v3 u0 u1 u2 u3 uTop =
+    iterN1Max v0 v1 v2 v3 u0 u1 u2 u3 uTop := by
+  simp [iterN1_v4]
+
+theorem iterN1_v4_qout_ge_trial_sub_two
+    (bltu : Bool) (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) :
+    let qHat : Word := if bltu then div128Quot_v4 u1 u0 v0 else signExtend12 4095
+    let out := iterN1_v4 bltu v0 v1 v2 v3 u0 u1 u2 u3 uTop
+    qHat.toNat - 2 ≤ out.1.toNat := by
+  intro qHat out
+  subst qHat
+  subst out
+  cases bltu
+  · simp only [iterN1_v4_false]
+    unfold iterN1Max
+    exact iterWithDoubleAddback_qout_ge_sub_two
+      (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3 uTop (by
+        rw [signExtend12_4095_toNat]
+        norm_num)
+  · simp only [ite_true, iterN1_v4_true]
+    unfold iterN1Call_v4
+    exact iterWithDoubleAddback_qout_ge_tsub_two
+      (div128Quot_v4 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary\n- add v4 N1 per-iteration definitions using div128Quot_v4 on the call path\n- preserve the existing max path\n- prove the v4 iteration output is at least qHat - 2\n- add v4 fullDivN1R3/R2/R1/R0 result-chain mirrors and per-step qHat - 2 wrappers\n\n## Verification\n- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4 EvmAsm.Evm64.DivMod\n- scripts/check-file-size.sh\n\nStacked on #1675; includes #1677 base content.\n\nCloses evm-asm-n6m.9.4.3\nCloses evm-asm-n6m.9.4.4