### PR TITLE
prove(memory): specialize generic access dword interval

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -341,6 +341,13 @@ theorem evmMemExpand_access_byte_dword_interval
     evmMemExpand_access_byte_dword_end_le
       sizeBytes offset length byteIndex hlen h_byte⟩
 
+theorem evmMemExpand_access_dword_interval
+    (sizeBytes offset length : Nat) (hlen : length ≠ 0) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset length ∧
+      (offset / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset length := by
+  exact evmMemExpand_access_byte_dword_interval
+    sizeBytes offset length 0 hlen (Nat.pos_of_ne_zero hlen)
+
 /-- MLOAD is a 32-byte byte-addressed access: expansion covers the byte just
     past the requested range for any starting byte offset. -/
 theorem evmMemExpand_mload_ge_end (sizeBytes offset : Nat) :

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -348,6 +348,18 @@ theorem evmMemExpand_access_dword_interval
   exact evmMemExpand_access_byte_dword_interval
     sizeBytes offset length 0 hlen (Nat.pos_of_ne_zero hlen)
 
+theorem evmMemExpand_access_last_dword_interval
+    (sizeBytes offset length : Nat) (hlen : length ≠ 0) :
+    ((offset + (length - 1)) / 8) * 8 <
+        evmMemExpand sizeBytes offset length ∧
+      ((offset + (length - 1)) / 8 + 1) * 8 ≤
+        evmMemExpand sizeBytes offset length := by
+  have h_byte : length - 1 < length := by
+    have h_pos : 0 < length := Nat.pos_of_ne_zero hlen
+    omega
+  exact evmMemExpand_access_byte_dword_interval
+    sizeBytes offset length (length - 1) hlen h_byte
+
 /-- MLOAD is a 32-byte byte-addressed access: expansion covers the byte just
     past the requested range for any starting byte offset. -/
 theorem evmMemExpand_mload_ge_end (sizeBytes offset : Nat) :


### PR DESCRIPTION
Stacked on #1907.

Adds evmMemExpand_access_dword_interval, documenting that every nonempty access expansion covers the dword containing the selected offset.

Refs evm-asm-caje and GH #99.

Local verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Authored by @pirapira; implemented by Codex.