### PR TITLE
define(mstore): add four-limb CodeReq

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -69,4 +69,12 @@ theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
   unfold mstoreEpilogueCode
   exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
 
+/-- Compact CodeReq for the full MSTORE program, split into prologue, four
+    one-limb byte-unpack blocks, and the final stack-pop epilogue. -/
+def mstoreStackCode
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  (mstorePrologueCode offReg addrReg memBaseReg base).union
+    ((mstoreFourLimbsCode addrReg byteReg accReg base).union
+      (mstoreEpilogueCode (base + 280)))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -10,6 +10,19 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- CodeReq for all four MSTORE value-limb byte-unpack blocks, placed after
+    the two-instruction address prologue. -/
+def mstoreFourLimbsCode
+    (addrReg byteReg accReg : Reg) (base : Word) : CodeReq :=
+  (mstoreOneLimbCode addrReg byteReg accReg
+      32 24 25 26 27 28 29 30 31 (base + 8)).union
+    ((mstoreOneLimbCode addrReg byteReg accReg
+        40 16 17 18 19 20 21 22 23 (base + 76)).union
+      ((mstoreOneLimbCode addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15 (base + 144)).union
+        (mstoreOneLimbCode addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7 (base + 212))))
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=


### PR DESCRIPTION
Stacked on #1882.

Adds mstoreFourLimbsCode for the four concrete MSTORE one-limb byte-unpack blocks following the address prologue. This gives evm_mstore_stack_spec_within a named CodeReq component for the value write body.

Local builds passed:
- lake build EvmAsm.Evm64.MStore
- lake build

References evm-asm-4wak, evm-asm-k655, and GH #99.

Authored by @pirapira; implemented by Codex.