### PR TITLE
prove(rlp): add ninety-eight-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1823,6 +1823,16 @@ theorem decodeAux_ninety_seven_byte_long_string :
       some (.bytes rlpNinetySevenBytePayload, []) := by
   native_decide
 
+/-- Concrete 98-byte long-string payload used by the executable examples below. -/
+def rlpNinetyEightBytePayload : List Byte :=
+  List.replicate 98 (0x50 : Byte)
+
+/-- Executable example: 98-byte long string (prefix `0xB8`, length byte `0x62`). -/
+theorem decodeAux_ninety_eight_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x62 : Byte)] ++ rlpNinetyEightBytePayload) =
+      some (.bytes rlpNinetyEightBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3416,6 +3426,13 @@ theorem decode_ninety_seven_byte_long_string :
       some (.bytes rlpNinetySevenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x62] ++ rlpNinetyEightBytePayload`
+    returns the concrete 98-byte payload. -/
+theorem decode_ninety_eight_byte_long_string :
+    decode ([(0xB8 : Byte), (0x62 : Byte)] ++ rlpNinetyEightBytePayload) =
+      some (.bytes rlpNinetyEightBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4493,6 +4510,12 @@ theorem encodeBytes_ninety_six_long :
 theorem encodeBytes_ninety_seven_long :
     encodeBytes rlpNinetySevenBytePayload =
       [(0xB8 : Byte), (0x61 : Byte)] ++ rlpNinetySevenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 98-byte long-string payload. -/
+theorem encodeBytes_ninety_eight_long :
+    encodeBytes rlpNinetyEightBytePayload =
+      [(0xB8 : Byte), (0x62 : Byte)] ++ rlpNinetyEightBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2022.

Adds executable decodeAux, decode, and encodeBytes examples for a 98-byte long-form RLP byte string (prefix 0xB8, length byte 0x62).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-dp6y and GH #120.

Authored by @pirapira; implemented by Codex.