### PR TITLE
feat(rlp): add prefix length helpers

### DIFF
--- a/EvmAsm/EL/RLP/Prefix.lean
+++ b/EvmAsm/EL/RLP/Prefix.lean
@@ -27,6 +27,22 @@ def classifyPrefix (pfx : Byte) : PrefixClass :=
   else if p ≤ 0xF7 then .shortList
   else .longList
 
+/-- Payload length encoded directly in a short string prefix (`0x80..0xB7`). -/
+def rlpPrefixShortBytesPayloadLen (pfx : Byte) : Nat :=
+  pfx.toNat - 0x80
+
+/-- Number of length bytes following a long string prefix (`0xB8..0xBF`). -/
+def rlpPrefixLongBytesLenOfLen (pfx : Byte) : Nat :=
+  pfx.toNat - 0xB7
+
+/-- Payload length encoded directly in a short list prefix (`0xC0..0xF7`). -/
+def rlpPrefixShortListPayloadLen (pfx : Byte) : Nat :=
+  pfx.toNat - 0xC0
+
+/-- Number of length bytes following a long list prefix (`0xF8..0xFF`). -/
+def rlpPrefixLongListLenOfLen (pfx : Byte) : Nat :=
+  pfx.toNat - 0xF7
+
 theorem classifyPrefix_singleByte_iff (pfx : Byte) :
     classifyPrefix pfx = .singleByte ↔ pfx.toNat < 0x80 := by
   unfold classifyPrefix
@@ -96,5 +112,48 @@ theorem classifyPrefix_longList_iff (pfx : Byte) :
       · by_cases h3 : pfx.toNat ≤ 0xF7
         · simp [h0, h1, h2, h3] <;> omega
         · simp [h0, h1, h2, h3] <;> omega
+
+theorem rlpPrefixShortBytesPayloadLen_le_55_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .shortBytes) :
+    rlpPrefixShortBytesPayloadLen pfx ≤ 55 := by
+  rw [classifyPrefix_shortBytes_iff] at h
+  unfold rlpPrefixShortBytesPayloadLen
+  omega
+
+theorem rlpPrefixShortListPayloadLen_le_55_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .shortList) :
+    rlpPrefixShortListPayloadLen pfx ≤ 55 := by
+  rw [classifyPrefix_shortList_iff] at h
+  unfold rlpPrefixShortListPayloadLen
+  omega
+
+theorem rlpPrefixLongBytesLenOfLen_pos_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .longBytes) :
+    0 < rlpPrefixLongBytesLenOfLen pfx := by
+  rw [classifyPrefix_longBytes_iff] at h
+  unfold rlpPrefixLongBytesLenOfLen
+  omega
+
+theorem rlpPrefixLongBytesLenOfLen_le_8_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .longBytes) :
+    rlpPrefixLongBytesLenOfLen pfx ≤ 8 := by
+  rw [classifyPrefix_longBytes_iff] at h
+  unfold rlpPrefixLongBytesLenOfLen
+  omega
+
+theorem rlpPrefixLongListLenOfLen_pos_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .longList) :
+    0 < rlpPrefixLongListLenOfLen pfx := by
+  rw [classifyPrefix_longList_iff] at h
+  unfold rlpPrefixLongListLenOfLen
+  omega
+
+theorem rlpPrefixLongListLenOfLen_le_8_of_class {pfx : Byte}
+    (h : classifyPrefix pfx = .longList) :
+    rlpPrefixLongListLenOfLen pfx ≤ 8 := by
+  rw [classifyPrefix_longList_iff] at h
+  unfold rlpPrefixLongListLenOfLen
+  have h_bound : pfx.toNat < 256 := pfx.isLt
+  omega
 
 end EvmAsm.EL.RLP


### PR DESCRIPTION
Stacked on #1786.

Adds pure EL/RLP prefix helper definitions for short payload length and long length-of-length, plus class-derived bounds used by Phase 2 length extraction.

Refs evm-asm-h6mz.4 and GH #120.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.EL.RLP
- lake build