### PR TITLE
prove(rlp): add one-hundred-fourteen-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1983,6 +1983,16 @@ theorem decodeAux_one_hundred_thirteen_byte_long_string :
       some (.bytes rlpOneHundredThirteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 114-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFourteenBytePayload : List Byte :=
+  List.replicate 114 (0x60 : Byte)
+
+/-- Executable example: 114-byte long string (prefix `0xB8`, length byte `0x72`). -/
+theorem decodeAux_one_hundred_fourteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload) =
+      some (.bytes rlpOneHundredFourteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3688,6 +3698,13 @@ theorem decode_one_hundred_thirteen_byte_long_string :
       some (.bytes rlpOneHundredThirteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x72] ++ rlpOneHundredFourteenBytePayload`
+    returns the concrete 114-byte payload. -/
+theorem decode_one_hundred_fourteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload) =
+      some (.bytes rlpOneHundredFourteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4861,6 +4878,12 @@ theorem encodeBytes_one_hundred_twelve_long :
 theorem encodeBytes_one_hundred_thirteen_long :
     encodeBytes rlpOneHundredThirteenBytePayload =
       [(0xB8 : Byte), (0x71 : Byte)] ++ rlpOneHundredThirteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 114-byte long-string payload. -/
+theorem encodeBytes_one_hundred_fourteen_long :
+    encodeBytes rlpOneHundredFourteenBytePayload =
+      [(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2038.

Adds executable decodeAux, decode, and encodeBytes examples for a 114-byte long-form RLP byte string (prefix 0xB8, length byte 0x72).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-3z8f and GH #120.

Authored by @pirapira; implemented by Codex.