### PR TITLE
prove(rlp): add eighty-four-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1683,6 +1683,16 @@ theorem decodeAux_eighty_three_byte_long_string
         rest) := by
   simp [decodeAux, readLength, takeBytes, Nat.fromBytesBE]
 
+/-- Concrete 84-byte long-string payload used by the executable examples below. -/
+def rlpEightyFourBytePayload : List Byte :=
+  List.replicate 84 (0x42 : Byte)
+
+/-- Executable example: 84-byte long string (prefix `0xB8`, length byte `0x54`). -/
+theorem decodeAux_eighty_four_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x54 : Byte)] ++ rlpEightyFourBytePayload) =
+      some (.bytes rlpEightyFourBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3178,6 +3188,13 @@ theorem decode_eighty_three_byte_long_string
         []) := by
   simp [decode, decodeAux, readLength, takeBytes, Nat.fromBytesBE]
 
+/-- `decode [0xB8, 0x54] ++ rlpEightyFourBytePayload`
+    returns the concrete 84-byte payload. -/
+theorem decode_eighty_four_byte_long_string :
+    decode ([(0xB8 : Byte), (0x54 : Byte)] ++ rlpEightyFourBytePayload) =
+      some (.bytes rlpEightyFourBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4172,6 +4189,12 @@ theorem encodeBytes_eighty_three_long
         be, bf, bg, bh, bi, bj, bk, bl, bm, bn, bo, bp, bq, br, bs, bt, bu, bv, bw,
         bx, bz, ca, cb, cc, cd, ce, cf, cg] := by
   simp [encodeBytes, Nat.toBytesBE]
+
+/-- Executable encoding example for the concrete 84-byte long-string payload. -/
+theorem encodeBytes_eighty_four_long :
+    encodeBytes rlpEightyFourBytePayload =
+      [(0xB8 : Byte), (0x54 : Byte)] ++ rlpEightyFourBytePayload := by
+  native_decide
 
 /-! ## Encoding produces non-empty output -/
 


### PR DESCRIPTION
Stacked on #2001.\n\nAdds executable EL/RLP coverage for an 84-byte long-form byte string: decodeAux, top-level decode, and encodeBytes examples with prefix 0xB8 and length byte 0x54.\n\nRefs evm-asm-v8ve and GH #120.\n\nLocal verification:\n- lake build EvmAsm.EL.RLP.Properties\n- rg -n "sorry|admit|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/RLP/Properties.lean\n- scripts/check-file-size.sh --report\n- lake build\n\nAuthored by @pirapira; implemented by Codex.