### PR TITLE
feat(rlp): prove prefix classifier single-byte path

### DIFF
--- a/EvmAsm/EL/RLP.lean
+++ b/EvmAsm/EL/RLP.lean
@@ -7,4 +7,5 @@
 import EvmAsm.EL.RLP.Prefix
 import EvmAsm.EL.RLP.PrefixDecode
 import EvmAsm.EL.RLP.Program
+import EvmAsm.EL.RLP.ProgramSpec
 import EvmAsm.EL.RLP.Properties

--- a/EvmAsm/EL/RLP/Program.lean
+++ b/EvmAsm/EL/RLP/Program.lean
@@ -90,4 +90,25 @@ theorem rlp_prefix_classify_byte_length (pfxReg outReg tmpReg : Reg) :
     4 * (rlp_prefix_classify pfxReg outReg tmpReg).length = 72 := by
   rw [rlp_prefix_classify_length]
 
+/--
+  Executable Phase-2 helper for short RLP payload lengths.
+
+  For short byte strings use `baseTag = 0x80`; for short lists use
+  `baseTag = 0xC0`. The result is `pfx - baseTag`, written to `outReg`.
+-/
+def rlp_prefix_short_payload_len (pfxReg outReg tmpReg : Reg) (baseTag : Word) : Program :=
+  LI tmpReg baseTag ;;
+  SUB outReg pfxReg tmpReg
+
+theorem rlp_prefix_short_payload_len_length
+    (pfxReg outReg tmpReg : Reg) (baseTag : Word) :
+    (rlp_prefix_short_payload_len pfxReg outReg tmpReg baseTag).length = 2 := by
+  unfold rlp_prefix_short_payload_len LI SUB seq single
+  rfl
+
+theorem rlp_prefix_short_payload_len_byte_length
+    (pfxReg outReg tmpReg : Reg) (baseTag : Word) :
+    4 * (rlp_prefix_short_payload_len pfxReg outReg tmpReg baseTag).length = 8 := by
+  rw [rlp_prefix_short_payload_len_length]
+
 end EvmAsm.EL.RLP

--- a/EvmAsm/EL/RLP/ProgramSpec.lean
+++ b/EvmAsm/EL/RLP/ProgramSpec.lean
@@ -273,4 +273,62 @@ theorem rlp_prefix_short_list_payload_len_spec_within
         (.x6 ↦ᵣ (0xC0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
   rlp_prefix_short_payload_len_spec_within (pfx.zeroExtend 64) outOld tmpOld (0xC0 : Word) base
 
+theorem rlpPrefixShortBytesPayloadLen_toWord_of_class
+    (pfx : Byte) (h_class : classifyPrefix pfx = .shortBytes) :
+    (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx) : Word) =
+      pfx.zeroExtend 64 - (0x80 : Word) := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofNat]
+  rw [BitVec.toNat_sub_of_le]
+  · rw [BitVec.zeroExtend_eq_setWidth]
+    simp [rlpPrefixShortBytesPayloadLen, BitVec.toNat_setWidth]
+    have h_range := (classifyPrefix_shortBytes_iff pfx).mp h_class
+    omega
+  · rw [BitVec.le_def]
+    rw [BitVec.zeroExtend_eq_setWidth]
+    simp [BitVec.toNat_setWidth]
+    have h_range := (classifyPrefix_shortBytes_iff pfx).mp h_class
+    omega
+
+theorem rlpPrefixShortListPayloadLen_toWord_of_class
+    (pfx : Byte) (h_class : classifyPrefix pfx = .shortList) :
+    (BitVec.ofNat 64 (rlpPrefixShortListPayloadLen pfx) : Word) =
+      pfx.zeroExtend 64 - (0xC0 : Word) := by
+  apply BitVec.eq_of_toNat_eq
+  rw [BitVec.toNat_ofNat]
+  rw [BitVec.toNat_sub_of_le]
+  · rw [BitVec.zeroExtend_eq_setWidth]
+    simp [rlpPrefixShortListPayloadLen, BitVec.toNat_setWidth]
+    have h_range := (classifyPrefix_shortList_iff pfx).mp h_class
+    omega
+  · rw [BitVec.le_def]
+    rw [BitVec.zeroExtend_eq_setWidth]
+    simp [BitVec.toNat_setWidth]
+    have h_range := (classifyPrefix_shortList_iff pfx).mp h_class
+    omega
+
+theorem rlp_prefix_short_bytes_payload_len_of_class_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word)
+    (h_class : classifyPrefix pfx = .shortBytes) :
+    cpsTripleWithin 2 base (base + 8) (rlp_prefix_short_payload_len_code base (0x80 : Word))
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortBytesPayloadLen pfx) : Word)) **
+        (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x6 ↦ᵣ (0x80 : Word)) **
+        (.x0 ↦ᵣ (0 : Word))) := by
+  rw [rlpPrefixShortBytesPayloadLen_toWord_of_class pfx h_class]
+  exact rlp_prefix_short_bytes_payload_len_spec_within pfx outOld tmpOld base
+
+theorem rlp_prefix_short_list_payload_len_of_class_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word)
+    (h_class : classifyPrefix pfx = .shortList) :
+    cpsTripleWithin 2 base (base + 8) (rlp_prefix_short_payload_len_code base (0xC0 : Word))
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ (BitVec.ofNat 64 (rlpPrefixShortListPayloadLen pfx) : Word)) **
+        (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x6 ↦ᵣ (0xC0 : Word)) **
+        (.x0 ↦ᵣ (0 : Word))) := by
+  rw [rlpPrefixShortListPayloadLen_toWord_of_class pfx h_class]
+  exact rlp_prefix_short_list_payload_len_spec_within pfx outOld tmpOld base
+
 end EvmAsm.EL.RLP

--- a/EvmAsm/EL/RLP/ProgramSpec.lean
+++ b/EvmAsm/EL/RLP/ProgramSpec.lean
@@ -191,4 +191,86 @@ theorem rlp_prefix_classify_singleByte_of_classifyPrefix_spec_within
   simp [BitVec.toNat_setWidth, BitVec.toNat_ofNat]
   omega
 
+abbrev rlp_prefix_short_payload_len_code (base baseTag : Word) : CodeReq :=
+  CodeReq.ofProg base (rlp_prefix_short_payload_len .x5 .x10 .x6 baseTag)
+
+/--
+  Executable short-payload length helper.
+
+  The helper loads the class base tag (`0x80` for short byte strings or `0xC0`
+  for short lists) and subtracts it from the prefix byte already in `x5`.
+-/
+theorem rlp_prefix_short_payload_len_spec_within
+    (pfx outOld tmpOld baseTag : Word) (base : Word) :
+    cpsTripleWithin 2 base (base + 8) (rlp_prefix_short_payload_len_code base baseTag)
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx) ** (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ pfx - baseTag) ** (.x5 ↦ᵣ pfx) **
+        (.x6 ↦ᵣ baseTag) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have I0 := li_spec_gen_within .x6 tmpOld baseTag base (by nofun)
+  have I0_ext := cpsTripleWithin_extend_code
+    (cr' := rlp_prefix_short_payload_len_code base baseTag) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_short_payload_len_code base baseTag base = some (.LI .x6 baseTag)
+        change CodeReq.ofProg base (.LI .x6 baseTag :: _) base = some (.LI .x6 baseTag)
+        rw [CodeReq.ofProg_cons]
+        simp [CodeReq.union, CodeReq.singleton]
+      · simp at h) I0
+  have I0_framed := cpsTripleWithin_frameR
+    ((.x5 ↦ᵣ pfx) ** (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+    (by pcFree) I0_ext
+  have I1 := sub_spec_gen_within .x10 .x5 .x6 pfx baseTag outOld (base + 4) (by nofun)
+  have I1_ext := cpsTripleWithin_extend_code
+    (cr' := rlp_prefix_short_payload_len_code base baseTag) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_short_payload_len_code base baseTag (base + 4) =
+          some (.SUB .x10 .x5 .x6)
+        exact CodeReq.ofProg_lookup base
+          (rlp_prefix_short_payload_len .x5 .x10 .x6 baseTag) 1
+          (by rw [rlp_prefix_short_payload_len_length]; norm_num)
+          (by rw [rlp_prefix_short_payload_len_length]; norm_num)
+      · simp at h) I1
+  have I1_framed := cpsTripleWithin_frameR
+    ((.x0 ↦ᵣ (0 : Word)))
+    (by pcFree) I1_ext
+  have ha_mid : (base : Word) + 4 = base + 4 := rfl
+  have ha_exit : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [ha_mid] at I0_framed
+  rw [ha_exit] at I1_framed
+  have Hseq := cpsTripleWithin_seq_perm_same_cr
+    (fun h hp => by xperm_hyp hp) I0_framed I1_framed
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    Hseq
+
+theorem rlp_prefix_short_bytes_payload_len_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word) :
+    cpsTripleWithin 2 base (base + 8) (rlp_prefix_short_payload_len_code base (0x80 : Word))
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ pfx.zeroExtend 64 - (0x80 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+  rlp_prefix_short_payload_len_spec_within (pfx.zeroExtend 64) outOld tmpOld (0x80 : Word) base
+
+theorem rlp_prefix_short_list_payload_len_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word) :
+    cpsTripleWithin 2 base (base + 8) (rlp_prefix_short_payload_len_code base (0xC0 : Word))
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ pfx.zeroExtend 64 - (0xC0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x6 ↦ᵣ (0xC0 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+  rlp_prefix_short_payload_len_spec_within (pfx.zeroExtend 64) outOld tmpOld (0xC0 : Word) base
+
 end EvmAsm.EL.RLP

--- a/EvmAsm/EL/RLP/ProgramSpec.lean
+++ b/EvmAsm/EL/RLP/ProgramSpec.lean
@@ -171,4 +171,24 @@ theorem rlp_prefix_classify_singleByte_spec_within
     exact cpsTripleWithin_seq_same_cr Hli I3_framed
   exact cpsTripleWithin_seq_same_cr Htaken Hsuffix
 
+/--
+  Pure-classifier bridge for the single-byte executable path.
+
+  This version takes the EL/RLP predicate `classifyPrefix pfx = .singleByte`
+  and feeds the zero-extended byte to the executable classifier spec.
+-/
+theorem rlp_prefix_classify_singleByte_of_classifyPrefix_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word)
+    (h_class : classifyPrefix pfx = .singleByte) :
+    cpsTripleWithin 4 base (base + 72) (rlp_prefix_classify_code base)
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  apply rlp_prefix_classify_singleByte_spec_within
+  have h_lt := (classifyPrefix_singleByte_iff pfx).mp h_class
+  rw [BitVec.zeroExtend_eq_setWidth, BitVec.ult]
+  simp [BitVec.toNat_setWidth, BitVec.toNat_ofNat]
+  omega
+
 end EvmAsm.EL.RLP

--- a/EvmAsm/EL/RLP/ProgramSpec.lean
+++ b/EvmAsm/EL/RLP/ProgramSpec.lean
@@ -1,0 +1,174 @@
+/-
+  EvmAsm.EL.RLP.ProgramSpec
+
+  Executable specs for RLP decoder programs.
+-/
+
+import EvmAsm.EL.RLP.Program
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Rv64.ControlFlow
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.RunBlock
+import EvmAsm.Rv64.Tactics.XSimp
+
+open EvmAsm.Rv64
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.EL.RLP
+
+abbrev rlp_prefix_classify_code (base : Word) : CodeReq :=
+  CodeReq.ofProg base (rlp_prefix_classify .x5 .x10 .x6)
+
+/--
+  Single-byte path of the executable RLP prefix classifier.
+
+  If the input prefix in `x5` is below `0x80`, the first BLTU jumps to the
+  single-byte block, writes the `.singleByte` tag to `x10`, and then reaches
+  the common exit at `base + 72`.
+-/
+theorem rlp_prefix_classify_singleByte_spec_within
+    (pfx outOld tmpOld : Word) (base : Word)
+    (h_single : BitVec.ult pfx (0x80 : Word)) :
+    cpsTripleWithin 4 base (base + 72) (rlp_prefix_classify_code base)
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx) ** (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  have I0 := li_spec_gen_within .x6 tmpOld (0x80 : Word) base (by nofun)
+  have Hbr_raw := bltu_spec_gen_within .x5 .x6 rlpPrefixClassifyBranchOff
+    pfx (0x80 : Word) (base + 4)
+  have ha_t : (base + 4) + signExtend13 rlpPrefixClassifyBranchOff = base + 40 := by
+    unfold rlpPrefixClassifyBranchOff
+    rv64_addr
+  have ha_f : (base + 4 : Word) + 4 = base + 8 := by bv_addr
+  rw [ha_t, ha_f] at Hbr_raw
+  have Hbr_framed := cpsBranchWithin_frameR
+    ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+    (by pcFree) Hbr_raw
+  have Hbr_ext : cpsBranchWithin 1 (base + 4) (rlp_prefix_classify_code base)
+      (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word))) **
+        ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word))))
+      (base + 40)
+        (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜BitVec.ult pfx (0x80 : Word)⌝) **
+          ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word))))
+      (base + 8)
+        (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜¬BitVec.ult pfx (0x80 : Word)⌝) **
+          ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))) :=
+    cpsBranchWithin_extend_code (cr' := rlp_prefix_classify_code base) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_classify_code base (base + 4) = some (.BLTU .x5 .x6 rlpPrefixClassifyBranchOff)
+        exact CodeReq.ofProg_lookup base (rlp_prefix_classify .x5 .x10 .x6) 1
+          (by rw [rlp_prefix_classify_length]; norm_num)
+          (by rw [rlp_prefix_classify_length]; norm_num)
+      · simp at h) Hbr_framed
+  have Hprefix : cpsBranchWithin 2 base (rlp_prefix_classify_code base)
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx) ** (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      (base + 40)
+        (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜BitVec.ult pfx (0x80 : Word)⌝) **
+          ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word))))
+      (base + 8)
+        (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜¬BitVec.ult pfx (0x80 : Word)⌝) **
+          ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))) := by
+    have I0_ext := cpsTripleWithin_extend_code (cr' := rlp_prefix_classify_code base) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_classify_code base base = some (.LI .x6 (0x80 : Word))
+        change CodeReq.ofProg base (.LI .x6 (0x80 : Word) :: _) base = some (.LI .x6 (0x80 : Word))
+        rw [CodeReq.ofProg_cons]
+        simp [CodeReq.union, CodeReq.singleton]
+      · simp at h) I0
+    have I0_framed := cpsTripleWithin_frameR
+      ((.x5 ↦ᵣ pfx) ** (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcFree) I0_ext
+    exact cpsTripleWithin_seq_cpsBranchWithin_perm_same_cr
+      (fun h hp => by xperm_hyp hp) I0_framed Hbr_ext
+  have Htaken := cpsBranchWithin_takenPath Hprefix (fun hp hQf => by
+    obtain ⟨_, _, _, _, ⟨_, _, _, _, _, h_pure⟩, _⟩ := hQf
+    exact ((sepConj_pure_right _).1 h_pure).2 h_single)
+  have I2 := li_spec_gen_within .x10 outOld (PrefixClass.toWord .singleByte) (base + 40) (by nofun)
+  have I3 := jal_x0_spec_gen_within rlpPrefixClassifySingleByteExitOff (base + 44)
+  have ha_exit : (base + 44) + signExtend21 rlpPrefixClassifySingleByteExitOff = base + 72 := by
+    unfold rlpPrefixClassifySingleByteExitOff
+    rv64_addr
+  rw [ha_exit] at I3
+  have Hsuffix : cpsTripleWithin 2 (base + 40) (base + 72) (rlp_prefix_classify_code base)
+      (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜BitVec.ult pfx (0x80 : Word)⌝) **
+        ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word))))
+      ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+    have I2_ext := cpsTripleWithin_extend_code (cr' := rlp_prefix_classify_code base) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_classify_code base (base + 40) =
+          some (.LI .x10 (PrefixClass.toWord .singleByte))
+        exact CodeReq.ofProg_lookup base (rlp_prefix_classify .x5 .x10 .x6) 10
+          (by rw [rlp_prefix_classify_length]; norm_num)
+          (by rw [rlp_prefix_classify_length]; norm_num)
+      · simp at h) I2
+    have I3_ext := cpsTripleWithin_extend_code (cr' := rlp_prefix_classify_code base) (fun a i h => by
+      simp only [CodeReq.singleton] at h
+      split at h
+      · next heq =>
+        rw [beq_iff_eq] at heq
+        rw [heq]
+        simp only [Option.some.injEq] at h
+        subst h
+        show rlp_prefix_classify_code base (base + 44) =
+          some (.JAL .x0 rlpPrefixClassifySingleByteExitOff)
+        exact CodeReq.ofProg_lookup base (rlp_prefix_classify .x5 .x10 .x6) 11
+          (by rw [rlp_prefix_classify_length]; norm_num)
+          (by rw [rlp_prefix_classify_length]; norm_num)
+      · simp at h) I3
+    have I3_framed_raw := cpsTripleWithin_frameR
+      ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+      (by pcFree) I3_ext
+    have I3_framed : cpsTripleWithin 1 (base + 44) (base + 72) (rlp_prefix_classify_code base)
+        ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+          (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+        ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+          (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+      cpsTripleWithin_weaken
+        (fun h hp => by simpa [sepConj_emp_left', sepConj_emp_right'] using hp)
+        (fun h hp => by simpa [sepConj_emp_left', sepConj_emp_right'] using hp)
+        I3_framed_raw
+    have Hli : cpsTripleWithin 1 (base + 40) (base + 44) (rlp_prefix_classify_code base)
+        (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** ⌜BitVec.ult pfx (0x80 : Word)⌝) **
+          ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word))))
+        ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx) **
+          (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) :=
+      by
+        have I2_framed := cpsTripleWithin_frameR
+          ((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word)))
+          (by pcFree) I2_ext
+        have ha : (base + 40 : Word) + 4 = base + 44 := by bv_addr
+        rw [ha] at I2_framed
+        exact cpsTripleWithin_weaken
+          (fun h hp => by
+            have hp_no_pure :
+                (((.x5 ↦ᵣ pfx) ** (.x6 ↦ᵣ (0x80 : Word))) **
+                  ((.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))) h :=
+              sepConj_mono_left
+                (sepConj_mono_right (fun h' hp' => ((sepConj_pure_right h').1 hp').1)) h hp
+            xperm_hyp hp_no_pure)
+          (fun h hp => hp)
+          I2_framed
+    exact cpsTripleWithin_seq_same_cr Hli I3_framed
+  exact cpsTripleWithin_seq_same_cr Htaken Hsuffix
+
+end EvmAsm.EL.RLP


### PR DESCRIPTION
Stacked on #2047.\n\nAdds the first executable CPS path spec for the RLP prefix classifier program. The new theorem proves that when the prefix in x5 is below 0x80, rlp_prefix_classify jumps to the single-byte block, writes PrefixClass.singleByte to x10, preserves the prefix/tmp facts expected by the path, and reaches the common exit at base + 72.\n\nVerification:\n- lake build EvmAsm.EL.RLP\n- scripts/check-file-size.sh --report\n- lake build\n\nRefs evm-asm-qq3e, GH #120.\n\nAuthored by @pirapira; implemented by Codex.