### PR TITLE
prove(push): add concrete PUSH2 offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -230,6 +230,54 @@ theorem push7Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
 theorem push7Byte6DstOffset : pushByteDstOffset 7 6 = 0 := by
   rfl
 
+theorem push8Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push8Byte0DstOffset : pushByteDstOffset 8 0 = 7 := by
+  rfl
+
+theorem push8Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push8Byte1DstOffset : pushByteDstOffset 8 1 = 6 := by
+  rfl
+
+theorem push8Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push8Byte2DstOffset : pushByteDstOffset 8 2 = 5 := by
+  rfl
+
+theorem push8Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push8Byte3DstOffset : pushByteDstOffset 8 3 = 4 := by
+  rfl
+
+theorem push8Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push8Byte4DstOffset : pushByteDstOffset 8 4 = 3 := by
+  rfl
+
+theorem push8Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push8Byte5DstOffset : pushByteDstOffset 8 5 = 2 := by
+  rfl
+
+theorem push8Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push8Byte6DstOffset : pushByteDstOffset 8 6 = 1 := by
+  rfl
+
+theorem push8Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push8Byte7DstOffset : pushByteDstOffset 8 7 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -878,6 +878,108 @@ theorem push16Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
 theorem push16Byte15DstOffset : pushByteDstOffset 16 15 = 0 := by
   rfl
 
+theorem push17Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push17Byte0DstOffset : pushByteDstOffset 17 0 = 16 := by
+  rfl
+
+theorem push17Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push17Byte1DstOffset : pushByteDstOffset 17 1 = 15 := by
+  rfl
+
+theorem push17Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push17Byte2DstOffset : pushByteDstOffset 17 2 = 14 := by
+  rfl
+
+theorem push17Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push17Byte3DstOffset : pushByteDstOffset 17 3 = 13 := by
+  rfl
+
+theorem push17Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push17Byte4DstOffset : pushByteDstOffset 17 4 = 12 := by
+  rfl
+
+theorem push17Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push17Byte5DstOffset : pushByteDstOffset 17 5 = 11 := by
+  rfl
+
+theorem push17Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push17Byte6DstOffset : pushByteDstOffset 17 6 = 10 := by
+  rfl
+
+theorem push17Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push17Byte7DstOffset : pushByteDstOffset 17 7 = 9 := by
+  rfl
+
+theorem push17Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push17Byte8DstOffset : pushByteDstOffset 17 8 = 8 := by
+  rfl
+
+theorem push17Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push17Byte9DstOffset : pushByteDstOffset 17 9 = 7 := by
+  rfl
+
+theorem push17Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push17Byte10DstOffset : pushByteDstOffset 17 10 = 6 := by
+  rfl
+
+theorem push17Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push17Byte11DstOffset : pushByteDstOffset 17 11 = 5 := by
+  rfl
+
+theorem push17Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push17Byte12DstOffset : pushByteDstOffset 17 12 = 4 := by
+  rfl
+
+theorem push17Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push17Byte13DstOffset : pushByteDstOffset 17 13 = 3 := by
+  rfl
+
+theorem push17Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push17Byte14DstOffset : pushByteDstOffset 17 14 = 2 := by
+  rfl
+
+theorem push17Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push17Byte15DstOffset : pushByteDstOffset 17 15 = 1 := by
+  rfl
+
+theorem push17Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push17Byte16DstOffset : pushByteDstOffset 17 16 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -188,6 +188,48 @@ theorem push6Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
 theorem push6Byte5DstOffset : pushByteDstOffset 6 5 = 0 := by
   rfl
 
+theorem push7Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push7Byte0DstOffset : pushByteDstOffset 7 0 = 6 := by
+  rfl
+
+theorem push7Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push7Byte1DstOffset : pushByteDstOffset 7 1 = 5 := by
+  rfl
+
+theorem push7Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push7Byte2DstOffset : pushByteDstOffset 7 2 = 4 := by
+  rfl
+
+theorem push7Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push7Byte3DstOffset : pushByteDstOffset 7 3 = 3 := by
+  rfl
+
+theorem push7Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push7Byte4DstOffset : pushByteDstOffset 7 4 = 2 := by
+  rfl
+
+theorem push7Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push7Byte5DstOffset : pushByteDstOffset 7 5 = 1 := by
+  rfl
+
+theorem push7Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push7Byte6DstOffset : pushByteDstOffset 7 6 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -392,6 +392,72 @@ theorem push10Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
 theorem push10Byte9DstOffset : pushByteDstOffset 10 9 = 0 := by
   rfl
 
+theorem push11Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push11Byte0DstOffset : pushByteDstOffset 11 0 = 10 := by
+  rfl
+
+theorem push11Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push11Byte1DstOffset : pushByteDstOffset 11 1 = 9 := by
+  rfl
+
+theorem push11Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push11Byte2DstOffset : pushByteDstOffset 11 2 = 8 := by
+  rfl
+
+theorem push11Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push11Byte3DstOffset : pushByteDstOffset 11 3 = 7 := by
+  rfl
+
+theorem push11Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push11Byte4DstOffset : pushByteDstOffset 11 4 = 6 := by
+  rfl
+
+theorem push11Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push11Byte5DstOffset : pushByteDstOffset 11 5 = 5 := by
+  rfl
+
+theorem push11Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push11Byte6DstOffset : pushByteDstOffset 11 6 = 4 := by
+  rfl
+
+theorem push11Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push11Byte7DstOffset : pushByteDstOffset 11 7 = 3 := by
+  rfl
+
+theorem push11Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push11Byte8DstOffset : pushByteDstOffset 11 8 = 2 := by
+  rfl
+
+theorem push11Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push11Byte9DstOffset : pushByteDstOffset 11 9 = 1 := by
+  rfl
+
+theorem push11Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push11Byte10DstOffset : pushByteDstOffset 11 10 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -332,6 +332,66 @@ theorem push9Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
 theorem push9Byte8DstOffset : pushByteDstOffset 9 8 = 0 := by
   rfl
 
+theorem push10Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push10Byte0DstOffset : pushByteDstOffset 10 0 = 9 := by
+  rfl
+
+theorem push10Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push10Byte1DstOffset : pushByteDstOffset 10 1 = 8 := by
+  rfl
+
+theorem push10Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push10Byte2DstOffset : pushByteDstOffset 10 2 = 7 := by
+  rfl
+
+theorem push10Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push10Byte3DstOffset : pushByteDstOffset 10 3 = 6 := by
+  rfl
+
+theorem push10Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push10Byte4DstOffset : pushByteDstOffset 10 4 = 5 := by
+  rfl
+
+theorem push10Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push10Byte5DstOffset : pushByteDstOffset 10 5 = 4 := by
+  rfl
+
+theorem push10Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push10Byte6DstOffset : pushByteDstOffset 10 6 = 3 := by
+  rfl
+
+theorem push10Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push10Byte7DstOffset : pushByteDstOffset 10 7 = 2 := by
+  rfl
+
+theorem push10Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push10Byte8DstOffset : pushByteDstOffset 10 8 = 1 := by
+  rfl
+
+theorem push10Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push10Byte9DstOffset : pushByteDstOffset 10 9 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -68,6 +68,18 @@ theorem push1Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
 theorem push1Byte0DstOffset : pushByteDstOffset 1 0 = 0 := by
   rfl
 
+theorem push2Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push2Byte0DstOffset : pushByteDstOffset 2 0 = 1 := by
+  rfl
+
+theorem push2Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push2Byte1DstOffset : pushByteDstOffset 2 1 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -458,6 +458,78 @@ theorem push11Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
 theorem push11Byte10DstOffset : pushByteDstOffset 11 10 = 0 := by
   rfl
 
+theorem push12Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push12Byte0DstOffset : pushByteDstOffset 12 0 = 11 := by
+  rfl
+
+theorem push12Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push12Byte1DstOffset : pushByteDstOffset 12 1 = 10 := by
+  rfl
+
+theorem push12Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push12Byte2DstOffset : pushByteDstOffset 12 2 = 9 := by
+  rfl
+
+theorem push12Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push12Byte3DstOffset : pushByteDstOffset 12 3 = 8 := by
+  rfl
+
+theorem push12Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push12Byte4DstOffset : pushByteDstOffset 12 4 = 7 := by
+  rfl
+
+theorem push12Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push12Byte5DstOffset : pushByteDstOffset 12 5 = 6 := by
+  rfl
+
+theorem push12Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push12Byte6DstOffset : pushByteDstOffset 12 6 = 5 := by
+  rfl
+
+theorem push12Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push12Byte7DstOffset : pushByteDstOffset 12 7 = 4 := by
+  rfl
+
+theorem push12Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push12Byte8DstOffset : pushByteDstOffset 12 8 = 3 := by
+  rfl
+
+theorem push12Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push12Byte9DstOffset : pushByteDstOffset 12 9 = 2 := by
+  rfl
+
+theorem push12Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push12Byte10DstOffset : pushByteDstOffset 12 10 = 1 := by
+  rfl
+
+theorem push12Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push12Byte11DstOffset : pushByteDstOffset 12 11 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -608,6 +608,90 @@ theorem push13Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
 theorem push13Byte12DstOffset : pushByteDstOffset 13 12 = 0 := by
   rfl
 
+theorem push14Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push14Byte0DstOffset : pushByteDstOffset 14 0 = 13 := by
+  rfl
+
+theorem push14Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push14Byte1DstOffset : pushByteDstOffset 14 1 = 12 := by
+  rfl
+
+theorem push14Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push14Byte2DstOffset : pushByteDstOffset 14 2 = 11 := by
+  rfl
+
+theorem push14Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push14Byte3DstOffset : pushByteDstOffset 14 3 = 10 := by
+  rfl
+
+theorem push14Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push14Byte4DstOffset : pushByteDstOffset 14 4 = 9 := by
+  rfl
+
+theorem push14Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push14Byte5DstOffset : pushByteDstOffset 14 5 = 8 := by
+  rfl
+
+theorem push14Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push14Byte6DstOffset : pushByteDstOffset 14 6 = 7 := by
+  rfl
+
+theorem push14Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push14Byte7DstOffset : pushByteDstOffset 14 7 = 6 := by
+  rfl
+
+theorem push14Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push14Byte8DstOffset : pushByteDstOffset 14 8 = 5 := by
+  rfl
+
+theorem push14Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push14Byte9DstOffset : pushByteDstOffset 14 9 = 4 := by
+  rfl
+
+theorem push14Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push14Byte10DstOffset : pushByteDstOffset 14 10 = 3 := by
+  rfl
+
+theorem push14Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push14Byte11DstOffset : pushByteDstOffset 14 11 = 2 := by
+  rfl
+
+theorem push14Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push14Byte12DstOffset : pushByteDstOffset 14 12 = 1 := by
+  rfl
+
+theorem push14Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push14Byte13DstOffset : pushByteDstOffset 14 13 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -152,6 +152,42 @@ theorem push5Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
 theorem push5Byte4DstOffset : pushByteDstOffset 5 4 = 0 := by
   rfl
 
+theorem push6Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push6Byte0DstOffset : pushByteDstOffset 6 0 = 5 := by
+  rfl
+
+theorem push6Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push6Byte1DstOffset : pushByteDstOffset 6 1 = 4 := by
+  rfl
+
+theorem push6Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push6Byte2DstOffset : pushByteDstOffset 6 2 = 3 := by
+  rfl
+
+theorem push6Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push6Byte3DstOffset : pushByteDstOffset 6 3 = 2 := by
+  rfl
+
+theorem push6Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push6Byte4DstOffset : pushByteDstOffset 6 4 = 1 := by
+  rfl
+
+theorem push6Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push6Byte5DstOffset : pushByteDstOffset 6 5 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -278,6 +278,60 @@ theorem push8Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
 theorem push8Byte7DstOffset : pushByteDstOffset 8 7 = 0 := by
   rfl
 
+theorem push9Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push9Byte0DstOffset : pushByteDstOffset 9 0 = 8 := by
+  rfl
+
+theorem push9Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push9Byte1DstOffset : pushByteDstOffset 9 1 = 7 := by
+  rfl
+
+theorem push9Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push9Byte2DstOffset : pushByteDstOffset 9 2 = 6 := by
+  rfl
+
+theorem push9Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push9Byte3DstOffset : pushByteDstOffset 9 3 = 5 := by
+  rfl
+
+theorem push9Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push9Byte4DstOffset : pushByteDstOffset 9 4 = 4 := by
+  rfl
+
+theorem push9Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push9Byte5DstOffset : pushByteDstOffset 9 5 = 3 := by
+  rfl
+
+theorem push9Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push9Byte6DstOffset : pushByteDstOffset 9 6 = 2 := by
+  rfl
+
+theorem push9Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push9Byte7DstOffset : pushByteDstOffset 9 7 = 1 := by
+  rfl
+
+theorem push9Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push9Byte8DstOffset : pushByteDstOffset 9 8 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -980,6 +980,114 @@ theorem push17Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
 theorem push17Byte16DstOffset : pushByteDstOffset 17 16 = 0 := by
   rfl
 
+theorem push18Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push18Byte0DstOffset : pushByteDstOffset 18 0 = 17 := by
+  rfl
+
+theorem push18Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push18Byte1DstOffset : pushByteDstOffset 18 1 = 16 := by
+  rfl
+
+theorem push18Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push18Byte2DstOffset : pushByteDstOffset 18 2 = 15 := by
+  rfl
+
+theorem push18Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push18Byte3DstOffset : pushByteDstOffset 18 3 = 14 := by
+  rfl
+
+theorem push18Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push18Byte4DstOffset : pushByteDstOffset 18 4 = 13 := by
+  rfl
+
+theorem push18Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push18Byte5DstOffset : pushByteDstOffset 18 5 = 12 := by
+  rfl
+
+theorem push18Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push18Byte6DstOffset : pushByteDstOffset 18 6 = 11 := by
+  rfl
+
+theorem push18Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push18Byte7DstOffset : pushByteDstOffset 18 7 = 10 := by
+  rfl
+
+theorem push18Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push18Byte8DstOffset : pushByteDstOffset 18 8 = 9 := by
+  rfl
+
+theorem push18Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push18Byte9DstOffset : pushByteDstOffset 18 9 = 8 := by
+  rfl
+
+theorem push18Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push18Byte10DstOffset : pushByteDstOffset 18 10 = 7 := by
+  rfl
+
+theorem push18Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push18Byte11DstOffset : pushByteDstOffset 18 11 = 6 := by
+  rfl
+
+theorem push18Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push18Byte12DstOffset : pushByteDstOffset 18 12 = 5 := by
+  rfl
+
+theorem push18Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push18Byte13DstOffset : pushByteDstOffset 18 13 = 4 := by
+  rfl
+
+theorem push18Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push18Byte14DstOffset : pushByteDstOffset 18 14 = 3 := by
+  rfl
+
+theorem push18Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push18Byte15DstOffset : pushByteDstOffset 18 15 = 2 := by
+  rfl
+
+theorem push18Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push18Byte16DstOffset : pushByteDstOffset 18 16 = 1 := by
+  rfl
+
+theorem push18Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push18Byte17DstOffset : pushByteDstOffset 18 17 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -80,6 +80,24 @@ theorem push2Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
 theorem push2Byte1DstOffset : pushByteDstOffset 2 1 = 0 := by
   rfl
 
+theorem push3Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push3Byte0DstOffset : pushByteDstOffset 3 0 = 2 := by
+  rfl
+
+theorem push3Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push3Byte1DstOffset : pushByteDstOffset 3 1 = 1 := by
+  rfl
+
+theorem push3Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push3Byte2DstOffset : pushByteDstOffset 3 2 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -692,6 +692,96 @@ theorem push14Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
 theorem push14Byte13DstOffset : pushByteDstOffset 14 13 = 0 := by
   rfl
 
+theorem push15Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push15Byte0DstOffset : pushByteDstOffset 15 0 = 14 := by
+  rfl
+
+theorem push15Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push15Byte1DstOffset : pushByteDstOffset 15 1 = 13 := by
+  rfl
+
+theorem push15Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push15Byte2DstOffset : pushByteDstOffset 15 2 = 12 := by
+  rfl
+
+theorem push15Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push15Byte3DstOffset : pushByteDstOffset 15 3 = 11 := by
+  rfl
+
+theorem push15Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push15Byte4DstOffset : pushByteDstOffset 15 4 = 10 := by
+  rfl
+
+theorem push15Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push15Byte5DstOffset : pushByteDstOffset 15 5 = 9 := by
+  rfl
+
+theorem push15Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push15Byte6DstOffset : pushByteDstOffset 15 6 = 8 := by
+  rfl
+
+theorem push15Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push15Byte7DstOffset : pushByteDstOffset 15 7 = 7 := by
+  rfl
+
+theorem push15Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push15Byte8DstOffset : pushByteDstOffset 15 8 = 6 := by
+  rfl
+
+theorem push15Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push15Byte9DstOffset : pushByteDstOffset 15 9 = 5 := by
+  rfl
+
+theorem push15Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push15Byte10DstOffset : pushByteDstOffset 15 10 = 4 := by
+  rfl
+
+theorem push15Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push15Byte11DstOffset : pushByteDstOffset 15 11 = 3 := by
+  rfl
+
+theorem push15Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push15Byte12DstOffset : pushByteDstOffset 15 12 = 2 := by
+  rfl
+
+theorem push15Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push15Byte13DstOffset : pushByteDstOffset 15 13 = 1 := by
+  rfl
+
+theorem push15Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push15Byte14DstOffset : pushByteDstOffset 15 14 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -122,6 +122,36 @@ theorem push4Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
 theorem push4Byte3DstOffset : pushByteDstOffset 4 3 = 0 := by
   rfl
 
+theorem push5Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push5Byte0DstOffset : pushByteDstOffset 5 0 = 4 := by
+  rfl
+
+theorem push5Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push5Byte1DstOffset : pushByteDstOffset 5 1 = 3 := by
+  rfl
+
+theorem push5Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push5Byte2DstOffset : pushByteDstOffset 5 2 = 2 := by
+  rfl
+
+theorem push5Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push5Byte3DstOffset : pushByteDstOffset 5 3 = 1 := by
+  rfl
+
+theorem push5Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push5Byte4DstOffset : pushByteDstOffset 5 4 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -782,6 +782,102 @@ theorem push15Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
 theorem push15Byte14DstOffset : pushByteDstOffset 15 14 = 0 := by
   rfl
 
+theorem push16Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push16Byte0DstOffset : pushByteDstOffset 16 0 = 15 := by
+  rfl
+
+theorem push16Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push16Byte1DstOffset : pushByteDstOffset 16 1 = 14 := by
+  rfl
+
+theorem push16Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push16Byte2DstOffset : pushByteDstOffset 16 2 = 13 := by
+  rfl
+
+theorem push16Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push16Byte3DstOffset : pushByteDstOffset 16 3 = 12 := by
+  rfl
+
+theorem push16Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push16Byte4DstOffset : pushByteDstOffset 16 4 = 11 := by
+  rfl
+
+theorem push16Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push16Byte5DstOffset : pushByteDstOffset 16 5 = 10 := by
+  rfl
+
+theorem push16Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push16Byte6DstOffset : pushByteDstOffset 16 6 = 9 := by
+  rfl
+
+theorem push16Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push16Byte7DstOffset : pushByteDstOffset 16 7 = 8 := by
+  rfl
+
+theorem push16Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push16Byte8DstOffset : pushByteDstOffset 16 8 = 7 := by
+  rfl
+
+theorem push16Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push16Byte9DstOffset : pushByteDstOffset 16 9 = 6 := by
+  rfl
+
+theorem push16Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push16Byte10DstOffset : pushByteDstOffset 16 10 = 5 := by
+  rfl
+
+theorem push16Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push16Byte11DstOffset : pushByteDstOffset 16 11 = 4 := by
+  rfl
+
+theorem push16Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push16Byte12DstOffset : pushByteDstOffset 16 12 = 3 := by
+  rfl
+
+theorem push16Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push16Byte13DstOffset : pushByteDstOffset 16 13 = 2 := by
+  rfl
+
+theorem push16Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push16Byte14DstOffset : pushByteDstOffset 16 14 = 1 := by
+  rfl
+
+theorem push16Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push16Byte15DstOffset : pushByteDstOffset 16 15 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -530,6 +530,84 @@ theorem push12Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
 theorem push12Byte11DstOffset : pushByteDstOffset 12 11 = 0 := by
   rfl
 
+theorem push13Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push13Byte0DstOffset : pushByteDstOffset 13 0 = 12 := by
+  rfl
+
+theorem push13Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push13Byte1DstOffset : pushByteDstOffset 13 1 = 11 := by
+  rfl
+
+theorem push13Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push13Byte2DstOffset : pushByteDstOffset 13 2 = 10 := by
+  rfl
+
+theorem push13Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push13Byte3DstOffset : pushByteDstOffset 13 3 = 9 := by
+  rfl
+
+theorem push13Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push13Byte4DstOffset : pushByteDstOffset 13 4 = 8 := by
+  rfl
+
+theorem push13Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push13Byte5DstOffset : pushByteDstOffset 13 5 = 7 := by
+  rfl
+
+theorem push13Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push13Byte6DstOffset : pushByteDstOffset 13 6 = 6 := by
+  rfl
+
+theorem push13Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push13Byte7DstOffset : pushByteDstOffset 13 7 = 5 := by
+  rfl
+
+theorem push13Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push13Byte8DstOffset : pushByteDstOffset 13 8 = 4 := by
+  rfl
+
+theorem push13Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push13Byte9DstOffset : pushByteDstOffset 13 9 = 3 := by
+  rfl
+
+theorem push13Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push13Byte10DstOffset : pushByteDstOffset 13 10 = 2 := by
+  rfl
+
+theorem push13Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push13Byte11DstOffset : pushByteDstOffset 13 11 = 1 := by
+  rfl
+
+theorem push13Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push13Byte12DstOffset : pushByteDstOffset 13 12 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -98,6 +98,30 @@ theorem push3Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
 theorem push3Byte2DstOffset : pushByteDstOffset 3 2 = 0 := by
   rfl
 
+theorem push4Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push4Byte0DstOffset : pushByteDstOffset 4 0 = 3 := by
+  rfl
+
+theorem push4Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push4Byte1DstOffset : pushByteDstOffset 4 1 = 2 := by
+  rfl
+
+theorem push4Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push4Byte2DstOffset : pushByteDstOffset 4 2 = 1 := by
+  rfl
+
+theorem push4Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push4Byte3DstOffset : pushByteDstOffset 4 3 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 


### PR DESCRIPTION
Stacked on #1801.

Adds concrete source and destination byte offset lemmas for PUSH2 byte 0 and byte 1, covering the smallest multi-byte immediate layout.

Refs evm-asm-nrj6 and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build