### PR TITLE
prove(rlp): add twenty-six-byte short string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -369,6 +369,23 @@ theorem decodeAux_twenty_five_byte_string
         rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Twenty-six-byte short string (prefix `0x9A`). Multi-byte payload
+    bypasses the canonical-form check. -/
+theorem decodeAux_twenty_six_byte_string
+    (fuel : Nat)
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
+      b23 b24 b25 b26 : Byte)
+    (rest : List Byte) :
+    decodeAux (fuel + 1)
+        ((0x9A : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
+          b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
+          b22 :: b23 :: b24 :: b25 :: b26 :: rest) =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20, b21, b22, b23, b24, b25, b26],
+        rest) := by
+  simp [decodeAux, takeBytes]
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -820,6 +837,19 @@ theorem decode_twenty_five_byte_string
         []) := by
   simp [decode, decodeAux, takeBytes]
 
+/-- `decode [0x9A, b1..b26] = some (.bytes [b1..b26], [])` — the
+    canonical twenty-six-byte short-string encoding. -/
+theorem decode_twenty_six_byte_string
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
+      b23 b24 b25 b26 : Byte) :
+    decode [(0x9A : Byte), b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14,
+      b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26] =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20, b21, b22, b23, b24, b25, b26],
+        []) := by
+  simp [decode, decodeAux, takeBytes]
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -1019,6 +1049,17 @@ theorem encodeBytes_quinviguple
       y] =
       [BitVec.ofNat 8 0x99, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t,
         u, v, w, x, y] := by
+  simp [encodeBytes]
+
+/-- Twenty-six-byte short string:
+    `encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z] =
+    [0x9A, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z]`. -/
+theorem encodeBytes_sesviguple
+    (a b c d e f g h i j k l m n o p q r s t u v w x y z : Byte) :
+    encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x,
+      y, z] =
+      [BitVec.ofNat 8 0x9A, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t,
+        u, v, w, x, y, z] := by
   simp [encodeBytes]
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #1944.\n\nPR #1946 has already merged into this base branch, so this continues the live RLP short-string stack from #1944.\n\nAdds decodeAux, decode, and encodeBytes examples for the canonical twenty-six-byte short-string RLP form.\n\nVerification:\n- lake build EvmAsm.EL.RLP.Properties\n- lake build\n- scripts/check-file-size.sh --report\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/RLP/Properties.lean\n\nRefs evm-asm-wbqi and GH #120.\n\nAuthored by @pirapira; implemented by Codex.