### PR TITLE
prove(push): add PUSH9 byte offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -278,6 +278,60 @@ theorem push8Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
 theorem push8Byte7DstOffset : pushByteDstOffset 8 7 = 0 := by
   rfl
 
+theorem push9Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push9Byte0DstOffset : pushByteDstOffset 9 0 = 8 := by
+  rfl
+
+theorem push9Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push9Byte1DstOffset : pushByteDstOffset 9 1 = 7 := by
+  rfl
+
+theorem push9Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push9Byte2DstOffset : pushByteDstOffset 9 2 = 6 := by
+  rfl
+
+theorem push9Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push9Byte3DstOffset : pushByteDstOffset 9 3 = 5 := by
+  rfl
+
+theorem push9Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push9Byte4DstOffset : pushByteDstOffset 9 4 = 4 := by
+  rfl
+
+theorem push9Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push9Byte5DstOffset : pushByteDstOffset 9 5 = 3 := by
+  rfl
+
+theorem push9Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push9Byte6DstOffset : pushByteDstOffset 9 6 = 2 := by
+  rfl
+
+theorem push9Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push9Byte7DstOffset : pushByteDstOffset 9 7 = 1 := by
+  rfl
+
+theorem push9Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push9Byte8DstOffset : pushByteDstOffset 9 8 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 


### PR DESCRIPTION
Stacked on #1822.

Adds concrete source and destination byte-offset lemmas for every PUSH9 immediate byte.

Refs evm-asm-9zvq and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build