### PR TITLE
prove(memory): specialize MSTORE8 dword interval

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -370,6 +370,12 @@ theorem evmMemExpand_mstore8_byte_dword_interval
     evmMemExpand_mstore8_byte_dword_start_lt sizeBytes offset byteIndex h_byte,
     evmMemExpand_mstore8_byte_dword_end_le sizeBytes offset byteIndex h_byte⟩
 
+theorem evmMemExpand_mstore8_dword_interval
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 1 ∧
+      (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 1 := by
+  exact evmMemExpand_mstore8_byte_dword_interval sizeBytes offset 0 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1914.

Adds evmMemExpand_mstore8_dword_interval as the selected-byte specialization of the MSTORE8 owning-dword interval theorem.

Refs evm-asm-y8zc and GH #99.

Local verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Authored by @pirapira; implemented by Codex.