### PR TITLE
prove(rlp): add one-hundred-eleven-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -2013,6 +2013,16 @@ theorem decodeAux_one_hundred_sixteen_byte_long_string :
       some (.bytes rlpOneHundredSixteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 117-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSeventeenBytePayload : List Byte :=
+  List.replicate 117 (0x63 : Byte)
+
+/-- Executable example: 117-byte long string (prefix `0xB8`, length byte `0x75`). -/
+theorem decodeAux_one_hundred_seventeen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload) =
+      some (.bytes rlpOneHundredSeventeenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3739,6 +3749,13 @@ theorem decode_one_hundred_sixteen_byte_long_string :
       some (.bytes rlpOneHundredSixteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x75] ++ rlpOneHundredSeventeenBytePayload`
+    returns the concrete 117-byte payload. -/
+theorem decode_one_hundred_seventeen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload) =
+      some (.bytes rlpOneHundredSeventeenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4930,6 +4947,12 @@ theorem encodeBytes_one_hundred_fifteen_long :
 theorem encodeBytes_one_hundred_sixteen_long :
     encodeBytes rlpOneHundredSixteenBytePayload =
       [(0xB8 : Byte), (0x74 : Byte)] ++ rlpOneHundredSixteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 117-byte long-string payload. -/
+theorem encodeBytes_one_hundred_seventeen_long :
+    encodeBytes rlpOneHundredSeventeenBytePayload =
+      [(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1953,6 +1953,16 @@ theorem decodeAux_one_hundred_ten_byte_long_string :
       some (.bytes rlpOneHundredTenBytePayload, []) := by
   native_decide
 
+/-- Concrete 111-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredElevenBytePayload : List Byte :=
+  List.replicate 111 (0x5D : Byte)
+
+/-- Executable example: 111-byte long string (prefix `0xB8`, length byte `0x6F`). -/
+theorem decodeAux_one_hundred_eleven_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x6F : Byte)] ++ rlpOneHundredElevenBytePayload) =
+      some (.bytes rlpOneHundredElevenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3637,6 +3647,13 @@ theorem decode_one_hundred_ten_byte_long_string :
       some (.bytes rlpOneHundredTenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x6F] ++ rlpOneHundredElevenBytePayload`
+    returns the concrete 111-byte payload. -/
+theorem decode_one_hundred_eleven_byte_long_string :
+    decode ([(0xB8 : Byte), (0x6F : Byte)] ++ rlpOneHundredElevenBytePayload) =
+      some (.bytes rlpOneHundredElevenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4792,6 +4809,12 @@ theorem encodeBytes_one_hundred_nine_long :
 theorem encodeBytes_one_hundred_ten_long :
     encodeBytes rlpOneHundredTenBytePayload =
       [(0xB8 : Byte), (0x6E : Byte)] ++ rlpOneHundredTenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 111-byte long-string payload. -/
+theorem encodeBytes_one_hundred_eleven_long :
+    encodeBytes rlpOneHundredElevenBytePayload =
+      [(0xB8 : Byte), (0x6F : Byte)] ++ rlpOneHundredElevenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1993,6 +1993,16 @@ theorem decodeAux_one_hundred_fourteen_byte_long_string :
       some (.bytes rlpOneHundredFourteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 115-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFifteenBytePayload : List Byte :=
+  List.replicate 115 (0x61 : Byte)
+
+/-- Executable example: 115-byte long string (prefix `0xB8`, length byte `0x73`). -/
+theorem decodeAux_one_hundred_fifteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload) =
+      some (.bytes rlpOneHundredFifteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3705,6 +3715,13 @@ theorem decode_one_hundred_fourteen_byte_long_string :
       some (.bytes rlpOneHundredFourteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x73] ++ rlpOneHundredFifteenBytePayload`
+    returns the concrete 115-byte payload. -/
+theorem decode_one_hundred_fifteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload) =
+      some (.bytes rlpOneHundredFifteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4884,6 +4901,12 @@ theorem encodeBytes_one_hundred_thirteen_long :
 theorem encodeBytes_one_hundred_fourteen_long :
     encodeBytes rlpOneHundredFourteenBytePayload =
       [(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 115-byte long-string payload. -/
+theorem encodeBytes_one_hundred_fifteen_long :
+    encodeBytes rlpOneHundredFifteenBytePayload =
+      [(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1963,6 +1963,16 @@ theorem decodeAux_one_hundred_eleven_byte_long_string :
       some (.bytes rlpOneHundredElevenBytePayload, []) := by
   native_decide
 
+/-- Concrete 112-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredTwelveBytePayload : List Byte :=
+  List.replicate 112 (0x5E : Byte)
+
+/-- Executable example: 112-byte long string (prefix `0xB8`, length byte `0x70`). -/
+theorem decodeAux_one_hundred_twelve_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload) =
+      some (.bytes rlpOneHundredTwelveBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3654,6 +3664,13 @@ theorem decode_one_hundred_eleven_byte_long_string :
       some (.bytes rlpOneHundredElevenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x70] ++ rlpOneHundredTwelveBytePayload`
+    returns the concrete 112-byte payload. -/
+theorem decode_one_hundred_twelve_byte_long_string :
+    decode ([(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload) =
+      some (.bytes rlpOneHundredTwelveBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4815,6 +4832,12 @@ theorem encodeBytes_one_hundred_ten_long :
 theorem encodeBytes_one_hundred_eleven_long :
     encodeBytes rlpOneHundredElevenBytePayload =
       [(0xB8 : Byte), (0x6F : Byte)] ++ rlpOneHundredElevenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 112-byte long-string payload. -/
+theorem encodeBytes_one_hundred_twelve_long :
+    encodeBytes rlpOneHundredTwelveBytePayload =
+      [(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -2003,6 +2003,16 @@ theorem decodeAux_one_hundred_fifteen_byte_long_string :
       some (.bytes rlpOneHundredFifteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 116-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSixteenBytePayload : List Byte :=
+  List.replicate 116 (0x62 : Byte)
+
+/-- Executable example: 116-byte long string (prefix `0xB8`, length byte `0x74`). -/
+theorem decodeAux_one_hundred_sixteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x74 : Byte)] ++ rlpOneHundredSixteenBytePayload) =
+      some (.bytes rlpOneHundredSixteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3722,6 +3732,13 @@ theorem decode_one_hundred_fifteen_byte_long_string :
       some (.bytes rlpOneHundredFifteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x74] ++ rlpOneHundredSixteenBytePayload`
+    returns the concrete 116-byte payload. -/
+theorem decode_one_hundred_sixteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x74 : Byte)] ++ rlpOneHundredSixteenBytePayload) =
+      some (.bytes rlpOneHundredSixteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4907,6 +4924,12 @@ theorem encodeBytes_one_hundred_fourteen_long :
 theorem encodeBytes_one_hundred_fifteen_long :
     encodeBytes rlpOneHundredFifteenBytePayload =
       [(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 116-byte long-string payload. -/
+theorem encodeBytes_one_hundred_sixteen_long :
+    encodeBytes rlpOneHundredSixteenBytePayload =
+      [(0xB8 : Byte), (0x74 : Byte)] ++ rlpOneHundredSixteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1983,6 +1983,16 @@ theorem decodeAux_one_hundred_thirteen_byte_long_string :
       some (.bytes rlpOneHundredThirteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 114-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFourteenBytePayload : List Byte :=
+  List.replicate 114 (0x60 : Byte)
+
+/-- Executable example: 114-byte long string (prefix `0xB8`, length byte `0x72`). -/
+theorem decodeAux_one_hundred_fourteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload) =
+      some (.bytes rlpOneHundredFourteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3688,6 +3698,13 @@ theorem decode_one_hundred_thirteen_byte_long_string :
       some (.bytes rlpOneHundredThirteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x72] ++ rlpOneHundredFourteenBytePayload`
+    returns the concrete 114-byte payload. -/
+theorem decode_one_hundred_fourteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload) =
+      some (.bytes rlpOneHundredFourteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4861,6 +4878,12 @@ theorem encodeBytes_one_hundred_twelve_long :
 theorem encodeBytes_one_hundred_thirteen_long :
     encodeBytes rlpOneHundredThirteenBytePayload =
       [(0xB8 : Byte), (0x71 : Byte)] ++ rlpOneHundredThirteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 114-byte long-string payload. -/
+theorem encodeBytes_one_hundred_fourteen_long :
+    encodeBytes rlpOneHundredFourteenBytePayload =
+      [(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1973,6 +1973,16 @@ theorem decodeAux_one_hundred_twelve_byte_long_string :
       some (.bytes rlpOneHundredTwelveBytePayload, []) := by
   native_decide
 
+/-- Concrete 113-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredThirteenBytePayload : List Byte :=
+  List.replicate 113 (0x5F : Byte)
+
+/-- Executable example: 113-byte long string (prefix `0xB8`, length byte `0x71`). -/
+theorem decodeAux_one_hundred_thirteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x71 : Byte)] ++ rlpOneHundredThirteenBytePayload) =
+      some (.bytes rlpOneHundredThirteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3671,6 +3681,13 @@ theorem decode_one_hundred_twelve_byte_long_string :
       some (.bytes rlpOneHundredTwelveBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x71] ++ rlpOneHundredThirteenBytePayload`
+    returns the concrete 113-byte payload. -/
+theorem decode_one_hundred_thirteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x71 : Byte)] ++ rlpOneHundredThirteenBytePayload) =
+      some (.bytes rlpOneHundredThirteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4838,6 +4855,12 @@ theorem encodeBytes_one_hundred_eleven_long :
 theorem encodeBytes_one_hundred_twelve_long :
     encodeBytes rlpOneHundredTwelveBytePayload =
       [(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 113-byte long-string payload. -/
+theorem encodeBytes_one_hundred_thirteen_long :
+    encodeBytes rlpOneHundredThirteenBytePayload =
+      [(0xB8 : Byte), (0x71 : Byte)] ++ rlpOneHundredThirteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2035.

Adds executable decodeAux, decode, and encodeBytes examples for a 111-byte long-form RLP byte string (prefix 0xB8, length byte 0x6F).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-g1gt and GH #120.

Authored by @pirapira; implemented by Codex.