### PR TITLE
prove(push): add PUSH19 byte offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -1088,6 +1088,120 @@ theorem push18Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
 theorem push18Byte17DstOffset : pushByteDstOffset 18 17 = 0 := by
   rfl
 
+theorem push19Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push19Byte0DstOffset : pushByteDstOffset 19 0 = 18 := by
+  rfl
+
+theorem push19Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push19Byte1DstOffset : pushByteDstOffset 19 1 = 17 := by
+  rfl
+
+theorem push19Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push19Byte2DstOffset : pushByteDstOffset 19 2 = 16 := by
+  rfl
+
+theorem push19Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push19Byte3DstOffset : pushByteDstOffset 19 3 = 15 := by
+  rfl
+
+theorem push19Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push19Byte4DstOffset : pushByteDstOffset 19 4 = 14 := by
+  rfl
+
+theorem push19Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push19Byte5DstOffset : pushByteDstOffset 19 5 = 13 := by
+  rfl
+
+theorem push19Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push19Byte6DstOffset : pushByteDstOffset 19 6 = 12 := by
+  rfl
+
+theorem push19Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push19Byte7DstOffset : pushByteDstOffset 19 7 = 11 := by
+  rfl
+
+theorem push19Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push19Byte8DstOffset : pushByteDstOffset 19 8 = 10 := by
+  rfl
+
+theorem push19Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push19Byte9DstOffset : pushByteDstOffset 19 9 = 9 := by
+  rfl
+
+theorem push19Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push19Byte10DstOffset : pushByteDstOffset 19 10 = 8 := by
+  rfl
+
+theorem push19Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push19Byte11DstOffset : pushByteDstOffset 19 11 = 7 := by
+  rfl
+
+theorem push19Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push19Byte12DstOffset : pushByteDstOffset 19 12 = 6 := by
+  rfl
+
+theorem push19Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push19Byte13DstOffset : pushByteDstOffset 19 13 = 5 := by
+  rfl
+
+theorem push19Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push19Byte14DstOffset : pushByteDstOffset 19 14 = 4 := by
+  rfl
+
+theorem push19Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push19Byte15DstOffset : pushByteDstOffset 19 15 = 3 := by
+  rfl
+
+theorem push19Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push19Byte16DstOffset : pushByteDstOffset 19 16 = 2 := by
+  rfl
+
+theorem push19Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push19Byte17DstOffset : pushByteDstOffset 19 17 = 1 := by
+  rfl
+
+theorem push19Byte18SrcOffset : pushByteSrcOffset 18 = 19 := by
+  rfl
+
+theorem push19Byte18DstOffset : pushByteDstOffset 19 18 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 


### PR DESCRIPTION
Stacked on #1836.

Adds concrete source and destination byte-offset lemmas for every PUSH19 immediate byte.

Refs evm-asm-imh5 and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build