### PR TITLE
prove(rlp): add one-hundred-four-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1883,6 +1883,16 @@ theorem decodeAux_one_hundred_three_byte_long_string :
       some (.bytes rlpOneHundredThreeBytePayload, []) := by
   native_decide
 
+/-- Concrete 104-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFourBytePayload : List Byte :=
+  List.replicate 104 (0x56 : Byte)
+
+/-- Executable example: 104-byte long string (prefix `0xB8`, length byte `0x68`). -/
+theorem decodeAux_one_hundred_four_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload) =
+      some (.bytes rlpOneHundredFourBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3518,6 +3528,13 @@ theorem decode_one_hundred_three_byte_long_string :
       some (.bytes rlpOneHundredThreeBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x68] ++ rlpOneHundredFourBytePayload`
+    returns the concrete 104-byte payload. -/
+theorem decode_one_hundred_four_byte_long_string :
+    decode ([(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload) =
+      some (.bytes rlpOneHundredFourBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4631,6 +4648,12 @@ theorem encodeBytes_one_hundred_two_long :
 theorem encodeBytes_one_hundred_three_long :
     encodeBytes rlpOneHundredThreeBytePayload =
       [(0xB8 : Byte), (0x67 : Byte)] ++ rlpOneHundredThreeBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 104-byte long-string payload. -/
+theorem encodeBytes_one_hundred_four_long :
+    encodeBytes rlpOneHundredFourBytePayload =
+      [(0xB8 : Byte), (0x68 : Byte)] ++ rlpOneHundredFourBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2028.

Adds executable decodeAux, decode, and encodeBytes examples for a 104-byte long-form RLP byte string (prefix 0xB8, length byte 0x68).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-gq3f and GH #120.

Authored by @pirapira; implemented by Codex.