### PR TITLE
prove(memory): specialize MLOAD last dword interval

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -355,6 +355,12 @@ theorem evmMemExpand_mload_dword_interval
       (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 0 (by decide)
 
+theorem evmMemExpand_mload_last_dword_interval
+    (sizeBytes offset : Nat) :
+    ((offset + 31) / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact evmMemExpand_mload_byte_dword_interval sizeBytes offset 31 (by decide)
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1919.

Adds evmMemExpand_mload_last_dword_interval, documenting that MLOAD expansion covers the dword containing the final loaded byte for unaligned accesses.

Refs evm-asm-j8js and GH #99.

Local verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Authored by @pirapira; implemented by Codex.