### PR TITLE
prove(memory): cover bytes in MLOAD owning dwords

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -349,6 +349,19 @@ theorem evmMemExpand_mload_byte_dword_interval
     evmMemExpand_mload_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mload_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mload_byte_dword_byte_lt
+    (sizeBytes offset byteIndex dwordByte : Nat)
+    (h_byte : byteIndex < 32) (h_dword : dwordByte < 8) :
+    ((offset + byteIndex) / 8) * 8 + dwordByte <
+      evmMemExpand sizeBytes offset 32 := by
+  have h_interval :=
+    evmMemExpand_mload_byte_dword_interval sizeBytes offset byteIndex h_byte
+  have h_lt_end :
+      ((offset + byteIndex) / 8) * 8 + dwordByte <
+        ((offset + byteIndex) / 8 + 1) * 8 := by
+    omega
+  exact Nat.lt_of_lt_of_le h_lt_end h_interval.2
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1894.

Summary:
- Add evmMemExpand_mload_byte_dword_byte_lt in EvmAsm/Evm64/Memory.lean.
- Show every byte inside the RV64 dword owning any MLOAD-selected byte is below the expanded high-water mark, making the unaligned MLOAD coverage bridge explicit.

Verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-j94y and GH #99.

Authored by @pirapira; implemented by Codex.