### PR TITLE
chore(divmod): name phaseBStep0Off (= 68) for phaseB n=4 selection step

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseB.lean
@@ -58,14 +58,14 @@ theorem divK_phaseB_init2_code_sub_modCode {base : Word} :
   exact sub_modCode_of_phaseB_left a i h1
 
 theorem addi_x5_singleton_sub_modCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 68) (.ADDI .x5 .x0 4)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBStep0Off) (.ADDI .x5 .x0 4)) a = some i →
       (modCode base) a = some i := by
   unfold modCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
   rw [bv64_4mul_9,
-      show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 36 = base + phaseBStep0Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_modCode_of_phaseB_left a i h1
 
@@ -94,8 +94,8 @@ theorem divK_phaseB_tail_code_sub_modCode {base : Word} :
 -- The former `mod_phB_off_28` (identical to PhaseAB's private `phB_off_28`)
 -- now lives in `Compose/Base.lean` as the shared `phB_off_28` and is used
 -- directly from both the DIV and MOD sides.
-theorem mod_phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
-theorem mod_phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + phaseBBneOff := by bv_addr
+theorem mod_phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + phaseBStep0Off := by bv_addr
+theorem mod_phB_addi_4 {base : Word} : (base + phaseBStep0Off : Word) + 4 = base + phaseBBneOff := by bv_addr
 theorem mod_phB_bne_4 {base : Word} : (base + phaseBBneOff : Word) + 4 = base + 76 := by bv_addr
 theorem mod_phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
 -- `mod_signExtend13_24` → use `se13_24` from `Compose/Base.lean`.
@@ -148,7 +148,7 @@ theorem evm_mod_phaseB_n4_spec_within (sp base : Word)
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_modCode hinit2_raw
   seqFrame hinit1f hinit2
   -- ---- Step 3: ADDI x5 x0 4 at base+68 → base+72
-  have haddi_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [mod_phB_addi_4, se12_4] at haddi_raw
   have haddi := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode haddi_raw
   seqFrame hinit1fhinit2 haddi

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn21.lean
@@ -65,7 +65,7 @@ theorem evm_mod_phaseB_n2_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR
@@ -236,7 +236,7 @@ theorem evm_mod_phaseB_n1_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModPhaseBn3.lean
@@ -64,7 +64,7 @@ theorem evm_mod_phaseB_n3_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [mod_phB_addi_4, se12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_modCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR

--- a/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Offsets.lean
@@ -59,6 +59,14 @@ abbrev phaseAOff    : Word :=    0
 abbrev phaseABeqOff : Word :=   28
 /-- Offset of `divK_phaseB` (b=0 branch + leading-limb analysis). -/
 abbrev phaseBOff    : Word :=   32
+/-- Offset of the `divK_phaseB` step0 selection instruction (n=4 path).
+    Entry PC of the `ADDI x5, x0, 4` that loads the limb-count `n = 4` into
+    `x5`; the immediately-following `BNE x7, x0, +8` (at `phaseBBneOff = 72`)
+    selects the n=4 path when the top divisor limb is non-zero. Sub-offset
+    relative to `divK_phaseB` (= phaseBOff + 36 = phaseBBneOff − 4).
+    Mirrors `phaseBStep1Off` (76, n=3 selection) and `phaseBStep2Off`
+    (84, n=2 selection). -/
+abbrev phaseBStep0Off : Word :=   68
 /-- Offset of the BNE-to-`divK_phaseB_tail` instruction inside `divK_phaseB`.
     Entry PC of the `BNE x10, x0, +24` that ends the leading-limb-analysis
     cascade step and branches forward into `divK_phaseB_tail` when the current

--- a/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/PhaseAB.lean
@@ -87,14 +87,14 @@ private theorem divK_phaseB_init2_code_sub_divCode {base : Word} :
 
 /-- ADDI x5 x0 4 singleton at base+68 (part of block 1: phaseB) is subsumed by divCode. -/
 private theorem addi_x5_singleton_sub_divCode {base : Word} :
-    ∀ a i, (CodeReq.singleton (base + 68) (.ADDI .x5 .x0 4)) a = some i →
+    ∀ a i, (CodeReq.singleton (base + phaseBStep0Off) (.ADDI .x5 .x0 4)) a = some i →
       (divCode base) a = some i := by
   unfold divCode; simp only [CodeReq.unionAll_cons]
   intro a i h
   have hlookup := CodeReq.ofProg_lookup (base + phaseBOff) divK_phaseB 9
     (by decide) (by decide)
   rw [bv64_4mul_9,
-      show (base + phaseBOff : Word) + 36 = base + 68 from by bv_addr] at hlookup
+      show (base + phaseBOff : Word) + 36 = base + phaseBStep0Off from by bv_addr] at hlookup
   have h1 := CodeReq.singleton_mono hlookup a i h
   exact sub_divCode_of_phaseB_left a i h1
 
@@ -143,8 +143,8 @@ private theorem divK_phaseB_n4_nm1_x8 :
 
 -- Address normalization lemmas `phB_off_{4..28}` now live in `Compose/Base.lean`
 -- and are shared with the MOD-side files (ModPhaseB / ModPhaseBn3 / ModPhaseBn21).
-private theorem phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + 68 := by bv_addr
-private theorem phB_addi_4 {base : Word} : (base + 68 : Word) + 4 = base + phaseBBneOff := by bv_addr
+private theorem phB_i2_8 {base : Word} : (base + 60 : Word) + 8 = base + phaseBStep0Off := by bv_addr
+private theorem phB_addi_4 {base : Word} : (base + phaseBStep0Off : Word) + 4 = base + phaseBBneOff := by bv_addr
 private theorem phB_bne_4 {base : Word} : (base + phaseBBneOff : Word) + 4 = base + 76 := by bv_addr
 private theorem phB_t_20 {base : Word} : (base + phaseBTailOff : Word) + 20 = base + clzOff := by bv_addr
 private theorem phB_sp24_32 {sp : Word} : (sp + (24 : Word) + (32 : Word)) = sp + 56 := by bv_addr
@@ -282,7 +282,7 @@ theorem evm_div_phaseB_n4_spec_within (sp base : Word)
   have hinit2 := cpsTripleWithin_extend_code divK_phaseB_init2_code_sub_divCode hinit2_raw
   seqFrame hinit1f hinit2
   -- ---- Step 3: ADDI x5 x0 4 at base+68 → base+72
-  have haddi_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [phB_addi_4, signExtend12_4] at haddi_raw
   have haddi := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode haddi_raw
   seqFrame hinit1fhinit2 haddi
@@ -530,7 +530,7 @@ theorem evm_div_phaseB_n3_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [phB_addi_4, signExtend12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR
@@ -665,7 +665,7 @@ theorem evm_div_phaseB_n2_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [phB_addi_4, signExtend12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR
@@ -835,7 +835,7 @@ theorem evm_div_phaseB_n1_spec_within (sp base : Word)
   have h12 := cpsTripleWithin_seq_perm_same_cr
     (fun h hp => by xperm_hyp hp) hinit1f hinit2f
   -- ---- Cascade step 0: ADDI x5=4 (base+68 → base+72)
-  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + 68) (by nofun)
+  have haddi0_raw := addi_x0_spec_gen_within .x5 v5 4 (base + phaseBStep0Off) (by nofun)
   simp only [phB_addi_4, signExtend12_4] at haddi0_raw
   have haddi0 := cpsTripleWithin_extend_code addi_x5_singleton_sub_divCode haddi0_raw
   have haddi0f := cpsTripleWithin_frameR


### PR DESCRIPTION
Adds `phaseBStep0Off : Word := 68` to `EvmAsm/Evm64/DivMod/Compose/Offsets.lean` — the entry PC of `ADDI x5, x0, 4` (loads limb count `n = 4` into `x5`; the next BNE x7 falls through to keep n=4 when the top divisor limb is non-zero). Mirrors `phaseBStep1Off` (76, n=3 selection — PR #1727) and `phaseBStep2Off` (84, n=2 selection — PR #1731).

Migrated all 16 `base + 68` occurrences in:
- `Compose/PhaseAB.lean` (8)
- `Compose/ModPhaseB.lean` (5; one not previously listed picked up via grep)
- `Compose/ModPhaseBn21.lean` (2)
- `Compose/ModPhaseBn3.lean` (1)

`LimbSpec/Div128Step2{,v4}.lean` occurrences of `base + 68` are subroutine-local block lengths and stay unchanged per `docs/divmod-offset-audit.md` (same reasoning as base+100 / base+124).

Local `lake build`: green (1476 jobs).

Refs: evm-asm-mfs4 / evm-asm-nqj / GH #301

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).