### PR TITLE
prove(memory): bundle MSTORE dword span

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -380,6 +380,14 @@ theorem evmMemExpand_mstore_last_dword_interval
       ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
   exact evmMemExpand_mstore_byte_dword_interval sizeBytes offset 31 (by decide)
 
+theorem evmMemExpand_mstore_dword_span
+    (sizeBytes offset : Nat) :
+    (offset / 8) * 8 < evmMemExpand sizeBytes offset 32 ∧
+      ((offset + 31) / 8 + 1) * 8 ≤ evmMemExpand sizeBytes offset 32 := by
+  exact ⟨
+    (evmMemExpand_mstore_dword_interval sizeBytes offset).1,
+    (evmMemExpand_mstore_last_dword_interval sizeBytes offset).2⟩
+
 theorem evmMemExpand_le_max_old_access_plus_31
     (sizeBytes offset length : Nat) :
     evmMemExpand sizeBytes offset length ≤ max sizeBytes (offset + length + 31) := by


### PR DESCRIPTION
Stacked on #1921. #1922 has already been merged into #1921's branch, so this PR targets the live #1921 branch.

Adds evmMemExpand_mstore_dword_span, bundling the first and final touched dword bounds for the unaligned 32-byte MSTORE access.

Refs evm-asm-9rvx and GH #99.

Local verification:
- lake build EvmAsm.Evm64.Memory
- scripts/check-file-size.sh --report
- lake build

Authored by @pirapira; implemented by Codex.