### PR TITLE
prove(rlp): add one-hundred-seventeen-byte long string examples

### DIFF
--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -2013,6 +2013,16 @@ theorem decodeAux_one_hundred_sixteen_byte_long_string :
       some (.bytes rlpOneHundredSixteenBytePayload, []) := by
   native_decide
 
+/-- Concrete 117-byte long-string payload used by the executable examples below. -/
+def rlpOneHundredSeventeenBytePayload : List Byte :=
+  List.replicate 117 (0x63 : Byte)
+
+/-- Executable example: 117-byte long string (prefix `0xB8`, length byte `0x75`). -/
+theorem decodeAux_one_hundred_seventeen_byte_long_string :
+    decodeAux 100 ([(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload) =
+      some (.bytes rlpOneHundredSeventeenBytePayload, []) := by
+  native_decide
+
 /-- Canonical-form rejection: prefix `0x81` followed by a byte `b`
     with `b.toNat < 0x80` is non-canonical (the byte should have
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
@@ -3739,6 +3749,13 @@ theorem decode_one_hundred_sixteen_byte_long_string :
       some (.bytes rlpOneHundredSixteenBytePayload, []) := by
   native_decide
 
+/-- `decode [0xB8, 0x75] ++ rlpOneHundredSeventeenBytePayload`
+    returns the concrete 117-byte payload. -/
+theorem decode_one_hundred_seventeen_byte_long_string :
+    decode ([(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload) =
+      some (.bytes rlpOneHundredSeventeenBytePayload, []) := by
+  native_decide
+
 /-! ## encodeBytes characterizations -/
 
 /-- Empty byte string encodes to the single prefix `[0x80]`. -/
@@ -4930,6 +4947,12 @@ theorem encodeBytes_one_hundred_fifteen_long :
 theorem encodeBytes_one_hundred_sixteen_long :
     encodeBytes rlpOneHundredSixteenBytePayload =
       [(0xB8 : Byte), (0x74 : Byte)] ++ rlpOneHundredSixteenBytePayload := by
+  native_decide
+
+/-- Executable encoding example for the concrete 117-byte long-string payload. -/
+theorem encodeBytes_one_hundred_seventeen_long :
+    encodeBytes rlpOneHundredSeventeenBytePayload =
+      [(0xB8 : Byte), (0x75 : Byte)] ++ rlpOneHundredSeventeenBytePayload := by
   native_decide
 
 /-! ## Encoding produces non-empty output -/


### PR DESCRIPTION
Stacked on #2041.

Adds executable decodeAux, decode, and encodeBytes examples for a 117-byte long-form RLP byte string (prefix 0xB8, length byte 0x75).

Verification:
- lake build EvmAsm.EL.RLP.Properties
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-alja and GH #120.

Authored by @pirapira; implemented by Codex.