### PR TITLE
prove(push): add PUSH17 byte offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -878,6 +878,108 @@ theorem push16Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
 theorem push16Byte15DstOffset : pushByteDstOffset 16 15 = 0 := by
   rfl
 
+theorem push17Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push17Byte0DstOffset : pushByteDstOffset 17 0 = 16 := by
+  rfl
+
+theorem push17Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push17Byte1DstOffset : pushByteDstOffset 17 1 = 15 := by
+  rfl
+
+theorem push17Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push17Byte2DstOffset : pushByteDstOffset 17 2 = 14 := by
+  rfl
+
+theorem push17Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push17Byte3DstOffset : pushByteDstOffset 17 3 = 13 := by
+  rfl
+
+theorem push17Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push17Byte4DstOffset : pushByteDstOffset 17 4 = 12 := by
+  rfl
+
+theorem push17Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push17Byte5DstOffset : pushByteDstOffset 17 5 = 11 := by
+  rfl
+
+theorem push17Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push17Byte6DstOffset : pushByteDstOffset 17 6 = 10 := by
+  rfl
+
+theorem push17Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push17Byte7DstOffset : pushByteDstOffset 17 7 = 9 := by
+  rfl
+
+theorem push17Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push17Byte8DstOffset : pushByteDstOffset 17 8 = 8 := by
+  rfl
+
+theorem push17Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push17Byte9DstOffset : pushByteDstOffset 17 9 = 7 := by
+  rfl
+
+theorem push17Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push17Byte10DstOffset : pushByteDstOffset 17 10 = 6 := by
+  rfl
+
+theorem push17Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push17Byte11DstOffset : pushByteDstOffset 17 11 = 5 := by
+  rfl
+
+theorem push17Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push17Byte12DstOffset : pushByteDstOffset 17 12 = 4 := by
+  rfl
+
+theorem push17Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push17Byte13DstOffset : pushByteDstOffset 17 13 = 3 := by
+  rfl
+
+theorem push17Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push17Byte14DstOffset : pushByteDstOffset 17 14 = 2 := by
+  rfl
+
+theorem push17Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push17Byte15DstOffset : pushByteDstOffset 17 15 = 1 := by
+  rfl
+
+theorem push17Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push17Byte16DstOffset : pushByteDstOffset 17 16 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 


### PR DESCRIPTION
Stacked on #1834.

Adds concrete source and destination byte-offset lemmas for every PUSH17 immediate byte.

Refs evm-asm-n7ni and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build