### PR TITLE
prove(rlp): add ninety-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1743,6 +1743,16 @@ theorem decodeAux_eighty_nine_byte_long_string :
       some (.bytes rlpEightyNineBytePayload, []) := by
   native_decide
 
+/-- Concrete 90-byte long-string payload used by the executable examples below. -/
+def rlpNinetyBytePayload : List Byte :=
+  List.replicate 90 (0x48 : Byte)
+
+/-- Executable example: 90-byte long string (prefix `0xB8`, length byte `0x5A`). -/
+theorem decodeAux_ninety_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x5A : Byte)] ++ rlpNinetyBytePayload) =
+      some (.bytes rlpNinetyBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3280,6 +3290,13 @@ theorem decode_eighty_nine_byte_long_string :
       some (.bytes rlpEightyNineBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x5A] ++ rlpNinetyBytePayload`
+    returns the concrete 90-byte payload. -/
+theorem decode_ninety_byte_long_string :
+    decode ([(0xB8 : Byte), (0x5A : Byte)] ++ rlpNinetyBytePayload) =
+      some (.bytes rlpNinetyBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4309,6 +4326,12 @@ theorem encodeBytes_eighty_eight_long :
 theorem encodeBytes_eighty_nine_long :
     encodeBytes rlpEightyNineBytePayload =
       [(0xB8 : Byte), (0x59 : Byte)] ++ rlpEightyNineBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 90-byte long-string payload. -/
+theorem encodeBytes_ninety_long :
+    encodeBytes rlpNinetyBytePayload =
+      [(0xB8 : Byte), (0x5A : Byte)] ++ rlpNinetyBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2014.\n\nAdds executable EL/RLP coverage for a 90-byte long-form byte string:\n- decodeAux example for prefix 0xB8 with length byte 0x5A\n- top-level decode example for the same payload\n- encodeBytes example for the concrete payload\n\nLocal verification:\n- lake build EvmAsm.EL.RLP.Properties\n- rg forbidden-pattern scan in EvmAsm/EL/RLP/Properties.lean\n- scripts/check-file-size.sh --report\n- lake build\n\nRefs evm-asm-lpjh and GH #120.\n\nAuthored by @pirapira; implemented by Codex.