### PR TITLE
prove(rlp): bridge positive short headers to ranges

### DIFF
--- a/EvmAsm/EL/RLP/Prefix.lean
+++ b/EvmAsm/EL/RLP/Prefix.lean
@@ -353,9 +353,20 @@ theorem rlpPrefixHeaderBytes_eq_one_iff_shortClass (pfx : Byte) :
 theorem rlpPrefixHeaderBytes_eq_one_iff_short_ranges (pfx : Byte) :
     rlpPrefixHeaderBytes pfx = 1 ↔
       (0x80 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xB7) ∨
-        (0xC0 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xF7) := by
+      (0xC0 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xF7) := by
   rw [rlpPrefixHeaderBytes_eq_one_iff_shortClass,
     classifyPrefix_shortBytes_iff, classifyPrefix_shortList_iff]
+
+theorem rlpPrefixHeaderBytes_pos_and_le_one_iff_short_ranges (pfx : Byte) :
+    0 < rlpPrefixHeaderBytes pfx ∧ rlpPrefixHeaderBytes pfx ≤ 1 ↔
+      (0x80 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xB7) ∨
+      (0xC0 ≤ pfx.toNat ∧ pfx.toNat ≤ 0xF7) := by
+  constructor
+  · intro h
+    exact (rlpPrefixHeaderBytes_eq_one_iff_short_ranges pfx).mp (by omega)
+  · intro h_short
+    have h_one := (rlpPrefixHeaderBytes_eq_one_iff_short_ranges pfx).mpr h_short
+    omega
 
 theorem rlpPrefixHeaderBytes_ge_two_iff_longClass (pfx : Byte) :
     2 ≤ rlpPrefixHeaderBytes pfx ↔


### PR DESCRIPTION
Stacked on #1889.

Summary:
- Add rlpPrefixHeaderBytes_pos_and_le_one_iff_short_ranges in EvmAsm/EL/RLP/Prefix.lean.
- Characterize positive headerBytes <= 1 exactly as the short string/list prefix ranges for decoder-side branch conditions.

Verification:
- lake build EvmAsm.EL.RLP
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-pql6 and GH #120.

Authored by @pirapira; implemented by Codex.