### PR TITLE
prove(byteops): add alignToDword byte-offset bridge

### DIFF
--- a/EvmAsm/Rv64/ByteOps.lean
+++ b/EvmAsm/Rv64/ByteOps.lean
@@ -9,6 +9,7 @@ import EvmAsm.Rv64.CPSSpec
 import Mathlib.Tactic.IntervalCases
 import Mathlib.Tactic.FinCases
 import Mathlib.Data.Fintype.Basic
+import Std.Tactic.BVDecide
 
 namespace EvmAsm.Rv64
 
@@ -17,6 +18,18 @@ namespace EvmAsm.Rv64
 theorem byteOffset_lt_8 {addr : Word} : byteOffset addr < 8 := by
   unfold byteOffset; rw [BitVec.toNat_and]
   exact Nat.lt_of_le_of_lt Nat.and_le_right (by decide)
+
+theorem byteOffset_alignToDword (addr : Word) :
+    byteOffset (alignToDword addr) = 0 := by
+  unfold byteOffset alignToDword
+  rw [show (addr &&& ~~~7#64 &&& 7#64) = 0#64 by bv_decide]
+  rfl
+
+theorem alignToDword_add_byteOffset (addr : Word) :
+    alignToDword addr + BitVec.ofNat 64 (byteOffset addr) = addr := by
+  unfold alignToDword byteOffset
+  rw [BitVec.ofNat_toNat]
+  bv_decide
 
 /-! ## extractByte / replaceByte algebra
 


### PR DESCRIPTION
Adds Rv64 byte-address bridge lemmas for unaligned EVM memory proofs.\n\nSummary:\n- prove byteOffset_alignToDword\n- prove alignToDword_add_byteOffset\n- keep MLOAD/MSTORE byte-addressed specs explicit without assuming EVM memory alignment\n\nBuilds:\n- lake build EvmAsm.Rv64.ByteOps\n- lake build\n\nReferences evm-asm-unp9 and GH #99.\n\nAuthored by @pirapira; implemented by Codex.