### PR TITLE
prove(push): add PUSH29 byte offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -2852,6 +2852,192 @@ theorem push30Byte29SrcOffset : pushByteSrcOffset 29 = 30 := by
 theorem push30Byte29DstOffset : pushByteDstOffset 30 29 = 0 := by
   rfl
 
+theorem push31Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push31Byte0DstOffset : pushByteDstOffset 31 0 = 30 := by
+  rfl
+
+theorem push31Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push31Byte1DstOffset : pushByteDstOffset 31 1 = 29 := by
+  rfl
+
+theorem push31Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push31Byte2DstOffset : pushByteDstOffset 31 2 = 28 := by
+  rfl
+
+theorem push31Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push31Byte3DstOffset : pushByteDstOffset 31 3 = 27 := by
+  rfl
+
+theorem push31Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push31Byte4DstOffset : pushByteDstOffset 31 4 = 26 := by
+  rfl
+
+theorem push31Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push31Byte5DstOffset : pushByteDstOffset 31 5 = 25 := by
+  rfl
+
+theorem push31Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push31Byte6DstOffset : pushByteDstOffset 31 6 = 24 := by
+  rfl
+
+theorem push31Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push31Byte7DstOffset : pushByteDstOffset 31 7 = 23 := by
+  rfl
+
+theorem push31Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push31Byte8DstOffset : pushByteDstOffset 31 8 = 22 := by
+  rfl
+
+theorem push31Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push31Byte9DstOffset : pushByteDstOffset 31 9 = 21 := by
+  rfl
+
+theorem push31Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push31Byte10DstOffset : pushByteDstOffset 31 10 = 20 := by
+  rfl
+
+theorem push31Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push31Byte11DstOffset : pushByteDstOffset 31 11 = 19 := by
+  rfl
+
+theorem push31Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push31Byte12DstOffset : pushByteDstOffset 31 12 = 18 := by
+  rfl
+
+theorem push31Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push31Byte13DstOffset : pushByteDstOffset 31 13 = 17 := by
+  rfl
+
+theorem push31Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push31Byte14DstOffset : pushByteDstOffset 31 14 = 16 := by
+  rfl
+
+theorem push31Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push31Byte15DstOffset : pushByteDstOffset 31 15 = 15 := by
+  rfl
+
+theorem push31Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push31Byte16DstOffset : pushByteDstOffset 31 16 = 14 := by
+  rfl
+
+theorem push31Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push31Byte17DstOffset : pushByteDstOffset 31 17 = 13 := by
+  rfl
+
+theorem push31Byte18SrcOffset : pushByteSrcOffset 18 = 19 := by
+  rfl
+
+theorem push31Byte18DstOffset : pushByteDstOffset 31 18 = 12 := by
+  rfl
+
+theorem push31Byte19SrcOffset : pushByteSrcOffset 19 = 20 := by
+  rfl
+
+theorem push31Byte19DstOffset : pushByteDstOffset 31 19 = 11 := by
+  rfl
+
+theorem push31Byte20SrcOffset : pushByteSrcOffset 20 = 21 := by
+  rfl
+
+theorem push31Byte20DstOffset : pushByteDstOffset 31 20 = 10 := by
+  rfl
+
+theorem push31Byte21SrcOffset : pushByteSrcOffset 21 = 22 := by
+  rfl
+
+theorem push31Byte21DstOffset : pushByteDstOffset 31 21 = 9 := by
+  rfl
+
+theorem push31Byte22SrcOffset : pushByteSrcOffset 22 = 23 := by
+  rfl
+
+theorem push31Byte22DstOffset : pushByteDstOffset 31 22 = 8 := by
+  rfl
+
+theorem push31Byte23SrcOffset : pushByteSrcOffset 23 = 24 := by
+  rfl
+
+theorem push31Byte23DstOffset : pushByteDstOffset 31 23 = 7 := by
+  rfl
+
+theorem push31Byte24SrcOffset : pushByteSrcOffset 24 = 25 := by
+  rfl
+
+theorem push31Byte24DstOffset : pushByteDstOffset 31 24 = 6 := by
+  rfl
+
+theorem push31Byte25SrcOffset : pushByteSrcOffset 25 = 26 := by
+  rfl
+
+theorem push31Byte25DstOffset : pushByteDstOffset 31 25 = 5 := by
+  rfl
+
+theorem push31Byte26SrcOffset : pushByteSrcOffset 26 = 27 := by
+  rfl
+
+theorem push31Byte26DstOffset : pushByteDstOffset 31 26 = 4 := by
+  rfl
+
+theorem push31Byte27SrcOffset : pushByteSrcOffset 27 = 28 := by
+  rfl
+
+theorem push31Byte27DstOffset : pushByteDstOffset 31 27 = 3 := by
+  rfl
+
+theorem push31Byte28SrcOffset : pushByteSrcOffset 28 = 29 := by
+  rfl
+
+theorem push31Byte28DstOffset : pushByteDstOffset 31 28 = 2 := by
+  rfl
+
+theorem push31Byte29SrcOffset : pushByteSrcOffset 29 = 30 := by
+  rfl
+
+theorem push31Byte29DstOffset : pushByteDstOffset 31 29 = 1 := by
+  rfl
+
+theorem push31Byte30SrcOffset : pushByteSrcOffset 30 = 31 := by
+  rfl
+
+theorem push31Byte30DstOffset : pushByteDstOffset 31 30 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -2498,6 +2498,180 @@ theorem push28Byte27SrcOffset : pushByteSrcOffset 27 = 28 := by
 theorem push28Byte27DstOffset : pushByteDstOffset 28 27 = 0 := by
   rfl
 
+theorem push29Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push29Byte0DstOffset : pushByteDstOffset 29 0 = 28 := by
+  rfl
+
+theorem push29Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push29Byte1DstOffset : pushByteDstOffset 29 1 = 27 := by
+  rfl
+
+theorem push29Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push29Byte2DstOffset : pushByteDstOffset 29 2 = 26 := by
+  rfl
+
+theorem push29Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push29Byte3DstOffset : pushByteDstOffset 29 3 = 25 := by
+  rfl
+
+theorem push29Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push29Byte4DstOffset : pushByteDstOffset 29 4 = 24 := by
+  rfl
+
+theorem push29Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push29Byte5DstOffset : pushByteDstOffset 29 5 = 23 := by
+  rfl
+
+theorem push29Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push29Byte6DstOffset : pushByteDstOffset 29 6 = 22 := by
+  rfl
+
+theorem push29Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push29Byte7DstOffset : pushByteDstOffset 29 7 = 21 := by
+  rfl
+
+theorem push29Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push29Byte8DstOffset : pushByteDstOffset 29 8 = 20 := by
+  rfl
+
+theorem push29Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push29Byte9DstOffset : pushByteDstOffset 29 9 = 19 := by
+  rfl
+
+theorem push29Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push29Byte10DstOffset : pushByteDstOffset 29 10 = 18 := by
+  rfl
+
+theorem push29Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push29Byte11DstOffset : pushByteDstOffset 29 11 = 17 := by
+  rfl
+
+theorem push29Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push29Byte12DstOffset : pushByteDstOffset 29 12 = 16 := by
+  rfl
+
+theorem push29Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push29Byte13DstOffset : pushByteDstOffset 29 13 = 15 := by
+  rfl
+
+theorem push29Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push29Byte14DstOffset : pushByteDstOffset 29 14 = 14 := by
+  rfl
+
+theorem push29Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push29Byte15DstOffset : pushByteDstOffset 29 15 = 13 := by
+  rfl
+
+theorem push29Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push29Byte16DstOffset : pushByteDstOffset 29 16 = 12 := by
+  rfl
+
+theorem push29Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push29Byte17DstOffset : pushByteDstOffset 29 17 = 11 := by
+  rfl
+
+theorem push29Byte18SrcOffset : pushByteSrcOffset 18 = 19 := by
+  rfl
+
+theorem push29Byte18DstOffset : pushByteDstOffset 29 18 = 10 := by
+  rfl
+
+theorem push29Byte19SrcOffset : pushByteSrcOffset 19 = 20 := by
+  rfl
+
+theorem push29Byte19DstOffset : pushByteDstOffset 29 19 = 9 := by
+  rfl
+
+theorem push29Byte20SrcOffset : pushByteSrcOffset 20 = 21 := by
+  rfl
+
+theorem push29Byte20DstOffset : pushByteDstOffset 29 20 = 8 := by
+  rfl
+
+theorem push29Byte21SrcOffset : pushByteSrcOffset 21 = 22 := by
+  rfl
+
+theorem push29Byte21DstOffset : pushByteDstOffset 29 21 = 7 := by
+  rfl
+
+theorem push29Byte22SrcOffset : pushByteSrcOffset 22 = 23 := by
+  rfl
+
+theorem push29Byte22DstOffset : pushByteDstOffset 29 22 = 6 := by
+  rfl
+
+theorem push29Byte23SrcOffset : pushByteSrcOffset 23 = 24 := by
+  rfl
+
+theorem push29Byte23DstOffset : pushByteDstOffset 29 23 = 5 := by
+  rfl
+
+theorem push29Byte24SrcOffset : pushByteSrcOffset 24 = 25 := by
+  rfl
+
+theorem push29Byte24DstOffset : pushByteDstOffset 29 24 = 4 := by
+  rfl
+
+theorem push29Byte25SrcOffset : pushByteSrcOffset 25 = 26 := by
+  rfl
+
+theorem push29Byte25DstOffset : pushByteDstOffset 29 25 = 3 := by
+  rfl
+
+theorem push29Byte26SrcOffset : pushByteSrcOffset 26 = 27 := by
+  rfl
+
+theorem push29Byte26DstOffset : pushByteDstOffset 29 26 = 2 := by
+  rfl
+
+theorem push29Byte27SrcOffset : pushByteSrcOffset 27 = 28 := by
+  rfl
+
+theorem push29Byte27DstOffset : pushByteDstOffset 29 27 = 1 := by
+  rfl
+
+theorem push29Byte28SrcOffset : pushByteSrcOffset 28 = 29 := by
+  rfl
+
+theorem push29Byte28DstOffset : pushByteDstOffset 29 28 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -3044,6 +3044,186 @@ theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
 theorem push32Byte0DstOffset : pushByteDstOffset 32 0 = 31 := by
   rfl
 
+theorem push32Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push32Byte1DstOffset : pushByteDstOffset 32 1 = 30 := by
+  rfl
+
+theorem push32Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push32Byte2DstOffset : pushByteDstOffset 32 2 = 29 := by
+  rfl
+
+theorem push32Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push32Byte3DstOffset : pushByteDstOffset 32 3 = 28 := by
+  rfl
+
+theorem push32Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push32Byte4DstOffset : pushByteDstOffset 32 4 = 27 := by
+  rfl
+
+theorem push32Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push32Byte5DstOffset : pushByteDstOffset 32 5 = 26 := by
+  rfl
+
+theorem push32Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push32Byte6DstOffset : pushByteDstOffset 32 6 = 25 := by
+  rfl
+
+theorem push32Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push32Byte7DstOffset : pushByteDstOffset 32 7 = 24 := by
+  rfl
+
+theorem push32Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push32Byte8DstOffset : pushByteDstOffset 32 8 = 23 := by
+  rfl
+
+theorem push32Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push32Byte9DstOffset : pushByteDstOffset 32 9 = 22 := by
+  rfl
+
+theorem push32Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push32Byte10DstOffset : pushByteDstOffset 32 10 = 21 := by
+  rfl
+
+theorem push32Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push32Byte11DstOffset : pushByteDstOffset 32 11 = 20 := by
+  rfl
+
+theorem push32Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push32Byte12DstOffset : pushByteDstOffset 32 12 = 19 := by
+  rfl
+
+theorem push32Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push32Byte13DstOffset : pushByteDstOffset 32 13 = 18 := by
+  rfl
+
+theorem push32Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push32Byte14DstOffset : pushByteDstOffset 32 14 = 17 := by
+  rfl
+
+theorem push32Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push32Byte15DstOffset : pushByteDstOffset 32 15 = 16 := by
+  rfl
+
+theorem push32Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push32Byte16DstOffset : pushByteDstOffset 32 16 = 15 := by
+  rfl
+
+theorem push32Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push32Byte17DstOffset : pushByteDstOffset 32 17 = 14 := by
+  rfl
+
+theorem push32Byte18SrcOffset : pushByteSrcOffset 18 = 19 := by
+  rfl
+
+theorem push32Byte18DstOffset : pushByteDstOffset 32 18 = 13 := by
+  rfl
+
+theorem push32Byte19SrcOffset : pushByteSrcOffset 19 = 20 := by
+  rfl
+
+theorem push32Byte19DstOffset : pushByteDstOffset 32 19 = 12 := by
+  rfl
+
+theorem push32Byte20SrcOffset : pushByteSrcOffset 20 = 21 := by
+  rfl
+
+theorem push32Byte20DstOffset : pushByteDstOffset 32 20 = 11 := by
+  rfl
+
+theorem push32Byte21SrcOffset : pushByteSrcOffset 21 = 22 := by
+  rfl
+
+theorem push32Byte21DstOffset : pushByteDstOffset 32 21 = 10 := by
+  rfl
+
+theorem push32Byte22SrcOffset : pushByteSrcOffset 22 = 23 := by
+  rfl
+
+theorem push32Byte22DstOffset : pushByteDstOffset 32 22 = 9 := by
+  rfl
+
+theorem push32Byte23SrcOffset : pushByteSrcOffset 23 = 24 := by
+  rfl
+
+theorem push32Byte23DstOffset : pushByteDstOffset 32 23 = 8 := by
+  rfl
+
+theorem push32Byte24SrcOffset : pushByteSrcOffset 24 = 25 := by
+  rfl
+
+theorem push32Byte24DstOffset : pushByteDstOffset 32 24 = 7 := by
+  rfl
+
+theorem push32Byte25SrcOffset : pushByteSrcOffset 25 = 26 := by
+  rfl
+
+theorem push32Byte25DstOffset : pushByteDstOffset 32 25 = 6 := by
+  rfl
+
+theorem push32Byte26SrcOffset : pushByteSrcOffset 26 = 27 := by
+  rfl
+
+theorem push32Byte26DstOffset : pushByteDstOffset 32 26 = 5 := by
+  rfl
+
+theorem push32Byte27SrcOffset : pushByteSrcOffset 27 = 28 := by
+  rfl
+
+theorem push32Byte27DstOffset : pushByteDstOffset 32 27 = 4 := by
+  rfl
+
+theorem push32Byte28SrcOffset : pushByteSrcOffset 28 = 29 := by
+  rfl
+
+theorem push32Byte28DstOffset : pushByteDstOffset 32 28 = 3 := by
+  rfl
+
+theorem push32Byte29SrcOffset : pushByteSrcOffset 29 = 30 := by
+  rfl
+
+theorem push32Byte29DstOffset : pushByteDstOffset 32 29 = 2 := by
+  rfl
+
+theorem push32Byte30SrcOffset : pushByteSrcOffset 30 = 31 := by
+  rfl
+
+theorem push32Byte30DstOffset : pushByteDstOffset 32 30 = 1 := by
+  rfl
+
 theorem push32Byte31SrcOffset : pushByteSrcOffset 31 = 32 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -62,6 +62,17 @@ theorem pushByteDstOffset_lt_width_of_lt {n i : Nat} (hi : i < n) :
   unfold pushByteDstOffset
   omega
 
+theorem pushByteOffsets_valid_of_lt {n i : Nat}
+    (hn : n ≤ 32) (hi : i < n) :
+    0 < pushByteSrcOffset i ∧
+      pushByteSrcOffset i ≤ 32 ∧
+      pushByteDstOffset n i < 32 ∧
+      pushByteDstOffset n i < n := by
+  exact ⟨pushByteSrcOffset_pos i,
+    pushByteSrcOffset_le_32_of_lt hn hi,
+    pushByteDstOffset_lt_32_of_lt hn hi,
+    pushByteDstOffset_lt_width_of_lt hi⟩
+
 theorem push1Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -2672,6 +2672,186 @@ theorem push29Byte28SrcOffset : pushByteSrcOffset 28 = 29 := by
 theorem push29Byte28DstOffset : pushByteDstOffset 29 28 = 0 := by
   rfl
 
+theorem push30Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
+  rfl
+
+theorem push30Byte0DstOffset : pushByteDstOffset 30 0 = 29 := by
+  rfl
+
+theorem push30Byte1SrcOffset : pushByteSrcOffset 1 = 2 := by
+  rfl
+
+theorem push30Byte1DstOffset : pushByteDstOffset 30 1 = 28 := by
+  rfl
+
+theorem push30Byte2SrcOffset : pushByteSrcOffset 2 = 3 := by
+  rfl
+
+theorem push30Byte2DstOffset : pushByteDstOffset 30 2 = 27 := by
+  rfl
+
+theorem push30Byte3SrcOffset : pushByteSrcOffset 3 = 4 := by
+  rfl
+
+theorem push30Byte3DstOffset : pushByteDstOffset 30 3 = 26 := by
+  rfl
+
+theorem push30Byte4SrcOffset : pushByteSrcOffset 4 = 5 := by
+  rfl
+
+theorem push30Byte4DstOffset : pushByteDstOffset 30 4 = 25 := by
+  rfl
+
+theorem push30Byte5SrcOffset : pushByteSrcOffset 5 = 6 := by
+  rfl
+
+theorem push30Byte5DstOffset : pushByteDstOffset 30 5 = 24 := by
+  rfl
+
+theorem push30Byte6SrcOffset : pushByteSrcOffset 6 = 7 := by
+  rfl
+
+theorem push30Byte6DstOffset : pushByteDstOffset 30 6 = 23 := by
+  rfl
+
+theorem push30Byte7SrcOffset : pushByteSrcOffset 7 = 8 := by
+  rfl
+
+theorem push30Byte7DstOffset : pushByteDstOffset 30 7 = 22 := by
+  rfl
+
+theorem push30Byte8SrcOffset : pushByteSrcOffset 8 = 9 := by
+  rfl
+
+theorem push30Byte8DstOffset : pushByteDstOffset 30 8 = 21 := by
+  rfl
+
+theorem push30Byte9SrcOffset : pushByteSrcOffset 9 = 10 := by
+  rfl
+
+theorem push30Byte9DstOffset : pushByteDstOffset 30 9 = 20 := by
+  rfl
+
+theorem push30Byte10SrcOffset : pushByteSrcOffset 10 = 11 := by
+  rfl
+
+theorem push30Byte10DstOffset : pushByteDstOffset 30 10 = 19 := by
+  rfl
+
+theorem push30Byte11SrcOffset : pushByteSrcOffset 11 = 12 := by
+  rfl
+
+theorem push30Byte11DstOffset : pushByteDstOffset 30 11 = 18 := by
+  rfl
+
+theorem push30Byte12SrcOffset : pushByteSrcOffset 12 = 13 := by
+  rfl
+
+theorem push30Byte12DstOffset : pushByteDstOffset 30 12 = 17 := by
+  rfl
+
+theorem push30Byte13SrcOffset : pushByteSrcOffset 13 = 14 := by
+  rfl
+
+theorem push30Byte13DstOffset : pushByteDstOffset 30 13 = 16 := by
+  rfl
+
+theorem push30Byte14SrcOffset : pushByteSrcOffset 14 = 15 := by
+  rfl
+
+theorem push30Byte14DstOffset : pushByteDstOffset 30 14 = 15 := by
+  rfl
+
+theorem push30Byte15SrcOffset : pushByteSrcOffset 15 = 16 := by
+  rfl
+
+theorem push30Byte15DstOffset : pushByteDstOffset 30 15 = 14 := by
+  rfl
+
+theorem push30Byte16SrcOffset : pushByteSrcOffset 16 = 17 := by
+  rfl
+
+theorem push30Byte16DstOffset : pushByteDstOffset 30 16 = 13 := by
+  rfl
+
+theorem push30Byte17SrcOffset : pushByteSrcOffset 17 = 18 := by
+  rfl
+
+theorem push30Byte17DstOffset : pushByteDstOffset 30 17 = 12 := by
+  rfl
+
+theorem push30Byte18SrcOffset : pushByteSrcOffset 18 = 19 := by
+  rfl
+
+theorem push30Byte18DstOffset : pushByteDstOffset 30 18 = 11 := by
+  rfl
+
+theorem push30Byte19SrcOffset : pushByteSrcOffset 19 = 20 := by
+  rfl
+
+theorem push30Byte19DstOffset : pushByteDstOffset 30 19 = 10 := by
+  rfl
+
+theorem push30Byte20SrcOffset : pushByteSrcOffset 20 = 21 := by
+  rfl
+
+theorem push30Byte20DstOffset : pushByteDstOffset 30 20 = 9 := by
+  rfl
+
+theorem push30Byte21SrcOffset : pushByteSrcOffset 21 = 22 := by
+  rfl
+
+theorem push30Byte21DstOffset : pushByteDstOffset 30 21 = 8 := by
+  rfl
+
+theorem push30Byte22SrcOffset : pushByteSrcOffset 22 = 23 := by
+  rfl
+
+theorem push30Byte22DstOffset : pushByteDstOffset 30 22 = 7 := by
+  rfl
+
+theorem push30Byte23SrcOffset : pushByteSrcOffset 23 = 24 := by
+  rfl
+
+theorem push30Byte23DstOffset : pushByteDstOffset 30 23 = 6 := by
+  rfl
+
+theorem push30Byte24SrcOffset : pushByteSrcOffset 24 = 25 := by
+  rfl
+
+theorem push30Byte24DstOffset : pushByteDstOffset 30 24 = 5 := by
+  rfl
+
+theorem push30Byte25SrcOffset : pushByteSrcOffset 25 = 26 := by
+  rfl
+
+theorem push30Byte25DstOffset : pushByteDstOffset 30 25 = 4 := by
+  rfl
+
+theorem push30Byte26SrcOffset : pushByteSrcOffset 26 = 27 := by
+  rfl
+
+theorem push30Byte26DstOffset : pushByteDstOffset 30 26 = 3 := by
+  rfl
+
+theorem push30Byte27SrcOffset : pushByteSrcOffset 27 = 28 := by
+  rfl
+
+theorem push30Byte27DstOffset : pushByteDstOffset 30 27 = 2 := by
+  rfl
+
+theorem push30Byte28SrcOffset : pushByteSrcOffset 28 = 29 := by
+  rfl
+
+theorem push30Byte28DstOffset : pushByteDstOffset 30 28 = 1 := by
+  rfl
+
+theorem push30Byte29SrcOffset : pushByteSrcOffset 29 = 30 := by
+  rfl
+
+theorem push30Byte29DstOffset : pushByteDstOffset 30 29 = 0 := by
+  rfl
+
 theorem push32Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 

--- a/EvmAsm/Evm64/Push/Spec.lean
+++ b/EvmAsm/Evm64/Push/Spec.lean
@@ -135,6 +135,18 @@ theorem push_zero_slot_word_zero_right (nsp : Word) (Q : Assertion) :
 -- Per-byte helper (mirror of `dup_pair_spec_within` for LBU+SB)
 -- ============================================================================
 
+theorem push_one_byte_code_eq_ofProg
+    (base : Word) (codeOff dstOff : BitVec 12) :
+    ((CodeReq.singleton base (.LBU .x7 .x10 codeOff)).union
+      (CodeReq.singleton (base + 4) (.SB .x12 .x7 dstOff))) =
+    CodeReq.ofProg base
+      (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff) := by
+  unfold LBU SB single seq
+  change _ =
+    CodeReq.ofProg base
+      [.LBU .x7 .x10 codeOff, .SB .x12 .x7 dstOff]
+  rw [CodeReq.ofProg_cons, CodeReq.ofProg_singleton]
+
 /-- Two-instruction spec for one PUSH byte: LBU x7 from EVM code at
     `codePtr + codeOff`, then SB x7 to the new stack slot at
     `sp + dstOff`.
@@ -170,5 +182,30 @@ theorem push_one_byte_spec_within
   have S := sb_spec_gen_within .x12 .x7 sp byteZext dstOff (base + 4)
     dstDwordAddr dstWordOld h_dst_align h_dst_valid
   runBlock L S
+
+theorem push_one_byte_ofProg_spec_within
+    (codePtr sp v7Old codeWord dstWordOld : Word)
+    (codeDwordAddr dstDwordAddr : Word)
+    (codeOff dstOff : BitVec 12) (base : Word)
+    (h_code_align : alignToDword (codePtr + signExtend12 codeOff) = codeDwordAddr)
+    (h_code_valid : isValidByteAccess (codePtr + signExtend12 codeOff) = true)
+    (h_dst_align  : alignToDword (sp + signExtend12 dstOff) = dstDwordAddr)
+    (h_dst_valid  : isValidByteAccess (sp + signExtend12 dstOff) = true) :
+    let byteZext :=
+      (extractByte codeWord (byteOffset (codePtr + signExtend12 codeOff))).zeroExtend 64
+    cpsTripleWithin 2 base (base + 8)
+      (CodeReq.ofProg base (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff))
+      ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7Old) **
+       (codeDwordAddr ↦ₘ codeWord) ** (dstDwordAddr ↦ₘ dstWordOld))
+      ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ byteZext) **
+       (codeDwordAddr ↦ₘ codeWord) **
+       (dstDwordAddr ↦ₘ
+         replaceByte dstWordOld (byteOffset (sp + signExtend12 dstOff))
+           (byteZext.truncate 8))) := by
+  intro byteZext
+  rw [← push_one_byte_code_eq_ofProg]
+  exact push_one_byte_spec_within codePtr sp v7Old codeWord dstWordOld
+    codeDwordAddr dstDwordAddr codeOff dstOff base
+    h_code_align h_code_valid h_dst_align h_dst_valid
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1846.

Adds concrete source and destination byte-offset lemmas for every PUSH29 immediate byte.

Refs evm-asm-e71i and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build