### PR TITLE
prove(rlp): add one-hundred-fifteen-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -1993,6 +1993,16 @@ theorem decodeAux_one_hundred_fourteen_byte_long_string :
       some (.bytes rlpOneHundredFourteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 115-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredFifteenBytePayload : List Byte :=
+  List.replicate 115 (0x61 : Byte)
+
+/-- Executable example: 115-byte long string (prefix `0xB8`, length byte `0x73`). -/
+theorem decodeAux_one_hundred_fifteen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload) =
+      some (.bytes rlpOneHundredFifteenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3705,6 +3715,13 @@ theorem decode_one_hundred_fourteen_byte_long_string :
       some (.bytes rlpOneHundredFourteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x73] ++ rlpOneHundredFifteenBytePayload`
+    returns the concrete 115-byte payload. -/
+theorem decode_one_hundred_fifteen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload) =
+      some (.bytes rlpOneHundredFifteenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4884,6 +4901,12 @@ theorem encodeBytes_one_hundred_thirteen_long :
 theorem encodeBytes_one_hundred_fourteen_long :
     encodeBytes rlpOneHundredFourteenBytePayload =
       [(0xB8 : Byte), (0x72 : Byte)] ++ rlpOneHundredFourteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 115-byte long-string payload. -/
+theorem encodeBytes_one_hundred_fifteen_long :
+    encodeBytes rlpOneHundredFifteenBytePayload =
+      [(0xB8 : Byte), (0x73 : Byte)] ++ rlpOneHundredFifteenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2039.

Adds executable decodeAux, decode, and encodeBytes examples for a 115-byte long-form RLP byte string (prefix 0xB8, length byte 0x73).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-1p1u and GH #120.

Authored by @pirapira; implemented by Codex.