### PR TITLE
prove(rlp): add one-hundred-six-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1903,6 +1903,16 @@ theorem decodeAux_one_hundred_five_byte_long_string :
       some (.bytes rlpOneHundredFiveBytePayload, []) := by
   native_decide
 
+/-- Concrete 106-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSixBytePayload : List Byte :=
+  List.replicate 106 (0x58 : Byte)
+
+/-- Executable example: 106-byte long string (prefix `0xB8`, length byte `0x6A`). -/
+theorem decodeAux_one_hundred_six_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload) =
+      some (.bytes rlpOneHundredSixBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3552,6 +3562,13 @@ theorem decode_one_hundred_five_byte_long_string :
       some (.bytes rlpOneHundredFiveBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6A] ++ rlpOneHundredSixBytePayload`
+    returns the concrete 106-byte payload. -/
+theorem decode_one_hundred_six_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload) =
+      some (.bytes rlpOneHundredSixBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4677,6 +4694,12 @@ theorem encodeBytes_one_hundred_four_long :
 theorem encodeBytes_one_hundred_five_long :
     encodeBytes rlpOneHundredFiveBytePayload =
       [(0xB8 : Byte), (0x69 : Byte)] ++ rlpOneHundredFiveBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 106-byte long-string payload. -/
+theorem encodeBytes_one_hundred_six_long :
+    encodeBytes rlpOneHundredSixBytePayload =
+      [(0xB8 : Byte), (0x6A : Byte)] ++ rlpOneHundredSixBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2030.

Adds executable decodeAux, decode, and encodeBytes examples for a 106-byte long-form RLP byte string (prefix 0xB8, length byte 0x6A).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-4r4q and GH #120.

Authored by @pirapira; implemented by Codex.