### PR TITLE
prove(rlp): add twenty-byte short string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -270,6 +270,21 @@ theorem decodeAux_nineteen_byte_string
         rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Twenty-byte short string (prefix `0x94`). Multi-byte payload
+    bypasses the canonical-form check. -/
+theorem decodeAux_twenty_byte_string
+    (fuel : Nat)
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 : Byte)
+    (rest : List Byte) :
+    decodeAux (fuel + 1)
+        ((0x94 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
+          b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: rest) =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20],
+        rest) := by
+  simp [decodeAux, takeBytes]
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -645,6 +660,18 @@ theorem decode_nineteen_byte_string
         []) := by
   simp [decode, decodeAux, takeBytes]
 
+/-- `decode [0x94, b1..b20] = some (.bytes [b1..b20], [])` — the
+    canonical twenty-byte short-string encoding. -/
+theorem decode_twenty_byte_string
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 : Byte) :
+    decode [(0x94 : Byte), b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14,
+      b15, b16, b17, b18, b19, b20] =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20],
+        []) := by
+  simp [decode, decodeAux, takeBytes]
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -789,6 +816,14 @@ theorem encodeBytes_octodecuple (a b c d e f g h i j k l m n o p q r : Byte) :
 theorem encodeBytes_novemdecuple (a b c d e f g h i j k l m n o p q r s : Byte) :
     encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s] =
       [BitVec.ofNat 8 0x93, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s] := by
+  simp [encodeBytes]
+
+/-- Twenty-byte short string:
+    `encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t] =
+    [0x94, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t]`. -/
+theorem encodeBytes_viguple (a b c d e f g h i j k l m n o p q r s t : Byte) :
+    encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t] =
+      [BitVec.ofNat 8 0x94, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t] := by
   simp [encodeBytes]
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #1940.\n\nAdds decodeAux, decode, and encodeBytes examples for the canonical twenty-byte short-string RLP form.\n\nVerification:\n- lake build EvmAsm.EL.RLP.Properties\n- lake build\n- scripts/check-file-size.sh --report\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/RLP/Properties.lean\n\nRefs evm-asm-ukpr and GH #120.\n\nAuthored by @pirapira; implemented by Codex.