### PR TITLE
chore(divmod): name phaseABeqOff (= 28) for phaseA-end BEQ PC

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Epilogue.lean
@@ -310,7 +310,7 @@ private theorem divK_zeroPath_code_sub_modCode {base : Word} :
   exact CodeReq.union_mono_left
 
 private theorem beq_singleton_sub_modCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 28) (.BEQ .x5 .x0 1020)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseABeqOff) (.BEQ .x5 .x0 1020)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
@@ -341,9 +341,9 @@ theorem evm_mod_bzero_spec_within (sp base : Word)
   have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_modCode
     (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
-  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
-      show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -389,9 +389,9 @@ theorem evm_mod_phaseA_ntaken_spec_within (sp base : Word)
   have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_modCode
     (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
-  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
-      show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -16,6 +16,7 @@
   Layout of `divCode` / `modCode` (all values in bytes from program base):
 
     [phaseAOff    =   0] divK_phaseA        (32 bytes)
+      [phaseABeqOff =  28]  phaseA-end BEQ → zeroPath (phaseAOff + 28)
     [phaseBOff    =  32] divK_phaseB        (84 bytes)
       [phaseBTailOff = 96]  divK_phaseB_tail sub-block (phaseBOff + 64)
     [clzOff       = 116] divK_clz           (96 bytes)
@@ -49,6 +50,13 @@ open EvmAsm.Rv64
 
 /-- Offset of `divK_phaseA` (the entry block). -/
 abbrev phaseAOff    : Word :=    0
+/-- Offset of the phaseA-end BEQ instruction inside `divK_phaseA`.
+    Entry PC of the `BEQ x5, x0, 1020` instruction that branches to
+    `divK_zeroPath` when the OR-reduce of the four divisor limbs equals 0
+    (the b=0 detection at the end of phaseA). Sub-offset relative to the
+    phaseA block (= phaseAOff + 28, i.e. 7 instructions into phaseA — the
+    final branch instruction, with the next PC = `phaseBOff`). -/
+abbrev phaseABeqOff : Word :=   28
 /-- Offset of `divK_phaseB` (b=0 branch + leading-limb analysis). -/
 abbrev phaseBOff    : Word :=   32
 /-- Offset of the `divK_phaseB_tail` sub-block inside `divK_phaseB`.
@@ -207,6 +215,10 @@ abbrev div128CallRetOff : Word := 516
 -- reduce to concrete numerals).
 -- ============================================================================
 
+/-- phaseABeqOff = phaseAOff + 28 (sub-block offset within `divK_phaseA`).
+    The phaseA-end BEQ to `divK_zeroPath` sits 7 instructions into phaseA. -/
+example : phaseABeqOff = phaseAOff + 28 := by decide
+example : phaseABeqOff + 4 = phaseBOff := by decide
 /-- phaseBOff = phaseAOff + 4 · |divK_phaseA 1020|. -/
 example : phaseBOff = phaseAOff + 4 * (divK_phaseA 1020).length := by decide
 /-- clzOff = phaseBOff + 4 · |divK_phaseB|. -/

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -55,7 +55,7 @@ private theorem divK_zeroPath_code_sub_divCode {base : Word} :
 
 /-- BEQ singleton at base+28 is subsumed by divCode (part of block 0: phaseA). -/
 private theorem beq_singleton_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 28) (.BEQ .x5 .x0 1020)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseABeqOff) (.BEQ .x5 .x0 1020)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
@@ -172,9 +172,9 @@ theorem evm_div_bzero_spec_within (sp base : Word)
   have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_divCode
     (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate ntaken via hbz
-  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
-      show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranchWithin_takenStripPure2 hbeq_raw
     (fun hp hQf => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQf
@@ -222,9 +222,9 @@ theorem evm_div_phaseA_ntaken_spec_within (sp base : Word)
   have hbody := cpsTripleWithin_extend_code divK_phaseA_code_sub_divCode
     (divK_phaseA_body_spec_within sp base b0 b1 b2 b3 v5 v10)
   -- Step 2: BEQ at base+28, eliminate taken path (b=0 absurd since hbnz)
-  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + 28)
-  rw [show (base + 28 : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
-      show (base + 28 : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
+  have hbeq_raw := beq_spec_gen_within .x5 .x0 1020 (b0 ||| b1 ||| b2 ||| b3) (0 : Word) (base + phaseABeqOff)
+  rw [show (base + phaseABeqOff : Word) + signExtend13 1020 = base + zeroPathOff from by rv64_addr,
+      show (base + phaseABeqOff : Word) + 4 = base + phaseBOff from by bv_addr] at hbeq_raw
   have hbeq_clean := cpsBranchWithin_ntakenStripPure2 hbeq_raw
     (fun hp hQt => by
       obtain ⟨_, _, _, _, _, h_rest⟩ := hQt


### PR DESCRIPTION
Adds `abbrev phaseABeqOff : Word := 28` to `Compose/Offsets.lean` (the phaseA-end BEQ → zeroPath instruction, 7 instructions into `divK_phaseA`) with equation lemmas (`phaseABeqOff = phaseAOff + 28`, `phaseABeqOff + 4 = phaseBOff`) and a layout-schematic entry.

Migrates the 14 `base + 28` literals in `Compose/PhaseAB.lean` (7) and `Compose/Epilogue.lean` (7) to `base + phaseABeqOff`.

`LimbSpec/*` uses of `base + 28` are block-relative offsets (e.g. div128 sub-block PCs) and intentionally remain unchanged.

Slice of #301 (beads evm-asm-nqj / evm-asm-fae8).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).