### PR TITLE
chore(shake): drop unused RunBlock import in MStore8/Spec.lean

### DIFF
--- a/EvmAsm/Evm64/MStore8/Spec.lean
+++ b/EvmAsm/Evm64/MStore8/Spec.lean
@@ -25,7 +25,6 @@
 import EvmAsm.Evm64.MStore8.Program
 import EvmAsm.Evm64.Memory
 import EvmAsm.Rv64.SyscallSpecs
-import EvmAsm.Rv64.Tactics.RunBlock
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
Single-file shake-filter cleanup under #1045 (beads evm-asm-9tq parent / evm-asm-e2l9 slice).

`scripts/shake-filter.py` flags this file as a pure-remove (no compensating `add`), and the file does not reference `runBlock` or any other tactic from `EvmAsm.Rv64.Tactics.RunBlock` — it only composes `sb_spec_gen_within`.

Verified locally with `lake build` (1476 jobs OK).

Refs #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).