### PR TITLE
chore(divmod): name phaseBBne3Off (= 88) for phaseB BNE-to-tail PC #3

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -214,14 +214,14 @@ theorem addi_x5_2_sub_modCode {base : Word} :
 
 -- BNE x6 x0 8 at base+88 (index 14 of phaseB)
 theorem bne_x6_8_sub_modCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 88) (.BNE .x6 .x0 8)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBBne3Off) (.BNE .x6 .x0 8)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
   rw [bv64_4mul_14,
-      show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 56 = base + phaseBBne3Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left a i h1
 
@@ -259,8 +259,8 @@ theorem mod_divK_phaseB_n1_nm1_x8 :
 -- Cascade address normalization
 theorem mod_phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by bv_addr
 theorem mod_phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
-theorem mod_phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
-theorem mod_phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
+theorem mod_phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + phaseBBne3Off := by bv_addr
+theorem mod_phB_step2_8 {base : Word} : (base + phaseBBne3Off : Word) + 4 = base + 92 := by bv_addr
 theorem mod_phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr
 
 -- Tail memory address normalization

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -150,8 +150,8 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
   have h1234567 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
-  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
     (fun hp hQf => by
@@ -321,8 +321,8 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
   have h1234567 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
-  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by rv64_addr,
       mod_phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -66,6 +66,13 @@ abbrev phaseBOff    : Word :=   32
     cascade step otherwise). Sub-offset relative to `divK_phaseB`
     (= phaseBOff + 40 = phaseBTailOff − 24). -/
 abbrev phaseBBneOff : Word :=   72
+/-- Offset of the third BNE-to-`divK_phaseB_tail` instruction inside
+    `divK_phaseB`. Entry PC of the `BNE x6, x0, +8` that ends the
+    third per-limb leading-limb-analysis cascade step and branches
+    forward into `divK_phaseB_tail` when `x6 = b[1] ≠ 0` (yielding
+    n = 2; falls through to the n = 1 fallback otherwise). Sub-offset
+    relative to `divK_phaseB` (= phaseBOff + 56 = phaseBTailOff − 8). -/
+abbrev phaseBBne3Off : Word :=   88
 /-- Offset of the `divK_phaseB_tail` sub-block inside `divK_phaseB`.
     Entry PC of the leading-limb-analysis tail (16 instructions / 64 bytes
     into `divK_phaseB`); the per-limb cascade in `divK_phaseB_cascade` falls
@@ -315,6 +322,12 @@ example : trialJalOff + 4 = div128CallRetOff := by decide
     `divK_phaseB`, 24 bytes (6 instructions) before `phaseBTailOff`. -/
 example : phaseBBneOff = phaseBOff + 40 := by decide
 example : phaseBBneOff + 24 = phaseBTailOff := by decide
+/-- phaseBBne3Off = phaseBOff + 56 (sub-block offset within `divK_phaseB`).
+    The third BNE-to-`divK_phaseB_tail` instruction sits 14 instructions
+    into `divK_phaseB`, 8 bytes (2 instructions) before `phaseBTailOff`. -/
+example : phaseBBne3Off = phaseBOff + 56 := by decide
+example : phaseBBne3Off + 8 = phaseBTailOff := by decide
+example : phaseBBne3Off = phaseBBneOff + 16 := by decide
 /-- mulsubOff = loopBodyOff + 88 (sub-block offset within `divK_loopBody`).
     The `divK_mulsub_correction` snippet starts 22 instructions into the loop
     body, after the trial-divide entry (~13 instructions) and the div128 call

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -421,14 +421,14 @@ private theorem addi_x5_2_sub_divCode {base : Word} :
 
 -- BNE x6 x0 8 at base+88 (index 14 of phaseB)
 private theorem bne_x6_8_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 88) (.BNE .x6 .x0 8)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBBne3Off) (.BNE .x6 .x0 8)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 14
     (by decide) (by decide)
   rw [bv64_4mul_14,
-      show (base + phaseBOff : Word) + 56 = base + 88 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 56 = base + phaseBBne3Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left a i h1
 
@@ -467,8 +467,8 @@ private theorem divK_phaseB_n1_nm1_x8 :
 -- Cascade address normalization
 private theorem phB_step1_4 {base : Word} : (base + 76 : Word) + 4 = base + 80 := by bv_addr
 private theorem phB_step1_8 {base : Word} : (base + 80 : Word) + 4 = base + 84 := by bv_addr
-private theorem phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + 88 := by bv_addr
-private theorem phB_step2_8 {base : Word} : (base + 88 : Word) + 4 = base + 92 := by bv_addr
+private theorem phB_step2_4 {base : Word} : (base + 84 : Word) + 4 = base + phaseBBne3Off := by bv_addr
+private theorem phB_step2_8 {base : Word} : (base + phaseBBne3Off : Word) + 4 = base + 92 := by bv_addr
 private theorem phB_fall_4 {base : Word} : (base + 92 : Word) + 4 = base + phaseBTailOff := by bv_addr
 
 -- Tail memory address normalization
@@ -750,8 +750,8 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
   have h1234567 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 taken (base+88 → base+96, b1≠0)
-  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
         rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_takenStripPure2 hbne2_raw
     (fun hp hQf => by
@@ -920,8 +920,8 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
   have h1234567 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) h123456 haddi2f
   -- ---- Cascade step 2: BNE x6 ntaken (base+88 → base+92, b1=0)
-  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + 88)
-  rw [show (base + 88 : Word) + signExtend13 8 = base + phaseBTailOff from by
+  have hbne2_raw := bne_spec_gen_within .x6 .x0 8 b1 (0 : Word) (base + phaseBBne3Off)
+  rw [show (base + phaseBBne3Off : Word) + signExtend13 8 = base + phaseBTailOff from by
         rv64_addr, phB_step2_8] at hbne2_raw
   have hbne2_clean := cpsBranchWithin_ntakenStripPure2 hbne2_raw
     (fun hp hQt => by


### PR DESCRIPTION
Slice of #301. Sibling of PR #1718 (phaseBBneOff = 72, step 1) and PR #1728 (phaseBBne2Off = 80, step 2).

Adds `abbrev phaseBBne3Off : Word := 88` for the BNE x6 x0 8 at `phaseBOff + 56` that ends the third leading-limb-analysis cascade step in `divK_phaseB` and branches forward into `divK_phaseB_tail` when `x6 = b[1] ≠ 0` (yielding n = 2).

Migrates 16 `base + 88` literals across:
- `Compose/PhaseAB.lean` (8)
- `Compose/ModPhaseB.lean` (4)
- `Compose/ModPhaseBn21.lean` (4)

LimbSpec/Div128Step{1v2,2v4} `base + 88` literals are block-relative (different `base`) and intentionally unchanged.

Adds three drift-check `example`s tying `phaseBBne3Off` to `phaseBOff + 56`, `phaseBBne3Off + 8 = phaseBTailOff`, and `phaseBBne3Off = phaseBBneOff + 16`.

`abbrev` reduces by rfl so callers continue to typecheck. `lake build` clean locally.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
Refs: evm-asm-muli, parent evm-asm-nqj.