### PR TITLE
prove(rlp): bridge prefix classifier to decoder branches

### DIFF
--- a/EvmAsm/EL/RLP.lean
+++ b/EvmAsm/EL/RLP.lean
@@ -5,4 +5,5 @@
 -/
 -- `Properties` transitively imports `Decode`, which transitively imports `Basic`.
 import EvmAsm.EL.RLP.Prefix
+import EvmAsm.EL.RLP.PrefixDecode
 import EvmAsm.EL.RLP.Properties

--- a/EvmAsm/EL/RLP/PrefixDecode.lean
+++ b/EvmAsm/EL/RLP/PrefixDecode.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.EL.RLP.PrefixDecode
+
+  Bridges from the pure RLP prefix classifier to the canonical decoder.
+-/
+
+import EvmAsm.EL.RLP.Decode
+import EvmAsm.EL.RLP.Prefix
+
+namespace EvmAsm.EL.RLP
+
+/-- A classified single-byte prefix selects the single-byte `decodeAux` branch. -/
+theorem decodeAux_cons_singleByte_of_classifyPrefix
+    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (h : classifyPrefix pfx = .singleByte) :
+    decodeAux (fuel + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
+  have h_lt := (classifyPrefix_singleByte_iff pfx).mp h
+  simp [decodeAux, h_lt]
+
+/-- A classified short-byte-string prefix selects the short-string branch. -/
+theorem decodeAux_cons_shortBytes_of_classifyPrefix
+    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (h : classifyPrefix pfx = .shortBytes) :
+    decodeAux (fuel + 1) (pfx :: rest) =
+      (do
+        let (data, rest') ← takeBytes rest (rlpPrefixShortBytesPayloadLen pfx)
+        match data with
+        | [b] => if b.toNat < 0x80 then none else some (.bytes data, rest')
+        | _ => some (.bytes data, rest')) := by
+  have h_range := (classifyPrefix_shortBytes_iff pfx).mp h
+  have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
+  simp [decodeAux, rlpPrefixShortBytesPayloadLen, h_not_lt, h_range.2]
+  rfl
+
+/-- A classified long-byte-string prefix selects the long-string branch. -/
+theorem decodeAux_cons_longBytes_of_classifyPrefix
+    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (h : classifyPrefix pfx = .longBytes) :
+    decodeAux (fuel + 1) (pfx :: rest) =
+      (do
+        let (lenVal, rest') ← readLength rest (rlpPrefixLongBytesLenOfLen pfx)
+        if lenVal ≤ 55 then none
+        else do
+          let (data, rest'') ← takeBytes rest' lenVal
+          some (.bytes data, rest'')) := by
+  have h_range := (classifyPrefix_longBytes_iff pfx).mp h
+  have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
+  have h_not_short : ¬ pfx.toNat ≤ 0xB7 := by omega
+  simp [decodeAux, rlpPrefixLongBytesLenOfLen,
+    h_not_lt, h_not_short, h_range.2]
+
+/-- A classified short-list prefix selects the short-list branch. -/
+theorem decodeAux_cons_shortList_of_classifyPrefix
+    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (h : classifyPrefix pfx = .shortList) :
+    decodeAux (fuel + 1) (pfx :: rest) =
+      (do
+        let (payload, rest') ← takeBytes rest (rlpPrefixShortListPayloadLen pfx)
+        let (items, leftover) ← decodeItems fuel payload
+        if List.isEmpty leftover then some (.list items, rest') else none) := by
+  have h_range := (classifyPrefix_shortList_iff pfx).mp h
+  have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
+  have h_not_shortBytes : ¬ pfx.toNat ≤ 0xB7 := by omega
+  have h_not_longBytes : ¬ pfx.toNat ≤ 0xBF := by omega
+  simp [decodeAux, rlpPrefixShortListPayloadLen,
+    h_not_lt, h_not_shortBytes, h_not_longBytes, h_range.2]
+
+/-- A classified long-list prefix selects the long-list branch. -/
+theorem decodeAux_cons_longList_of_classifyPrefix
+    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (h : classifyPrefix pfx = .longList) :
+    decodeAux (fuel + 1) (pfx :: rest) =
+      (do
+        let (lenVal, rest') ← readLength rest (rlpPrefixLongListLenOfLen pfx)
+        if lenVal ≤ 55 then none
+        else do
+          let (payload, rest'') ← takeBytes rest' lenVal
+          let (items, leftover) ← decodeItems fuel payload
+          if List.isEmpty leftover then some (.list items, rest'') else none) := by
+  have h_range := (classifyPrefix_longList_iff pfx).mp h
+  have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
+  have h_not_shortBytes : ¬ pfx.toNat ≤ 0xB7 := by omega
+  have h_not_longBytes : ¬ pfx.toNat ≤ 0xBF := by omega
+  have h_not_shortList : ¬ pfx.toNat ≤ 0xF7 := by omega
+  simp [decodeAux, rlpPrefixLongListLenOfLen,
+    h_not_lt, h_not_shortBytes, h_not_longBytes, h_not_shortList]
+
+end EvmAsm.EL.RLP


### PR DESCRIPTION
Adds PrefixDecode with classifyPrefix-driven decodeAux branch equations for all five RLP prefix classes, giving the executable prefix-classifier work a semantic bridge target.

Verification:
- lake build EvmAsm.EL.RLP
- scripts/check-file-size.sh --report
- lake build

Refs evm-asm-a2pc and GH #120.

Authored by @pirapira; implemented by Codex.