### PR TITLE
prove(rlp): bridge one-byte headers to ranges

### DIFF
--- a/EvmAsm/EL/RLP/Prefix.lean
+++ b/EvmAsm/EL/RLP/Prefix.lean
@@ -337,6 +337,13 @@ theorem rlpPrefixHeaderBytes_eq_one_iff_shortClass (pfx : Byte) :
     · exact rlpPrefixHeaderBytes_eq_one_of_shortBytes h_shortBytes
     · exact rlpPrefixHeaderBytes_eq_one_of_shortList h_shortList
 
+theorem rlpPrefixHeaderBytes_eq_one_iff_short_ranges (pfx : Byte) :
+    rlpPrefixHeaderBytes pfx = 1 ↔
+      (0x80 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xB7) ∨
+        (0xC0 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xF7) := by
+  rw [rlpPrefixHeaderBytes_eq_one_iff_shortClass,
+    classifyPrefix_shortBytes_iff, classifyPrefix_shortList_iff]
+
 theorem rlpPrefixHeaderBytes_ge_two_iff_longClass (pfx : Byte) :
     2 ≤ rlpPrefixHeaderBytes pfx ↔
       classifyPrefix pfx = .longBytes ∨ classifyPrefix pfx = .longList := by


### PR DESCRIPTION
Stacked on #1826.

Adds a range-level iff connecting one-byte RLP headers to the short-bytes and short-list prefix ranges.

Refs evm-asm-ghtl and GH #120.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.EL.RLP
- lake build