### PR TITLE
prove(mload): add five-byte pair composition

### DIFF
--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -658,6 +658,96 @@ theorem mload_byte_pack_four_pair_spec_within
       exact leaf h_b24_b28 h_b24_b32 h_b24_b36
   exact cpsTripleWithin_seq hd_step three step
 
+/-- Five-byte big-endian byte-pack composition for an unaligned source window. -/
+theorem mload_byte_pack_five_pair_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld loVal hiVal loAddr hiAddr : Word)
+    (off0 off1 off2 off3 off4 : BitVec 12) (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0  : accReg  ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 off0) =
+        mloadDwordPairAddr loAddr hiAddr start 0)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 off1) =
+        mloadDwordPairAddr loAddr hiAddr start 1)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 off2) =
+        mloadDwordPairAddr loAddr hiAddr start 2)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 off3) =
+        mloadDwordPairAddr loAddr hiAddr start 3)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 off4) =
+        mloadDwordPairAddr loAddr hiAddr start 4)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true) :
+    let b0 := (mloadByteFromDwordPair loVal hiVal start 0).zeroExtend 64
+    let b1 := (mloadByteFromDwordPair loVal hiVal start 1).zeroExtend 64
+    let b2 := (mloadByteFromDwordPair loVal hiVal start 2).zeroExtend 64
+    let b3 := (mloadByteFromDwordPair loVal hiVal start 3).zeroExtend 64
+    let b4 := (mloadByteFromDwordPair loVal hiVal start 4).zeroExtend 64
+    let accAfter4 :=
+      ((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3
+    let accFinal := (accAfter4 <<< (8 : Nat)) ||| b4
+    let cr := mloadBytePackFiveCode addrReg byteReg accReg off0 off1 off2 off3 off4 base
+    cpsTripleWithin 13 base (base + 52) cr
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b4) ** (accReg ↦ᵣ accFinal) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal)) := by
+  intro b0 b1 b2 b3 b4 accAfter4 accFinal cr
+  have four := mload_byte_pack_four_pair_spec_within addrReg byteReg accReg
+    addrPtr accOld byteOld loVal hiVal loAddr hiAddr off0 off1 off2 off3 start base
+    h_byte_ne_x0 h_acc_ne_x0
+    h_align0 h_byte0 h_valid0 h_align1 h_byte1 h_valid1
+    h_align2 h_byte2 h_valid2 h_align3 h_byte3 h_valid3
+  have step := mload_byte_pack_step_pair_spec_within addrReg byteReg accReg
+    addrPtr accAfter4 b3 loVal hiVal loAddr hiAddr off4 start 4 (base + 40)
+    h_byte_ne_x0 h_acc_ne_x0 h_align4 h_byte4 h_valid4
+  rw [show (base + 40 : Word) + 12 = base + 52 from by bv_omega] at step
+  rw [show (base + 40 : Word) + 4 = base + 44 from by bv_omega,
+      show (base + 40 : Word) + 8 = base + 48 from by bv_omega] at step
+  have hd_step : CodeReq.Disjoint
+      (mloadBytePackFourCode addrReg byteReg accReg off0 off1 off2 off3 base)
+      ((CodeReq.singleton (base + 40) (.LBU byteReg addrReg off4)).union
+       ((CodeReq.singleton (base + 44) (.SLLI accReg accReg (BitVec.ofNat 6 8))).union
+        (CodeReq.singleton (base + 48) (.OR accReg accReg byteReg)))) := by
+    unfold mloadBytePackFourCode mloadBytePackThreeCode mloadBytePackTwoCode
+    have leaf : ∀ {a : Word} {i : Instr},
+        a ≠ base + 40 → a ≠ base + 44 → a ≠ base + 48 →
+        CodeReq.Disjoint (CodeReq.singleton a i)
+            ((CodeReq.singleton (base + 40) (.LBU byteReg addrReg off4)).union
+             ((CodeReq.singleton (base + 44) (.SLLI accReg accReg (BitVec.ofNat 6 8))).union
+              (CodeReq.singleton (base + 48) (.OR accReg accReg byteReg)))) := by
+      intro a i h40 h44 h48
+      exact CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton h40)
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton h44)
+          (CodeReq.Disjoint.singleton h48))
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+      · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+    · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+      refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+      exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+  exact cpsTripleWithin_seq hd_step four step
+
 /--
   Pack eight consecutive bytes starting at byte offset `start` in `lo`,
   crossing into adjacent dword `hi` when needed.


### PR DESCRIPTION
Stacked on #1765.\n\nAdds the next unaligned pair composition rung, mload_byte_pack_five_pair_spec_within, by composing the four-byte pair theorem with one additional pair step over the same low/high dword pair.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n\nReferences evm-asm-oae2 and GH #99.\n\nAuthored by @pirapira; implemented by Codex.