### PR TITLE
prove(memory): specialize MSTORE8 dword byte coverage

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -383,6 +383,13 @@ theorem evmMemExpand_mstore8_byte_dword_byte_lt
     omega
   exact Nat.lt_of_lt_of_le h_lt_end h_interval.2
 
+theorem evmMemExpand_mstore8_dword_byte_lt
+    (sizeBytes offset dwordByte : Nat) (h_dwordByte : dwordByte < 8) :
+    (offset / 8) * 8 + dwordByte <
+      evmMemExpand sizeBytes offset 1 := by
+  exact evmMemExpand_mstore8_byte_dword_byte_lt
+    sizeBytes offset 0 dwordByte (by decide) h_dwordByte
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1916.

Summary:
- Add evmMemExpand_mstore8_dword_byte_lt in EvmAsm/Evm64/Memory.lean.
- Specialize MSTORE8 owning-dword byte coverage to the single selected byte, removing the byteIndex argument for downstream specs.

Verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-xh9s and GH #99.

Authored by @pirapira; implemented by Codex.