### PR TITLE
chore(imports): narrow And/Or/Xor/Not/Add/Sub Program.lean per shake

### DIFF
--- a/EvmAsm/Evm64/Add/Program.lean
+++ b/EvmAsm/Evm64/Add/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM ADD program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -8,6 +8,7 @@
 -- `Add.LimbSpec → Add.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Add.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/And/Program.lean
+++ b/EvmAsm/Evm64/And/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM AND program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `And.LimbSpec → And.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.And.LimbSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Not/Program.lean
+++ b/EvmAsm/Evm64/Not/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM NOT program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Or/Program.lean
+++ b/EvmAsm/Evm64/Or/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM OR program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Or.LimbSpec → Or.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Or.LimbSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64

--- a/EvmAsm/Evm64/Sub/Program.lean
+++ b/EvmAsm/Evm64/Sub/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM SUB program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -8,6 +8,7 @@
 -- `Sub.LimbSpec → Sub.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Sub.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Xor/Program.lean
+++ b/EvmAsm/Evm64/Xor/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM XOR program definition.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Xor.LimbSpec → Xor.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Xor.LimbSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
Apply shake-suggested narrowing: replace `import EvmAsm.Evm64.Stack` with `import EvmAsm.Rv64.Program` in EvmAsm/Evm64/{And,Or,Xor,Not,Add,Sub}/Program.lean. For And/Or/Xor/Add/Sub also add `import EvmAsm.Evm64.Stack` to the corresponding Spec.lean (Not/Spec.lean already imports it).

Mirrors PR #1454 (comparison Program.lean) and the closed sibling beads task evm-asm-h2kr (Pop/Push0/Dup/Swap).

Refs #1045. Beads: evm-asm-g2ni.

`lake build` green locally (1479 jobs, 0 errors, 0 sorries).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).