### PR TITLE
ci(benchmark): per-module lakeprof timing job (#949 follow-up)

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -226,3 +226,105 @@ jobs:
             cache_get.log
           if-no-files-found: warn
           retention-days: 90
+
+  # Per-module timing via lakeprof (https://github.com/Kha/lakeprof).
+  # Independent of `benchmark` so a lakeprof break never gates the wall/RSS
+  # metric. Same trigger; appends `kind=lakeprof` records to
+  # `benchmark-history`. See docs/949-lakeprof-design.md (#949 follow-up).
+  lakeprof:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    env:
+      LAKEPROF_TOP_N: '20'
+
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - uses: leanprover/lean-action@v1
+        with:
+          use-mathlib-cache: true
+          use-github-cache: false
+          lake-package-directory: .
+          # We run our own build via `lakeprof record`.
+          build: "false"
+
+      - name: Mathlib cache get
+        run: lake exe cache get
+
+      - name: Install uv (for uvx)
+        uses: astral-sh/setup-uv@v3
+
+      - name: lakeprof record
+        id: record
+        run: |
+          set -o pipefail
+          uvx --from git+https://github.com/Kha/lakeprof \
+            lakeprof record -o lakeprof.log lake build 2>&1 | tee lakeprof.record.log
+
+      - name: lakeprof report (chrome-trace + crit-path)
+        id: report
+        if: steps.record.outcome == 'success'
+        run: |
+          set -o pipefail
+          uvx --from git+https://github.com/Kha/lakeprof \
+            lakeprof report \
+              -i lakeprof.log \
+              --save-chrome-trace lakeprof.trace.json \
+              --print-crit-path \
+              --print-avg-crit \
+              2>&1 | tee lakeprof.report.txt
+
+      - name: Extract top-N
+        id: topn
+        if: steps.report.outcome == 'success'
+        run: |
+          python3 .github/workflows/scripts/lakeprof_topn.py \
+            --in lakeprof.trace.json \
+            --out lakeprof.topn.json \
+            --n "${LAKEPROF_TOP_N}"
+
+      - name: Write job summary
+        if: always()
+        run: |
+          {
+            echo "## lakeprof top-${LAKEPROF_TOP_N} slowest modules"
+            echo
+            echo "| field      | value |"
+            echo "|------------|-------|"
+            echo "| commit     | \`${GITHUB_SHA}\` |"
+            echo "| ref        | \`${GITHUB_REF}\` |"
+            echo "| trigger    | ${GITHUB_EVENT_NAME} |"
+            echo "| timestamp  | $(date -u +%Y-%m-%dT%H:%M:%SZ) |"
+            if [ -f lakeprof.topn.json ]; then
+              python3 .github/workflows/scripts/lakeprof_md.py \
+                --in lakeprof.topn.json
+            else
+              echo
+              echo "_lakeprof did not produce a top-N file (record/report failed)._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Append top-modules to benchmark-history
+        if: steps.topn.outcome == 'success'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          LAKEPROF_TOPN_JSON: lakeprof.topn.json
+        run: bash .github/workflows/scripts/lakeprof_append.sh
+
+      - name: Upload lakeprof artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lakeprof-${{ github.run_id }}
+          path: |
+            lakeprof.log
+            lakeprof.trace.json
+            lakeprof.report.txt
+            lakeprof.record.log
+            lakeprof.topn.json
+          if-no-files-found: warn
+          retention-days: 90

--- a/.github/workflows/scripts/lakeprof_append.sh
+++ b/.github/workflows/scripts/lakeprof_append.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Append a lakeprof top-N record to the benchmark-history orphan branch.
+#
+# Mirrors the existing "Persist record to benchmark-history branch" step
+# in `.github/workflows/benchmark.yml`, but writes a record with
+# `kind="lakeprof"` carrying ONLY {commit, ref, run_id, top_modules}.
+#
+# Inputs (env):
+#   GITHUB_TOKEN      — write-capable token for the repo
+#   GITHUB_REPOSITORY — owner/repo (set by Actions)
+#   GITHUB_SHA        — commit benchmarked
+#   GITHUB_REF        — branch / ref triggering the run
+#   GITHUB_RUN_ID     — run ID
+#   GITHUB_EVENT_NAME — event ('schedule' / 'workflow_dispatch')
+#   LAKEPROF_TOPN_JSON — path to lakeprof.topn.json (default: ./lakeprof.topn.json)
+#
+# The record's `kind` field distinguishes lakeprof entries from the
+# build (wall+RSS) records appended by the sibling `benchmark` job.
+# Existing pre-#949-followup records have neither key; consumers default
+# to `"build"` when absent (per docs/949-lakeprof-design.md §5).
+
+set -euo pipefail
+
+TOPN_JSON="${LAKEPROF_TOPN_JSON:-./lakeprof.topn.json}"
+
+if [ ! -f "$TOPN_JSON" ]; then
+  echo "lakeprof_append: $TOPN_JSON not found, skipping history append" >&2
+  exit 0
+fi
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+git -c protocol.version=2 clone --no-checkout --filter=blob:none \
+  "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+  "$tmpdir/history"
+cd "$tmpdir/history"
+git config user.name  'github-actions[bot]'
+git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+
+if git ls-remote --exit-code --heads origin benchmark-history >/dev/null 2>&1; then
+  git fetch --depth=1 origin benchmark-history
+  git checkout benchmark-history
+else
+  # The wall/RSS job creates this branch on first run; in the rare case
+  # the lakeprof job races ahead, initialize a minimal orphan with an
+  # empty log so the append still works. The README describes wall/RSS
+  # fields; we intentionally do NOT rewrite it here so a later run of
+  # the wall/RSS job populates the canonical README content.
+  git checkout --orphan benchmark-history
+  git rm -rf --quiet . 2>/dev/null || true
+  printf '# benchmark-history\n\nSee benchmark.yml for schema.\n' > README.md
+  : > history.jsonl
+fi
+
+export TOPN_JSON_ABS="$(cd "$OLDPWD" && readlink -f "$TOPN_JSON")"
+export TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+script="$tmpdir/append_record.py"
+cat > "$script" <<'PY'
+import json, os
+with open(os.environ["TOPN_JSON_ABS"], "r", encoding="utf-8") as f:
+    topn = json.load(f).get("top_modules") or []
+rec = {
+    "kind":         "lakeprof",
+    "commit":       os.environ["GITHUB_SHA"],
+    "ref":          os.environ["GITHUB_REF"],
+    "timestamp":    os.environ["TIMESTAMP"],
+    "trigger":      os.environ["GITHUB_EVENT_NAME"],
+    "run_id":       os.environ["GITHUB_RUN_ID"],
+    "top_modules":  topn,
+}
+with open("history.jsonl", "a", encoding="utf-8") as f:
+    f.write(json.dumps(rec, sort_keys=True) + "\n")
+PY
+python3 "$script"
+
+git add history.jsonl README.md
+git commit -m "lakeprof: ${GITHUB_SHA::12} top=$(python3 -c 'import json,os; print(len(json.load(open(os.environ["TOPN_JSON_ABS"])).get("top_modules") or []))')" \
+  --allow-empty
+
+# Push with retries: the workflow's `concurrency.group` should serialize
+# weekly runs, but a manual workflow_dispatch could still race against
+# the cron run, or against the sibling benchmark job's own append.
+for attempt in 1 2 3; do
+  if git push origin benchmark-history; then
+    echo "lakeprof history push: ok on attempt $attempt"
+    exit 0
+  fi
+  echo "lakeprof history push: attempt $attempt failed, refetching + re-applying" >&2
+  git fetch origin benchmark-history
+  git reset --hard origin/benchmark-history
+  python3 "$script"
+  git add history.jsonl README.md
+  git commit -m "lakeprof: ${GITHUB_SHA::12} top=$(python3 -c 'import json,os; print(len(json.load(open(os.environ["TOPN_JSON_ABS"])).get("top_modules") or []))')" \
+    --allow-empty
+  sleep 5
+done
+
+echo "lakeprof_append: push retries exhausted" >&2
+exit 1

--- a/.github/workflows/scripts/lakeprof_md.py
+++ b/.github/workflows/scripts/lakeprof_md.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Render a lakeprof top-N JSON file as a markdown table.
+
+Input shape (from lakeprof_topn.py):
+
+    {"top_modules": [{"name": "...", "dur_seconds": 12.34}, ...]}
+
+Output (stdout): a GitHub-flavored markdown table
+
+    | rank | module | seconds |
+    |------|--------|---------|
+    | 1    | ...    | 12.34   |
+    ...
+
+If `top_modules` is empty, prints a single-line note instead of a table.
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--in", dest="in_path", required=True,
+        help="Path to lakeprof.topn.json",
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.in_path)
+    if not in_path.is_file():
+        print(f"_lakeprof: input not found ({in_path})_")
+        return 0  # markdown should not break the run
+
+    try:
+        with in_path.open("r", encoding="utf-8") as f:
+            doc = json.load(f)
+    except json.JSONDecodeError as exc:
+        print(f"_lakeprof: malformed input — {exc}_")
+        return 0
+
+    rows = doc.get("top_modules") or []
+    if not rows:
+        print("_lakeprof: no module timings recorded._")
+        return 0
+
+    print()
+    print("| rank | module | seconds |")
+    print("|------|--------|---------|")
+    for i, row in enumerate(rows, start=1):
+        name = str(row.get("name", "")).replace("|", r"\|")
+        dur = row.get("dur_seconds", 0.0)
+        try:
+            dur_str = f"{float(dur):.2f}"
+        except (TypeError, ValueError):
+            dur_str = str(dur)
+        print(f"| {i} | `{name}` | {dur_str} |")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/scripts/lakeprof_topn.py
+++ b/.github/workflows/scripts/lakeprof_topn.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Extract top-N slowest modules from a lakeprof chrome-trace JSON file.
+
+Input: a chrome-trace JSON document produced by `lakeprof report
+--save-chrome-trace`. Either a top-level array of `trace_event` records,
+or an object with a `traceEvents` field (Chrome's "object" form). Each
+record has `name`, `ph`, `dur` (microseconds), and friends.
+
+Output: a JSON document of the shape
+
+    {
+      "top_modules": [
+        {"name": "EvmAsm.Evm64.DivMod.Spec.CallAddback",
+         "dur_seconds": 87.31},
+        ...
+      ]
+    }
+
+`top_modules` is sorted by `dur_seconds` descending, capped at N entries
+(default 20 via --n). `dur_seconds` is the raw lakeprof microsecond
+duration divided by 1_000_000 and rounded to two decimals (per design
+note docs/949-lakeprof-design.md).
+
+Stdlib only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def load_events(path: Path) -> list[dict]:
+    """Load chrome-trace events from a file.
+
+    Accepts either an array (the most common lakeprof shape) or an
+    object with a ``traceEvents`` field. Anything else is an error.
+    """
+    with path.open("r", encoding="utf-8") as f:
+        doc = json.load(f)
+    if isinstance(doc, list):
+        return doc
+    if isinstance(doc, dict) and isinstance(doc.get("traceEvents"), list):
+        return doc["traceEvents"]
+    raise ValueError(
+        f"unexpected chrome-trace shape in {path}: "
+        f"top-level must be a list or an object with 'traceEvents'"
+    )
+
+
+def top_modules(events: list[dict], n: int) -> list[dict]:
+    """Return the top-N (name, dur_seconds) records, ph='X' only."""
+    rows: list[tuple[str, float]] = []
+    for ev in events:
+        # Only "complete" events carry a duration; other phases (B/E,
+        # M = metadata, etc.) don't.
+        if ev.get("ph") != "X":
+            continue
+        name = ev.get("name")
+        dur_us = ev.get("dur")
+        if not isinstance(name, str) or not isinstance(dur_us, (int, float)):
+            continue
+        rows.append((name, float(dur_us) / 1_000_000.0))
+    # Sort by duration descending, ties broken by name ascending for
+    # determinism across reruns.
+    rows.sort(key=lambda r: (-r[1], r[0]))
+    out: list[dict] = []
+    for name, dur_s in rows[: max(0, n)]:
+        out.append({"name": name, "dur_seconds": round(dur_s, 2)})
+    return out
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--in", dest="in_path", required=True,
+        help="Path to lakeprof chrome-trace JSON (lakeprof.trace.json)",
+    )
+    parser.add_argument(
+        "--out", dest="out_path", required=True,
+        help="Path to write top-N JSON (lakeprof.topn.json)",
+    )
+    parser.add_argument(
+        "--n", dest="n", type=int, default=20,
+        help="Number of top entries to keep (default: 20)",
+    )
+    args = parser.parse_args(argv)
+
+    in_path = Path(args.in_path)
+    if not in_path.is_file():
+        print(f"error: input not found: {in_path}", file=sys.stderr)
+        return 2
+    try:
+        events = load_events(in_path)
+    except (ValueError, json.JSONDecodeError) as exc:
+        print(f"error: failed to parse {in_path}: {exc}", file=sys.stderr)
+        return 2
+
+    top = top_modules(events, args.n)
+
+    out_path = Path(args.out_path)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w", encoding="utf-8") as f:
+        json.dump({"top_modules": top}, f, indent=2, sort_keys=True)
+        f.write("\n")
+    print(
+        f"lakeprof_topn: wrote {len(top)} entries to {out_path}",
+        file=sys.stderr,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Adds a sibling `lakeprof` job to `.github/workflows/benchmark.yml` that runs on the same weekly trigger as the existing wall/RSS benchmark, captures per-module build timings via [lakeprof](https://github.com/Kha/lakeprof)'s chrome-trace output, surfaces a top-20 markdown table in the run summary, and appends a `kind=lakeprof` record to the `benchmark-history` orphan branch.

Implements the design from `docs/949-lakeprof-design.md` (PR #1682, evm-asm-mcc4 / #949 follow-up slice 1). Runs independently of the `benchmark` job so a lakeprof break never gates the wall/RSS metric. lakeprof is installed on-the-fly via `uvx`, no global tooling change.

New helpers under `.github/workflows/scripts/`:

- `lakeprof_topn.py` — parse chrome-trace JSON, emit top-N JSON (stdlib-only; handles both top-level array and `{traceEvents: [...]}` shapes)
- `lakeprof_md.py` — render top-N JSON as a markdown table for `GITHUB_STEP_SUMMARY`
- `lakeprof_append.sh` — clone `benchmark-history`, append a `kind=lakeprof` JSONL record with retries (mirrors the wall/RSS append loop)

Both Python scripts smoke-tested locally on synthetic chrome-trace inputs (top-level array, `{traceEvents}` form, empty input). The `lakeprof` job's trigger is `schedule` (Mondays 06:00 UTC) plus `workflow_dispatch` for first-run validation.

Closes beads `evm-asm-g9gu` (parent `evm-asm-hj6c`, GH #949 follow-up).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).