### PR TITLE
prove(mstore): add one-limb spec

### DIFF
--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -338,4 +338,123 @@ theorem mstore_byte_unpack_step_pair_last_spec_within
       xperm_hyp hp)
     step
 
+/-- One MSTORE source limb: load the limb from the EVM stack, then store its
+    eight big-endian bytes into an unaligned low/high destination dword pair. -/
+theorem mstore_one_limb_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat)
+    (srcOff off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 off0) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 off1) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 off2) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 off3) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 off4) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 off5) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 off6) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 off7) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8) :
+    cpsTripleWithin 17 base (base + 68)
+      (mstoreOneLimbCode addrReg byteReg accReg
+        srcOff off0 off1 off2 off3 off4 off5 off6 off7 base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal srcOff)
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start srcOff) := by
+  rw [mstoreOneLimbPre_unfold, mstoreOneLimbPost_unfold]
+  dsimp only []
+  let p0 := MStore.mstoreDwordPairReplaceByte loVal hiVal start 0 (extractByte limbVal 7)
+  let p1 := MStore.mstoreDwordPairReplaceByte p0.1 p0.2 start 1 (extractByte limbVal 6)
+  let p2 := MStore.mstoreDwordPairReplaceByte p1.1 p1.2 start 2 (extractByte limbVal 5)
+  let p3 := MStore.mstoreDwordPairReplaceByte p2.1 p2.2 start 3 (extractByte limbVal 4)
+  let p4 := MStore.mstoreDwordPairReplaceByte p3.1 p3.2 start 4 (extractByte limbVal 3)
+  let p5 := MStore.mstoreDwordPairReplaceByte p4.1 p4.2 start 5 (extractByte limbVal 2)
+  let p6 := MStore.mstoreDwordPairReplaceByte p5.1 p5.2 start 6 (extractByte limbVal 1)
+  let p7 := MStore.mstoreDwordPairReplaceByte p6.1 p6.2 start 7 (extractByte limbVal 0)
+  let b0 := limbVal >>> (BitVec.ofNat 6 ((7 - 0) * 8)).toNat
+  let b1 := limbVal >>> (BitVec.ofNat 6 ((7 - 1) * 8)).toNat
+  let b2 := limbVal >>> (BitVec.ofNat 6 ((7 - 2) * 8)).toNat
+  let b3 := limbVal >>> (BitVec.ofNat 6 ((7 - 3) * 8)).toNat
+  let b4 := limbVal >>> (BitVec.ofNat 6 ((7 - 4) * 8)).toNat
+  let b5 := limbVal >>> (BitVec.ofNat 6 ((7 - 5) * 8)).toNat
+  let b6 := limbVal >>> (BitVec.ofNat 6 ((7 - 6) * 8)).toNat
+  have composed :
+      cpsTripleWithin 17 base (base + 68)
+        (mstoreOneLimbCode addrReg byteReg accReg
+          srcOff off0 off1 off2 off3 off4 off5 off6 off7 base)
+        ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+         (loAddr ↦ₘ loVal) ** (hiAddr ↦ₘ hiVal) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((sp + signExtend12 srcOff) ↦ₘ limbVal))
+        ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limbVal) ** (accReg ↦ᵣ limbVal) **
+         (loAddr ↦ₘ p7.1) ** (hiAddr ↦ₘ p7.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+         ((sp + signExtend12 srcOff) ↦ₘ limbVal)) := by
+    unfold mstoreOneLimbCode mstoreByteUnpackEightCode
+    have L := mstore_one_limb_load_spec_within accReg sp accOld limbVal srcOff base h_acc_ne_x0
+    have S0 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal byteOld loVal hiVal loAddr hiAddr
+      0 start 0 off0 (base + 4) h_byte_ne_x0 (by decide) h_align0 h_valid0 h_byte0
+    have S1 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b0 p0.1 p0.2 loAddr hiAddr
+      1 start 1 off1 (base + 12) h_byte_ne_x0 (by decide) h_align1 h_valid1 h_byte1
+    have S2 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b1 p1.1 p1.2 loAddr hiAddr
+      2 start 2 off2 (base + 20) h_byte_ne_x0 (by decide) h_align2 h_valid2 h_byte2
+    have S3 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b2 p2.1 p2.2 loAddr hiAddr
+      3 start 3 off3 (base + 28) h_byte_ne_x0 (by decide) h_align3 h_valid3 h_byte3
+    have S4 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b3 p3.1 p3.2 loAddr hiAddr
+      4 start 4 off4 (base + 36) h_byte_ne_x0 (by decide) h_align4 h_valid4 h_byte4
+    have S5 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b4 p4.1 p4.2 loAddr hiAddr
+      5 start 5 off5 (base + 44) h_byte_ne_x0 (by decide) h_align5 h_valid5 h_byte5
+    have S6 := mstore_byte_unpack_step_pair_spec_within
+      addrReg byteReg accReg addrPtr limbVal b5 p5.1 p5.2 loAddr hiAddr
+      6 start 6 off6 (base + 52) h_byte_ne_x0 (by decide) h_align6 h_valid6 h_byte6
+    have S7 := mstore_byte_unpack_step_pair_last_spec_within
+      addrReg byteReg accReg addrPtr limbVal b6 p6.1 p6.2 loAddr hiAddr
+      start off7 (base + 60) h_byte_ne_x0 h_align7 h_valid7 h_byte7
+    exact by
+      (runBlock L S0 S1 S2 S3 S4 S5 S6 S7)
+  exact cpsTripleWithin_weaken
+    (fun _ hp => by xperm_hyp hp)
+    (fun _ hp => by
+      rw [MStore.mstoreDwordPairStoreLimb_unfold loVal hiVal limbVal start]
+      dsimp only []
+      xperm_hyp hp)
+    composed
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1879.

Adds mstore_one_limb_spec_within by composing the source-limb LD with eight unaligned dword-pair byte-unpack steps. This proves the one-limb MSTORE component without assuming destination alignment; the low/high dword selection is driven by MStore.mstoreDwordPairAddr.

Local builds passed:
- lake build EvmAsm.Evm64.MStore
- lake build

References evm-asm-jct3 and GH #99.

Authored by @pirapira; implemented by Codex.