### PR TITLE
prove(mload): add three-byte pair composition

### DIFF
--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -475,6 +475,87 @@ theorem mload_byte_pack_two_pair_spec_within
   exact cpsTripleWithin_seq hd_step s1 step
 
 /--
+  Three-byte big-endian byte-pack composition for an unaligned source window,
+  extending `mload_byte_pack_two_pair_spec_within` with one more pair step.
+-/
+theorem mload_byte_pack_three_pair_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld loVal hiVal loAddr hiAddr : Word)
+    (off0 off1 off2 : BitVec 12) (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0  : accReg  ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 off0) =
+        mloadDwordPairAddr loAddr hiAddr start 0)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 off1) =
+        mloadDwordPairAddr loAddr hiAddr start 1)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 off2) =
+        mloadDwordPairAddr loAddr hiAddr start 2)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true) :
+    let b0 := (mloadByteFromDwordPair loVal hiVal start 0).zeroExtend 64
+    let b1 := (mloadByteFromDwordPair loVal hiVal start 1).zeroExtend 64
+    let b2 := (mloadByteFromDwordPair loVal hiVal start 2).zeroExtend 64
+    let accAfter2 := (b0 <<< (8 : Nat)) ||| b1
+    let accFinal := (accAfter2 <<< (8 : Nat)) ||| b2
+    let cr := mloadBytePackThreeCode addrReg byteReg accReg off0 off1 off2 base
+    cpsTripleWithin 7 base (base + 28) cr
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b2) ** (accReg ↦ᵣ accFinal) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal)) := by
+  intro b0 b1 b2 accAfter2 accFinal cr
+  have two := mload_byte_pack_two_pair_spec_within addrReg byteReg accReg
+    addrPtr accOld byteOld loVal hiVal loAddr hiAddr off0 off1 start base
+    h_byte_ne_x0 h_acc_ne_x0
+    h_align0 h_byte0 h_valid0 h_align1 h_byte1 h_valid1
+  have step := mload_byte_pack_step_pair_spec_within addrReg byteReg accReg
+    addrPtr accAfter2 b1 loVal hiVal loAddr hiAddr off2 start 2 (base + 16)
+    h_byte_ne_x0 h_acc_ne_x0 h_align2 h_byte2 h_valid2
+  rw [show (base + 16 : Word) + 12 = base + 28 from by bv_omega] at step
+  rw [show (base + 16 : Word) + 4 = base + 20 from by bv_omega,
+      show (base + 16 : Word) + 8 = base + 24 from by bv_omega] at step
+  have h_b_b16  : base ≠ base + 16 := by bv_omega
+  have h_b_b20  : base ≠ base + 20 := by bv_omega
+  have h_b_b24  : base ≠ base + 24 := by bv_omega
+  have h_b4_b16 : base + 4 ≠ base + 16 := by bv_omega
+  have h_b4_b20 : base + 4 ≠ base + 20 := by bv_omega
+  have h_b4_b24 : base + 4 ≠ base + 24 := by bv_omega
+  have h_b8_b16 : base + 8 ≠ base + 16 := by bv_omega
+  have h_b8_b20 : base + 8 ≠ base + 20 := by bv_omega
+  have h_b8_b24 : base + 8 ≠ base + 24 := by bv_omega
+  have h_b12_b16 : base + 12 ≠ base + 16 := by bv_omega
+  have h_b12_b20 : base + 12 ≠ base + 20 := by bv_omega
+  have h_b12_b24 : base + 12 ≠ base + 24 := by bv_omega
+  have hd_step : CodeReq.Disjoint
+      (mloadBytePackTwoCode addrReg byteReg accReg off0 off1 base)
+      ((CodeReq.singleton (base + 16) (.LBU byteReg addrReg off2)).union
+       ((CodeReq.singleton (base + 20) (.SLLI accReg accReg (BitVec.ofNat 6 8))).union
+        (CodeReq.singleton (base + 24) (.OR accReg accReg byteReg)))) := by
+    unfold mloadBytePackTwoCode
+    refine CodeReq.Disjoint.union_left ?_ (CodeReq.Disjoint.union_left ?_
+      (CodeReq.Disjoint.union_left ?_ ?_))
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b_b16) ?_
+      exact CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b_b20)
+        (CodeReq.Disjoint.singleton h_b_b24)
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b4_b16) ?_
+      exact CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b4_b20)
+        (CodeReq.Disjoint.singleton h_b4_b24)
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b8_b16) ?_
+      exact CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b8_b20)
+        (CodeReq.Disjoint.singleton h_b8_b24)
+    · refine CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b12_b16) ?_
+      exact CodeReq.Disjoint.union_right (CodeReq.Disjoint.singleton h_b12_b20)
+        (CodeReq.Disjoint.singleton h_b12_b24)
+  exact cpsTripleWithin_seq hd_step two step
+
+/--
   Pack eight consecutive bytes starting at byte offset `start` in `lo`,
   crossing into adjacent dword `hi` when needed.
 -/


### PR DESCRIPTION
Stacked on #1763.\n\nAdds the next unaligned pair composition rung, mload_byte_pack_three_pair_spec_within, by composing the two-byte pair theorem with one additional pair step over the same low/high dword pair.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n\nReferences evm-asm-bpol and GH #99.\n\nAuthored by @pirapira; implemented by Codex.