### PR TITLE
feat(rlp): bridge prefix classifier path to pure class

### DIFF
--- a/EvmAsm/EL/RLP/ProgramSpec.lean
+++ b/EvmAsm/EL/RLP/ProgramSpec.lean
@@ -171,4 +171,24 @@ theorem rlp_prefix_classify_singleByte_spec_within
     exact cpsTripleWithin_seq_same_cr Hli I3_framed
   exact cpsTripleWithin_seq_same_cr Htaken Hsuffix
 
+/--
+  Pure-classifier bridge for the single-byte executable path.
+
+  This version takes the EL/RLP predicate `classifyPrefix pfx = .singleByte`
+  and feeds the zero-extended byte to the executable classifier spec.
+-/
+theorem rlp_prefix_classify_singleByte_of_classifyPrefix_spec_within
+    (pfx : Byte) (outOld tmpOld : Word) (base : Word)
+    (h_class : classifyPrefix pfx = .singleByte) :
+    cpsTripleWithin 4 base (base + 72) (rlp_prefix_classify_code base)
+      ((.x6 ↦ᵣ tmpOld) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ outOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((.x10 ↦ᵣ PrefixClass.toWord .singleByte) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x6 ↦ᵣ (0x80 : Word)) ** (.x0 ↦ᵣ (0 : Word))) := by
+  apply rlp_prefix_classify_singleByte_spec_within
+  have h_lt := (classifyPrefix_singleByte_iff pfx).mp h_class
+  rw [BitVec.zeroExtend_eq_setWidth, BitVec.ult]
+  simp [BitVec.toNat_setWidth, BitVec.toNat_ofNat]
+  omega
+
 end EvmAsm.EL.RLP


### PR DESCRIPTION
Stacked on #2048.\n\nAdds a pure-to-executable bridge for the RLP prefix classifier single-byte path: from classifyPrefix pfx = PrefixClass.singleByte, the theorem feeds pfx.zeroExtend 64 into the executable path spec and proves the classifier writes the single-byte tag at the common exit.\n\nVerification:\n- lake build EvmAsm.EL.RLP\n- scripts/check-file-size.sh --report\n- lake build\n\nRefs evm-asm-x98i, GH #120.\n\nAuthored by @pirapira; implemented by Codex.