### PR TITLE
chore(divmod): name phaseBInit2Off (= 60) for phaseB init2 sub-block

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Base.lean
@@ -768,7 +768,7 @@ instance pcFreeInst_normBPost (sp nVal shift b0 b1 b2 b3 : Word) :
 -- in PhaseAB.lean and `mod_phB_off_28` in ModPhaseB.lean.
 -- ============================================================================
 
-theorem phB_off_28 {base : Word} : (base + phaseBOff : Word) + 28 = base + 60 := by bv_addr
+theorem phB_off_28 {base : Word} : (base + phaseBOff : Word) + 28 = base + phaseBInit2Off := by bv_addr
 
 -- n=4 special: x1 = signExtend12 4 - 4 = 0, used by the shift-0 fast path
 -- and the main `FullPathN4` path. Shared here so the two consumer files

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -49,10 +49,10 @@ theorem divK_phaseB_init1_code_sub_modCode {base : Word} :
   exact sub_modCode_of_phaseB_left a i h1
 
 theorem divK_phaseB_init2_code_sub_modCode {base : Word} :
-    ∀ a i, (divK_phaseB_init2_code (base + 60)) a = some i → (modCode base) a = some i := by
+    ∀ a i, (divK_phaseB_init2_code (base + phaseBInit2Off)) a = some i → (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + 60) divK_phaseB
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBInit2Off) divK_phaseB
     (divK_phaseB.drop 7 |>.take 2) 7
     (by bv_addr) (by decide) (by decide) (by decide) a i h
   exact sub_modCode_of_phaseB_left a i h1
@@ -94,7 +94,7 @@ theorem divK_phaseB_tail_code_sub_modCode {base : Word} :
 -- The former `mod_phB_off_28` (identical to PhaseAB's private `phB_off_28`)
 -- now lives in `Compose/Base.lean` as the shared `phB_off_28` and is used
 -- directly from both the DIV and MOD sides.
-theorem mod_phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+theorem mod_phB_i2_8 {base : Word} : (base + phaseBInit2Off : Word) + 8 = base + 68 := by bv_addr
 theorem mod_phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 theorem mod_phB_bne_4 {base : Word} : (base + 72 : Word) + 4 = base + 76 := by bv_addr
 theorem mod_phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
@@ -143,7 +143,7 @@ theorem evm_mod_phaseB_n4_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- Step 2: init2 (base+60 → base+68) — load b[1], b[2]
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [mod_phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode hinit2_raw
   seqFrame hinit1f hinit2

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -50,7 +50,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [mod_phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR
@@ -221,7 +221,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [mod_phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -49,7 +49,7 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [mod_phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -18,6 +18,7 @@
     [phaseAOff    =   0] divK_phaseA        (32 bytes)
       [phaseABeqOff =  28]  phaseA-end BEQ → zeroPath (phaseAOff + 28)
     [phaseBOff    =  32] divK_phaseB        (84 bytes)
+      [phaseBInit2Off = 60]  divK_phaseB_init2 sub-block (phaseBOff + 28)
       [phaseBTailOff = 96]  divK_phaseB_tail sub-block (phaseBOff + 64)
     [clzOff       = 116] divK_clz           (96 bytes)
     [phaseC2Off   = 212] divK_phaseC2       (16 bytes)
@@ -59,6 +60,13 @@ abbrev phaseAOff    : Word :=    0
 abbrev phaseABeqOff : Word :=   28
 /-- Offset of `divK_phaseB` (b=0 branch + leading-limb analysis). -/
 abbrev phaseBOff    : Word :=   32
+/-- Offset of the `divK_phaseB_init2` sub-block inside `divK_phaseB`.
+    Entry PC of the second pair of phaseB init loads (`LD x6 sp 16 ;; LD x7 sp 24`),
+    7 instructions / 28 bytes into `divK_phaseB`. The per-limb specs in
+    `Compose/PhaseAB.lean`, `Compose/ModPhaseB.lean`, `Compose/ModPhaseBn3.lean`,
+    and `Compose/ModPhaseBn21.lean` invoke `divK_phaseB_init2_spec_within` at
+    this address. Sub-offset relative to `divK_phaseB` (= phaseBOff + 28). -/
+abbrev phaseBInit2Off : Word :=   60
 /-- Offset of the `divK_phaseB_tail` sub-block inside `divK_phaseB`.
     Entry PC of the leading-limb-analysis tail (16 instructions / 64 bytes
     into `divK_phaseB`); the per-limb cascade in `divK_phaseB_cascade` falls
@@ -219,6 +227,10 @@ abbrev div128CallRetOff : Word := 516
     The phaseA-end BEQ to `divK_zeroPath` sits 7 instructions into phaseA. -/
 example : phaseABeqOff = phaseAOff + 28 := by decide
 example : phaseABeqOff + 4 = phaseBOff := by decide
+/-- phaseBInit2Off = phaseBOff + 28 (sub-block offset within `divK_phaseB`).
+    The second pair of phaseB init loads (`LD x6 sp 16 ;; LD x7 sp 24`) sits
+    7 instructions into phaseB. -/
+example : phaseBInit2Off = phaseBOff + 28 := by decide
 /-- phaseBOff = phaseAOff + 4 · |divK_phaseA 1020|. -/
 example : phaseBOff = phaseAOff + 4 * (divK_phaseA 1020).length := by decide
 /-- clzOff = phaseBOff + 4 · |divK_phaseB|. -/

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -77,10 +77,10 @@ private theorem divK_phaseB_init1_code_sub_divCode {base : Word} :
 
 /-- Phase B init2 code (ofProg sub-range of block 1) is subsumed by divCode. -/
 private theorem divK_phaseB_init2_code_sub_divCode {base : Word} :
-    ∀ a i, (divK_phaseB_init2_code (base + 60)) a = some i → (divCode base) a = some i := by
+    ∀ a i, (divK_phaseB_init2_code (base + phaseBInit2Off)) a = some i → (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
-  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + 60) divK_phaseB
+  have h1 := CodeReq.ofProg_mono_sub (base + phaseBOff) (base + phaseBInit2Off) divK_phaseB
     (divK_phaseB.drop 7 |>.take 2) 7
     (by bv_addr) (by decide) (by decide) (by decide) a i h
   exact sub_divCode_of_phaseB_left a i h1
@@ -143,7 +143,7 @@ private theorem divK_phaseB_n4_nm1_x8 :
 
 -- Address normalization lemmas `phB_off_{4..28}` now live in `Compose/Base.lean`
 -- and are shared with the MOD-side files (ModPhaseB / ModPhaseBn3 / ModPhaseBn21).
-private theorem phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
+private theorem phB_i2_8 {base : Word} : (base + phaseBInit2Off : Word) + 8 = base + 68 := by bv_addr
 private theorem phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + 72 := by bv_addr
 private theorem phB_bne_4 {base : Word} : (base + 72 : Word) + 4 = base + 76 := by bv_addr
 private theorem phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
@@ -277,7 +277,7 @@ theorem evm_div_phaseB_n4_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- Step 2: init2 (base+60 → base+68) — load b[1], b[2]
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode hinit2_raw
   seqFrame hinit1f hinit2
@@ -515,7 +515,7 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR
@@ -650,7 +650,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR
@@ -820,7 +820,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
      ((sp + signExtend12 3984) ↦ₘ nMem))
     (by pcFree) hinit1
   -- ---- init2 (base+60 → base+68)
-  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + 60) b1 b2 v6 v7
+  have hinit2_raw := divK_phaseB_init2_spec_within sp (base + phaseBInit2Off) b1 b2 v6 v7
   simp only [phB_i2_8] at hinit2_raw
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode hinit2_raw
   have hinit2f := cpsTripleWithin_frameR


### PR DESCRIPTION
Sub-slice of #301 (beads evm-asm-oqhq).

Replace 15 hardcoded `base + 60` literals across Compose/{PhaseAB,ModPhaseB,ModPhaseBn3,ModPhaseBn21,Base}.lean with the new named offset constant `phaseBInit2Off = 60 = phaseBOff + 28` (entry PC of `divK_phaseB_init2`, the second pair of phaseB init loads at which `divK_phaseB_init2_spec_within` is invoked).

Adds the abbrev to `Compose/Offsets.lean` with a docstring + a `phaseBInit2Off = phaseBOff + 28` example check, alongside the existing `phaseABeqOff` / `phaseBTailOff` entries.

`lake build` green locally; no new sorries.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).