### PR TITLE
prove(push): add instruction byte offsets

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -93,4 +93,39 @@ theorem evm_push_byte_length (n : Nat) :
   rw [evm_push_length]
   omega
 
+/-- Byte offset of the PUSH stack-slot allocation instruction. -/
+theorem evm_push_alloc_byte_off : 4 * 0 = 0 := by
+  rfl
+
+/-- Byte offset of the first PUSH zero-fill store. -/
+theorem evm_push_zero_limb0_store_byte_off : 4 * 1 = 4 := by
+  rfl
+
+/-- Byte offset of the second PUSH zero-fill store. -/
+theorem evm_push_zero_limb1_store_byte_off : 4 * 2 = 8 := by
+  rfl
+
+/-- Byte offset of the third PUSH zero-fill store. -/
+theorem evm_push_zero_limb2_store_byte_off : 4 * 3 = 12 := by
+  rfl
+
+/-- Byte offset of the fourth PUSH zero-fill store. -/
+theorem evm_push_zero_limb3_store_byte_off : 4 * 4 = 16 := by
+  rfl
+
+/-- Byte offset of the LBU instruction for immediate byte `i`. -/
+theorem evm_push_byte_lbu_byte_off (i : Nat) :
+    4 * (5 + 2 * i) = 20 + 8 * i := by
+  omega
+
+/-- Byte offset of the SB instruction for immediate byte `i`. -/
+theorem evm_push_byte_store_byte_off (i : Nat) :
+    4 * (5 + 2 * i + 1) = 24 + 8 * i := by
+  omega
+
+/-- Byte offset immediately after the full PUSHn program. -/
+theorem evm_push_end_byte_off (n : Nat) :
+    4 * (5 + 2 * n) = 20 + 8 * n := by
+  omega
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1861.

Adds public byte-offset lemmas for the parameterized `evm_push n` layout:

- fixed prologue offsets 0, 4, 8, 12, 16
- per-byte LBU offset `20 + 8 * i`
- per-byte SB offset `24 + 8 * i`
- end offset `20 + 8 * n`

Refs evm-asm-bep7 and GH #101.

Authored by @pirapira; implemented by Codex.

Local verification:
- lake build EvmAsm.Evm64.Push
- lake build