### PR TITLE
prove(rlp): add one-hundred-one-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1853,6 +1853,16 @@ theorem decodeAux_one_hundred_byte_long_string :
       some (.bytes rlpOneHundredBytePayload, []) := by
   native_decide
 
+/-- Concrete 101-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredOneBytePayload : List Byte :=
+  List.replicate 101 (0x53 : Byte)
+
+/-- Executable example: 101-byte long string (prefix `0xB8`, length byte `0x65`). -/
+theorem decodeAux_one_hundred_one_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x65 : Byte)] ++ rlpOneHundredOneBytePayload) =
+      some (.bytes rlpOneHundredOneBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3467,6 +3477,13 @@ theorem decode_one_hundred_byte_long_string :
       some (.bytes rlpOneHundredBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x65] ++ rlpOneHundredOneBytePayload`
+    returns the concrete 101-byte payload. -/
+theorem decode_one_hundred_one_byte_long_string :
+    decode ([(0xB8 : Byte), (0x65 : Byte)] ++ rlpOneHundredOneBytePayload) =
+      some (.bytes rlpOneHundredOneBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4562,6 +4579,12 @@ theorem encodeBytes_ninety_nine_long :
 theorem encodeBytes_one_hundred_long :
     encodeBytes rlpOneHundredBytePayload =
       [(0xB8 : Byte), (0x64 : Byte)] ++ rlpOneHundredBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 101-byte long-string payload. -/
+theorem encodeBytes_one_hundred_one_long :
+    encodeBytes rlpOneHundredOneBytePayload =
+      [(0xB8 : Byte), (0x65 : Byte)] ++ rlpOneHundredOneBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1863,6 +1863,16 @@ theorem decodeAux_one_hundred_one_byte_long_string :
       some (.bytes rlpOneHundredOneBytePayload, []) := by
   native_decide
 
+/-- Concrete 102-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredTwoBytePayload : List Byte :=
+  List.replicate 102 (0x54 : Byte)
+
+/-- Executable example: 102-byte long string (prefix `0xB8`, length byte `0x66`). -/
+theorem decodeAux_one_hundred_two_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x66 : Byte)] ++ rlpOneHundredTwoBytePayload) =
+      some (.bytes rlpOneHundredTwoBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3484,6 +3494,13 @@ theorem decode_one_hundred_one_byte_long_string :
       some (.bytes rlpOneHundredOneBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x66] ++ rlpOneHundredTwoBytePayload`
+    returns the concrete 102-byte payload. -/
+theorem decode_one_hundred_two_byte_long_string :
+    decode ([(0xB8 : Byte), (0x66 : Byte)] ++ rlpOneHundredTwoBytePayload) =
+      some (.bytes rlpOneHundredTwoBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4585,6 +4602,12 @@ theorem encodeBytes_one_hundred_long :
 theorem encodeBytes_one_hundred_one_long :
     encodeBytes rlpOneHundredOneBytePayload =
       [(0xB8 : Byte), (0x65 : Byte)] ++ rlpOneHundredOneBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 102-byte long-string payload. -/
+theorem encodeBytes_one_hundred_two_long :
+    encodeBytes rlpOneHundredTwoBytePayload =
+      [(0xB8 : Byte), (0x66 : Byte)] ++ rlpOneHundredTwoBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2025.

Adds executable decodeAux, decode, and encodeBytes examples for a 101-byte long-form RLP byte string (prefix 0xB8, length byte 0x65).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-aobr and GH #120.

Authored by @pirapira; implemented by Codex.