### PR TITLE
prove(rlp): add eighty-seven-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1713,6 +1713,16 @@ theorem decodeAux_eighty_six_byte_long_string :
       some (.bytes rlpEightySixBytePayload, []) := by
   native_decide
 
+/-- Concrete 87-byte long-string payload used by the executable examples below. -/
+def rlpEightySevenBytePayload : List Byte :=
+  List.replicate 87 (0x45 : Byte)
+
+/-- Executable example: 87-byte long string (prefix `0xB8`, length byte `0x57`). -/
+theorem decodeAux_eighty_seven_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x57 : Byte)] ++ rlpEightySevenBytePayload) =
+      some (.bytes rlpEightySevenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3229,6 +3239,13 @@ theorem decode_eighty_six_byte_long_string :
       some (.bytes rlpEightySixBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x57] ++ rlpEightySevenBytePayload`
+    returns the concrete 87-byte payload. -/
+theorem decode_eighty_seven_byte_long_string :
+    decode ([(0xB8 : Byte), (0x57 : Byte)] ++ rlpEightySevenBytePayload) =
+      some (.bytes rlpEightySevenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4240,6 +4257,12 @@ theorem encodeBytes_eighty_five_long :
 theorem encodeBytes_eighty_six_long :
     encodeBytes rlpEightySixBytePayload =
       [(0xB8 : Byte), (0x56 : Byte)] ++ rlpEightySixBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 87-byte long-string payload. -/
+theorem encodeBytes_eighty_seven_long :
+    encodeBytes rlpEightySevenBytePayload =
+      [(0xB8 : Byte), (0x57 : Byte)] ++ rlpEightySevenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2010.\n\nAdds executable EL/RLP coverage for an 87-byte long-form byte string:\n- decodeAux example for prefix 0xB8 with length byte 0x57\n- top-level decode example for the same payload\n- encodeBytes example for the concrete payload\n\nLocal verification:\n- lake build EvmAsm.EL.RLP.Properties\n- rg forbidden-pattern scan in EvmAsm/EL/RLP/Properties.lean\n- scripts/check-file-size.sh --report\n- lake build\n\nRefs evm-asm-eepy and GH #120.\n\nAuthored by @pirapira; implemented by Codex.