### PR TITLE
prove(memory): cover MLOAD owning dword cells

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -339,6 +339,16 @@ theorem evmMemExpand_mload_byte_dword_start_lt
     exact Nat.div_mul_le_self (offset + byteIndex) 8
   exact Nat.lt_of_le_of_lt h_start_le h_byte_lt
 
+theorem evmMemExpand_mload_byte_dword_interval
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8) * 8 <
+        evmMemExpand sizeBytes offset 32 ∧
+      ((offset + byteIndex) / 8 + 1) * 8 ≤
+        evmMemExpand sizeBytes offset 32 := by
+  exact ⟨
+    evmMemExpand_mload_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
+    evmMemExpand_mload_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -349,6 +349,12 @@ theorem evmMemExpand_mload_byte_dword_interval
     evmMemExpand_mload_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mload_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mload_dword_interval
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 0 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -355,6 +355,12 @@ theorem evmMemExpand_mload_dword_interval
       (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 0 (by decide)
 
+theorem evmMemExpand_mload_last_dword_interval
+    (sizeBytes offset : Nat) :
+    ((offset + 31) / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 31 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -361,6 +361,14 @@ theorem evmMemExpand_mload_last_dword_interval
       ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 31 (by decide)
 
+theorem evmMemExpand_mload_dword_span
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact ⟨
+    (evmMemExpand_mload_dword_interval sizeBytes offset).1,
+    (evmMemExpand_mload_last_dword_interval sizeBytes offset).2⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -318,6 +318,18 @@ theorem evmMemExpand_mload_byte_lt
   have h_end := evmMemExpand_mload_ge_end sizeBytes offset
   omega
 
+theorem evmMemExpand_mload_byte_dword_end_le
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8 + 1) * 8 ≤
+      evmMemExpand sizeBytes offset 32 := by
+  unfold evmMemExpand
+  rw [if_neg (by decide : (32 : Nat) ≠ 0)]
+  have h_round : ((offset + byteIndex) / 8 + 1) * 8 ≤
+      roundUpTo32 (offset + 32) := by
+    unfold roundUpTo32
+    omega
+  exact Nat.le_trans h_round (Nat.le_max_right _ _)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -330,6 +330,15 @@ theorem evmMemExpand_mload_byte_dword_end_le
     omega
   exact Nat.le_trans h_round (Nat.le_max_right _ _)
 
+theorem evmMemExpand_mload_byte_dword_start_lt
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8) * 8 <
+      evmMemExpand sizeBytes offset 32 := by
+  have h_byte_lt := evmMemExpand_mload_byte_lt sizeBytes offset byteIndex h_byte
+  have h_start_le : ((offset + byteIndex) / 8) * 8 ≤ offset + byteIndex := by
+    exact Nat.div_mul_le_self (offset + byteIndex) 8
+  exact Nat.lt_of_le_of_lt h_start_le h_byte_lt
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1821.

Adds evmMemExpand_mload_byte_dword_end_le, proving that byte-addressed MLOAD expansion covers the full RV64 dword cell that owns every selected byte. This is the dword-cell coverage bridge needed by unaligned byte-level LBU proofs and carries no alignment precondition on the MLOAD offset.

Builds:
- lake build EvmAsm.Evm64.Memory
- lake build

Refs evm-asm-j1h1, GH #99.

Authored by @pirapira; implemented by Codex.