### PR TITLE
prove(exp): bundle boundary program code subsumptions

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -167,6 +167,13 @@ theorem expBoundaryProgramCode_epilogue_sub {base : Word} :
       rw [expBoundaryProgram_len]
       norm_num)
 
+theorem expBoundaryProgramCode_block_subs {base : Word} :
+    (∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
+      (expBoundaryProgramCode base) a = some i) ∧
+    (∀ a i, (CodeReq.ofProg (base + 24) EvmAsm.Evm64.exp_epilogue) a = some i →
+      (expBoundaryProgramCode base) a = some i) := by
+  exact ⟨expBoundaryProgramCode_prologue_sub, expBoundaryProgramCode_epilogue_sub⟩
+
 theorem expBoundaryProgramCode_program_sub {base : Word} :
     ∀ a i, (expBoundaryCode base) a = some i →
       (expBoundaryProgramCode base) a = some i := by


### PR DESCRIPTION
Stacked on #1820.

Summary:
- Add expBoundaryProgramCode_block_subs in EvmAsm/Evm64/Exp/Compose/Base.lean.
- Bundle the boundary-program prologue and epilogue CodeReq subsumption facts for downstream EXP composition proofs.

Verification:
- lake build EvmAsm.Evm64.Exp
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-2hm5 and GH #92.

Authored by @pirapira; implemented by Codex.