### PR TITLE
prove(mload): fold dword pairs to byte word

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -93,4 +93,55 @@ theorem mloadLoadedWordFromDwordPairs_eq_mloadLoadedWordFromBytes
       (mloadByteFromDwordPair lo0 hi0 start0 7) := by
   rfl
 
+/--
+  Direct stack fold for the unaligned executable result into the byte-level
+  MLOAD semantic word.
+-/
+theorem mloadLoadedWordFromDwordPairs_evmWordIs_fold_bytes
+    (sp : Word)
+    (lo0 hi0 : Word) (start0 : Nat)
+    (lo1 hi1 : Word) (start1 : Nat)
+    (lo2 hi2 : Word) (start2 : Nat)
+    (lo3 hi3 : Word) (start3 : Nat) :
+    ((sp ↦ₘ mloadPackedLimbFromDwordPair lo0 hi0 start0) **
+     ((sp + 8) ↦ₘ mloadPackedLimbFromDwordPair lo1 hi1 start1) **
+     ((sp + 16) ↦ₘ mloadPackedLimbFromDwordPair lo2 hi2 start2) **
+     ((sp + 24) ↦ₘ mloadPackedLimbFromDwordPair lo3 hi3 start3)) =
+    evmWordIs sp
+      (mloadLoadedWordFromBytes
+        (mloadByteFromDwordPair lo3 hi3 start3 0)
+        (mloadByteFromDwordPair lo3 hi3 start3 1)
+        (mloadByteFromDwordPair lo3 hi3 start3 2)
+        (mloadByteFromDwordPair lo3 hi3 start3 3)
+        (mloadByteFromDwordPair lo3 hi3 start3 4)
+        (mloadByteFromDwordPair lo3 hi3 start3 5)
+        (mloadByteFromDwordPair lo3 hi3 start3 6)
+        (mloadByteFromDwordPair lo3 hi3 start3 7)
+        (mloadByteFromDwordPair lo2 hi2 start2 0)
+        (mloadByteFromDwordPair lo2 hi2 start2 1)
+        (mloadByteFromDwordPair lo2 hi2 start2 2)
+        (mloadByteFromDwordPair lo2 hi2 start2 3)
+        (mloadByteFromDwordPair lo2 hi2 start2 4)
+        (mloadByteFromDwordPair lo2 hi2 start2 5)
+        (mloadByteFromDwordPair lo2 hi2 start2 6)
+        (mloadByteFromDwordPair lo2 hi2 start2 7)
+        (mloadByteFromDwordPair lo1 hi1 start1 0)
+        (mloadByteFromDwordPair lo1 hi1 start1 1)
+        (mloadByteFromDwordPair lo1 hi1 start1 2)
+        (mloadByteFromDwordPair lo1 hi1 start1 3)
+        (mloadByteFromDwordPair lo1 hi1 start1 4)
+        (mloadByteFromDwordPair lo1 hi1 start1 5)
+        (mloadByteFromDwordPair lo1 hi1 start1 6)
+        (mloadByteFromDwordPair lo1 hi1 start1 7)
+        (mloadByteFromDwordPair lo0 hi0 start0 0)
+        (mloadByteFromDwordPair lo0 hi0 start0 1)
+        (mloadByteFromDwordPair lo0 hi0 start0 2)
+        (mloadByteFromDwordPair lo0 hi0 start0 3)
+        (mloadByteFromDwordPair lo0 hi0 start0 4)
+        (mloadByteFromDwordPair lo0 hi0 start0 5)
+        (mloadByteFromDwordPair lo0 hi0 start0 6)
+        (mloadByteFromDwordPair lo0 hi0 start0 7)) := by
+  rw [mloadLoadedWordFromDwordPairs_evmWordIs_fold]
+  rw [mloadLoadedWordFromDwordPairs_eq_mloadLoadedWordFromBytes]
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1772.

Adds mloadLoadedWordFromDwordPairs_evmWordIs_fold_bytes, a direct stack assertion fold from the unaligned executable dword-pair limbs to the byte-level MLOAD semantic word. This is another bridge toward evm_mload_stack_spec_within without assuming 8-byte alignment.

Local verification:
- lake build EvmAsm.Evm64.MLoad
- lake build

Refs evm-asm-j1m7.1, GH #99.

Authored by @pirapira; implemented by Codex.