### PR TITLE
prove(rlp): add one-hundred-twelve-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1963,6 +1963,16 @@ theorem decodeAux_one_hundred_eleven_byte_long_string :
       some (.bytes rlpOneHundredElevenBytePayload, []) := by
   native_decide
 
+/-- Concrete 112-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredTwelveBytePayload : List Byte :=
+  List.replicate 112 (0x5E : Byte)
+
+/-- Executable example: 112-byte long string (prefix `0xB8`, length byte `0x70`). -/
+theorem decodeAux_one_hundred_twelve_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload) =
+      some (.bytes rlpOneHundredTwelveBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3654,6 +3664,13 @@ theorem decode_one_hundred_eleven_byte_long_string :
       some (.bytes rlpOneHundredElevenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x70] ++ rlpOneHundredTwelveBytePayload`
+    returns the concrete 112-byte payload. -/
+theorem decode_one_hundred_twelve_byte_long_string :
+    decode ([(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload) =
+      some (.bytes rlpOneHundredTwelveBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4815,6 +4832,12 @@ theorem encodeBytes_one_hundred_ten_long :
 theorem encodeBytes_one_hundred_eleven_long :
     encodeBytes rlpOneHundredElevenBytePayload =
       [(0xB8 : Byte), (0x6F : Byte)] ++ rlpOneHundredElevenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 112-byte long-string payload. -/
+theorem encodeBytes_one_hundred_twelve_long :
+    encodeBytes rlpOneHundredTwelveBytePayload =
+      [(0xB8 : Byte), (0x70 : Byte)] ++ rlpOneHundredTwelveBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2036.

Adds executable decodeAux, decode, and encodeBytes examples for a 112-byte long-form RLP byte string (prefix 0xB8, length byte 0x70).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-gj43 and GH #120.

Authored by @pirapira; implemented by Codex.