### PR TITLE
prove(rlp): add one-hundred-three-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1903,6 +1903,16 @@ theorem decodeAux_one_hundred_five_byte_long_string :
       some (.bytes rlpOneHundredFiveBytePayload, []) := by
   native_decide
 
+/-- Concrete 106-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSixBytePayload : List Byte :=
+  List.replicate 106 (0x58 : Byte)
+
+/-- Executable example: 106-byte long string (prefix `0xB8`, length byte `0x6A`). -/
+theorem decodeAux_one_hundred_six_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload) =
+      some (.bytes rlpOneHundredSixBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3552,6 +3562,13 @@ theorem decode_one_hundred_five_byte_long_string :
       some (.bytes rlpOneHundredFiveBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6A] ++ rlpOneHundredSixBytePayload`
+    returns the concrete 106-byte payload. -/
+theorem decode_one_hundred_six_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload) =
+      some (.bytes rlpOneHundredSixBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4677,6 +4694,12 @@ theorem encodeBytes_one_hundred_four_long :
 theorem encodeBytes_one_hundred_five_long :
     encodeBytes rlpOneHundredFiveBytePayload =
       [(0xB8 : Byte), (0x69 : Byte)] ++ rlpOneHundredFiveBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 106-byte long-string payload. -/
+theorem encodeBytes_one_hundred_six_long :
+    encodeBytes rlpOneHundredSixBytePayload =
+      [(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1943,6 +1943,16 @@ theorem decodeAux_one_hundred_nine_byte_long_string :
       some (.bytes rlpOneHundredNineBytePayload, []) := by
   native_decide
 
+/-- Concrete 110-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredTenBytePayload : List Byte :=
+  List.replicate 110 (0x5C : Byte)
+
+/-- Executable example: 110-byte long string (prefix `0xB8`, length byte `0x6E`). -/
+theorem decodeAux_one_hundred_ten_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload) =
+      some (.bytes rlpOneHundredTenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3620,6 +3630,13 @@ theorem decode_one_hundred_nine_byte_long_string :
       some (.bytes rlpOneHundredNineBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6E] ++ rlpOneHundredTenBytePayload`
+    returns the concrete 110-byte payload. -/
+theorem decode_one_hundred_ten_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload) =
+      some (.bytes rlpOneHundredTenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4769,6 +4786,12 @@ theorem encodeBytes_one_hundred_eight_long :
 theorem encodeBytes_one_hundred_nine_long :
     encodeBytes rlpOneHundredNineBytePayload =
       [(0xB8 : Byte), (0x6D : Byte)] ++ rlpOneHundredNineBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 110-byte long-string payload. -/
+theorem encodeBytes_one_hundred_ten_long :
+    encodeBytes rlpOneHundredTenBytePayload =
+      [(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1883,6 +1883,16 @@ theorem decodeAux_one_hundred_three_byte_long_string :
       some (.bytes rlpOneHundredThreeBytePayload, []) := by
   native_decide
 
+/-- Concrete 104-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFourBytePayload : List Byte :=
+  List.replicate 104 (0x56 : Byte)
+
+/-- Executable example: 104-byte long string (prefix `0xB8`, length byte `0x68`). -/
+theorem decodeAux_one_hundred_four_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload) =
+      some (.bytes rlpOneHundredFourBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3518,6 +3528,13 @@ theorem decode_one_hundred_three_byte_long_string :
       some (.bytes rlpOneHundredThreeBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x68] ++ rlpOneHundredFourBytePayload`
+    returns the concrete 104-byte payload. -/
+theorem decode_one_hundred_four_byte_long_string :
+    decode ([(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload) =
+      some (.bytes rlpOneHundredFourBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4631,6 +4648,12 @@ theorem encodeBytes_one_hundred_two_long :
 theorem encodeBytes_one_hundred_three_long :
     encodeBytes rlpOneHundredThreeBytePayload =
       [(0xB8 : Byte), (0x67 : Byte)] ++ rlpOneHundredThreeBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 104-byte long-string payload. -/
+theorem encodeBytes_one_hundred_four_long :
+    encodeBytes rlpOneHundredFourBytePayload =
+      [(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1893,6 +1893,16 @@ theorem decodeAux_one_hundred_four_byte_long_string :
       some (.bytes rlpOneHundredFourBytePayload, []) := by
   native_decide
 
+/-- Concrete 105-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFiveBytePayload : List Byte :=
+  List.replicate 105 (0x57 : Byte)
+
+/-- Executable example: 105-byte long string (prefix `0xB8`, length byte `0x69`). -/
+theorem decodeAux_one_hundred_five_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x69 : Byte)] ++ rlpOneHundredFiveBytePayload) =
+      some (.bytes rlpOneHundredFiveBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3535,6 +3545,13 @@ theorem decode_one_hundred_four_byte_long_string :
       some (.bytes rlpOneHundredFourBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x69] ++ rlpOneHundredFiveBytePayload`
+    returns the concrete 105-byte payload. -/
+theorem decode_one_hundred_five_byte_long_string :
+    decode ([(0xB8 : Byte), (0x69 : Byte)] ++ rlpOneHundredFiveBytePayload) =
+      some (.bytes rlpOneHundredFiveBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4654,6 +4671,12 @@ theorem encodeBytes_one_hundred_three_long :
 theorem encodeBytes_one_hundred_four_long :
     encodeBytes rlpOneHundredFourBytePayload =
       [(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 105-byte long-string payload. -/
+theorem encodeBytes_one_hundred_five_long :
+    encodeBytes rlpOneHundredFiveBytePayload =
+      [(0xB8 : Byte), (0x69 : Byte)] ++ rlpOneHundredFiveBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1873,6 +1873,16 @@ theorem decodeAux_one_hundred_two_byte_long_string :
       some (.bytes rlpOneHundredTwoBytePayload, []) := by
   native_decide
 
+/-- Concrete 103-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredThreeBytePayload : List Byte :=
+  List.replicate 103 (0x55 : Byte)
+
+/-- Executable example: 103-byte long string (prefix `0xB8`, length byte `0x67`). -/
+theorem decodeAux_one_hundred_three_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x67 : Byte)] ++ rlpOneHundredThreeBytePayload) =
+      some (.bytes rlpOneHundredThreeBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3501,6 +3511,13 @@ theorem decode_one_hundred_two_byte_long_string :
       some (.bytes rlpOneHundredTwoBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x67] ++ rlpOneHundredThreeBytePayload`
+    returns the concrete 103-byte payload. -/
+theorem decode_one_hundred_three_byte_long_string :
+    decode ([(0xB8 : Byte), (0x67 : Byte)] ++ rlpOneHundredThreeBytePayload) =
+      some (.bytes rlpOneHundredThreeBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4608,6 +4625,12 @@ theorem encodeBytes_one_hundred_one_long :
 theorem encodeBytes_one_hundred_two_long :
     encodeBytes rlpOneHundredTwoBytePayload =
       [(0xB8 : Byte), (0x66 : Byte)] ++ rlpOneHundredTwoBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 103-byte long-string payload. -/
+theorem encodeBytes_one_hundred_three_long :
+    encodeBytes rlpOneHundredThreeBytePayload =
+      [(0xB8 : Byte), (0x67 : Byte)] ++ rlpOneHundredThreeBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1933,6 +1933,16 @@ theorem decodeAux_one_hundred_eight_byte_long_string :
       some (.bytes rlpOneHundredEightBytePayload, []) := by
   native_decide
 
+/-- Concrete 109-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredNineBytePayload : List Byte :=
+  List.replicate 109 (0x5B : Byte)
+
+/-- Executable example: 109-byte long string (prefix `0xB8`, length byte `0x6D`). -/
+theorem decodeAux_one_hundred_nine_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6D : Byte)] ++ rlpOneHundredNineBytePayload) =
+      some (.bytes rlpOneHundredNineBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3603,6 +3613,13 @@ theorem decode_one_hundred_eight_byte_long_string :
       some (.bytes rlpOneHundredEightBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6D] ++ rlpOneHundredNineBytePayload`
+    returns the concrete 109-byte payload. -/
+theorem decode_one_hundred_nine_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6D : Byte)] ++ rlpOneHundredNineBytePayload) =
+      some (.bytes rlpOneHundredNineBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4746,6 +4763,12 @@ theorem encodeBytes_one_hundred_seven_long :
 theorem encodeBytes_one_hundred_eight_long :
     encodeBytes rlpOneHundredEightBytePayload =
       [(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 109-byte long-string payload. -/
+theorem encodeBytes_one_hundred_nine_long :
+    encodeBytes rlpOneHundredNineBytePayload =
+      [(0xB8 : Byte), (0x6D : Byte)] ++ rlpOneHundredNineBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1913,6 +1913,16 @@ theorem decodeAux_one_hundred_six_byte_long_string :
       some (.bytes rlpOneHundredSixBytePayload, []) := by
   native_decide
 
+/-- Concrete 107-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSevenBytePayload : List Byte :=
+  List.replicate 107 (0x59 : Byte)
+
+/-- Executable example: 107-byte long string (prefix `0xB8`, length byte `0x6B`). -/
+theorem decodeAux_one_hundred_seven_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6B : Byte)] ++ rlpOneHundredSevenBytePayload) =
+      some (.bytes rlpOneHundredSevenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3569,6 +3579,13 @@ theorem decode_one_hundred_six_byte_long_string :
       some (.bytes rlpOneHundredSixBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6B] ++ rlpOneHundredSevenBytePayload`
+    returns the concrete 107-byte payload. -/
+theorem decode_one_hundred_seven_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6B : Byte)] ++ rlpOneHundredSevenBytePayload) =
+      some (.bytes rlpOneHundredSevenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4700,6 +4717,12 @@ theorem encodeBytes_one_hundred_five_long :
 theorem encodeBytes_one_hundred_six_long :
     encodeBytes rlpOneHundredSixBytePayload =
       [(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 107-byte long-string payload. -/
+theorem encodeBytes_one_hundred_seven_long :
+    encodeBytes rlpOneHundredSevenBytePayload =
+      [(0xB8 : Byte), (0x6B : Byte)] ++ rlpOneHundredSevenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1923,6 +1923,16 @@ theorem decodeAux_one_hundred_seven_byte_long_string :
       some (.bytes rlpOneHundredSevenBytePayload, []) := by
   native_decide
 
+/-- Concrete 108-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredEightBytePayload : List Byte :=
+  List.replicate 108 (0x5A : Byte)
+
+/-- Executable example: 108-byte long string (prefix `0xB8`, length byte `0x6C`). -/
+theorem decodeAux_one_hundred_eight_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload) =
+      some (.bytes rlpOneHundredEightBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3586,6 +3596,13 @@ theorem decode_one_hundred_seven_byte_long_string :
       some (.bytes rlpOneHundredSevenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6C] ++ rlpOneHundredEightBytePayload`
+    returns the concrete 108-byte payload. -/
+theorem decode_one_hundred_eight_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload) =
+      some (.bytes rlpOneHundredEightBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4723,6 +4740,12 @@ theorem encodeBytes_one_hundred_six_long :
 theorem encodeBytes_one_hundred_seven_long :
     encodeBytes rlpOneHundredSevenBytePayload =
       [(0xB8 : Byte), (0x6B : Byte)] ++ rlpOneHundredSevenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 108-byte long-string payload. -/
+theorem encodeBytes_one_hundred_eight_long :
+    encodeBytes rlpOneHundredEightBytePayload =
+      [(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2027.

Adds executable decodeAux, decode, and encodeBytes examples for a 103-byte long-form RLP byte string (prefix 0xB8, length byte 0x67).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-fc6v and GH #120.

Authored by @pirapira; implemented by Codex.