### PR TITLE
chore(divmod): name phaseBBne2Off (= 80) for phaseB BNE-to-tail PC #2

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -188,14 +188,14 @@ theorem addi_x5_3_sub_modCode {base : Word} :
 
 -- BNE x7 x0 16 at base+80 (index 12 of phaseB)
 theorem bne_x7_16_sub_modCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 80) (.BNE .x7 .x0 16)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
   rw [bv64_4mul_12,
-      show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 48 = base + phaseBBne2Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left a i h1
 
@@ -257,8 +257,8 @@ theorem mod_divK_phaseB_n1_nm1_x8 :
   decide
 
 -- Cascade address normalization
-theorem mod_phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by bv_addr
-theorem mod_phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
+theorem mod_phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + phaseBBne2Off := by bv_addr
+theorem mod_phB_step1_8 {base : Word} : (base + phaseBBne2Off : Word) + 4 = base + 84 := by bv_addr
 theorem mod_phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
 theorem mod_phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
 theorem mod_phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -115,8 +115,8 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -286,8 +286,8 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -114,8 +114,8 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
     (fun hp hQf => by

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -66,6 +66,14 @@ abbrev phaseBOff    : Word :=   32
     cascade step otherwise). Sub-offset relative to `divK_phaseB`
     (= phaseBOff + 40 = phaseBTailOff − 24). -/
 abbrev phaseBBneOff : Word :=   72
+/-- Offset of the second BNE-to-`divK_phaseB_tail` instruction inside
+    `divK_phaseB`. Entry PC of the `BNE x7, x0, +16` that ends the
+    second per-limb leading-limb-analysis cascade step and branches
+    forward into `divK_phaseB_tail` when the current candidate top limb
+    is non-zero (falls through to the next per-limb cascade step
+    otherwise). Sub-offset relative to `divK_phaseB`
+    (= phaseBOff + 48 = phaseBTailOff − 16). -/
+abbrev phaseBBne2Off : Word :=   80
 /-- Offset of the `divK_phaseB_tail` sub-block inside `divK_phaseB`.
     Entry PC of the leading-limb-analysis tail (16 instructions / 64 bytes
     into `divK_phaseB`); the per-limb cascade in `divK_phaseB_cascade` falls
@@ -315,6 +323,12 @@ example : trialJalOff + 4 = div128CallRetOff := by decide
     `divK_phaseB`, 24 bytes (6 instructions) before `phaseBTailOff`. -/
 example : phaseBBneOff = phaseBOff + 40 := by decide
 example : phaseBBneOff + 24 = phaseBTailOff := by decide
+/-- phaseBBne2Off = phaseBOff + 48 (sub-block offset within `divK_phaseB`).
+    The second BNE-to-`divK_phaseB_tail` instruction sits 12 instructions
+    into `divK_phaseB`, 16 bytes (4 instructions) before `phaseBTailOff`. -/
+example : phaseBBne2Off = phaseBOff + 48 := by decide
+example : phaseBBne2Off + 16 = phaseBTailOff := by decide
+example : phaseBBne2Off = phaseBBneOff + 8 := by decide
 /-- mulsubOff = loopBodyOff + 88 (sub-block offset within `divK_loopBody`).
     The `divK_mulsub_correction` snippet starts 22 instructions into the loop
     body, after the trial-divide entry (~13 instructions) and the div128 call

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -395,14 +395,14 @@ private theorem addi_x5_3_sub_divCode {base : Word} :
 
 -- BNE x7 x0 16 at base+80 (index 12 of phaseB)
 private theorem bne_x7_16_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 80) (.BNE .x7 .x0 16)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBBne2Off) (.BNE .x7 .x0 16)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 12
     (by decide) (by decide)
   rw [bv64_4mul_12,
-      show (base + phaseBOff : Word) + 48 = base + 80 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 48 = base + phaseBBne2Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left a i h1
 
@@ -465,8 +465,8 @@ private theorem divK_phaseB_n1_nm1_x8 :
   decide
 
 -- Cascade address normalization
-private theorem phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by bv_addr
-private theorem phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
+private theorem phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + phaseBBne2Off := by bv_addr
+private theorem phB_step1_8 {base : Word} : (base + phaseBBne2Off : Word) + 4 = base + 84 := by bv_addr
 private theorem phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
 private theorem phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
 private theorem phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr
@@ -580,8 +580,8 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 taken (base+80 → base+96, b2≠0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_takenStripPure2 hbne1_raw
     (fun hp hQf => by
@@ -715,8 +715,8 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by
@@ -885,8 +885,8 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
   have h12345 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h1234 haddi1f
   -- ---- Cascade step 1: BNE x7 ntaken (base+80 → base+84, b2=0)
-  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + 80)
-  rw [show (base + 80 : Word) + signExtend13 16 = base + phaseBTailOff from by
+  have hbne1_raw := bne_spec_gen_within .x7 .x0 16 b2 (0 : Word) (base + phaseBBne2Off)
+  rw [show (base + phaseBBne2Off : Word) + signExtend13 16 = base + phaseBTailOff from by
         rv64_addr, phB_step1_8] at hbne1_raw
   have hbne1_clean := cpsBranchWithin_ntakenStripPure2 hbne1_raw
     (fun hp hQt => by


### PR DESCRIPTION
Add `abbrev phaseBBne2Off : Word := 80` to Compose/Offsets.lean for the `BNE x7 x0 16` instruction at `phaseBOff + 48` that ends the SECOND per-limb leading-limb-analysis cascade step in `divK_phaseB` and branches forward into `divK_phaseB_tail`. Mirror of `phaseBBneOff` (= 72, PR #1718, sibling step 1).

Migrate the 20 `base + 80` literals across the four Compose files (PhaseAB.lean ×10, ModPhaseB.lean ×4, ModPhaseBn21.lean ×4, ModPhaseBn3.lean ×2). `LimbSpec/Div128Step1v2.lean` and `LimbSpec/Div128Step2v4.lean` also mention `base + 80` but there `base` is the local block base, not the program base; those are block-relative and stay unchanged. Other unrelated `base + 80` occurrences (MLoad, Multiply, Eq/Sgt/Slt) are also untouched.

Three drift checks added:
- `phaseBBne2Off = phaseBOff + 48`
- `phaseBBne2Off + 16 = phaseBTailOff`
- `phaseBBne2Off = phaseBBneOff + 8`

Slice of #301. `abbrev` reduces by rfl, so callers continue to typecheck without changes. Local `lake build` green.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
Refs: GH #301, beads evm-asm-110n (parent evm-asm-nqj).