### PR TITLE
chore(divmod): name phaseBTailOff (= phaseBOff + 64) and migrate base+96

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -82,10 +82,10 @@ theorem bne_x10_singleton_sub_modCode {base : Word} :
   exact sub_modCode_of_phaseB_left a i h1
 
 theorem divK_phaseB_tail_code_sub_modCode {base : Word} :
-    ∀ a i, (divK_phaseB_tail_code (base + 96)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_phaseB_tail_code (base + phaseBTailOff)) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + 96) divK_phaseB
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBTailOff) divK_phaseB
     (divK_phaseB.drop 16) 16
     (by bv_addr) (by decide) (by decide) (by decide) a i h
   exact sub_modCode_of_phaseB_left a i h1
@@ -97,7 +97,7 @@ theorem divK_phaseB_tail_code_sub_modCode {base : Word} :
 theorem mod_phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
 theorem mod_phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 theorem mod_phB_bne_4 {base : Word} : (base + 72 : Word) + 4 = base + 76 := by bv_addr
-theorem mod_phB_t_20 {base : Word} : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
+theorem mod_phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
 -- `mod_signExtend13_24` → use `se13_24` from `Compose/Base.lean`.
 theorem mod_phB_sp24_32 {sp : Word} :
     sp + ((4 : Word) + signExtend12 (4095 : BitVec 12)) <<< (3 : BitVec 6).toNat +
@@ -154,7 +154,7 @@ theorem evm_mod_phaseB_n4_spec_within (sp base : Word)
   seqFrame hinit1fhinit2 haddi
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by rv64_addr,
       mod_phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranchWithin_takenStripPure2 hbne_raw
     (fun hp hQf => by
@@ -163,7 +163,7 @@ theorem evm_mod_phaseB_n4_spec_within (sp base : Word)
   have hbne := cpsTripleWithin_extend_code bne_x10_singleton_sub_modCode hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]
-  have htail_raw := divK_phaseB_tail_spec_within sp (4 : Word) b3 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (4 : Word) b3 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
              mod_phB_t_20, mod_phB_sp24_32] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_modCode htail_raw
@@ -261,7 +261,7 @@ theorem mod_phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by
 theorem mod_phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
 theorem mod_phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
 theorem mod_phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
-theorem mod_phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + 96 := by bv_addr
+theorem mod_phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr
 
 -- Tail memory address normalization
 theorem mod_phB_sp16_32 {sp : Word} :

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -81,7 +81,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by rv64_addr,
       mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -116,7 +116,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -151,7 +151,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by rv64_addr,
+  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
     (fun hp hQf => by
@@ -170,7 +170,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
   have h12345678 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
     mod_phB_t_20, mod_divK_phaseB_n2_nm1_x8, se12_32,
     mod_phB_sp8_32] at htail_raw
@@ -252,7 +252,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by rv64_addr,
       mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -287,7 +287,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -322,7 +322,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by rv64_addr,
+  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
@@ -356,7 +356,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
   have h123456789 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
     mod_phB_t_20, mod_divK_phaseB_n1_nm1_x8, se12_32,
     mod_phB_sp0_32] at htail_raw

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -80,7 +80,7 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by rv64_addr,
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by rv64_addr,
       mod_phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -115,7 +115,7 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by rv64_addr,
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
     (fun hp hQf => by
@@ -134,7 +134,7 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
   have h123456 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
     mod_phB_t_20, mod_divK_phaseB_n3_nm1_x8, se12_32,
     mod_phB_sp16_32] at htail_raw

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -17,6 +17,7 @@
 
     [phaseAOff    =   0] divK_phaseA        (32 bytes)
     [phaseBOff    =  32] divK_phaseB        (84 bytes)
+      [phaseBTailOff = 96]  divK_phaseB_tail sub-block (phaseBOff + 64)
     [clzOff       = 116] divK_clz           (96 bytes)
     [phaseC2Off   = 212] divK_phaseC2       (16 bytes)
     [normBOff     = 228] divK_normB         (84 bytes)
@@ -50,6 +51,14 @@ open EvmAsm.Rv64
 abbrev phaseAOff    : Word :=    0
 /-- Offset of `divK_phaseB` (b=0 branch + leading-limb analysis). -/
 abbrev phaseBOff    : Word :=   32
+/-- Offset of the `divK_phaseB_tail` sub-block inside `divK_phaseB`.
+    Entry PC of the leading-limb-analysis tail (16 instructions / 64 bytes
+    into `divK_phaseB`); the per-limb cascade in `divK_phaseB_cascade` falls
+    through to this PC, and the per-limb specs in `Compose/PhaseAB.lean`,
+    `Compose/ModPhaseB.lean`, and `Compose/ModPhaseBn21.lean` invoke
+    `divK_phaseB_tail_spec_within` at this address. Sub-offset relative to
+    `divK_phaseB` (= phaseBOff + 64). -/
+abbrev phaseBTailOff : Word :=   96
 /-- Offset of `divK_clz` (count leading zeros for shift amount). -/
 abbrev clzOff       : Word :=  116
 /-- Offset of `divK_phaseC2` (branch on shift=0 fast path). -/

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -113,10 +113,10 @@ private theorem bne_x10_singleton_sub_divCode {base : Word} :
 
 /-- Phase B tail code (ofProg sub-range of block 1) is subsumed by divCode. -/
 private theorem divK_phaseB_tail_code_sub_divCode {base : Word} :
-    ∀ a i, (divK_phaseB_tail_code (base + 96)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_phaseB_tail_code (base + phaseBTailOff)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + 96) divK_phaseB
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBTailOff) divK_phaseB
     (divK_phaseB.drop 16) 16
     (by bv_addr) (by decide) (by decide) (by decide) a i h
   exact sub_divCode_of_phaseB_left a i h1
@@ -146,7 +146,7 @@ private theorem divK_phaseB_n4_nm1_x8 :
 private theorem phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
 private theorem phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 private theorem phB_bne_4 {base : Word} : (base + 72 : Word) + 4 = base + 76 := by bv_addr
-private theorem phB_t_20 {base : Word} : (base + 96 : Word) + 20 = base + clzOff := by bv_addr
+private theorem phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
 private theorem phB_sp24_32 {sp : Word} : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_addr
 
 -- ============================================================================
@@ -288,7 +288,7 @@ theorem evm_div_phaseB_n4_spec_within (sp base : Word)
   seqFrame hinit1fhinit2 haddi
   -- ---- Step 4: BNE x10 x0 24 at base+72, elim ntaken (b3=0 absurd)
   have hbne_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by
         rv64_addr, phB_bne_4] at hbne_raw
   have hbne_clean := cpsBranchWithin_takenStripPure2 hbne_raw
     (fun hp hQf => by
@@ -297,7 +297,7 @@ theorem evm_div_phaseB_n4_spec_within (sp base : Word)
   have hbne := cpsTripleWithin_extend_code bne_x10_singleton_sub_divCode hbne_clean
   seqFrame hinit1fhinit2haddi hbne
   -- ---- Step 5: Tail (base+96 → base+116) — store n=4, load leading limb b[3]
-  have htail_raw := divK_phaseB_tail_spec_within sp (4 : Word) b3 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (4 : Word) b3 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
              phB_t_20, divK_phaseB_n4_nm1_x8, signExtend12_32, phB_sp24_32] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode htail_raw
@@ -469,7 +469,7 @@ private theorem phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 :
 private theorem phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
 private theorem phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
 private theorem phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
-private theorem phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + 96 := by bv_addr
+private theorem phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr
 
 -- Tail memory address normalization
 private theorem phB_sp16_32 {sp : Word} : (sp + (16 : Word) + (32 : Word)) = sp + 48 := by bv_addr
@@ -546,7 +546,7 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by
         rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -581,7 +581,7 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
     (fun hp hQf => by
@@ -600,7 +600,7 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
   have h123456 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345 hbne1f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (3 : Word) b2 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
              phB_t_20, divK_phaseB_n3_nm1_x8, signExtend12_32, phB_sp16_32] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode htail_raw
@@ -681,7 +681,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by
         rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -716,7 +716,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -751,7 +751,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
   have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
+  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by
         rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
     (fun hp hQf => by
@@ -770,7 +770,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
   have h12345678 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234567 hbne2f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (2 : Word) b1 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
              phB_t_20, divK_phaseB_n2_nm1_x8, signExtend12_32, phB_sp8_32] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode htail_raw
@@ -851,7 +851,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h12 haddi0f
   -- ---- Cascade step 0: BNE x10 ntaken (base+72 → base+76, b3=0)
   have hbne0_raw := bne_spec_gen_within .x10 .x0 24 b3 (0 : Word) (base + 72)
-  rw [show (base + 72 : Word) + signExtend13 24 = base + 96 from by
+  rw [show (base + 72 : Word) + signExtend13 24 = base + phaseBTailOff from by
         rv64_addr, phB_bne_4] at hbne0_raw
   have hbne0_clean := cpsBranchWithin_ntakenStripPure2 hbne0_raw
     (fun hp hQt => by
@@ -886,7 +886,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
   have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + 96 from by
+  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -921,7 +921,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
   have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + 96 from by
+  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by
         rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by
@@ -955,7 +955,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
   have h123456789 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h12345678 haddi3f
   -- ---- Tail (base+96 → base+116)
-  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + 96)
+  have htail_raw := divK_phaseB_tail_spec_within sp (1 : Word) b0 nMem (base + phaseBTailOff)
   simp only [divK_phaseB_tail_pre_unfold, divK_phaseB_tail_post_unfold,
              phB_t_20, divK_phaseB_n1_nm1_x8, signExtend12_32, phB_sp0_32] at htail_raw
   have htail := cpsTripleWithin_extend_code divK_phaseB_tail_code_sub_divCode htail_raw


### PR DESCRIPTION
Adds `phaseBTailOff : Word := 96` to `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` with a doc-comment placing it as a sub-offset of `divK_phaseB` (= `phaseBOff + 64`), the entry of the `divK_phaseB_tail` block invoked by `divK_phaseB_tail_spec_within` in:

- `Compose/PhaseAB.lean`
- `Compose/ModPhaseB.lean`
- `Compose/ModPhaseBn21.lean`
- `Compose/ModPhaseBn3.lean`

Migrates the 34 ad-hoc `base + 96` literals across those four files to `base + phaseBTailOff`. The remaining 6 occurrences in `LimbSpec/Div128Step1v2.lean` are LOCAL block-length constants inside the self-contained `divKDiv128Step1V2Code` block (per the audit fix in beads `evm-asm-by3m`), not the global divK offset, and are intentionally left alone.

Pure rename via the existing `abbrev` mechanism — no proof changes.

Refs: GH #301, beads `evm-asm-uxu8` (under `evm-asm-nqj`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).