### PR TITLE
proof(divmod): bound v4 N1 final-step remainder

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
@@ -332,4 +332,95 @@ theorem fullDivN1R0_v4_extended_remainder_lt
     (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
     hvnz hcon hge
 
+theorem fullDivN1ExtendedRemainder_v4_lt_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_v4_j0 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    n1StepRemainderVal
+        (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) +
+        n1StepsCarryVal
+          (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+          (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3) <
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+  let r3 := fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
+  let r2 := fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
+  let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  let r0 := fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+  have hv1z := fullDivN1NormV_v1_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hshift_nz
+  have hv2z := fullDivN1NormV_v2_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hnormv := fullDivN1NormV_val256_eq_scaled b0 b1 b2 b3 hb3z hshift_nz
+  have hV_eq : EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 =
+      EvmWord.val256 b0 b1 b2 b3 * 2 ^ ((fullDivN1Shift b0).toNat % 64) := by
+    rw [← hnormv]
+    rw [hv3z]
+  have hV_lt_pow64 : EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 < 2^64 := by
+    unfold EvmWord.val256
+    simp [hv1z, hv2z]
+    exact (fullDivN1NormV b0 b1 b2 b3).1.isLt
+  have hR3 : n1StepRemainderVal r3 + n1StepTopVal r3 * 2^256 <
+      EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 := by
+    subst r3
+    exact fullDivN1R3_v4_extended_remainder_lt
+      bltu_3 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz hcarry2 hbltu_3
+  have hR2 : n1StepRemainderVal r2 + n1StepTopVal r2 * 2^256 <
+      EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 := by
+    subst r2
+    exact fullDivN1R2_v4_extended_remainder_lt
+      bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz hcarry2
+      hbltu_3 hbltu_2
+  have hR1 : n1StepRemainderVal r1 + n1StepTopVal r1 * 2^256 <
+      EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 := by
+    subst r1
+    exact fullDivN1R1_v4_extended_remainder_lt
+      bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz
+      hcarry2 hbltu_3 hbltu_2 hbltu_1
+  have hR0 : n1StepRemainderVal r0 + n1StepTopVal r0 * 2^256 <
+      EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+        (fullDivN1NormV b0 b1 b2 b3).2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 := by
+    subst r0
+    exact fullDivN1R0_v4_extended_remainder_lt
+      bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+      hshift_nz hcarry2 hbltu_3 hbltu_2 hbltu_1 hbltu_0
+  have ht3 : n1StepTopVal r3 = 0 := by
+    delta n1StepTopVal at hR3 ⊢
+    omega
+  have ht2 : n1StepTopVal r2 = 0 := by
+    delta n1StepTopVal at hR2 ⊢
+    omega
+  have ht1 : n1StepTopVal r1 = 0 := by
+    delta n1StepTopVal at hR1 ⊢
+    omega
+  have ht0 : n1StepTopVal r0 = 0 := by
+    delta n1StepTopVal at hR0 ⊢
+    omega
+  rw [← hV_eq]
+  change n1StepRemainderVal r0 + n1StepsCarryVal r3 r2 r1 r0 <
+    EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1 (fullDivN1NormV b0 b1 b2 b3).2.2.1 0
+  delta n1StepsCarryVal
+  simp [ht0, ht1, ht2, ht3] at hR0 ⊢
+  exact hR0
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1RemainderV4.lean
@@ -248,4 +248,88 @@ theorem fullDivN1R1_v4_extended_remainder_lt
     (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
     hvnz hcon hge
 
+theorem fullDivN1R0_v4_extended_remainder_lt
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_v4_j0 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    let v := fullDivN1NormV b0 b1 b2 b3
+    let r0 := fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    n1StepRemainderVal r0 + n1StepTopVal r0 * 2^256 <
+      EvmWord.val256 v.1 v.2.1 v.2.2.1 0 := by
+  intro v r0
+  subst v
+  subst r0
+  let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
+  have hv1z := fullDivN1NormV_v1_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hshift_nz
+  have hv2z := fullDivN1NormV_v2_eq_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z
+  have hv3z := fullDivN1NormV_v3_eq_zero_of_high_zero b0 b1 b2 b3 hb3z hb2z
+  have hvnz :
+      (fullDivN1NormV b0 b1 b2 b3).1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.1 |||
+        (fullDivN1NormV b0 b1 b2 b3).2.2.1 ||| (0 : Word) ≠ 0 := by
+    simpa [hv3z] using
+      fullDivN1NormV_or_ne_zero_of_high_zero b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+  have hprev := fullDivN1R1_v4_extended_remainder_lt
+    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz hshift_nz
+    hcarry2 hbltu_3 hbltu_2 hbltu_1
+  have hprev' : n1StepRemainderVal r1 + n1StepTopVal r1 * 2^256 <
+      ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    subst r1
+    simpa [hv1z, hv2z, EvmWord.val256] using hprev
+  have htop_lt_v0 : r1.2.1.toNat < ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    delta n1StepRemainderVal n1StepTopVal at hprev'
+    unfold EvmWord.val256 at hprev'
+    omega
+  have hcon := fullDivN1R0_v4_step_conservation
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+    hcarry2
+  have hqeq := fullDivN1R0_v4_qout_eq_local_digit
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 hb1z hb2z hb3z hbnz
+    hshift_nz hbltu_0
+  have hlocal : n1LocalFloorDigit (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormU a0 a1 a2 a3 b0).1 r1.2.1 =
+      (r1.2.1.toNat * 2^64 + (fullDivN1NormU a0 a1 a2 a3 b0).1.toNat) /
+        ((fullDivN1NormV b0 b1 b2 b3).1).toNat := by
+    delta n1LocalFloorDigit
+    rw [show BitVec.ult r1.2.1 (fullDivN1NormV b0 b1 b2 b3).1 = true from
+      (EvmWord.ult_iff).mpr htop_lt_v0]
+    simp only [if_true]
+  have hnum_eq :
+      EvmWord.val256 (fullDivN1NormU a0 a1 a2 a3 b0).1
+          r1.2.1 r1.2.2.1 r1.2.2.2.1 + r1.2.2.2.2.1.toNat * 2^256 =
+        r1.2.1.toNat * 2^64 + (fullDivN1NormU a0 a1 a2 a3 b0).1.toNat := by
+    delta n1StepRemainderVal n1StepTopVal at hprev'
+    unfold EvmWord.val256 at hprev' ⊢
+    omega
+  have hge :
+      (EvmWord.val256 (fullDivN1NormU a0 a1 a2 a3 b0).1
+          r1.2.1 r1.2.2.1 r1.2.2.2.1 + r1.2.2.2.2.1.toNat * 2^256) /
+        EvmWord.val256 (fullDivN1NormV b0 b1 b2 b3).1
+          (fullDivN1NormV b0 b1 b2 b3).2.1
+          (fullDivN1NormV b0 b1 b2 b3).2.2.1 0 ≤
+        (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1.toNat := by
+    rw [hqeq]
+    rw [hlocal]
+    rw [hnum_eq]
+    unfold EvmWord.val256
+    simp [hv1z, hv2z]
+  exact n1StepExtendedRemainder_lt_of_floor_le
+    (fullDivN1NormV b0 b1 b2 b3).1 (fullDivN1NormV b0 b1 b2 b3).2.1
+    (fullDivN1NormV b0 b1 b2 b3).2.2.1
+    (fullDivN1NormU a0 a1 a2 a3 b0).1
+    r1.2.1 r1.2.2.1 r1.2.2.2.1 r1.2.2.2.2.1
+    (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3)
+    hvnz hcon hge
+
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- prove fullDivN1R0_v4_extended_remainder_lt in FullPathN1RemainderV4
- use the R1 extended-remainder bound to show the final R0 local division digit is unsaturated and exact
- finish the per-step v4 N1 extended-remainder chain in the split remainder module

## Tests
- lake build EvmAsm.Evm64.DivMod.Compose.FullPathN1RemainderV4
- lake build EvmAsm.Evm64.DivMod
- scripts/check-file-size.sh
- git diff --check