### PR TITLE
feat(mload): mload_one_limb_spec_within (8 byte-pack + SD)

### DIFF
--- a/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
+++ b/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
@@ -307,6 +307,103 @@ def mloadOneLimbCode
       off0 off1 off2 off3 off4 off5 off6 off7 base).union
     (CodeReq.singleton (base + 88) (.SD .x12 accReg dstOff))
 
+/-- Bundled precondition for `mload_one_limb_spec_within`: the four
+    "byte-pack" atoms (`addrReg`, `byteReg`, `accReg`, source
+    `dwordAddr`) plus the SD-side atoms (`.x12 ↦ᵣ sp` and the
+    destination dword cell at `sp + signExtend12 dstOff`).
+
+    Pulled into an `@[irreducible]` definition (mirroring
+    `mloadBytePackEightPre`) so the spec statement is not cluttered by a
+    long chain of `let`-bindings; downstream callers see a single named
+    handle and use `mloadOneLimbPre_unfold` to expand on demand. -/
+@[irreducible]
+def mloadOneLimbPre
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld wordVal dwordAddr sp dstWordOld : Word)
+    (dstOff : BitVec 12) : Assertion :=
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+  (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 dstOff) ↦ₘ dstWordOld)
+
+theorem mloadOneLimbPre_unfold
+    {addrReg byteReg accReg : Reg}
+    {addrPtr accOld byteOld wordVal dwordAddr sp dstWordOld : Word}
+    {dstOff : BitVec 12} :
+    mloadOneLimbPre addrReg byteReg accReg
+        addrPtr accOld byteOld wordVal dwordAddr sp dstWordOld dstOff =
+    ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+     (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 dstOff) ↦ₘ dstWordOld)) := by
+  delta mloadOneLimbPre; rfl
+
+/-- Bundled postcondition for `mload_one_limb_spec_within`: after the
+    23-instruction sequence, `byteReg` holds the last loaded byte
+    (`b7`), `accReg` holds the big-endian fold `accFinal`, and the
+    destination dword slot at `sp + signExtend12 dstOff` has been
+    overwritten with `accFinal`. The byte/`accFinal` `let`-bindings
+    mirror `mloadBytePackEightPost` so downstream proofs can `rfl` past
+    the unfold and reuse the same atoms. -/
+@[irreducible]
+def mloadOneLimbPost
+    (addrReg byteReg accReg : Reg)
+    (addrPtr wordVal dwordAddr sp : Word)
+    (off0 off1 off2 off3 off4 off5 off6 off7 dstOff : BitVec 12) : Assertion :=
+  let b0 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off0))).zeroExtend 64
+  let b1 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off1))).zeroExtend 64
+  let b2 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off2))).zeroExtend 64
+  let b3 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off3))).zeroExtend 64
+  let b4 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off4))).zeroExtend 64
+  let b5 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off5))).zeroExtend 64
+  let b6 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off6))).zeroExtend 64
+  let b7 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off7))).zeroExtend 64
+  let accFinal :=
+    ((((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
+        <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6)
+        <<< (8 : Nat) ||| b7
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
+  (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 dstOff) ↦ₘ accFinal)
+
+theorem mloadOneLimbPost_unfold
+    {addrReg byteReg accReg : Reg}
+    {addrPtr wordVal dwordAddr sp : Word}
+    {off0 off1 off2 off3 off4 off5 off6 off7 dstOff : BitVec 12} :
+    mloadOneLimbPost addrReg byteReg accReg
+        addrPtr wordVal dwordAddr sp
+        off0 off1 off2 off3 off4 off5 off6 off7 dstOff =
+    (let b0 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off0))).zeroExtend 64
+     let b1 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off1))).zeroExtend 64
+     let b2 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off2))).zeroExtend 64
+     let b3 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off3))).zeroExtend 64
+     let b4 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off4))).zeroExtend 64
+     let b5 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off5))).zeroExtend 64
+     let b6 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off6))).zeroExtend 64
+     let b7 :=
+       (extractByte wordVal (byteOffset (addrPtr + signExtend12 off7))).zeroExtend 64
+     let accFinal :=
+       ((((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
+           <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6)
+           <<< (8 : Nat) ||| b7
+     (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
+     (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 dstOff) ↦ₘ accFinal)) := by
+  delta mloadOneLimbPost; rfl
+
 /-- One-limb MLOAD spec (23 instructions): pack eight big-endian bytes
     from EVM memory at `addrPtr + off0..off7` into `accReg` (via the
     seed-LBU + 7×(LBU+SLLI+OR) eight-byte rung), then `SD` the packed
@@ -349,36 +446,39 @@ theorem mload_one_limb_spec_within
     (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
     (h_align7 : alignToDword (addrPtr + signExtend12 off7) = dwordAddr)
     (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true) :
-    let b0 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off0))).zeroExtend 64
-    let b1 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off1))).zeroExtend 64
-    let b2 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off2))).zeroExtend 64
-    let b3 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off3))).zeroExtend 64
-    let b4 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off4))).zeroExtend 64
-    let b5 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off5))).zeroExtend 64
-    let b6 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off6))).zeroExtend 64
-    let b7 :=
-      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off7))).zeroExtend 64
-    let accFinal :=
-      ((((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
-          <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6)
-          <<< (8 : Nat) ||| b7
     cpsTripleWithin 23 base (base + 92)
       (mloadOneLimbCode addrReg byteReg accReg
         off0 off1 off2 off3 off4 off5 off6 off7 dstOff base)
-      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
-       (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
-       ((sp + signExtend12 dstOff) ↦ₘ dstWordOld))
-      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
-       (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
-       ((sp + signExtend12 dstOff) ↦ₘ accFinal)) := by
-  intro b0 b1 b2 b3 b4 b5 b6 b7 accFinal
+      (mloadOneLimbPre addrReg byteReg accReg
+        addrPtr accOld byteOld wordVal dwordAddr sp dstWordOld dstOff)
+      (mloadOneLimbPost addrReg byteReg accReg
+        addrPtr wordVal dwordAddr sp
+        off0 off1 off2 off3 off4 off5 off6 off7 dstOff) := by
+  rw [mloadOneLimbPre_unfold, mloadOneLimbPost_unfold]
+  -- Zeta-reduce the `let`-bindings exposed by `mloadOneLimbPost_unfold`
+  -- so that subsequent `set` tactics can fold occurrences of `b0..b7`
+  -- and `accFinal` uniformly across the goal.
+  dsimp only []
+  set b0 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off0))).zeroExtend 64
+  set b1 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off1))).zeroExtend 64
+  set b2 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off2))).zeroExtend 64
+  set b3 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off3))).zeroExtend 64
+  set b4 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off4))).zeroExtend 64
+  set b5 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off5))).zeroExtend 64
+  set b6 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off6))).zeroExtend 64
+  set b7 :=
+    (extractByte wordVal (byteOffset (addrPtr + signExtend12 off7))).zeroExtend 64
+  set accFinal :=
+    ((((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
+        <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6)
+        <<< (8 : Nat) ||| b7
   unfold mloadOneLimbCode
   rw [show (23 : Nat) = 22 + 1 from rfl,
       show (base + 92 : Word) = base + 88 + 4 from by bv_omega]

--- a/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
+++ b/EvmAsm/Evm64/MLoad/LimbSpecEight.lean
@@ -287,4 +287,217 @@ theorem mload_byte_pack_eight_spec_within
   -- The final code-req shape is `mloadBytePackEightCode = seven.union triple`.
   exact cpsTripleWithin_seq hd_step sevenRaw step
 
+/-! ## One-limb spec (8-byte byte-pack + final SD)
+
+Composes `mload_byte_pack_eight_spec_within` (22 instructions covering
+`base..base+88`) with `generic_sd_spec_within` (1 instruction at
+`base + 88`) into a single 23-instruction spec for one EVM-stack output
+limb. This is the level-2 building block per `docs/99-mload-design.md`
+§5.2; `evm_mload_stack_spec_within` (slice 3e) composes four of these
+back-to-back. Beads tracking: `evm-asm-h9e8`. -/
+
+/-- Bundled CodeReq for `mload_one_limb_spec_within`: the eight-byte
+    byte-pack block at `base..base+84` plus a single `SD .x12 accReg
+    dstOff` at `base + 88`. -/
+def mloadOneLimbCode
+    (addrReg byteReg accReg : Reg)
+    (off0 off1 off2 off3 off4 off5 off6 off7 dstOff : BitVec 12)
+    (base : Word) : CodeReq :=
+  (mloadBytePackEightCode addrReg byteReg accReg
+      off0 off1 off2 off3 off4 off5 off6 off7 base).union
+    (CodeReq.singleton (base + 88) (.SD .x12 accReg dstOff))
+
+/-- One-limb MLOAD spec (23 instructions): pack eight big-endian bytes
+    from EVM memory at `addrPtr + off0..off7` into `accReg` (via the
+    seed-LBU + 7×(LBU+SLLI+OR) eight-byte rung), then `SD` the packed
+    limb to the EVM stack slot at `sp + signExtend12 dstOff`.
+
+    Precondition: the four "byte-pack" atoms (`addrReg`, `byteReg`,
+    `accReg`, source `dwordAddr`) plus the SD-side atoms (`.x12 ↦ᵣ sp`
+    and the destination dword cell). Postcondition: `accReg` holds the
+    big-endian fold `accFinal`, `byteReg` holds the last loaded byte
+    (`b7`), and the destination dword has been overwritten with
+    `accFinal`.
+
+    Side conditions: `byteReg`/`accReg` are not `x0`; each source byte
+    address aligns to `dwordAddr` and is a valid byte access; the
+    destination dword address is aligned (it IS the address used as the
+    `↦ₘ` key) and a valid dword access. Register disjointness between
+    `.x12`, `accReg`, `addrReg`, `byteReg` is enforced implicitly by
+    `sepConj` compatibility in the precondition; it does NOT need to be
+    spelled out as separate hypotheses. -/
+theorem mload_one_limb_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld wordVal sp dstWordOld : Word)
+    (dwordAddr : Word)
+    (off0 off1 off2 off3 off4 off5 off6 off7 dstOff : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0  : accReg  ≠ .x0)
+    (h_align0 : alignToDword (addrPtr + signExtend12 off0) = dwordAddr)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_align1 : alignToDword (addrPtr + signExtend12 off1) = dwordAddr)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_align2 : alignToDword (addrPtr + signExtend12 off2) = dwordAddr)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
+    (h_align3 : alignToDword (addrPtr + signExtend12 off3) = dwordAddr)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
+    (h_align4 : alignToDword (addrPtr + signExtend12 off4) = dwordAddr)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
+    (h_align5 : alignToDword (addrPtr + signExtend12 off5) = dwordAddr)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
+    (h_align6 : alignToDword (addrPtr + signExtend12 off6) = dwordAddr)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
+    (h_align7 : alignToDword (addrPtr + signExtend12 off7) = dwordAddr)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true) :
+    let b0 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off0))).zeroExtend 64
+    let b1 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off1))).zeroExtend 64
+    let b2 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off2))).zeroExtend 64
+    let b3 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off3))).zeroExtend 64
+    let b4 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off4))).zeroExtend 64
+    let b5 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off5))).zeroExtend 64
+    let b6 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off6))).zeroExtend 64
+    let b7 :=
+      (extractByte wordVal (byteOffset (addrPtr + signExtend12 off7))).zeroExtend 64
+    let accFinal :=
+      ((((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
+          <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6)
+          <<< (8 : Nat) ||| b7
+    cpsTripleWithin 23 base (base + 92)
+      (mloadOneLimbCode addrReg byteReg accReg
+        off0 off1 off2 off3 off4 off5 off6 off7 dstOff base)
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 dstOff) ↦ₘ dstWordOld))
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
+       (dwordAddr ↦ₘ wordVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 dstOff) ↦ₘ accFinal)) := by
+  intro b0 b1 b2 b3 b4 b5 b6 b7 accFinal
+  unfold mloadOneLimbCode
+  rw [show (23 : Nat) = 22 + 1 from rfl,
+      show (base + 92 : Word) = base + 88 + 4 from by bv_omega]
+  -- Step 1: 22-instruction eight-byte byte-pack at `base`. Unfold its
+  -- bundled pre/post so the hypothesis is in raw `sepConj` shape.
+  have eight := mload_byte_pack_eight_spec_within addrReg byteReg accReg
+    addrPtr accOld byteOld wordVal dwordAddr
+    off0 off1 off2 off3 off4 off5 off6 off7 base
+    h_byte_ne_x0 h_acc_ne_x0
+    h_align0 h_valid0 h_align1 h_valid1 h_align2 h_valid2 h_align3 h_valid3
+    h_align4 h_valid4 h_align5 h_valid5 h_align6 h_valid6 h_align7 h_valid7
+  rw [mloadBytePackEightPre_unfold, mloadBytePackEightPost_unfold] at eight
+  -- Step 2: SD spec at `base + 88` with rs1 = .x12, rs2 = accReg.
+  have sd := generic_sd_spec_within (.x12 : Reg) accReg sp accFinal dstWordOld
+    dstOff (base + 88)
+  -- Frame eight with `(.x12 ↦ᵣ sp) ** (dstSlot ↦ₘ dstWordOld)` on the right.
+  have eightF := cpsTripleWithin_frameR
+    (F := ((.x12 : Reg) ↦ᵣ sp) ** ((sp + signExtend12 dstOff) ↦ₘ dstWordOld))
+    (by pcFree) eight
+  -- Frame SD with `(addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) **
+  -- (dwordAddr ↦ₘ wordVal)` on the left.
+  have sdF := cpsTripleWithin_frameL
+    (F := (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (dwordAddr ↦ₘ wordVal))
+    (by pcFree) sd
+  -- Bridge: eight's framed post equals sd's framed pre (AC-equivalence).
+  have hMid :
+      (((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (dwordAddr ↦ₘ wordVal)) **
+        (((.x12 : Reg) ↦ᵣ sp) ** (accReg ↦ᵣ accFinal) **
+         ((sp + signExtend12 dstOff) ↦ₘ dstWordOld))) =
+      (((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
+       (dwordAddr ↦ₘ wordVal)) **
+        (((.x12 : Reg) ↦ᵣ sp) **
+         ((sp + signExtend12 dstOff) ↦ₘ dstWordOld))) := by ac_rfl
+  -- Disjointness between the eight-byte block (addresses base, base+4,
+  -- …, base+84) and the trailing SD at base+88. 22 leaf inequalities.
+  have hd_step : CodeReq.Disjoint
+      (mloadBytePackEightCode addrReg byteReg accReg
+        off0 off1 off2 off3 off4 off5 off6 off7 base)
+      (CodeReq.singleton (base + 88) (.SD (.x12 : Reg) accReg dstOff)) := by
+    unfold mloadBytePackEightCode mloadBytePackSevenCode mloadBytePackSixCode
+      mloadBytePackFiveCode mloadBytePackFourCode mloadBytePackThreeCode
+      mloadBytePackTwoCode
+    have leaf : ∀ {a : Word} {i : Instr},
+        a ≠ base + 88 →
+        CodeReq.Disjoint (CodeReq.singleton a i)
+            (CodeReq.singleton (base + 88) (.SD (.x12 : Reg) accReg dstOff)) := by
+      intro a i h88
+      exact CodeReq.Disjoint.singleton h88
+    -- mloadBytePackEightCode unfolds to 22 leaves at offsets
+    -- 0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44, 48, 52, 56, 60,
+    -- 64, 68, 72, 76, 80, 84.
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · -- Seven block
+      refine CodeReq.Disjoint.union_left ?_ ?_
+      · -- Six block
+        refine CodeReq.Disjoint.union_left ?_ ?_
+        · -- Five block
+          refine CodeReq.Disjoint.union_left ?_ ?_
+          · -- Four block
+            refine CodeReq.Disjoint.union_left ?_ ?_
+            · -- (Two ∪ trio_16)
+              refine CodeReq.Disjoint.union_left ?_ ?_
+              · -- Two: leaves at base, +4, +8, +12
+                refine CodeReq.Disjoint.union_left
+                  (leaf (by bv_omega)) ?_
+                refine CodeReq.Disjoint.union_left
+                  (leaf (by bv_omega)) ?_
+                refine CodeReq.Disjoint.union_left
+                  (leaf (by bv_omega)) ?_
+                exact leaf (by bv_omega)
+              · -- trio_16: leaves at +16, +20, +24
+                refine CodeReq.Disjoint.union_left
+                  (leaf (by bv_omega)) ?_
+                refine CodeReq.Disjoint.union_left
+                  (leaf (by bv_omega)) ?_
+                exact leaf (by bv_omega)
+            · -- trio_28: leaves at +28, +32, +36
+              refine CodeReq.Disjoint.union_left
+                (leaf (by bv_omega)) ?_
+              refine CodeReq.Disjoint.union_left
+                (leaf (by bv_omega)) ?_
+              exact leaf (by bv_omega)
+          · -- trio_40: leaves at +40, +44, +48
+            refine CodeReq.Disjoint.union_left
+              (leaf (by bv_omega)) ?_
+            refine CodeReq.Disjoint.union_left
+              (leaf (by bv_omega)) ?_
+            exact leaf (by bv_omega)
+        · -- trio_52: leaves at +52, +56, +60
+          refine CodeReq.Disjoint.union_left
+            (leaf (by bv_omega)) ?_
+          refine CodeReq.Disjoint.union_left
+            (leaf (by bv_omega)) ?_
+          exact leaf (by bv_omega)
+      · -- trio_64: leaves at +64, +68, +72
+        refine CodeReq.Disjoint.union_left
+          (leaf (by bv_omega)) ?_
+        refine CodeReq.Disjoint.union_left
+          (leaf (by bv_omega)) ?_
+        exact leaf (by bv_omega)
+    · -- trio_76: leaves at +76, +80, +84
+      refine CodeReq.Disjoint.union_left
+        (leaf (by bv_omega)) ?_
+      refine CodeReq.Disjoint.union_left
+        (leaf (by bv_omega)) ?_
+      exact leaf (by bv_omega)
+  -- Compose: the running assertion at base+88 must match sdF's pre.
+  -- Use `cpsTripleWithin_seq` after rewriting eightF's post via `hMid`.
+  have composed := cpsTripleWithin_seq hd_step (hMid ▸ eightF) sdF
+  -- The composition's pre is `eightF.pre`, which is the eight-byte
+  -- pre re-associated under `frameR`:
+  --   ((addrReg ** byteReg ** accReg ** dwordAddr) ** (.x12 ** dstSlot))
+  -- Goal pre is the flat sepConj
+  --   addrReg ** byteReg ** accReg ** dwordAddr ** .x12 ** dstSlot
+  -- The composition's post is sdF.post, which is similarly re-associated.
+  -- Both AC-equal to the goal; use `cpsTripleWithin_weaken` + `sep_perm`.
+  exact cpsTripleWithin_weaken
+    (fun h hp => by sep_perm hp)
+    (fun h hp => by sep_perm hp)
+    composed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Composes `mload_byte_pack_eight_spec_within` (22 instructions covering `base..base+88`) with `generic_sd_spec_within` (1 instruction at `base + 88`) into a single 23-instruction spec for one EVM-stack output MLOAD limb.

This is the level-2 building block per `docs/99-mload-design.md` §5.2; `evm_mload_stack_spec_within` (slice 3e) will compose four of these back-to-back to form the full 256-bit MLOAD spec.

The proof:
1. Frames the 8-byte byte-pack spec on the right with the SD-side atoms (`(.x12 ↦ᵣ sp) ** (dstSlot ↦ₘ dstWordOld)`).
2. Frames the SD spec on the left with the byte-pack-side atoms (`(addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (dwordAddr ↦ₘ wordVal)`).
3. Bridges the framed post / framed pre via an `ac_rfl` rewrite.
4. Discharges 22 leaf disjointness inequalities (the trailing SD at `base+88` is distinct from each byte-pack instruction at `base+0, base+4, …, base+84`) by a tree of `CodeReq.Disjoint.union_left` applications, mirroring the seven/eight rung pattern from the existing slices.
5. Composes via `cpsTripleWithin_seq` and weakens the pre/post via `sep_perm` to flatten the framed associativity.

Pre/post are stated directly (not bundled into `@[irreducible]` handles) because the spec exposes only six atoms and there is one consumer (the upcoming slice 3e) — bundling can be added later if the consumer struggles.

Lands inside `EvmAsm/Evm64/MLoad/LimbSpecEight.lean` (final size 500 lines, well under the 1500-line cap). Full `lake build` green, no `sorry`, no `maxHeartbeats`/`maxRecDepth` overrides.

Refs GH #99, beads `evm-asm-h9e8` (slice 3d under parent `evm-asm-cegc`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).