### PR TITLE
prove(memory): fix aligned round-up

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -256,6 +256,12 @@ theorem roundUpTo32_le_add_31 (n : Nat) :
 theorem roundUpTo32_dvd (n : Nat) : 32 ∣ roundUpTo32 n := by
   unfold roundUpTo32; exact ⟨(n + 31) / 32, (Nat.mul_comm _ _)⟩
 
+theorem roundUpTo32_eq_self_of_dvd (n : Nat) (h : 32 ∣ n) :
+    roundUpTo32 n = n := by
+  rcases h with ⟨k, rfl⟩
+  unfold roundUpTo32
+  omega
+
 theorem roundUpTo32_idempotent (n : Nat) : roundUpTo32 (roundUpTo32 n) = roundUpTo32 n := by
   unfold roundUpTo32
   -- (n+31)/32 * 32 is already a multiple of 32, so adding 31 and dividing


### PR DESCRIPTION
Stacked on #1811.

Adds roundUpTo32_eq_self_of_dvd, showing that byte counts already divisible by 32 are fixed points of the EVM memory round-up helper.

Refs evm-asm-9j4v and GH #99.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Memory
- lake build