### PR TITLE
prove(rlp): add one-hundred-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1843,6 +1843,16 @@ theorem decodeAux_ninety_nine_byte_long_string :
       some (.bytes rlpNinetyNineBytePayload, []) := by
   native_decide
 
+/-- Concrete 100-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredBytePayload : List Byte :=
+  List.replicate 100 (0x52 : Byte)
+
+/-- Executable example: 100-byte long string (prefix `0xB8`, length byte `0x64`). -/
+theorem decodeAux_one_hundred_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x64 : Byte)] ++ rlpOneHundredBytePayload) =
+      some (.bytes rlpOneHundredBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3450,6 +3460,13 @@ theorem decode_ninety_nine_byte_long_string :
       some (.bytes rlpNinetyNineBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x64] ++ rlpOneHundredBytePayload`
+    returns the concrete 100-byte payload. -/
+theorem decode_one_hundred_byte_long_string :
+    decode ([(0xB8 : Byte), (0x64 : Byte)] ++ rlpOneHundredBytePayload) =
+      some (.bytes rlpOneHundredBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4539,6 +4556,12 @@ theorem encodeBytes_ninety_eight_long :
 theorem encodeBytes_ninety_nine_long :
     encodeBytes rlpNinetyNineBytePayload =
       [(0xB8 : Byte), (0x63 : Byte)] ++ rlpNinetyNineBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 100-byte long-string payload. -/
+theorem encodeBytes_one_hundred_long :
+    encodeBytes rlpOneHundredBytePayload =
+      [(0xB8 : Byte), (0x64 : Byte)] ++ rlpOneHundredBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2024.

Adds executable decodeAux, decode, and encodeBytes examples for a 100-byte long-form RLP byte string (prefix 0xB8, length byte 0x64).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-o1wo and GH #120.

Authored by @pirapira; implemented by Codex.