### PR TITLE
prove(memory): cover MSTORE8 owning dword bytes

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -383,6 +383,13 @@ theorem evmMemExpand_mstore8_byte_dword_byte_lt
     omega
   exact Nat.lt_of_lt_of_le h_lt_end h_interval.2
 
+theorem evmMemExpand_mstore8_dword_byte_lt
+    (sizeBytes offset dwordByte : Nat) (h_dwordByte : dwordByte < 8) :
+    (offset / 8) * 8 + dwordByte <
+      evmMemExpand sizeBytes offset 1 := by
+  exact evmMemExpand_mstore8_byte_dword_byte_lt
+    sizeBytes offset 0 dwordByte (by decide) h_dwordByte
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -370,6 +370,19 @@ theorem evmMemExpand_mstore8_byte_dword_interval
     evmMemExpand_mstore8_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mstore8_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mstore8_byte_dword_byte_lt
+    (sizeBytes offset byteIndex dwordByte : Nat)
+    (h_byte : byteIndex < 1) (h_dwordByte : dwordByte < 8) :
+    ((offset + byteIndex) / 8) * 8 + dwordByte <
+      evmMemExpand sizeBytes offset 1 := by
+  have h_interval :=
+    evmMemExpand_mstore8_byte_dword_interval sizeBytes offset byteIndex h_byte
+  have h_lt_end :
+      ((offset + byteIndex) / 8) * 8 + dwordByte <
+        ((offset + byteIndex) / 8 + 1) * 8 := by
+    omega
+  exact Nat.lt_of_lt_of_le h_lt_end h_interval.2
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1914.

Summary:
- Add evmMemExpand_mstore8_byte_dword_byte_lt in EvmAsm/Evm64/Memory.lean.
- Show every byte inside the RV64 dword owning the MSTORE8-selected byte is below the MSTORE8-expanded high-water mark.

Verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-k2yj and GH #99.

Authored by @pirapira; implemented by Codex.