### PR TITLE
prove(exp): expose epilogue word post

### DIFF
--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -534,4 +534,33 @@ theorem exp_epilogue_result_word_right
     (expResultWord_getLimbN_2 r0 r1 r2 r3)
     (expResultWord_getLimbN_3 r0 r1 r2 r3)
 
+/-- Consumer-facing epilogue spec with the copied result limbs folded into the
+    stack-word assertion used by later EXP composition proofs. -/
+theorem exp_epilogue_word_spec_within
+    (sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 9 base (base + 36) (CodeReq.ofProg base exp_epilogue)
+      ((.x2 ↦ᵣ sp) ** (.x12 ↦ᵣ evmSp) ** (.x5 ↦ᵣ tOld) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       ((evmSp + signExtend12 (32 : BitVec 12)) ↦ₘ d0) **
+       ((evmSp + signExtend12 (40 : BitVec 12)) ↦ₘ d1) **
+       ((evmSp + signExtend12 (48 : BitVec 12)) ↦ₘ d2) **
+       ((evmSp + signExtend12 (56 : BitVec 12)) ↦ₘ d3))
+      ((.x2 ↦ᵣ sp) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+       (.x5 ↦ᵣ r3) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ r0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ r1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ r2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ r3) **
+       evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3)) := by
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hq => by
+      rw [← exp_epilogue_result_word evmSp r0 r1 r2 r3]
+      xperm_hyp hq)
+    (exp_epilogue_ofProg_spec_within sp evmSp tOld r0 r1 r2 r3 d0 d1 d2 d3 base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1790.

Adds exp_epilogue_word_spec_within, a consumer-facing EXP epilogue spec whose postcondition folds the copied result limbs into evmWordIs (evmSp + 32) (expResultWord r0 r1 r2 r3).

Refs evm-asm-20z6.8 and GH #92.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Exp
- lake build