### PR TITLE
prove(mload): add eight-byte pair composition

### DIFF
--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -968,6 +968,132 @@ theorem mload_byte_pack_seven_pair_spec_within
       exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
   exact cpsTripleWithin_seq hd_step six step
 
+/-- Eight-byte big-endian byte-pack composition for an unaligned source window. -/
+theorem mload_byte_pack_eight_pair_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accOld byteOld loVal hiVal loAddr hiAddr : Word)
+    (off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0  : accReg  ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 off0) =
+        mloadDwordPairAddr loAddr hiAddr start 0)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 off1) =
+        mloadDwordPairAddr loAddr hiAddr start 1)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 off2) =
+        mloadDwordPairAddr loAddr hiAddr start 2)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 off3) =
+        mloadDwordPairAddr loAddr hiAddr start 3)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 off4) =
+        mloadDwordPairAddr loAddr hiAddr start 4)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 off5) =
+        mloadDwordPairAddr loAddr hiAddr start 5)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 off6) =
+        mloadDwordPairAddr loAddr hiAddr start 6)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 off7) =
+        mloadDwordPairAddr loAddr hiAddr start 7)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true) :
+    let b0 := (mloadByteFromDwordPair loVal hiVal start 0).zeroExtend 64
+    let b1 := (mloadByteFromDwordPair loVal hiVal start 1).zeroExtend 64
+    let b2 := (mloadByteFromDwordPair loVal hiVal start 2).zeroExtend 64
+    let b3 := (mloadByteFromDwordPair loVal hiVal start 3).zeroExtend 64
+    let b4 := (mloadByteFromDwordPair loVal hiVal start 4).zeroExtend 64
+    let b5 := (mloadByteFromDwordPair loVal hiVal start 5).zeroExtend 64
+    let b6 := (mloadByteFromDwordPair loVal hiVal start 6).zeroExtend 64
+    let b7 := (mloadByteFromDwordPair loVal hiVal start 7).zeroExtend 64
+    let accAfter7 :=
+      (((((((b0 <<< (8 : Nat)) ||| b1) <<< (8 : Nat)) ||| b2) <<< (8 : Nat) ||| b3)
+        <<< (8 : Nat) ||| b4) <<< (8 : Nat) ||| b5) <<< (8 : Nat) ||| b6
+    let accFinal := (accAfter7 <<< (8 : Nat)) ||| b7
+    let cr := mloadBytePackEightCode addrReg byteReg accReg
+      off0 off1 off2 off3 off4 off5 off6 off7 base
+    cpsTripleWithin 22 base (base + 88) cr
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ b7) ** (accReg ↦ᵣ accFinal) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal)) := by
+  intro b0 b1 b2 b3 b4 b5 b6 b7 accAfter7 accFinal cr
+  have seven := mload_byte_pack_seven_pair_spec_within addrReg byteReg accReg
+    addrPtr accOld byteOld loVal hiVal loAddr hiAddr
+    off0 off1 off2 off3 off4 off5 off6 start base
+    h_byte_ne_x0 h_acc_ne_x0
+    h_align0 h_byte0 h_valid0 h_align1 h_byte1 h_valid1
+    h_align2 h_byte2 h_valid2 h_align3 h_byte3 h_valid3
+    h_align4 h_byte4 h_valid4 h_align5 h_byte5 h_valid5
+    h_align6 h_byte6 h_valid6
+  have step := mload_byte_pack_step_pair_spec_within addrReg byteReg accReg
+    addrPtr accAfter7 b6 loVal hiVal loAddr hiAddr off7 start 7 (base + 76)
+    h_byte_ne_x0 h_acc_ne_x0 h_align7 h_byte7 h_valid7
+  rw [show (base + 76 : Word) + 12 = base + 88 from by bv_omega] at step
+  rw [show (base + 76 : Word) + 4 = base + 80 from by bv_omega,
+      show (base + 76 : Word) + 8 = base + 84 from by bv_omega] at step
+  have hd_step : CodeReq.Disjoint
+      (mloadBytePackSevenCode addrReg byteReg accReg off0 off1 off2 off3 off4 off5 off6 base)
+      ((CodeReq.singleton (base + 76) (.LBU byteReg addrReg off7)).union
+       ((CodeReq.singleton (base + 80) (.SLLI accReg accReg (BitVec.ofNat 6 8))).union
+        (CodeReq.singleton (base + 84) (.OR accReg accReg byteReg)))) := by
+    unfold mloadBytePackSevenCode mloadBytePackSixCode mloadBytePackFiveCode
+      mloadBytePackFourCode mloadBytePackThreeCode mloadBytePackTwoCode
+    have leaf : ∀ {a : Word} {i : Instr},
+        a ≠ base + 76 → a ≠ base + 80 → a ≠ base + 84 →
+        CodeReq.Disjoint (CodeReq.singleton a i)
+            ((CodeReq.singleton (base + 76) (.LBU byteReg addrReg off7)).union
+             ((CodeReq.singleton (base + 80) (.SLLI accReg accReg (BitVec.ofNat 6 8))).union
+              (CodeReq.singleton (base + 84) (.OR accReg accReg byteReg)))) := by
+      intro a i h76 h80 h84
+      exact CodeReq.Disjoint.union_right
+        (CodeReq.Disjoint.singleton h76)
+        (CodeReq.Disjoint.union_right
+          (CodeReq.Disjoint.singleton h80)
+          (CodeReq.Disjoint.singleton h84))
+    refine CodeReq.Disjoint.union_left ?_ ?_
+    · refine CodeReq.Disjoint.union_left ?_ ?_
+      · refine CodeReq.Disjoint.union_left ?_ ?_
+        · refine CodeReq.Disjoint.union_left ?_ ?_
+          · refine CodeReq.Disjoint.union_left ?_ ?_
+            · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+              refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+              refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+              exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+            · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+              refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+              exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+          · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+            refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+            exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+        · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+          refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+          exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+      · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+        exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+    · refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+      refine CodeReq.Disjoint.union_left (leaf (by bv_omega) (by bv_omega) (by bv_omega)) ?_
+      exact leaf (by bv_omega) (by bv_omega) (by bv_omega)
+  exact cpsTripleWithin_seq hd_step seven step
+
 /--
   Pack eight consecutive bytes starting at byte offset `start` in `lo`,
   crossing into adjacent dword `hi` when needed.


### PR DESCRIPTION
Stacked on #1768.\n\nAdds the final unaligned byte-pack pair composition rung, mload_byte_pack_eight_pair_spec_within, by composing the seven-byte pair theorem with one additional pair step over the same low/high dword pair.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n\nReferences evm-asm-e7v8 and GH #99.\n\nAuthored by @pirapira; implemented by Codex.