### PR TITLE
feat(exp): exp_epilogue (writeback result + advance x12) (#92 slice 3e)

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -234,6 +234,64 @@ def exp_prologue : Program :=
 
 theorem exp_prologue_length : exp_prologue.length = 6 := by decide
 
+-- ----------------------------------------------------------------------------
+-- Loop epilogue: result writeback + EVM stack advance (#92 slice 3e, beads
+-- evm-asm-tesj)
+-- ----------------------------------------------------------------------------
+--
+-- Per `docs/92-exp-survey.md` §"Result write-back" (line 178), once the
+-- 256-iteration square-and-multiply loop has finished, the four limbs of the
+-- running accumulator `result` (held in the local scratch frame at
+-- `sp + 0 .. sp + 24`) must be copied out to the EVM stack at
+-- `x12 + 32 .. x12 + 56` (the slot that originally held operand `a` on
+-- entry, since both `a` and `b` are popped and a single 256-bit result is
+-- pushed). Then `x12` advances by +32 (one EVM-word pop, since EXP pops
+-- two 256-bit operands and pushes one result).
+--
+-- This block does NOT include the LP64 `cc_epilogue` (which the surrounding
+-- `evm_exp` non-leaf wrapper emits separately, restoring `ra`/`sp` and
+-- returning to the caller). It is the EXP-specific tail of the body:
+-- writeback + EVM stack-pointer fixup, mirroring the role of `mul_epilogue`
+-- in `Evm64/Multiply/Program.lean` but with an additional 4-limb LD/SD
+-- copy because EXP holds its accumulator in the local scratch frame
+-- rather than directly on the EVM stack.
+--
+-- Register usage:
+--   x2  — sp; read-only (local scratch frame base for `result`).
+--   x12 — EVM stack pointer (a2); advanced by +32 at the very end.
+--   x5  — t0, used as a single-limb load/store temporary; caller-saved per
+--          LP64 and not live across the surrounding loop, so safe to clobber.
+--
+-- 9 instructions, 36 bytes:
+--   LD   t0, sp, 0     — t0          := result.limb0
+--   SD   x12, t0, 32   — evm_stack[0] := t0
+--   LD   t0, sp, 8     — t0          := result.limb1
+--   SD   x12, t0, 40   — evm_stack[1] := t0
+--   LD   t0, sp, 16    — t0          := result.limb2
+--   SD   x12, t0, 48   — evm_stack[2] := t0
+--   LD   t0, sp, 24    — t0          := result.limb3
+--   SD   x12, t0, 56   — evm_stack[3] := t0
+--   ADDI x12, x12, 32  — pop one EVM word
+
+/-- EXP-specific epilogue: copy the four limbs of the running accumulator
+    `result` from the local scratch frame at `sp + 0 .. sp + 24` to the
+    EVM stack at `x12 + 32 .. x12 + 56`, then advance the EVM stack
+    pointer `x12` by +32 (one EVM-word pop). Excludes the LP64
+    `cc_epilogue` (which the surrounding `evm_exp` wrapper emits
+    separately). 9 instructions. -/
+def exp_epilogue : Program :=
+  LD .x5 .x2 0 ;;
+  SD .x12 .x5 32 ;;
+  LD .x5 .x2 8 ;;
+  SD .x12 .x5 40 ;;
+  LD .x5 .x2 16 ;;
+  SD .x12 .x5 48 ;;
+  LD .x5 .x2 24 ;;
+  SD .x12 .x5 56 ;;
+  ADDI .x12 .x12 32
+
+theorem exp_epilogue_length : exp_epilogue.length = 9 := by decide
+
 -- Placeholder: `evm_exp : Program` lands in slice 3 (evm-asm-ahaz).
 -- See `docs/92-exp-survey.md` for the algorithm and reuse points.
 


### PR DESCRIPTION
Adds the EXP-specific epilogue block to `EvmAsm/Evm64/Exp/Program.lean`: copies the four limbs of the running accumulator `result` from the local scratch frame at `sp+0..sp+24` to the EVM stack at `x12+32..x12+56`, then advances `x12` by +32 (one EVM-word pop). Excludes `cc_epilogue` (handled by the surrounding non-leaf `evm_exp` wrapper).

9 instructions: 4× (`LD .x5 .x2 N ;; SD .x12 .x5 (N+32)`) for N ∈ {0,8,16,24}, followed by `ADDI .x12 .x12 32`. Length lemma `exp_epilogue_length` proved by `decide`.

Mirrors the role of `mul_epilogue` in `Multiply/Program.lean` but with an extra 4-limb LD/SD copy, since EXP holds its accumulator in the local scratch frame rather than directly on the EVM stack.

Per `docs/92-exp-survey.md` §'Result write-back' (line 178).

Refs GH #92. Beads: `evm-asm-tesj` (slice of `evm-asm-ahaz` / `evm-asm-20z6`).

`lake build` green locally; no spec yet (lands in slice 4/5).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).