### PR TITLE
proof(divmod): bound v4 N1 third-step remainder

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
@@ -167,4 +167,85 @@ theorem fullDivN1R2_v4_extended_remainder_lt
     (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
     hvnz hcon hge
 
+theorem fullDivN1R1_v4_extended_remainder_lt
+    (bltu_3 bltu_2 bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+    n1StepRemainderVal r1 + n1StepTopVal r1 * 2^256 <
+      EvmWord.val256 v.1 v.2.1 v.2.2.1 0 := by
+  intro v r1
+  subst v
+  subst r1
+  let r2 := fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  have hv1z := fullDivN1NormV_v1_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hshift_nz
+  have hv2z := fullDivN1NormV_v2_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hvnz :
+      (fullDivN1NormV b0 b1 b2 b3).1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 ||| (0 : Word) ≠ 0 := by
+    simpa [hv3z] using
+      fullDivN1NormV_or_ne_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+  have hprev := fullDivN1R2_v4_extended_remainder_lt
+    bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz
+    hcarry2 hbltu_3 hbltu_2
+  have hprev' : n1StepRemainderVal r2 + n1StepTopVal r2 * 2^256 <
+      ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    subst r2
+    simpa [hv1z, hv2z, EvmWord.val256] using hprev
+  have htop_lt_v0 : r2.2.1.toNat < ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    delta n1StepRemainderVal n1StepTopVal at hprev'
+    unfold EvmWord.val256 at hprev'
+    omega
+  have hcon := fullDivN1R1_v4_step_conservation
+    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hcarry2
+  have hqeq := fullDivN1R1_v4_qout_eq_local_digit
+    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz
+    hbltu_1
+  have hlocal : n1LocalFloorDigit (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormU a0 a1 a2 a3 b0).2.1 r2.2.1 =
+      (r2.2.1.toNat * 2^64 + (fullDivN1NormU a0 a1 a2 a3 b0).2.1.toNat) /
+        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    delta n1LocalFloorDigit
+    rw [show BitVec.ult r2.2.1 (fullDivN1NormV b0 b1 b2 b3).1 = true from
+      (EvmWord.ult_iff).mpr htop_lt_v0]
+    simp only [if_true]
+  have hnum_eq :
+      EvmWord.val256 (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+          r2.2.1 r2.2.2.1 r2.2.2.2.1 + r2.2.2.2.2.1.toNat * 2^256 =
+        r2.2.1.toNat * 2^64 + (fullDivN1NormU a0 a1 a2 a3 b0).2.1.toNat := by
+    delta n1StepRemainderVal n1StepTopVal at hprev'
+    unfold EvmWord.val256 at hprev' ⊢
+    omega
+  have hge :
+      (EvmWord.val256 (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+          r2.2.1 r2.2.2.1 r2.2.2.2.1 + r2.2.2.2.2.1.toNat * 2^256) /
+        EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 ≤
+        (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+    rw [hqeq]
+    rw [hlocal]
+    rw [hnum_eq]
+    unfold EvmWord.val256
+    simp [hv1z, hv2z]
+  exact n1StepExtendedRemainder_lt_of_floor_le
+    (fullDivN1NormV b0 b1 b2 b3).1 (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).2.1
+    r2.2.1 r2.2.2.1 r2.2.2.2.1 r2.2.2.2.2.1
+    (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    hvnz hcon hge
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- prove fullDivN1R1_v4_extended_remainder_lt in FullPathN1RemainderV4
- use the R2 extended-remainder bound to show the R1 local division digit is unsaturated and exact
- keep the proof in the split remainder module under the file-size guardrail

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1RemainderV4
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- git diff --check