### PR TITLE
prove(mstore): add stack-pointer epilogue spec

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -43,4 +43,17 @@ theorem mstore_prologue_spec_within
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at h_add
   runBlock h_ld h_add
 
+/-- CodeReq for the final MSTORE stack-pop epilogue. -/
+def mstoreEpilogueCode (base : Word) : CodeReq :=
+  CodeReq.singleton base (.ADDI .x12 .x12 64)
+
+/-- MSTORE epilogue spec: pop the offset and value words from the EVM stack. -/
+theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (mstoreEpilogueCode base)
+      (((.x12 : Reg) ↦ᵣ sp))
+      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
+  unfold mstoreEpilogueCode
+  exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1881.

Adds mstoreEpilogueCode and mstore_epilogue_spec_within for the final ADDI x12 x12 64 instruction that pops the offset and value words after MSTORE writes memory.

Local builds passed:
- lake build EvmAsm.Evm64.MStore
- lake build

References evm-asm-7o11, evm-asm-k655, and GH #99.

Authored by @pirapira; implemented by Codex.