### PR TITLE
chore(shake): drop unused N2RemainderWord import; flag 5 noshake false positives

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2ModBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2ModBridge.lean
@@ -16,7 +16,6 @@
 -/
 
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
-import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord
 import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
 
 namespace EvmAsm.Evm64

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -106,4 +106,8 @@
  "EvmAsm.Evm64.DivMod.LoopIterN2":
   ["EvmAsm.Evm64.DivMod.LoopBodyN2"],
  "EvmAsm.Evm64.DivMod.LoopIterN3":
-  ["EvmAsm.Evm64.DivMod.LoopBodyN3"]}}
+  ["EvmAsm.Evm64.DivMod.LoopBodyN3"],
+ "EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation":
+  ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.CompensationCases", "EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback", "EvmAsm.Evm64.EvmWordArith.ModBridgeUtop"],
+ "EvmAsm.Evm64.DivMod.Spec.Dispatcher":
+  ["EvmAsm.Evm64.DivMod.Spec.Base", "EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge"]}}


### PR DESCRIPTION
Pure-removal slice for #1045 — verified one shake suggestion was correct and flagged the remaining batch as confirmed false positives.

**Removed (shake correct):**
- `EvmAsm/Evm64/DivMod/Spec/N2ModBridge.lean`: `import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord` was genuinely unused (`lake build` green after removal).

**Flagged in scripts/noshake.json (shake false positives — removals broke the build):**
- `EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation` uses
  - `val256_mod_mul_pow_lt_pow256_of_b3_bound` (from `ModBridgeUtop`)
  - `div128Quot_ge_q_true_normalized` (from `DivN4DoubleAddback`)
  - `iterN1_val256_conservation_v3_zero_of_carry2` (from `CallSkipLowerBoundV2.CompensationCases`)
- `EvmAsm.Evm64.DivMod.Spec.Dispatcher` uses `denorm_4limb_eq_mod_of_val256_eq_amod_pow_s_of_or_ne_zero` from `CallSkipOverestimateBridge`, and `Spec.Base`.

After the noshake update, `lake exe shake EvmAsm` no longer suggests these removals on the affected files. `lake build` is green.

Refs #1045; beads `evm-asm-zay6` (parent `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).