### PR TITLE
prove(mload): add unaligned dword-pair byte bridge

### DIFF
--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -112,6 +112,16 @@ def mloadByteFromDwordPair (lo hi : Word) (start i : Nat) : BitVec 8 :=
   let pos := start + i
   extractByte (if pos < 8 then lo else hi) (pos % 8)
 
+theorem mloadByteFromDwordPair_low
+    (lo hi : Word) {start i : Nat} (h_pos : start + i < 8) :
+    mloadByteFromDwordPair lo hi start i = extractByte lo ((start + i) % 8) := by
+  simp [mloadByteFromDwordPair, h_pos]
+
+theorem mloadByteFromDwordPair_high
+    (lo hi : Word) {start i : Nat} (h_pos : 8 ≤ start + i) :
+    mloadByteFromDwordPair lo hi start i = extractByte hi ((start + i) % 8) := by
+  simp [mloadByteFromDwordPair, show ¬ start + i < 8 from by omega]
+
 /--
   Pack eight consecutive bytes starting at byte offset `start` in `lo`,
   crossing into adjacent dword `hi` when needed.

--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -103,6 +103,65 @@ theorem mloadPackedLimb_eq_fold
   bv_decide
 
 /--
+  Select the `i`th byte of an 8-byte MLOAD limb window from two adjacent
+  source dwords.  `start` is the byte offset of the first byte within `lo`.
+  When `start + i ≥ 8`, the byte comes from `hi` at wrapped position
+  `(start + i) % 8`.
+-/
+def mloadByteFromDwordPair (lo hi : Word) (start i : Nat) : BitVec 8 :=
+  let pos := start + i
+  extractByte (if pos < 8 then lo else hi) (pos % 8)
+
+/--
+  Pack eight consecutive bytes starting at byte offset `start` in `lo`,
+  crossing into adjacent dword `hi` when needed.
+-/
+def mloadPackedLimbFromDwordPair (lo hi : Word) (start : Nat) : Word :=
+  mloadPackedLimb
+    (mloadByteFromDwordPair lo hi start 0)
+    (mloadByteFromDwordPair lo hi start 1)
+    (mloadByteFromDwordPair lo hi start 2)
+    (mloadByteFromDwordPair lo hi start 3)
+    (mloadByteFromDwordPair lo hi start 4)
+    (mloadByteFromDwordPair lo hi start 5)
+    (mloadByteFromDwordPair lo hi start 6)
+    (mloadByteFromDwordPair lo hi start 7)
+
+/--
+  Runtime shift/or byte packing for an unaligned 8-byte window computes the
+  same big-endian limb as `mloadPackedLimbFromDwordPair`.
+-/
+theorem mloadPackedLimbFromDwordPair_eq_fold
+    (lo hi : Word) (start : Nat) :
+    let b0 := mloadByteFromDwordPair lo hi start 0
+    let b1 := mloadByteFromDwordPair lo hi start 1
+    let b2 := mloadByteFromDwordPair lo hi start 2
+    let b3 := mloadByteFromDwordPair lo hi start 3
+    let b4 := mloadByteFromDwordPair lo hi start 4
+    let b5 := mloadByteFromDwordPair lo hi start 5
+    let b6 := mloadByteFromDwordPair lo hi start 6
+    let b7 := mloadByteFromDwordPair lo hi start 7
+    ((((((((((((((b0.zeroExtend 64
+        <<< (8 : Nat)) ||| b1.zeroExtend 64)
+        <<< (8 : Nat)) ||| b2.zeroExtend 64)
+        <<< (8 : Nat)) ||| b3.zeroExtend 64)
+        <<< (8 : Nat)) ||| b4.zeroExtend 64)
+        <<< (8 : Nat)) ||| b5.zeroExtend 64)
+        <<< (8 : Nat)) ||| b6.zeroExtend 64)
+        <<< (8 : Nat)) ||| b7.zeroExtend 64)
+      = mloadPackedLimbFromDwordPair lo hi start := by
+  dsimp only []
+  exact mloadPackedLimb_eq_fold
+    (mloadByteFromDwordPair lo hi start 0)
+    (mloadByteFromDwordPair lo hi start 1)
+    (mloadByteFromDwordPair lo hi start 2)
+    (mloadByteFromDwordPair lo hi start 3)
+    (mloadByteFromDwordPair lo hi start 4)
+    (mloadByteFromDwordPair lo hi start 5)
+    (mloadByteFromDwordPair lo hi start 6)
+    (mloadByteFromDwordPair lo hi start 7)
+
+/--
   The 256-bit value loaded by MLOAD from 32 consecutive EVM-memory bytes.
 
   `b00` is the most-significant byte at the requested offset and `b31` is

--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -172,6 +172,58 @@ theorem mloadPackedLimbFromDwordPair_eq_fold
     (mloadByteFromDwordPair lo hi start 7)
 
 /--
+  Precondition shape for an unaligned one-limb MLOAD proof: the 8-byte
+  source window may read from the low dword, the high dword, or both.
+-/
+@[irreducible]
+def mloadOneLimbUnalignedPre
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld loVal hiVal loAddr hiAddr sp dstWordOld : Word)
+    (dstOff : BitVec 12) : Assertion :=
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+  (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 dstOff) ↦ₘ dstWordOld)
+
+theorem mloadOneLimbUnalignedPre_unfold
+    {addrReg byteReg accReg : Reg}
+    {addrPtr accOld byteOld loVal hiVal loAddr hiAddr sp dstWordOld : Word}
+    {dstOff : BitVec 12} :
+    mloadOneLimbUnalignedPre addrReg byteReg accReg
+        addrPtr accOld byteOld loVal hiVal loAddr hiAddr sp dstWordOld dstOff =
+    ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+     (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 dstOff) ↦ₘ dstWordOld)) := by
+  delta mloadOneLimbUnalignedPre; rfl
+
+/--
+  Postcondition shape for an unaligned one-limb MLOAD proof, after folding
+  the runtime shift/or accumulator into `mloadPackedLimbFromDwordPair`.
+-/
+@[irreducible]
+def mloadOneLimbUnalignedPost
+    (addrReg byteReg accReg : Reg)
+    (addrPtr loVal hiVal loAddr hiAddr sp : Word)
+    (start : Nat) (dstOff : BitVec 12) : Assertion :=
+  let lastByte := (mloadByteFromDwordPair loVal hiVal start 7).zeroExtend 64
+  let accFinal := mloadPackedLimbFromDwordPair loVal hiVal start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ lastByte) ** (accReg ↦ᵣ accFinal) **
+  (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 dstOff) ↦ₘ accFinal)
+
+theorem mloadOneLimbUnalignedPost_unfold
+    {addrReg byteReg accReg : Reg}
+    {addrPtr loVal hiVal loAddr hiAddr sp : Word}
+    {start : Nat} {dstOff : BitVec 12} :
+    mloadOneLimbUnalignedPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp start dstOff =
+    (let lastByte := (mloadByteFromDwordPair loVal hiVal start 7).zeroExtend 64
+     let accFinal := mloadPackedLimbFromDwordPair loVal hiVal start
+     (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ lastByte) ** (accReg ↦ᵣ accFinal) **
+     (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 dstOff) ↦ₘ accFinal)) := by
+  delta mloadOneLimbUnalignedPost; rfl
+
+/--
   The 256-bit value loaded by MLOAD from 32 consecutive EVM-memory bytes.
 
   `b00` is the most-significant byte at the requested offset and `b31` is


### PR DESCRIPTION
Stacked on #1750.\n\nAdds the first unaligned MLOAD limb bridge for evm-asm-j1m7.2 / GH #99: mloadByteFromDwordPair, mloadPackedLimbFromDwordPair, and a fold theorem proving the runtime shift/or byte pack computes the packed limb for an 8-byte window that may cross from one RV64 dword into the next.\n\nThis addresses the alignment gap found in the existing mload_one_limb_spec_within, which assumes all eight bytes align to a single dwordAddr. A follow-up Hoare triple can now target this two-dword byte source shape.\n\nVerification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build