### PR TITLE
prove(push): add concrete offset checks

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -62,6 +62,24 @@ theorem pushByteDstOffset_lt_width_of_lt {n i : Nat} (hi : i < n) :
   unfold pushByteDstOffset
   omega
 
+theorem push1Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push1Byte0DstOffset : pushByteDstOffset 1 0 = 0 := by
+  rfl
+
+theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push32Byte0DstOffset : pushByteDstOffset 32 0 = 31 := by
+  rfl
+
+theorem push32Byte31SrcOffset : pushByteSrcOffset 31 = 32 := by
+  rfl
+
+theorem push32Byte31DstOffset : pushByteDstOffset 32 31 = 0 := by
+  rfl
+
 /-- Read one immediate byte and store it into the new EVM stack slot.
 
     `n` is the PUSH width (1..32) and `i` is the byte index in


### PR DESCRIPTION
Stacked on #1800.

Adds concrete PUSH1 and PUSH32 endpoint source/destination byte-offset facts from pushByteSrcOffset and pushByteDstOffset.

Refs evm-asm-f0f5.8 and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build