### PR TITLE
prove(rlp): add forty-three-byte short string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -685,6 +685,27 @@ theorem decodeAux_forty_two_byte_string
         rest) := by
   simp [decodeAux, takeBytes]
 
+/-- Forty-three-byte short string (prefix `0xAB`). Multi-byte payload
+    bypasses the canonical-form check. -/
+theorem decodeAux_forty_three_byte_string
+    (fuel : Nat)
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
+      b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 b41 b42
+      b43 : Byte)
+    (rest : List Byte) :
+    decodeAux (fuel + 1)
+        ((0xAB : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
+          b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
+          b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
+          b32 :: b33 :: b34 :: b35 :: b36 :: b37 :: b38 :: b39 :: b40 :: b41 ::
+          b42 :: b43 :: rest) =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30, b31, b32,
+          b33, b34, b35, b36, b37, b38, b39, b40, b41, b42, b43],
+        rest) := by
+  simp [decodeAux, takeBytes]
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -1382,6 +1403,22 @@ theorem decode_forty_two_byte_string
         []) := by
   simp [decode, decodeAux, takeBytes]
 
+/-- `decode [0xAB, b1..b43] = some (.bytes [b1..b43], [])` — the
+    canonical forty-three-byte short-string encoding. -/
+theorem decode_forty_three_byte_string
+    (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
+      b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 b41 b42
+      b43 : Byte) :
+    decode [(0xAB : Byte), b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14,
+      b15, b16, b17, b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30,
+      b31, b32, b33, b34, b35, b36, b37, b38, b39, b40, b41, b42, b43] =
+      some (.bytes
+        [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15, b16, b17,
+          b18, b19, b20, b21, b22, b23, b24, b25, b26, b27, b28, b29, b30, b31, b32,
+          b33, b34, b35, b36, b37, b38, b39, b40, b41, b42, b43],
+        []) := by
+  simp [decode, decodeAux, takeBytes]
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -1777,6 +1814,19 @@ theorem encodeBytes_duoquadragintuple
       [BitVec.ofNat 8 0xAA, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t,
         u, v, w, x, y, z, aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao,
         ap] := by
+  simp [encodeBytes]
+
+/-- Forty-three-byte short string:
+    `encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao, ap, aq] =
+    [0xAB, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao, ap, aq]`. -/
+theorem encodeBytes_tresquadragintuple
+    (a b c d e f g h i j k l m n o p q r s t u v w x y z aa ab ac ad ae af ag ah ai aj ak al am an ao ap aq :
+      Byte) :
+    encodeBytes [a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x,
+      y, z, aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao, ap, aq] =
+      [BitVec.ofNat 8 0xAB, a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t,
+        u, v, w, x, y, z, aa, ab, ac, ad, ae, af, ag, ah, ai, aj, ak, al, am, an, ao,
+        ap, aq] := by
   simp [encodeBytes]
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #1963.

Adds canonical forty-three-byte short-string coverage in EvmAsm/EL/RLP/Properties.lean:
- decodeAux_forty_three_byte_string
- decode_forty_three_byte_string
- encodeBytes_tresquadragintuple

Local verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/RLP/Properties.lean (no matches)
- lake build

Refs evm-asm-2pdk and GH #120.

Authored by @pirapira; implemented by Codex.