### PR TITLE
prove(rlp): add one-hundred-ten-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1943,6 +1943,16 @@ theorem decodeAux_one_hundred_nine_byte_long_string :
       some (.bytes rlpOneHundredNineBytePayload, []) := by
   native_decide
 
+/-- Concrete 110-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredTenBytePayload : List Byte :=
+  List.replicate 110 (0x5C : Byte)
+
+/-- Executable example: 110-byte long string (prefix `0xB8`, length byte `0x6E`). -/
+theorem decodeAux_one_hundred_ten_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload) =
+      some (.bytes rlpOneHundredTenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3620,6 +3630,13 @@ theorem decode_one_hundred_nine_byte_long_string :
       some (.bytes rlpOneHundredNineBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6E] ++ rlpOneHundredTenBytePayload`
+    returns the concrete 110-byte payload. -/
+theorem decode_one_hundred_ten_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload) =
+      some (.bytes rlpOneHundredTenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4769,6 +4786,12 @@ theorem encodeBytes_one_hundred_eight_long :
 theorem encodeBytes_one_hundred_nine_long :
     encodeBytes rlpOneHundredNineBytePayload =
       [(0xB8 : Byte), (0x6D : Byte)] ++ rlpOneHundredNineBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 110-byte long-string payload. -/
+theorem encodeBytes_one_hundred_ten_long :
+    encodeBytes rlpOneHundredTenBytePayload =
+      [(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2034.

Adds executable decodeAux, decode, and encodeBytes examples for a 110-byte long-form RLP byte string (prefix 0xB8, length byte 0x6E).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-yhfq and GH #120.

Authored by @pirapira; implemented by Codex.