### PR TITLE
prove(mload): add expanded size write helper

### DIFF
--- a/EvmAsm/Evm64/MLoad.lean
+++ b/EvmAsm/Evm64/MLoad.lean
@@ -4,3 +4,4 @@ import EvmAsm.Evm64.MLoad.LimbSpec
 import EvmAsm.Evm64.MLoad.LimbSpecEight
 import EvmAsm.Evm64.MLoad.Spec
 import EvmAsm.Evm64.MLoad.StackSpec
+import EvmAsm.Evm64.MLoad.Expansion

--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -1,0 +1,74 @@
+/-
+  EvmAsm.Evm64.MLoad.Expansion
+
+  Small executable helpers for MLOAD memory-size bookkeeping.
+-/
+
+import EvmAsm.Evm64.Memory
+import EvmAsm.Rv64.SyscallSpecs
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/--
+  Store a precomputed 32-byte-access expanded high-water mark into the EVM
+  memory-size cell. The arithmetic that computes
+  `evmMemExpand sizeBytes offset 32` can be supplied by a caller or a later
+  arithmetic subroutine; this block is the one-instruction ownership update.
+-/
+def mload_write_expanded_size (sizeLocReg sizeReg : Reg) : Program :=
+  SD sizeLocReg sizeReg 0
+
+abbrev mload_write_expanded_size_code
+    (sizeLocReg sizeReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.singleton base (.SD sizeLocReg sizeReg 0)
+
+theorem mload_write_expanded_size_code_eq_ofProg
+    (sizeLocReg sizeReg : Reg) (base : Word) :
+    mload_write_expanded_size_code sizeLocReg sizeReg base =
+      CodeReq.ofProg base (mload_write_expanded_size sizeLocReg sizeReg) := by
+  unfold mload_write_expanded_size_code mload_write_expanded_size SD single
+  rfl
+
+/--
+  One-instruction size-cell update for a 32-byte MLOAD access, assuming the
+  expanded high-water mark has already been computed into `sizeReg`.
+-/
+theorem mload_write_expanded_size_spec_within
+    (sizeLocReg sizeReg : Reg)
+    (sizeLoc : Word) (sizeBytes offset : Nat) (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (mload_write_expanded_size_code sizeLocReg sizeReg base)
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 (evmMemExpand sizeBytes offset 32)) **
+       evmMemSizeIs sizeLoc sizeBytes)
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 (evmMemExpand sizeBytes offset 32)) **
+       evmMemSizeIsWordExpanded sizeLoc sizeBytes offset) := by
+  rw [evmMemSizeIs_unfold, evmMemSizeIsWordExpanded_unfold, evmMemSizeIs_unfold]
+  convert
+    (sd_spec_gen_within sizeLocReg sizeReg sizeLoc
+      (BitVec.ofNat 64 (evmMemExpand sizeBytes offset 32))
+      (BitVec.ofNat 64 sizeBytes) 0 base) using 1
+  · rw [signExtend12_0]
+    simp
+  · rw [signExtend12_0]
+    simp
+
+theorem mload_write_expanded_size_ofProg_spec_within
+    (sizeLocReg sizeReg : Reg)
+    (sizeLoc : Word) (sizeBytes offset : Nat) (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.ofProg base (mload_write_expanded_size sizeLocReg sizeReg))
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 (evmMemExpand sizeBytes offset 32)) **
+       evmMemSizeIs sizeLoc sizeBytes)
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 (evmMemExpand sizeBytes offset 32)) **
+       evmMemSizeIsWordExpanded sizeLoc sizeBytes offset) := by
+  rw [← mload_write_expanded_size_code_eq_ofProg]
+  exact mload_write_expanded_size_spec_within
+    sizeLocReg sizeReg sizeLoc sizeBytes offset base
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -71,4 +71,28 @@ theorem mload_write_expanded_size_ofProg_spec_within
   exact mload_write_expanded_size_spec_within
     sizeLocReg sizeReg sizeLoc sizeBytes offset base
 
+/--
+  No-expansion specialization of `mload_write_expanded_size_ofProg_spec_within`:
+  when the 32-byte MLOAD access already fits inside the current 32-byte-aligned
+  high-water mark, writing the current size back preserves `evmMemSizeIs`.
+-/
+theorem mload_write_current_size_no_expansion_spec_within
+    (sizeLocReg sizeReg : Reg)
+    (sizeLoc : Word) (sizeBytes offset : Nat) (base : Word)
+    (h_end : offset + 32 ≤ sizeBytes) (h_size_dvd : 32 ∣ sizeBytes) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.ofProg base (mload_write_expanded_size sizeLocReg sizeReg))
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 sizeBytes) **
+       evmMemSizeIs sizeLoc sizeBytes)
+      ((sizeLocReg ↦ᵣ sizeLoc) **
+       (sizeReg ↦ᵣ BitVec.ofNat 64 sizeBytes) **
+       evmMemSizeIs sizeLoc sizeBytes) := by
+  convert
+    (mload_write_expanded_size_ofProg_spec_within
+      sizeLocReg sizeReg sizeLoc sizeBytes offset base) using 1
+  · rw [evmMemExpand_word_eq_old_of_end_le sizeBytes offset h_end h_size_dvd]
+  · rw [evmMemExpand_word_eq_old_of_end_le sizeBytes offset h_end h_size_dvd,
+      evmMemSizeIsWordExpanded_eq_current_of_mload_within h_end h_size_dvd]
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -262,6 +262,12 @@ theorem roundUpTo32_eq_self_of_dvd (n : Nat) (h : 32 ∣ n) :
   unfold roundUpTo32
   omega
 
+theorem roundUpTo32_le_of_le_dvd {n m : Nat} (h_le : n ≤ m) (h_dvd : 32 ∣ m) :
+    roundUpTo32 n ≤ m := by
+  rcases h_dvd with ⟨k, rfl⟩
+  unfold roundUpTo32
+  omega
+
 theorem roundUpTo32_idempotent (n : Nat) : roundUpTo32 (roundUpTo32 n) = roundUpTo32 n := by
   unfold roundUpTo32
   -- (n+31)/32 * 32 is already a multiple of 32, so adding 31 and dividing
@@ -304,6 +310,13 @@ theorem evmMemExpand_word_eq (sizeBytes offset : Nat) :
   unfold evmMemExpand
   simp
 
+theorem evmMemExpand_word_eq_old_of_end_le
+    (sizeBytes offset : Nat) (h_end : offset + 32 ≤ sizeBytes)
+    (h_size_dvd : 32 ∣ sizeBytes) :
+    evmMemExpand sizeBytes offset 32 = sizeBytes := by
+  rw [evmMemExpand_word_eq]
+  exact max_eq_left (roundUpTo32_le_of_le_dvd h_end h_size_dvd)
+
 /--
   Named size-cell postcondition for a 32-byte MLOAD/MSTORE-style access.
   This keeps opcode specs from repeating the high-water expression in every
@@ -325,6 +338,14 @@ theorem evmMemSizeIsWordExpanded_unfold_max
     evmMemSizeIsWordExpanded sizeLoc sizeBytes offset =
       evmMemSizeIs sizeLoc (max sizeBytes (roundUpTo32 (offset + 32))) := by
   rw [evmMemSizeIsWordExpanded_unfold, evmMemExpand_word_eq]
+
+theorem evmMemSizeIsWordExpanded_eq_current_of_mload_within
+    {sizeLoc : Word} {sizeBytes offset : Nat}
+    (h_end : offset + 32 ≤ sizeBytes) (h_size_dvd : 32 ∣ sizeBytes) :
+    evmMemSizeIsWordExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc sizeBytes := by
+  rw [evmMemSizeIsWordExpanded_unfold,
+    evmMemExpand_word_eq_old_of_end_le sizeBytes offset h_end h_size_dvd]
 
 theorem pcFree_evmMemSizeIsWordExpanded
     {sizeLoc : Word} {sizeBytes offset : Nat} :


### PR DESCRIPTION
Stacked on #2006.\n\nAdds EvmAsm.Evm64.MLoad.Expansion with a one-instruction executable helper that writes a precomputed evmMemExpand sizeBytes offset 32 value to the memory-size cell, plus cpsTriple specs targeting evmMemSizeIsWordExpanded. This moves MLOAD memory-expansion bookkeeping closer to the eventual executable update path without changing evm_mload yet.\n\nRefs evm-asm-yph8 and GH #99.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad\n- scripts/check-file-size.sh --report\n- lake build\n\nAuthored by @pirapira; implemented by Codex.