### PR TITLE
feat(exp): add exp_prologue (init result=1, counter x9=256)

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -176,6 +176,64 @@ theorem exp_loop_back_length (backOff : BitVec 13) :
   show (ADDI .x9 .x9 (-1) ;; single (.BNE .x9 .x0 backOff)).length = 2
   rfl
 
+-- ----------------------------------------------------------------------------
+-- Loop prologue: initialize accumulator + counter (#92 slice 3d, beads
+-- evm-asm-yvfr)
+-- ----------------------------------------------------------------------------
+--
+-- Per `docs/92-exp-survey.md` §2(b) and §4, the EXP body needs two pieces of
+-- state initialized before the 256-iteration square-and-multiply loop runs:
+--
+--   1. The running accumulator `result` (a 256-bit value held as 4 LE 64-bit
+--      limbs in the local RISC-V scratch frame at `sp+0 .. sp+24`) must be
+--      initialized to 1, i.e. (limb0, limb1, limb2, limb3) = (1, 0, 0, 0).
+--   2. The master iteration counter `x9` must be initialized to 256.
+--
+-- This block does NOT include the LP64 `cc_prologue` (which is emitted by the
+-- surrounding non-leaf `evm_exp` wrapper) and does NOT marshal the EVM stack
+-- operands `a` / `b` into LP64 a0/a1 slots (handled per-iteration by the
+-- scaffold introduced in slice evm-asm-w5mk). It is the EXP-specific tail of
+-- the prologue: counter init + accumulator init.
+--
+-- Convention assumed by this block: the `evm_exp` wrapper has already moved
+-- `sp` (x2) down by enough bytes to give us a 32-byte 8-byte-aligned region
+-- at offsets `[0, 24]` for the four `result` limbs (low limb at +0, high
+-- limb at +24). The wrapper will lay out the rest of its scratch frame —
+-- saved ra, alignment, any spilled values — at offsets ≥ 32, so the four
+-- SDs here only touch the result slots.
+--
+-- Register usage:
+--   x9  — master iteration counter (output: 256)
+--   x5  — t0, used as a temporary to hold the literal `1` before the SD;
+--          caller-saved per LP64, not live across calls so safe to clobber
+--          before the loop body ever runs.
+--   x2  — sp; read-only here.
+--   x0  — zero register, used directly in the three high-limb SDs to avoid
+--          a second ADDI for an additional zero temp.
+--
+-- 6 instructions, 24 bytes:
+--   ADDI x9, x0, 256   — counter := 256
+--   ADDI x5, x0, 1     — t0      := 1
+--   SD   sp, t0, 0     — result.limb0 := 1
+--   SD   sp, x0, 8     — result.limb1 := 0
+--   SD   sp, x0, 16    — result.limb2 := 0
+--   SD   sp, x0, 24    — result.limb3 := 0
+
+/-- EXP-specific prologue: initialize the master iteration counter
+    `x9 := 256` and the four limbs of the running accumulator `result`
+    in the local scratch frame at `sp+0 .. sp+24` to `(1, 0, 0, 0)`.
+    Excludes the LP64 `cc_prologue` (which the surrounding `evm_exp`
+    wrapper emits separately) and operand marshalling. 6 instructions. -/
+def exp_prologue : Program :=
+  ADDI .x9 .x0 256 ;;
+  ADDI .x5 .x0 1 ;;
+  SD .x2 .x5 0 ;;
+  SD .x2 .x0 8 ;;
+  SD .x2 .x0 16 ;;
+  SD .x2 .x0 24
+
+theorem exp_prologue_length : exp_prologue.length = 6 := by decide
+
 -- Placeholder: `evm_exp : Program` lands in slice 3 (evm-asm-ahaz).
 -- See `docs/92-exp-survey.md` for the algorithm and reuse points.
 


### PR DESCRIPTION
Sub-slice of #92 slice 3 (evm-asm-ahaz / parent evm-asm-yvfr).

Adds `exp_prologue` as a standalone `Program` block in
`EvmAsm/Evm64/Exp/Program.lean`, mirroring the slice 3a/3b/3c style
(`exp_bit_test_block`, `exp_square_block`, `exp_cond_mul_block`,
`exp_loop_back`).

## Contents

- `exp_prologue : Program` — 6 instructions, 24 bytes:
  - `ADDI x9, x0, 256` — master iteration counter
  - `ADDI x5, x0, 1`   — temp t0 := 1
  - `SD x2, x5, 0`     — `result.limb0 := 1`
  - `SD x2, x0, 8`     — `result.limb1 := 0`
  - `SD x2, x0, 16`    — `result.limb2 := 0`
  - `SD x2, x0, 24`    — `result.limb3 := 0`
- `exp_prologue_length : exp_prologue.length = 6`

## Scope

Out of scope (handled elsewhere):

- LP64 `cc_prologue` (emitted by the surrounding non-leaf `evm_exp`
  wrapper in slice evm-asm-ahaz).
- Operand marshalling into LP64 a0/a1 slots (per-iteration scaffold
  in slice evm-asm-w5mk).

The block assumes the surrounding `evm_exp` wrapper has already
allocated a 32-byte 8-byte-aligned region at `sp+0 .. sp+24` for the
four `result` limbs (saved ra / alignment / spills sit at offsets
≥ 32). See `docs/92-exp-survey.md` §2(b) and §4 for the algorithm
context.

## Verification

- `lake build` green locally.
- No new sorries.
- No `maxHeartbeats` / `maxRecDepth` overrides.

Refs: GH #92, beads evm-asm-yvfr (parent evm-asm-ahaz).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).