### PR TITLE
prove(byteops): add dword alignment helpers

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -18,6 +18,19 @@ theorem byteOffset_lt_8 {addr : Word} : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
 
+/-- Aligning a byte address down to its containing doubleword gives byte
+    offset zero. -/
+theorem alignToDword_byteOffset_zero (addr : Word) :
+    byteOffset (alignToDword addr) = 0 := by
+  unfold byteOffset alignToDword
+  bv_decide
+
+/-- Aligning an already dword-aligned address is idempotent. -/
+theorem alignToDword_idempotent (addr : Word) :
+    alignToDword (alignToDword addr) = alignToDword addr := by
+  unfold alignToDword
+  bv_decide
+
 /-! ## extractByte / replaceByte algebra
 
 Proved by `ext i` then `simp` + `interval_cases i` for the remaining


### PR DESCRIPTION
Adds reusable byte-address alignment lemmas for unaligned EVM memory proofs:

- `alignToDword_byteOffset_zero`: aligned dword addresses have byte offset zero
- `alignToDword_idempotent`: aligning twice is the same as aligning once

These support MLOAD/MSTORE byte-address reasoning without assuming EVM offsets are aligned.

Refs evm-asm-wwxy and GH #99.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Rv64.ByteOps
- lake build