### PR TITLE
prove(mstore): add dword-pair limb update fold

### DIFF
--- a/EvmAsm/Evm64/MStore.lean
+++ b/EvmAsm/Evm64/MStore.lean
@@ -1,3 +1,4 @@
 import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore.ByteAlg
 import EvmAsm.Evm64.MStore.LimbSpec
+import EvmAsm.Evm64.MStore.Spec

--- a/EvmAsm/Evm64/MStore/ByteAlg.lean
+++ b/EvmAsm/Evm64/MStore/ByteAlg.lean
@@ -156,4 +156,108 @@ theorem mstoreDwordPairStoreLimb_unfold
   unfold mstoreDwordPairStoreLimb
   rfl
 
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 0. -/
+theorem mstoreDwordPairStoreLimb_start0 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 0 =
+      (let lo0 := replaceByte lo 0 (extractByte limb 7)
+       let lo1 := replaceByte lo0 1 (extractByte limb 6)
+       let lo2 := replaceByte lo1 2 (extractByte limb 5)
+       let lo3 := replaceByte lo2 3 (extractByte limb 4)
+       let lo4 := replaceByte lo3 4 (extractByte limb 3)
+       let lo5 := replaceByte lo4 5 (extractByte limb 2)
+       let lo6 := replaceByte lo5 6 (extractByte limb 1)
+       (replaceByte lo6 7 (extractByte limb 0), hi)) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 1. -/
+theorem mstoreDwordPairStoreLimb_start1 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 1 =
+      (let lo0 := replaceByte lo 1 (extractByte limb 7)
+       let lo1 := replaceByte lo0 2 (extractByte limb 6)
+       let lo2 := replaceByte lo1 3 (extractByte limb 5)
+       let lo3 := replaceByte lo2 4 (extractByte limb 4)
+       let lo4 := replaceByte lo3 5 (extractByte limb 3)
+       let lo5 := replaceByte lo4 6 (extractByte limb 2)
+       let lo6 := replaceByte lo5 7 (extractByte limb 1)
+       (lo6, replaceByte hi 0 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 2. -/
+theorem mstoreDwordPairStoreLimb_start2 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 2 =
+      (let lo0 := replaceByte lo 2 (extractByte limb 7)
+       let lo1 := replaceByte lo0 3 (extractByte limb 6)
+       let lo2 := replaceByte lo1 4 (extractByte limb 5)
+       let lo3 := replaceByte lo2 5 (extractByte limb 4)
+       let lo4 := replaceByte lo3 6 (extractByte limb 3)
+       let lo5 := replaceByte lo4 7 (extractByte limb 2)
+       let hi0 := replaceByte hi 0 (extractByte limb 1)
+       (lo5, replaceByte hi0 1 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 3. -/
+theorem mstoreDwordPairStoreLimb_start3 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 3 =
+      (let lo0 := replaceByte lo 3 (extractByte limb 7)
+       let lo1 := replaceByte lo0 4 (extractByte limb 6)
+       let lo2 := replaceByte lo1 5 (extractByte limb 5)
+       let lo3 := replaceByte lo2 6 (extractByte limb 4)
+       let lo4 := replaceByte lo3 7 (extractByte limb 3)
+       let hi0 := replaceByte hi 0 (extractByte limb 2)
+       let hi1 := replaceByte hi0 1 (extractByte limb 1)
+       (lo4, replaceByte hi1 2 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 4. -/
+theorem mstoreDwordPairStoreLimb_start4 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 4 =
+      (let lo0 := replaceByte lo 4 (extractByte limb 7)
+       let lo1 := replaceByte lo0 5 (extractByte limb 6)
+       let lo2 := replaceByte lo1 6 (extractByte limb 5)
+       let lo3 := replaceByte lo2 7 (extractByte limb 4)
+       let hi0 := replaceByte hi 0 (extractByte limb 3)
+       let hi1 := replaceByte hi0 1 (extractByte limb 2)
+       let hi2 := replaceByte hi1 2 (extractByte limb 1)
+       (lo3, replaceByte hi2 3 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 5. -/
+theorem mstoreDwordPairStoreLimb_start5 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 5 =
+      (let lo0 := replaceByte lo 5 (extractByte limb 7)
+       let lo1 := replaceByte lo0 6 (extractByte limb 6)
+       let lo2 := replaceByte lo1 7 (extractByte limb 5)
+       let hi0 := replaceByte hi 0 (extractByte limb 4)
+       let hi1 := replaceByte hi0 1 (extractByte limb 3)
+       let hi2 := replaceByte hi1 2 (extractByte limb 2)
+       let hi3 := replaceByte hi2 3 (extractByte limb 1)
+       (lo2, replaceByte hi3 4 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 6. -/
+theorem mstoreDwordPairStoreLimb_start6 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 6 =
+      (let lo0 := replaceByte lo 6 (extractByte limb 7)
+       let lo1 := replaceByte lo0 7 (extractByte limb 6)
+       let hi0 := replaceByte hi 0 (extractByte limb 5)
+       let hi1 := replaceByte hi0 1 (extractByte limb 4)
+       let hi2 := replaceByte hi1 2 (extractByte limb 3)
+       let hi3 := replaceByte hi2 3 (extractByte limb 2)
+       let hi4 := replaceByte hi3 4 (extractByte limb 1)
+       (lo1, replaceByte hi4 5 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
+/-- Concrete byte-write split for an 8-byte MSTORE window starting at dword byte 7. -/
+theorem mstoreDwordPairStoreLimb_start7 (lo hi limb : Word) :
+    mstoreDwordPairStoreLimb lo hi limb 7 =
+      (let lo0 := replaceByte lo 7 (extractByte limb 7)
+       let hi0 := replaceByte hi 0 (extractByte limb 6)
+       let hi1 := replaceByte hi0 1 (extractByte limb 5)
+       let hi2 := replaceByte hi1 2 (extractByte limb 4)
+       let hi3 := replaceByte hi2 3 (extractByte limb 3)
+       let hi4 := replaceByte hi3 4 (extractByte limb 2)
+       let hi5 := replaceByte hi4 5 (extractByte limb 1)
+       (lo0, replaceByte hi5 6 (extractByte limb 0))) := by
+  simp [mstoreDwordPairStoreLimb, mstoreDwordPairReplaceByte]
+
 end EvmAsm.Evm64.MStore

--- a/EvmAsm/Evm64/MStore/ByteAlg.lean
+++ b/EvmAsm/Evm64/MStore/ByteAlg.lean
@@ -125,4 +125,35 @@ theorem mstoreDwordPairReplaceByte_high
       (lo, replaceByte hi ((start + i) % 8) b) := by
   simp [mstoreDwordPairReplaceByte, show ¬ start + i < 8 from by omega]
 
+/--
+  Apply the eight byte writes performed by one MSTORE limb to an adjacent
+  low/high destination dword pair. Byte `i` of the destination window
+  receives `extractByte limb (7 - i)`, matching the big-endian MSTORE
+  program order.
+-/
+def mstoreDwordPairStoreLimb
+    (lo hi limb : Word) (start : Nat) : Word × Word :=
+  let p0 := mstoreDwordPairReplaceByte lo hi start 0 (extractByte limb 7)
+  let p1 := mstoreDwordPairReplaceByte p0.1 p0.2 start 1 (extractByte limb 6)
+  let p2 := mstoreDwordPairReplaceByte p1.1 p1.2 start 2 (extractByte limb 5)
+  let p3 := mstoreDwordPairReplaceByte p2.1 p2.2 start 3 (extractByte limb 4)
+  let p4 := mstoreDwordPairReplaceByte p3.1 p3.2 start 4 (extractByte limb 3)
+  let p5 := mstoreDwordPairReplaceByte p4.1 p4.2 start 5 (extractByte limb 2)
+  let p6 := mstoreDwordPairReplaceByte p5.1 p5.2 start 6 (extractByte limb 1)
+  mstoreDwordPairReplaceByte p6.1 p6.2 start 7 (extractByte limb 0)
+
+theorem mstoreDwordPairStoreLimb_unfold
+    (lo hi limb : Word) (start : Nat) :
+    mstoreDwordPairStoreLimb lo hi limb start =
+      (let p0 := mstoreDwordPairReplaceByte lo hi start 0 (extractByte limb 7)
+       let p1 := mstoreDwordPairReplaceByte p0.1 p0.2 start 1 (extractByte limb 6)
+       let p2 := mstoreDwordPairReplaceByte p1.1 p1.2 start 2 (extractByte limb 5)
+       let p3 := mstoreDwordPairReplaceByte p2.1 p2.2 start 3 (extractByte limb 4)
+       let p4 := mstoreDwordPairReplaceByte p3.1 p3.2 start 4 (extractByte limb 3)
+       let p5 := mstoreDwordPairReplaceByte p4.1 p4.2 start 5 (extractByte limb 2)
+       let p6 := mstoreDwordPairReplaceByte p5.1 p5.2 start 6 (extractByte limb 1)
+       mstoreDwordPairReplaceByte p6.1 p6.2 start 7 (extractByte limb 0)) := by
+  unfold mstoreDwordPairStoreLimb
+  rfl
+
 end EvmAsm.Evm64.MStore

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -7,6 +7,7 @@
 import EvmAsm.Evm64.MStore.ByteAlg
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
 
 open EvmAsm.Rv64.Tactics
 
@@ -164,5 +165,48 @@ theorem mstore_byte_unpack_step_spec_within
     dwordAddr wordOld h_align h_valid
   rw [h_stored] at B
   runBlock S B
+
+/-- Low-dword form of `mstore_byte_unpack_step_spec_within` for an unaligned
+    low/high destination dword pair. The byte position `start + i` is still
+    inside the low dword, so the high dword is framed through unchanged. -/
+theorem mstore_byte_unpack_step_pair_low_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal byteOld loVal hiVal : Word)
+    (loAddr hiAddr : Word)
+    (k start i : Nat) (dstOff : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_k_lt : k < 8)
+    (h_pos : start + i < 8)
+    (h_align : alignToDword (addrPtr + signExtend12 dstOff) = loAddr)
+    (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
+    (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + i) % 8) :
+    let shift := BitVec.ofNat 6 ((7 - k) * 8)
+    let byteVal := accVal >>> shift.toNat
+    let storedByte := extractByte accVal (7 - k)
+    let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start i storedByte
+    let cr :=
+      (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
+        (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
+    cpsTripleWithin 2 base (base + 8) cr
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
+       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
+  intro shift byteVal storedByte stored cr
+  have step := mstore_byte_unpack_step_spec_within
+    addrReg byteReg accReg addrPtr accVal byteOld loVal loAddr
+    k dstOff base h_byte_ne_x0 h_k_lt h_align h_valid
+  dsimp only at step
+  have framed := cpsTripleWithin_frameR (hiAddr ↦ₘ hiVal) (by pcFree) step
+  rw [show stored = (replaceByte loVal ((start + i) % 8) storedByte, hiVal) by
+    unfold stored
+    rw [MStore.mstoreDwordPairReplaceByte_low loVal hiVal storedByte h_pos]]
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      rw [h_byte] at hp
+      dsimp only at hp ⊢
+      xperm_hyp hp)
+    framed
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -269,19 +269,19 @@ theorem mstore_byte_unpack_step_pair_high_spec_within
     (h_align : alignToDword (addrPtr + signExtend12 dstOff) = hiAddr)
     (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
     (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + i) % 8) :
-    let shift := BitVec.ofNat 6 ((7 - k) * 8)
-    let byteVal := accVal >>> shift.toNat
     let storedByte := extractByte accVal (7 - k)
     let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start i storedByte
+    let shift := BitVec.ofNat 6 ((7 - k) * 8)
     let cr :=
       (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
         (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
     cpsTripleWithin 2 base (base + 8) cr
-      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
-       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
-      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
-       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
-  intro shift byteVal storedByte stored cr
+      (mstoreBytePairStepPre addrReg byteReg accReg
+        addrPtr accVal byteOld loVal hiVal loAddr hiAddr)
+      (mstoreBytePairStepPost addrReg byteReg accReg
+        addrPtr accVal stored.1 stored.2 loAddr hiAddr k) := by
+  intro storedByte stored shift cr
+  rw [mstoreBytePairStepPre_unfold, mstoreBytePairStepPost_unfold]
   have step := mstore_byte_unpack_step_spec_within
     addrReg byteReg accReg addrPtr accVal byteOld hiVal hiAddr
     k dstOff base h_byte_ne_x0 h_k_lt h_align h_valid
@@ -331,17 +331,21 @@ theorem mstore_byte_unpack_step_pair_spec_within
         alignToDword (addrPtr + signExtend12 dstOff) = loAddr := by
       rw [MStore.mstoreDwordPairAddr_low loAddr hiAddr h_pos] at h_align
       exact h_align
-    exact mstore_byte_unpack_step_pair_low_spec_within
+    have h := mstore_byte_unpack_step_pair_low_spec_within
       addrReg byteReg accReg addrPtr accVal byteOld loVal hiVal loAddr hiAddr
       k start i dstOff base h_byte_ne_x0 h_k_lt h_pos h_align_low h_valid h_byte
+    simp only [mstoreBytePairStepPre_unfold, mstoreBytePairStepPost_unfold] at h
+    exact h
   · have h_high : 8 ≤ start + i := by omega
     have h_align_high :
         alignToDword (addrPtr + signExtend12 dstOff) = hiAddr := by
       rw [MStore.mstoreDwordPairAddr_high loAddr hiAddr h_high] at h_align
       exact h_align
-    exact mstore_byte_unpack_step_pair_high_spec_within
+    have h := mstore_byte_unpack_step_pair_high_spec_within
       addrReg byteReg accReg addrPtr accVal byteOld loVal hiVal loAddr hiAddr
       k start i dstOff base h_byte_ne_x0 h_k_lt h_high h_align_high h_valid h_byte
+    simp only [mstoreBytePairStepPre_unfold, mstoreBytePairStepPost_unfold] at h
+    exact h
 
 /-- Final dword-pair byte-unpack step for one MSTORE limb. At `k = 7`, the
     runtime `SRLI` is a zero shift, so the final value left in `byteReg` is the

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -166,6 +166,52 @@ theorem mstore_byte_unpack_step_spec_within
   rw [h_stored] at B
   runBlock S B
 
+/-- Bundled precondition for the dword-pair byte-unpack step lemmas. It pairs
+    the address/scratch registers with the two destination dwords that the
+    step may touch, before the SB stores its byte. -/
+@[irreducible]
+def mstoreBytePairStepPre
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal byteOld loVal hiVal loAddr hiAddr : Word) : Assertion :=
+  (addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
+  (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal)
+
+theorem mstoreBytePairStepPre_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal byteOld loVal hiVal loAddr hiAddr : Word) :
+    mstoreBytePairStepPre addrReg byteReg accReg
+        addrPtr accVal byteOld loVal hiVal loAddr hiAddr =
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal)) := by
+  delta mstoreBytePairStepPre
+  rfl
+
+/-- Bundled postcondition for the dword-pair byte-unpack step lemmas. It
+    captures the post-SRLI byte value in `byteReg` and the updated low/high
+    destination dwords. -/
+@[irreducible]
+def mstoreBytePairStepPost
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal storedLo storedHi loAddr hiAddr : Word)
+    (k : Nat) : Assertion :=
+  let shift := BitVec.ofNat 6 ((7 - k) * 8)
+  let byteVal := accVal >>> shift.toNat
+  (addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
+  (loAddr ↦ₘ storedLo) ** (hiAddr ↦ₘ storedHi)
+
+theorem mstoreBytePairStepPost_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal storedLo storedHi loAddr hiAddr : Word)
+    (k : Nat) :
+    mstoreBytePairStepPost addrReg byteReg accReg
+        addrPtr accVal storedLo storedHi loAddr hiAddr k =
+      (let shift := BitVec.ofNat 6 ((7 - k) * 8)
+       let byteVal := accVal >>> shift.toNat
+       (addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
+       (loAddr ↦ₘ storedLo) ** (hiAddr ↦ₘ storedHi)) := by
+  delta mstoreBytePairStepPost
+  rfl
+
 /-- Low-dword form of `mstore_byte_unpack_step_spec_within` for an unaligned
     low/high destination dword pair. The byte position `start + i` is still
     inside the low dword, so the high dword is framed through unchanged. -/
@@ -180,19 +226,19 @@ theorem mstore_byte_unpack_step_pair_low_spec_within
     (h_align : alignToDword (addrPtr + signExtend12 dstOff) = loAddr)
     (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
     (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + i) % 8) :
-    let shift := BitVec.ofNat 6 ((7 - k) * 8)
-    let byteVal := accVal >>> shift.toNat
     let storedByte := extractByte accVal (7 - k)
     let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start i storedByte
+    let shift := BitVec.ofNat 6 ((7 - k) * 8)
     let cr :=
       (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
         (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
     cpsTripleWithin 2 base (base + 8) cr
-      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
-       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
-      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
-       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
-  intro shift byteVal storedByte stored cr
+      (mstoreBytePairStepPre addrReg byteReg accReg
+        addrPtr accVal byteOld loVal hiVal loAddr hiAddr)
+      (mstoreBytePairStepPost addrReg byteReg accReg
+        addrPtr accVal stored.1 stored.2 loAddr hiAddr k) := by
+  intro storedByte stored shift cr
+  rw [mstoreBytePairStepPre_unfold, mstoreBytePairStepPost_unfold]
   have step := mstore_byte_unpack_step_spec_within
     addrReg byteReg accReg addrPtr accVal byteOld loVal loAddr
     k dstOff base h_byte_ne_x0 h_k_lt h_align h_valid

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -106,6 +106,19 @@ theorem mstoreOneLimbPost_unfold
   delta mstoreOneLimbPost
   rfl
 
+/-- One-instruction source-limb load used by `mstore_one_limb_spec_within`. -/
+theorem mstore_one_limb_load_spec_within
+    (accReg : Reg) (sp accOld limbVal : Word)
+    (srcOff : BitVec 12) (base : Word)
+    (h_acc_ne_x0 : accReg ≠ .x0) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.singleton base (.LD accReg .x12 srcOff))
+      (((.x12 : Reg) ↦ᵣ sp) ** (accReg ↦ᵣ accOld) **
+       ((sp + signExtend12 srcOff) ↦ₘ limbVal))
+      (((.x12 : Reg) ↦ᵣ sp) ** (accReg ↦ᵣ limbVal) **
+       ((sp + signExtend12 srcOff) ↦ₘ limbVal)) :=
+  ld_spec_gen_within accReg .x12 sp accOld limbVal srcOff base h_acc_ne_x0
+
 /-- Two-instruction MSTORE byte-unpack step:
     shift the selected byte of `accReg` into `byteReg`, then store that
     low byte to `addrReg + dstOff`.

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -209,4 +209,47 @@ theorem mstore_byte_unpack_step_pair_low_spec_within
       xperm_hyp hp)
     framed
 
+/-- High-dword form of `mstore_byte_unpack_step_spec_within` for an unaligned
+    low/high destination dword pair. The byte position `start + i` has crossed
+    into the high dword, so the low dword is framed through unchanged. -/
+theorem mstore_byte_unpack_step_pair_high_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal byteOld loVal hiVal : Word)
+    (loAddr hiAddr : Word)
+    (k start i : Nat) (dstOff : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_k_lt : k < 8)
+    (h_pos : 8 ≤ start + i)
+    (h_align : alignToDword (addrPtr + signExtend12 dstOff) = hiAddr)
+    (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
+    (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + i) % 8) :
+    let shift := BitVec.ofNat 6 ((7 - k) * 8)
+    let byteVal := accVal >>> shift.toNat
+    let storedByte := extractByte accVal (7 - k)
+    let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start i storedByte
+    let cr :=
+      (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
+        (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
+    cpsTripleWithin 2 base (base + 8) cr
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
+       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
+  intro shift byteVal storedByte stored cr
+  have step := mstore_byte_unpack_step_spec_within
+    addrReg byteReg accReg addrPtr accVal byteOld hiVal hiAddr
+    k dstOff base h_byte_ne_x0 h_k_lt h_align h_valid
+  dsimp only at step
+  have framed := cpsTripleWithin_frameL (loAddr ↦ₘ loVal) (by pcFree) step
+  rw [show stored = (loVal, replaceByte hiVal ((start + i) % 8) storedByte) by
+    unfold stored
+    rw [MStore.mstoreDwordPairReplaceByte_high loVal hiVal storedByte h_pos]]
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      rw [h_byte] at hp
+      dsimp only at hp ⊢
+      xperm_hyp hp)
+    framed
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -338,4 +338,123 @@ theorem mstore_byte_unpack_step_pair_last_spec_within
       xperm_hyp hp)
     step
 
+/-- One MSTORE source limb: load the limb from the EVM stack, then store its
+    eight big-endian bytes into an unaligned low/high destination dword pair. -/
+theorem mstore_one_limb_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat)
+    (srcOff off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 off0) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 off1) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 off2) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 off3) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 off4) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 off5) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 off6) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 off7) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8) :
+    cpsTripleWithin 17 base (base + 68)
+      (mstoreOneLimbCode addrReg byteReg accReg
+        srcOff off0 off1 off2 off3 off4 off5 off6 off7 base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal srcOff)
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start srcOff) := by
+  rw [mstoreOneLimbPre_unfold, mstoreOneLimbPost_unfold]
+  dsimp only []
+  let p0 := MStore.mstoreDwordPairReplaceByte loVal hiVal start 0 (extractByte limbVal 7)
+  let p1 := MStore.mstoreDwordPairReplaceByte p0.1 p0.2 start 1 (extractByte limbVal 6)
+  let p2 := MStore.mstoreDwordPairReplaceByte p1.1 p1.2 start 2 (extractByte limbVal 5)
+  let p3 := MStore.mstoreDwordPairReplaceByte p2.1 p2.2 start 3 (extractByte limbVal 4)
+  let p4 := MStore.mstoreDwordPairReplaceByte p3.1 p3.2 start 4 (extractByte limbVal 3)
+  let p5 := MStore.mstoreDwordPairReplaceByte p4.1 p4.2 start 5 (extractByte limbVal 2)
+  let p6 := MStore.mstoreDwordPairReplaceByte p5.1 p5.2 start 6 (extractByte limbVal 1)
+  let p7 := MStore.mstoreDwordPairReplaceByte p6.1 p6.2 start 7 (extractByte limbVal 0)
+  let b0 := limbVal >>> (BitVec.ofNat 6 ((7 - 0) * 8)).toNat
+  let b1 := limbVal >>> (BitVec.ofNat 6 ((7 - 1) * 8)).toNat
+  let b2 := limbVal >>> (BitVec.ofNat 6 ((7 - 2) * 8)).toNat
+  let b3 := limbVal >>> (BitVec.ofNat 6 ((7 - 3) * 8)).toNat
+  let b4 := limbVal >>> (BitVec.ofNat 6 ((7 - 4) * 8)).toNat
+  let b5 := limbVal >>> (BitVec.ofNat 6 ((7 - 5) * 8)).toNat
+  let b6 := limbVal >>> (BitVec.ofNat 6 ((7 - 6) * 8)).toNat
+  have composed :
+      cpsTripleWithin 17 base (base + 68)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          srcOff off0 off1 off2 off3 off4 off5 off6 off7 base)
+        ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((sp + signExtend12 srcOff) ↦ₘ limbVal))
+        ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ p7.1) ** (hiAddr ↦ₘ p7.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((sp + signExtend12 srcOff) ↦ₘ limbVal)) := by
+    unfold mstoreOneLimbCode mstoreByteUnpackEightCode
+    have L := mstore_one_limb_load_spec_within accReg sp accOld limbVal srcOff base h_acc_ne_x0
+    have S0 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal byteOld loVal hiVal loAddr hiAddr
+      0 start 0 off0 (base + 4) h_byte_ne_x0 (by decide) h_align0 h_valid0 h_byte0
+    have S1 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b0 p0.1 p0.2 loAddr hiAddr
+      1 start 1 off1 (base + 12) h_byte_ne_x0 (by decide) h_align1 h_valid1 h_byte1
+    have S2 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b1 p1.1 p1.2 loAddr hiAddr
+      2 start 2 off2 (base + 20) h_byte_ne_x0 (by decide) h_align2 h_valid2 h_byte2
+    have S3 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b2 p2.1 p2.2 loAddr hiAddr
+      3 start 3 off3 (base + 28) h_byte_ne_x0 (by decide) h_align3 h_valid3 h_byte3
+    have S4 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b3 p3.1 p3.2 loAddr hiAddr
+      4 start 4 off4 (base + 36) h_byte_ne_x0 (by decide) h_align4 h_valid4 h_byte4
+    have S5 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b4 p4.1 p4.2 loAddr hiAddr
+      5 start 5 off5 (base + 44) h_byte_ne_x0 (by decide) h_align5 h_valid5 h_byte5
+    have S6 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b5 p5.1 p5.2 loAddr hiAddr
+      6 start 6 off6 (base + 52) h_byte_ne_x0 (by decide) h_align6 h_valid6 h_byte6
+    have S7 := mstore_byte_unpack_step_pair_last_spec_within
+      addrReg byteReg accReg addrPtr limbVal b6 p6.1 p6.2 loAddr hiAddr
+      start off7 (base + 60) h_byte_ne_x0 h_align7 h_valid7 h_byte7
+    exact by
+      (runBlock L S0 S1 S2 S3 S4 S5 S6 S7)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      rw [MStore.mstoreDwordPairStoreLimb_unfold loVal hiVal limbVal start]
+      dsimp only []
+      xperm_hyp hp)
+    composed
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -14,6 +14,46 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- CodeReq for the eight SRLI/SB byte-unpack steps in one MSTORE limb. -/
+def mstoreByteUnpackEightCode
+    (addrReg byteReg accReg : Reg)
+    (off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12)
+    (base : Word) : CodeReq :=
+  ((CodeReq.singleton base
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 0) * 8)))).union
+   (CodeReq.singleton (base + 4) (.SB addrReg byteReg off0))).union
+  (((CodeReq.singleton (base + 8)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 1) * 8)))).union
+    (CodeReq.singleton (base + 12) (.SB addrReg byteReg off1))).union
+  (((CodeReq.singleton (base + 16)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 2) * 8)))).union
+    (CodeReq.singleton (base + 20) (.SB addrReg byteReg off2))).union
+  (((CodeReq.singleton (base + 24)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 3) * 8)))).union
+    (CodeReq.singleton (base + 28) (.SB addrReg byteReg off3))).union
+  (((CodeReq.singleton (base + 32)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 4) * 8)))).union
+    (CodeReq.singleton (base + 36) (.SB addrReg byteReg off4))).union
+  (((CodeReq.singleton (base + 40)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 5) * 8)))).union
+    (CodeReq.singleton (base + 44) (.SB addrReg byteReg off5))).union
+  (((CodeReq.singleton (base + 48)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 6) * 8)))).union
+    (CodeReq.singleton (base + 52) (.SB addrReg byteReg off6))).union
+   ((CodeReq.singleton (base + 56)
+      (.SRLI byteReg accReg (BitVec.ofNat 6 ((7 - 7) * 8)))).union
+    (CodeReq.singleton (base + 60) (.SB addrReg byteReg off7)))))))))
+
+/-- CodeReq for one MSTORE limb: load a source limb, then emit eight
+    byte-unpack SRLI/SB steps. -/
+def mstoreOneLimbCode
+    (addrReg byteReg accReg : Reg)
+    (srcOff off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12)
+    (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LD accReg .x12 srcOff)).union
+    (mstoreByteUnpackEightCode addrReg byteReg accReg
+      off0 off1 off2 off3 off4 off5 off6 off7 (base + 4))
+
 /-- Bundled precondition for the upcoming one-limb MSTORE spec. It contains
     the address/scratch registers, the two destination dwords that may be
     touched by an unaligned 8-byte limb write, and the source EVM-stack limb

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -14,6 +14,58 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- Bundled precondition for the upcoming one-limb MSTORE spec. It contains
+    the address/scratch registers, the two destination dwords that may be
+    touched by an unaligned 8-byte limb write, and the source EVM-stack limb
+    loaded from `sp + signExtend12 srcOff`. -/
+@[irreducible]
+def mstoreOneLimbPre
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (srcOff : BitVec 12) : Assertion :=
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+  (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 srcOff) ↦ₘ limbVal)
+
+theorem mstoreOneLimbPre_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (srcOff : BitVec 12) :
+    mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal srcOff =
+    ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+     (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 srcOff) ↦ₘ limbVal)) := by
+  delta mstoreOneLimbPre
+  rfl
+
+/-- Bundled postcondition for the upcoming one-limb MSTORE spec. The source
+    limb has been loaded into `accReg`, the final `byteReg` value is the last
+    SRLI result, and the low/high destination dwords are updated by the pure
+    eight-byte fold `mstoreDwordPairStoreLimb`. -/
+@[irreducible]
+def mstoreOneLimbPost
+    (addrReg byteReg accReg : Reg)
+    (addrPtr loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (srcOff : BitVec 12) : Assertion :=
+  let stored := MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+  (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 srcOff) ↦ₘ limbVal)
+
+theorem mstoreOneLimbPost_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (srcOff : BitVec 12) :
+    mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start srcOff =
+    (let stored := MStore.mstoreDwordPairStoreLimb loVal hiVal limbVal start
+     (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+     (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+     ((sp + signExtend12 srcOff) ↦ₘ limbVal)) := by
+  delta mstoreOneLimbPost
+  rfl
+
 /-- Two-instruction MSTORE byte-unpack step:
     shift the selected byte of `accReg` into `byteReg`, then store that
     low byte to `addrReg + dstOff`.

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -252,4 +252,49 @@ theorem mstore_byte_unpack_step_pair_high_spec_within
       xperm_hyp hp)
     framed
 
+/-- Dword-pair form of `mstore_byte_unpack_step_spec_within` that dispatches
+    to the low or high destination dword according to
+    `MStore.mstoreDwordPairAddr`. This is the uniform byte-step lemma used by
+    the one-limb MSTORE composition. -/
+theorem mstore_byte_unpack_step_pair_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr accVal byteOld loVal hiVal : Word)
+    (loAddr hiAddr : Word)
+    (k start i : Nat) (dstOff : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_k_lt : k < 8)
+    (h_align :
+      alignToDword (addrPtr + signExtend12 dstOff) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start i)
+    (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
+    (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + i) % 8) :
+    let shift := BitVec.ofNat 6 ((7 - k) * 8)
+    let byteVal := accVal >>> shift.toNat
+    let storedByte := extractByte accVal (7 - k)
+    let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start i storedByte
+    let cr :=
+      (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
+        (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
+    cpsTripleWithin 2 base (base + 8) cr
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ accVal) ** (byteReg ↦ᵣ byteVal) **
+       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
+  by_cases h_pos : start + i < 8
+  · have h_align_low :
+        alignToDword (addrPtr + signExtend12 dstOff) = loAddr := by
+      rw [MStore.mstoreDwordPairAddr_low loAddr hiAddr h_pos] at h_align
+      exact h_align
+    exact mstore_byte_unpack_step_pair_low_spec_within
+      addrReg byteReg accReg addrPtr accVal byteOld loVal hiVal loAddr hiAddr
+      k start i dstOff base h_byte_ne_x0 h_k_lt h_pos h_align_low h_valid h_byte
+  · have h_high : 8 ≤ start + i := by omega
+    have h_align_high :
+        alignToDword (addrPtr + signExtend12 dstOff) = hiAddr := by
+      rw [MStore.mstoreDwordPairAddr_high loAddr hiAddr h_high] at h_align
+      exact h_align
+    exact mstore_byte_unpack_step_pair_high_spec_within
+      addrReg byteReg accReg addrPtr accVal byteOld loVal hiVal loAddr hiAddr
+      k start i dstOff base h_byte_ne_x0 h_k_lt h_high h_align_high h_valid h_byte
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -297,4 +297,45 @@ theorem mstore_byte_unpack_step_pair_spec_within
       addrReg byteReg accReg addrPtr accVal byteOld loVal hiVal loAddr hiAddr
       k start i dstOff base h_byte_ne_x0 h_k_lt h_high h_align_high h_valid h_byte
 
+/-- Final dword-pair byte-unpack step for one MSTORE limb. At `k = 7`, the
+    runtime `SRLI` is a zero shift, so the final value left in `byteReg` is the
+    source limb itself. -/
+theorem mstore_byte_unpack_step_pair_last_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr limbVal byteOld loVal hiVal : Word)
+    (loAddr hiAddr : Word)
+    (start : Nat) (dstOff : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_align :
+      alignToDword (addrPtr + signExtend12 dstOff) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid : isValidByteAccess (addrPtr + signExtend12 dstOff) = true)
+    (h_byte : byteOffset (addrPtr + signExtend12 dstOff) = (start + 7) % 8) :
+    let shift := BitVec.ofNat 6 ((7 - 7) * 8)
+    let storedByte := extractByte limbVal (7 - 7)
+    let stored := MStore.mstoreDwordPairReplaceByte loVal hiVal start 7 storedByte
+    let cr :=
+      (CodeReq.singleton base (.SRLI byteReg accReg shift)).union
+        (CodeReq.singleton (base + 4) (.SB addrReg byteReg dstOff))
+    cpsTripleWithin 2 base (base + 8) cr
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ limbVal) ** (byteReg ↦ᵣ byteOld) **
+       (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal))
+      ((addrReg ↦ᵣ addrPtr) ** (accReg ↦ᵣ limbVal) ** (byteReg ↦ᵣ limbVal) **
+       (loAddr ↦ₘ stored.1) ** (hiAddr ↦ₘ stored.2)) := by
+  intro shift storedByte stored cr
+  have step := mstore_byte_unpack_step_pair_spec_within
+    addrReg byteReg accReg addrPtr limbVal byteOld loVal hiVal loAddr hiAddr
+    7 start 7 dstOff base h_byte_ne_x0 (by decide) h_align h_valid h_byte
+  dsimp only at step
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      try dsimp only at hp ⊢
+      simp at hp ⊢
+      unfold stored
+      unfold storedByte
+      simp
+      xperm_hyp hp)
+    step
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -69,4 +69,12 @@ theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
   unfold mstoreEpilogueCode
   exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
 
+/-- Compact CodeReq for the full MSTORE program, split into prologue, four
+    one-limb byte-unpack blocks, and the final stack-pop epilogue. -/
+def mstoreStackCode
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  (mstorePrologueCode offReg addrReg memBaseReg base).union
+    ((mstoreFourLimbsCode addrReg byteReg accReg base).union
+      (mstoreEpilogueCode (base + 280)))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -43,4 +43,17 @@ theorem mstore_prologue_spec_within
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at h_add
   runBlock h_ld h_add
 
+/-- CodeReq for the final MSTORE stack-pop epilogue. -/
+def mstoreEpilogueCode (base : Word) : CodeReq :=
+  CodeReq.singleton base (.ADDI .x12 .x12 64)
+
+/-- MSTORE epilogue spec: pop the offset and value words from the EVM stack. -/
+theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (mstoreEpilogueCode base)
+      (((.x12 : Reg) ↦ᵣ sp))
+      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
+  unfold mstoreEpilogueCode
+  exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -10,6 +10,19 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- CodeReq for all four MSTORE value-limb byte-unpack blocks, placed after
+    the two-instruction address prologue. -/
+def mstoreFourLimbsCode
+    (addrReg byteReg accReg : Reg) (base : Word) : CodeReq :=
+  (mstoreOneLimbCode addrReg byteReg accReg
+      32 24 25 26 27 28 29 30 31 (base + 8)).union
+    ((mstoreOneLimbCode addrReg byteReg accReg
+        40 16 17 18 19 20 21 22 23 (base + 76)).union
+      ((mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)).union
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212))))
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -1,0 +1,46 @@
+/-
+  EvmAsm.Evm64.MStore.Spec
+
+  Stack-level building blocks for the 256-bit EVM MSTORE program.
+-/
+
+import EvmAsm.Evm64.MStore.LimbSpec
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- CodeReq for the two-instruction MSTORE address prologue. -/
+def mstorePrologueCode
+    (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  (CodeReq.singleton base (.LD offReg .x12 0)).union
+    (CodeReq.singleton (base + 4) (.ADD addrReg memBaseReg offReg))
+
+/--
+  MSTORE prologue spec: load the low 64-bit offset limb from the EVM stack and
+  compute the concrete byte address `memBase + offset` used by the four
+  subsequent limb-store blocks.
+-/
+theorem mstore_prologue_spec_within
+    (offReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (mstorePrologueCode offReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  unfold mstorePrologueCode
+  have h_ld := ld_spec_within offReg (.x12 : Reg) sp offOld offset 0 base h_off_ne_x0
+  rw [show (sp + signExtend12 (0 : BitVec 12) : Word) = sp from by
+    rw [signExtend12_0]; bv_omega] at h_ld
+  have h_add := add_spec_gen_within addrReg memBaseReg offReg memBase offset addrOld
+    (base + 4) h_addr_ne_x0
+  rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at h_add
+  runBlock h_ld h_add
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1871.\n\nAdds a pure fold for the eight byte replacements performed by one unaligned MSTORE limb over a low/high dword pair.\n\nSummary:\n- define mstoreDwordPairStoreLimb\n- add mstoreDwordPairStoreLimb_unfold for future one-limb specs\n\nBuilds:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n\nReferences evm-asm-em5a, evm-asm-jct3, and GH #99.\n\nAuthored by @pirapira; implemented by Codex.