### PR TITLE
chore(shake): drop Stack import in Pop/Push0/Dup/Swap Program.lean (#1045)

### DIFF
--- a/EvmAsm/Evm64/Dup/Program.lean
+++ b/EvmAsm/Evm64/Dup/Program.lean
@@ -5,7 +5,7 @@
   9 instructions (1 ADDI + 4 × (LD + SD)).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Dup/Spec.lean
+++ b/EvmAsm/Evm64/Dup/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Dup.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Evm64/Pop/Program.lean
+++ b/EvmAsm/Evm64/Pop/Program.lean
@@ -5,7 +5,7 @@
   1 instruction (ADDI x12 x12 32).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Pop/Spec.lean
+++ b/EvmAsm/Evm64/Pop/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Pop.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Push0/Program.lean
+++ b/EvmAsm/Evm64/Push0/Program.lean
@@ -5,7 +5,7 @@
   5 instructions (ADDI + 4 × SD x0).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Push0/Spec.lean
+++ b/EvmAsm/Evm64/Push0/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Push0.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Evm64/Swap/Program.lean
+++ b/EvmAsm/Evm64/Swap/Program.lean
@@ -5,7 +5,7 @@
   16 instructions (4 × (LD + LD + SD + SD)).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Swap/Spec.lean
+++ b/EvmAsm/Evm64/Swap/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Swap.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock


### PR DESCRIPTION
Mirrors PR #1454 (comparison opcodes Lt/Gt/Eq/IsZero/Sgt) for the stack-manipulation opcodes Pop/Push0/Dup/Swap.

Each `Program.lean` previously imported `EvmAsm.Evm64.Stack` solely for the `Word` / `Program` / `CodeReq` types; only the corresponding `Spec.lean` actually uses `evmWordIs` / `evmStackIs`. This PR replaces the Program-side import with `EvmAsm.Rv64.SepLogic` (which transitively provides those types) and adds `EvmAsm.Evm64.Stack` to each `Spec.lean` so the spec files keep their direct dependency.

Verification:
- `lake build` green (1472 jobs)
- `lake exe shake EvmAsm` no longer flags any of the four `Program.lean` files

Refs: GH #1045, beads evm-asm-h2kr, sibling parent evm-asm-6qj.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).