### PR TITLE
define(mstore): add stack CodeReq

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -69,4 +69,12 @@ theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
   unfold mstoreEpilogueCode
   exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
 
+/-- Compact CodeReq for the full MSTORE program, split into prologue, four
+    one-limb byte-unpack blocks, and the final stack-pop epilogue. -/
+def mstoreStackCode
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  (mstorePrologueCode offReg addrReg memBaseReg base).union
+    ((mstoreFourLimbsCode addrReg byteReg accReg base).union
+      (mstoreEpilogueCode (base + 280)))
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #1883.

Adds mstoreStackCode, a compact full-program CodeReq for MSTORE that combines the address prologue, four concrete one-limb write blocks, and the final x12 += 64 epilogue at the concrete program offsets.

Local builds passed:
- lake build EvmAsm.Evm64.MStore
- lake build

References evm-asm-u526, evm-asm-k655, and GH #99.

Authored by @pirapira; implemented by Codex.