### PR TITLE
prove(memory): bundle MSTORE8 dword coverage

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -360,6 +360,16 @@ theorem evmMemExpand_mstore8_byte_dword_start_lt
     exact Nat.div_mul_le_self (offset + byteIndex) 8
   exact Nat.lt_of_le_of_lt h_start_le h_byte_lt
 
+theorem evmMemExpand_mstore8_byte_dword_interval
+    (sizeBytes offset byteIndex : Nat) (h_byte : byteIndex < 1) :
+    ((offset + byteIndex) / 8) * 8 <
+        evmMemExpand sizeBytes offset 1 ∧
+      ((offset + byteIndex) / 8 + 1) * 8 ≤
+        evmMemExpand sizeBytes offset 1 := by
+  exact ⟨
+    evmMemExpand_mstore8_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
+    evmMemExpand_mstore8_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -370,6 +370,12 @@ theorem evmMemExpand_mstore8_byte_dword_interval
     evmMemExpand_mstore8_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mstore8_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mstore8_dword_interval
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 1 ∧
+      (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 1 := by
+  exact evmMemExpand_mstore8_byte_dword_interval sizeBytes offset 0 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1904.

Summary:
- Add evmMemExpand_mstore8_byte_dword_interval in EvmAsm/Evm64/Memory.lean.
- Bundle owning-RV64-dword start/end coverage for the byte selected by MSTORE8.

Verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-d3wz and GH #99.

Authored by @pirapira; implemented by Codex.