### PR TITLE
proof(divmod): add v4 N1 iter conservation

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -92,6 +92,27 @@ theorem iterN1_v4_qout_ge_trial_sub_two
     exact iterWithDoubleAddback_qout_ge_tsub_two
       (div128Quot_v4 u1 u0 v0) v0 v1 v2 v3 u0 u1 u2 u3 uTop
 
+theorem iterN1_v4_val256_conservation_v3_zero_of_carry2
+    (bltu : Bool) (v0 v1 v2 u0 u1 u2 u3 uTop : Word)
+    (hbnz : v0 ||| v1 ||| v2 ||| (0 : Word) ≠ 0)
+    (hcarry2 : Carry2NzAll v0 v1 v2 0) :
+    let out := iterN1_v4 bltu v0 v1 v2 0 u0 u1 u2 u3 uTop
+    EvmWord.val256 u0 u1 u2 u3 + uTop.toNat * 2^256 =
+      out.1.toNat * EvmWord.val256 v0 v1 v2 0 +
+        EvmWord.val256 out.2.1 out.2.2.1 out.2.2.2.1 out.2.2.2.2.1 +
+        out.2.2.2.2.2.toNat * 2^256 := by
+  cases bltu
+  · simp only [iterN1_v4_false]
+    unfold iterN1Max
+    exact iterWithDoubleAddback_val256_conservation_v3_zero_of_carry2
+      (signExtend12 4095) v0 v1 v2 u0 u1 u2 u3 uTop hbnz
+      (hcarry2 (signExtend12 4095) u0 u1 u2 u3 uTop)
+  · simp only [iterN1_v4_true]
+    unfold iterN1Call_v4
+    exact iterWithDoubleAddback_val256_conservation_v3_zero_of_carry2
+      (div128Quot_v4 u1 u0 v0) v0 v1 v2 u0 u1 u2 u3 uTop hbnz
+      (hcarry2 (div128Quot_v4 u1 u0 v0) u0 u1 u2 u3 uTop)
+
 @[irreducible]
 def fullDivN1R3_v4 (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     Word × Word × Word × Word × Word × Word :=


### PR DESCRIPTION
## Summary
- add `iterN1_v4_val256_conservation_v3_zero_of_carry2`
- reuse the generic double-addback conservation theorem for both the max path and the `div128Quot_v4` call path
- closes bd bead evm-asm-n6m.9.8

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4 EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- git diff --check HEAD~1..HEAD

Stacked on #1689. This uses a narrow branch from the remote #1689 head because #1689 is queued and branch updates are locked.