### PR TITLE
feat(exp): bundle boundary byte offsets

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -97,6 +97,13 @@ theorem exp_boundary_end_byte_off :
       (EvmAsm.Evm64.exp_epilogue).length) = 60 := by
   simp only [exp_prologue_len, exp_epilogue_len]
 
+/-- Bundled byte offsets for the EXP boundary-code layout. -/
+theorem exp_boundary_block_byte_offsets :
+    4 * (EvmAsm.Evm64.exp_prologue).length = 24 ∧
+    4 * ((EvmAsm.Evm64.exp_prologue).length +
+      (EvmAsm.Evm64.exp_epilogue).length) = 60 := by
+  exact ⟨exp_boundary_epilogue_byte_off, exp_boundary_end_byte_off⟩
+
 /-- First EXP composition code skeleton: the verified boundary blocks around
     the loop. The loop body and callable-multiply blocks will extend this
     union as their composed specs land. -/


### PR DESCRIPTION
Stacked on #1820.

Summary:
- Add exp_boundary_block_byte_offsets in EvmAsm/Evm64/Exp/Compose/Base.lean.
- Bundle the existing EXP boundary epilogue and boundary end byte offsets for downstream composition proofs.

Verification:
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-s9lc and GH #92.

Authored by @pirapira; implemented by Codex.