### PR TITLE
prove(push): add concrete length checks

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -121,6 +121,15 @@ theorem evm_push_length (n : Nat) :
     push_bytes_length]
   omega
 
+theorem evm_push1_length : (evm_push 1).length = 7 := by
+  rw [evm_push_length]
+
+theorem evm_push2_length : (evm_push 2).length = 9 := by
+  rw [evm_push_length]
+
+theorem evm_push32_length : (evm_push 32).length = 69 := by
+  rw [evm_push_length]
+
 /-- CodeReq for `evm_push n`.
 
     Symbolic `n` prevents `CodeReq.ofProg` from fully reducing, but for


### PR DESCRIPTION
Stacked on #1799.

Adds concrete PUSH1, PUSH2, and PUSH32 length facts using evm_push_length, covering the acceptance-test widths for the parameterized program layout.

Refs evm-asm-f0f5.7 and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build