### PR TITLE
prove(memory): add MSTORE expansion coverage

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -368,6 +368,19 @@ theorem evmMemExpand_mstore_byte_dword_interval
     evmMemExpand_mstore_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mstore_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mstore_byte_dword_byte_lt
+    (sizeBytes offset byteIndex dwordByte : Nat)
+    (h_byte : byteIndex < 32) (h_dwordByte : dwordByte < 8) :
+    ((offset + byteIndex) / 8) * 8 + dwordByte <
+      evmMemExpand sizeBytes offset 32 := by
+  have h_interval :=
+    evmMemExpand_mstore_byte_dword_interval sizeBytes offset byteIndex h_byte
+  have h_lt_end :
+      ((offset + byteIndex) / 8) * 8 + dwordByte <
+        ((offset + byteIndex) / 8 + 1) * 8 := by
+    omega
+  exact Nat.lt_of_lt_of_le h_lt_end h_interval.2
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -380,6 +380,14 @@ theorem evmMemExpand_mstore_last_dword_interval
       ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mstore_byte_dword_interval sizeBytes offset 31 (by decide)
 
+theorem evmMemExpand_mstore_dword_span
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact ⟨
+    (evmMemExpand_mstore_dword_interval sizeBytes offset).1,
+    (evmMemExpand_mstore_last_dword_interval sizeBytes offset).2⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -368,6 +368,12 @@ theorem evmMemExpand_mstore_byte_dword_interval
     evmMemExpand_mstore_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mstore_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mstore_dword_interval
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mstore_byte_dword_interval sizeBytes offset 0 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -358,6 +358,16 @@ theorem evmMemExpand_mstore_byte_dword_start_lt
     exact Nat.div_mul_le_self (offset + byteIndex) 8
   exact Nat.lt_of_le_of_lt h_start_le h_byte_lt
 
+theorem evmMemExpand_mstore_byte_dword_interval
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8) * 8 <
+        evmMemExpand sizeBytes offset 32 ∧
+      ((offset + byteIndex) / 8 + 1) * 8 ≤
+        evmMemExpand sizeBytes offset 32 := by
+  exact ⟨
+    evmMemExpand_mstore_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
+    evmMemExpand_mstore_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -374,6 +374,12 @@ theorem evmMemExpand_mstore_dword_interval
       (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mstore_byte_dword_interval sizeBytes offset 0 (by decide)
 
+theorem evmMemExpand_mstore_last_dword_interval
+    (sizeBytes offset : Nat) :
+    ((offset + 31) / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mstore_byte_dword_interval sizeBytes offset 31 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -318,6 +318,25 @@ theorem evmMemExpand_mload_byte_lt
   have h_end := evmMemExpand_mload_ge_end sizeBytes offset
   omega
 
+/-- MSTORE is also a 32-byte byte-addressed access: expansion covers the byte
+    just past the requested range for any starting byte offset. -/
+theorem evmMemExpand_mstore_ge_end (sizeBytes offset : Nat) :
+    offset + 32 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_ge_end sizeBytes offset
+
+/-- MSTORE expansion covers the starting byte for any byte offset; no
+    doubleword-alignment precondition is needed. -/
+theorem evmMemExpand_mstore_ge_start (sizeBytes offset : Nat) :
+    offset ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_ge_start sizeBytes offset
+
+/-- Every byte selected by MSTORE lies below the expanded high-water mark,
+    independent of the offset's alignment. -/
+theorem evmMemExpand_mstore_byte_lt
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    offset + byteIndex < evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_byte_lt sizeBytes offset byteIndex h_byte
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -337,6 +337,18 @@ theorem evmMemExpand_mstore_byte_lt
     offset + byteIndex < evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mload_byte_lt sizeBytes offset byteIndex h_byte
 
+theorem evmMemExpand_mstore_byte_dword_end_le
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8 + 1) * 8 ≤
+      evmMemExpand sizeBytes offset 32 := by
+  unfold evmMemExpand
+  rw [if_neg (by decide : (32 : Nat) ≠ 0)]
+  have h_round : ((offset + byteIndex) / 8 + 1) * 8 ≤
+      roundUpTo32 (offset + 32) := by
+    unfold roundUpTo32
+    omega
+  exact Nat.le_trans h_round (Nat.le_max_right _ _)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -349,6 +349,15 @@ theorem evmMemExpand_mstore_byte_dword_end_le
     omega
   exact Nat.le_trans h_round (Nat.le_max_right _ _)
 
+theorem evmMemExpand_mstore_byte_dword_start_lt
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 32) :
+    ((offset + byteIndex) / 8) * 8 <
+      evmMemExpand sizeBytes offset 32 := by
+  have h_byte_lt := evmMemExpand_mstore_byte_lt sizeBytes offset byteIndex h_byte
+  have h_start_le : ((offset + byteIndex) / 8) * 8 ≤ offset + byteIndex := by
+    exact Nat.div_mul_le_self (offset + byteIndex) 8
+  exact Nat.lt_of_le_of_lt h_start_le h_byte_lt
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Summary:
- Add evmMemExpand_mstore_ge_end, evmMemExpand_mstore_ge_start, and evmMemExpand_mstore_byte_lt in EvmAsm/Evm64/Memory.lean.
- Provide MSTORE-named 32-byte expansion coverage bridges, matching the existing MLOAD coverage shape and documenting that no doubleword alignment precondition is needed.

Verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-k3it and GH #99.

Authored by @pirapira; implemented by Codex.