### PR TITLE
proof(divmod): add v4 N1 DIV bridge

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec.lean
+++ b/EvmAsm/Evm64/DivMod/Spec.lean
@@ -17,6 +17,7 @@ import EvmAsm.Evm64.DivMod.Spec.V4
 import EvmAsm.Evm64.DivMod.Spec.V4Addback
 import EvmAsm.Evm64.DivMod.Spec.N2RemainderWord
 import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Spec.N1V4DivBridge
 import EvmAsm.Evm64.DivMod.Spec.N1V4ModBridge
 import EvmAsm.Evm64.DivMod.Spec.N2QuotientWord
 import EvmAsm.Evm64.DivMod.Spec.N2DivStackSpec

--- a/EvmAsm/Evm64/DivMod/Spec/N1V4DivBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N1V4DivBridge.lean
@@ -1,0 +1,193 @@
+/-
+  EvmAsm.Evm64.DivMod.Spec.N1V4DivBridge
+
+  v4 n=1 DIV quotient bridges.
+-/
+
+import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Compose.FullPathN1RemainderV4
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+@[irreducible]
+def fullDivN1QuotientWord_v4 (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : EvmWord :=
+  EvmWord.fromLimbs (fun i : Fin 4 =>
+    match i with
+    | 0 => (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 1 => (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 2 => (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+    | 3 => (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1)
+
+theorem fullDivN1_hdivs_v4_of_word_eq
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv : fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 =
+      (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 3 =
+      (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 := by
+  constructor
+  · rw [← hdiv]
+    delta fullDivN1QuotientWord_v4
+    exact EvmWord.getLimbN_fromLimbs_0
+  constructor
+  · rw [← hdiv]
+    delta fullDivN1QuotientWord_v4
+    exact EvmWord.getLimbN_fromLimbs_1
+  constructor
+  · rw [← hdiv]
+    delta fullDivN1QuotientWord_v4
+    exact EvmWord.getLimbN_fromLimbs_2
+  · rw [← hdiv]
+    delta fullDivN1QuotientWord_v4
+    exact EvmWord.getLimbN_fromLimbs_3
+
+theorem fullDivN1QuotientWord_v4_eq_div_of_toNat_eq
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (hdiv_toNat :
+      (fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat) :
+    fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b :=
+  BitVec.eq_of_toNat_eq hdiv_toNat
+
+theorem fullDivN1QuotientWord_v4_toNat
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
+    (fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat =
+    EvmWord.val256
+      (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1
+      (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 := by
+  delta fullDivN1QuotientWord_v4
+  rw [EvmWord.fromLimbs_toNat]
+  rfl
+
+theorem fullDivN1QuotientWord_v4_toNat_eq_div_toNat_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_v4_j0 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    (fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat := by
+  have hquot := fullDivN1QuotientVal_v4_eq_div_of_runtime
+    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
+    hb1z hb2z hb3z hbnz hshift_nz hcarry2 hbltu_3 hbltu_2 hbltu_1 hbltu_0
+  have ha_val : EvmWord.val256 a0 a1 a2 a3 = a.toNat := by
+    rw [← ha0, ← ha1, ← ha2, ← ha3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat a
+  have hb_val : EvmWord.val256 b0 b1 b2 b3 = b.toNat := by
+    rw [← hb0, ← hb1, ← hb2, ← hb3]
+    simp only [← EvmWord.getLimb_as_getLimbN_0,
+      ← EvmWord.getLimb_as_getLimbN_1,
+      ← EvmWord.getLimb_as_getLimbN_2,
+      ← EvmWord.getLimb_as_getLimbN_3]
+    exact EvmWord.val256_eq_toNat b
+  have hb_ne : b ≠ 0 := by
+    intro hb_zero
+    have hb_toNat_zero : b.toNat = 0 := by simp [hb_zero]
+    have hb_pos : 0 < b.toNat := by
+      rw [← hb_val]
+      exact EvmWord.val256_pos_of_or_ne_zero hbnz
+    omega
+  have hdiv_toNat : (EvmWord.div a b).toNat = a.toNat / b.toNat := by
+    unfold EvmWord.div
+    rw [if_neg hb_ne]
+    exact BitVec.toNat_udiv
+  rw [fullDivN1QuotientWord_v4_toNat, hquot, ha_val, hb_val, hdiv_toNat]
+
+theorem fullDivN1QuotientWord_v4_eq_div_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_v4_j0 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    fullDivN1QuotientWord_v4 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b := by
+  exact fullDivN1QuotientWord_v4_eq_div_of_toNat_eq
+    bltu_3 bltu_2 bltu_1 bltu_0 a b a0 a1 a2 a3 b0 b1 b2 b3
+    (fullDivN1QuotientWord_v4_toNat_eq_div_toNat_of_runtime
+      bltu_3 bltu_2 bltu_1 bltu_0 a b a0 a1 a2 a3 b0 b1 b2 b3
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hb1z hb2z hb3z hbnz hshift_nz hcarry2
+      hbltu_3 hbltu_2 hbltu_1 hbltu_0)
+
+theorem fullDivN1_hdivs_v4_of_runtime
+    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
+    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
+    (ha0 : a.getLimbN 0 = a0) (ha1 : a.getLimbN 1 = a1)
+    (ha2 : a.getLimbN 2 = a2) (ha3 : a.getLimbN 3 = a3)
+    (hb0 : b.getLimbN 0 = b0) (hb1 : b.getLimbN 1 = b1)
+    (hb2 : b.getLimbN 2 = b2) (hb3 : b.getLimbN 3 = b3)
+    (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
+    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0)
+    (hshift_nz : fullDivN1Shift b0 ≠ 0)
+    (hcarry2 : Carry2NzAll
+      (fullDivN1NormV b0 b1 b2 b3).1
+      (fullDivN1NormV b0 b1 b2 b3).2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.1
+      (fullDivN1NormV b0 b1 b2 b3).2.2.2)
+    (hbltu_3 : isTrialN1_v4_j3 bltu_3 a3 b0)
+    (hbltu_2 : isTrialN1_v4_j2 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_1 : isTrialN1_v4_j1 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3)
+    (hbltu_0 : isTrialN1_v4_j0 bltu_3 bltu_2 bltu_1 bltu_0
+      a0 a1 a2 a3 b0 b1 b2 b3) :
+    (EvmWord.div a b).getLimbN 0 =
+      (fullDivN1R0_v4 bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 1 =
+      (fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 2 =
+      (fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3).1 ∧
+    (EvmWord.div a b).getLimbN 3 =
+      (fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3).1 := by
+  exact fullDivN1_hdivs_v4_of_word_eq
+    bltu_3 bltu_2 bltu_1 bltu_0 a b a0 a1 a2 a3 b0 b1 b2 b3
+    (fullDivN1QuotientWord_v4_eq_div_of_runtime
+      bltu_3 bltu_2 bltu_1 bltu_0 a b a0 a1 a2 a3 b0 b1 b2 b3
+      ha0 ha1 ha2 ha3 hb0 hb1 hb2 hb3 hb1z hb2z hb3z hbnz hshift_nz hcarry2
+      hbltu_3 hbltu_2 hbltu_1 hbltu_0)
+
+end EvmAsm.Evm64


### PR DESCRIPTION
## Summary
- add a focused N1V4DivBridge spec file for the v4 n=1 DIV quotient word
- expose v4 quotient limb equations from runtime hypotheses
- expose v4 toNat and word-equality bridges from runtime hypotheses to EvmWord.div

## Stacking
- depends on #1733, so this PR targets issue-61-v4-n1-mod-denorm-bridges

## Verification
- lake build EvmAsm.Evm64.DivMod.Spec.N1V4DivBridge
- lake build EvmAsm.Evm64.DivMod
- lake build
- scripts/check-file-size.sh
- git diff --check origin/issue-61-v4-n1-mod-denorm-bridges..HEAD