### PR TITLE
prove(memory): expose byte access validity

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -128,6 +128,16 @@ theorem evmMemByteOffset_lt_8 (memBase byteAddr : Word) :
   unfold evmMemByteOffset
   exact byteOffset_lt_8
 
+theorem evmMemByteAccess_valid_iff_memAddr_valid (memBase byteAddr : Word) :
+    isValidByteAccess (memBase + byteAddr) = true ↔
+      isValidMemAddr (memBase + byteAddr) = true := by
+  rfl
+
+theorem evmMemByteAccess_valid_of_memAddr_valid {memBase byteAddr : Word}
+    (h_valid : isValidMemAddr (memBase + byteAddr) = true) :
+    isValidByteAccess (memBase + byteAddr) = true := by
+  exact (evmMemByteAccess_valid_iff_memAddr_valid memBase byteAddr).mpr h_valid
+
 /-- The byte position inside the owning RV64 dword, packaged as a `Fin 8`
     for direct use with byte-algebra lemmas. -/
 def evmMemByteOffsetFin (memBase byteAddr : Word) : Fin 8 :=


### PR DESCRIPTION
Stacked on #1807.

Adds evmMemByteAccess_valid_iff_memAddr_valid and evmMemByteAccess_valid_of_memAddr_valid, making explicit that EVM byte access validity has no 8-byte alignment precondition. MLOAD still uses alignToDword only to identify the owning RV64 dword cell.

Refs evm-asm-e84h and GH #99.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Memory
- lake build