### PR TITLE
prove(exp): define one-iteration compose code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -26,6 +26,21 @@ theorem exp_prologue_len : (EvmAsm.Evm64.exp_prologue).length = 6 := by
 theorem exp_epilogue_len : (EvmAsm.Evm64.exp_epilogue).length = 9 := by
   exact EvmAsm.Evm64.exp_epilogue_length
 
+theorem exp_bit_test_block_len : (EvmAsm.Evm64.exp_bit_test_block).length = 3 := by
+  exact EvmAsm.Evm64.exp_bit_test_block_length
+
+theorem exp_square_block_len (mulOff : BitVec 21) :
+    (EvmAsm.Evm64.exp_square_block mulOff).length = 1 := by
+  exact EvmAsm.Evm64.exp_square_block_length mulOff
+
+theorem exp_cond_mul_block_len (mulOff : BitVec 21) (skipOff : BitVec 13) :
+    (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff).length = 2 := by
+  exact EvmAsm.Evm64.exp_cond_mul_block_length mulOff skipOff
+
+theorem exp_loop_back_len (backOff : BitVec 13) :
+    (EvmAsm.Evm64.exp_loop_back backOff).length = 2 := by
+  exact EvmAsm.Evm64.exp_loop_back_length backOff
+
 /-- First EXP composition code skeleton: the verified boundary blocks around
     the loop. The loop body and callable-multiply blocks will extend this
     union as their composed specs land. -/
@@ -50,6 +65,77 @@ theorem expBoundaryCode_epilogue_sub {base : Word} :
   apply CodeReq.mono_union_right
     (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
       simp only [exp_prologue_len, exp_epilogue_len] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+/-- CodeReq decomposition for one EXP loop iteration. This mirrors
+    `exp_loop`: bit-test (3 instructions), square call (1), conditional
+    multiply branch/call (2), and loop-back (2). -/
+abbrev expOneIterCode (base : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13) : CodeReq :=
+  CodeReq.unionAll [
+    CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block,
+    CodeReq.ofProg (base + 12) (EvmAsm.Evm64.exp_square_block mulOff),
+    CodeReq.ofProg (base + 16) (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff),
+    CodeReq.ofProg (base + 24) (EvmAsm.Evm64.exp_loop_back backOff)
+  ]
+
+theorem expOneIterCode_bit_test_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_bit_test_block) a = some i →
+      (expOneIterCode base mulOff skipOff backOff) a = some i := by
+  unfold expOneIterCode
+  simp only [CodeReq.unionAll_cons]
+  exact CodeReq.union_mono_left
+
+theorem expOneIterCode_square_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 12)
+      (EvmAsm.Evm64.exp_square_block mulOff)) a = some i →
+      (expOneIterCode base mulOff skipOff backOff) a = some i := by
+  unfold expOneIterCode
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_bit_test_block_len, exp_square_block_len] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem expOneIterCode_cond_mul_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 16)
+      (EvmAsm.Evm64.exp_cond_mul_block mulOff skipOff)) a = some i →
+      (expOneIterCode base mulOff skipOff backOff) a = some i := by
+  unfold expOneIterCode
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_bit_test_block_len, exp_cond_mul_block_len] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_square_block_len, exp_cond_mul_block_len] at hk1 hk2
+      bv_omega))
+  exact CodeReq.union_mono_left
+
+theorem expOneIterCode_loop_back_sub {base : Word}
+    {mulOff : BitVec 21} {skipOff backOff : BitVec 13} :
+    ∀ a i, (CodeReq.ofProg (base + 24)
+      (EvmAsm.Evm64.exp_loop_back backOff)) a = some i →
+      (expOneIterCode base mulOff skipOff backOff) a = some i := by
+  unfold expOneIterCode
+  simp only [CodeReq.unionAll_cons]
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_bit_test_block_len, exp_loop_back_len] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_square_block_len, exp_loop_back_len] at hk1 hk2
+      bv_omega))
+  apply CodeReq.mono_union_right
+    (CodeReq.ofProg_disjoint_range (fun k1 k2 hk1 hk2 => by
+      simp only [exp_cond_mul_block_len, exp_loop_back_len] at hk1 hk2
       bv_omega))
   exact CodeReq.union_mono_left
 


### PR DESCRIPTION
Stacked on #1792.

Adds expOneIterCode in Exp/Compose/Base.lean, decomposing one EXP loop iteration into bit-test, square, conditional multiply, and loop-back CodeReq blocks with per-block subset lemmas.

Refs evm-asm-20z6.10 and GH #92.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Exp
- lake build