### PR TITLE
prove(push): bundle byte offset validity

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -62,6 +62,17 @@ theorem pushByteDstOffset_lt_width_of_lt {n i : Nat} (hi : i < n) :
   unfold pushByteDstOffset
   omega
 
+theorem pushByteOffsets_valid_of_lt {n i : Nat}
+    (hn : n ≤ 32) (hi : i < n) :
+    0 < pushByteSrcOffset i ∧
+      pushByteSrcOffset i ≤ 32 ∧
+      pushByteDstOffset n i < 32 ∧
+      pushByteDstOffset n i < n := by
+  exact ⟨pushByteSrcOffset_pos i,
+    pushByteSrcOffset_le_32_of_lt hn hi,
+    pushByteDstOffset_lt_32_of_lt hn hi,
+    pushByteDstOffset_lt_width_of_lt hi⟩
+
 theorem push1Byte0SrcOffset : pushByteSrcOffset 0 = 1 := by
   rfl
 


### PR DESCRIPTION
Stacked on #1850.

Summary:
- Add pushByteOffsets_valid_of_lt in EvmAsm/Evm64/Push/Program.lean.
- Bundle source and destination byte-offset bounds for generic PUSH byte-copy composition under n <= 32 and i < n.

Verification:
- lake build EvmAsm.Evm64.Push
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-aus2 and GH #101.

Authored by @pirapira; implemented by Codex.