### PR TITLE
proof(divmod): add v4 N1 R3 conservation

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -486,4 +486,43 @@ theorem fullDivN1CorrectedTrialVal_v4_le_quotientVal_v4
   simp only [] at h3 h2 h1 h0 ⊢
   nlinarith [h3, h2, h1, h0]
 
+theorem fullDivN1R3_v4_step_conservation
+    (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let u := fullDivN1NormU a0 a1 a2 a3 b0
+    n1StepConservation v.1 v.2.1 v.2.2.1 u.2.2.2.1 u.2.2.2.2 0 0 0
+      (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3) := by
+  intro v u
+  subst v
+  subst u
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hvnz :
+      (fullDivN1NormV b0 b1 b2 b3).1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 ||| (0 : Word) ≠ 0 := by
+    simpa [hv3z] using
+      fullDivN1NormV_or_ne_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+  have hc :
+      Carry2NzAll (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 := by
+    simpa [hv3z] using hcarry2
+  have h := iterN1_v4_val256_conservation_v3_zero_of_carry2 bltu_3
+    (fullDivN1NormV b0 b1 b2 b3).1
+    (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.2.2.2
+    0 0 0 hvnz hc
+  delta n1StepConservation
+  delta fullDivN1R3_v4
+  simpa [hv3z] using h
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add `fullDivN1R3_v4_step_conservation`
- instantiate the new v4 iter conservation lemma for the first N1 full-path step
- closes bd bead evm-asm-n6m.9.9

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4 EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- git diff --check

Stacked on #1691.