### PR TITLE
prove(rlp): add one-hundred-eight-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1923,6 +1923,16 @@ theorem decodeAux_one_hundred_seven_byte_long_string :
       some (.bytes rlpOneHundredSevenBytePayload, []) := by
   native_decide
 
+/-- Concrete 108-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredEightBytePayload : List Byte :=
+  List.replicate 108 (0x5A : Byte)
+
+/-- Executable example: 108-byte long string (prefix `0xB8`, length byte `0x6C`). -/
+theorem decodeAux_one_hundred_eight_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload) =
+      some (.bytes rlpOneHundredEightBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3586,6 +3596,13 @@ theorem decode_one_hundred_seven_byte_long_string :
       some (.bytes rlpOneHundredSevenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6C] ++ rlpOneHundredEightBytePayload`
+    returns the concrete 108-byte payload. -/
+theorem decode_one_hundred_eight_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload) =
+      some (.bytes rlpOneHundredEightBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4723,6 +4740,12 @@ theorem encodeBytes_one_hundred_six_long :
 theorem encodeBytes_one_hundred_seven_long :
     encodeBytes rlpOneHundredSevenBytePayload =
       [(0xB8 : Byte), (0x6B : Byte)] ++ rlpOneHundredSevenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 108-byte long-string payload. -/
+theorem encodeBytes_one_hundred_eight_long :
+    encodeBytes rlpOneHundredEightBytePayload =
+      [(0xB8 : Byte), (0x6C : Byte)] ++ rlpOneHundredEightBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2032.

Adds executable decodeAux, decode, and encodeBytes examples for a 108-byte long-form RLP byte string (prefix 0xB8, length byte 0x6C).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-ow94 and GH #120.

Authored by @pirapira; implemented by Codex.