### PR TITLE
feat(mload): compose rounded access flag

### DIFF
--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -263,6 +263,141 @@ theorem mload_compute_expand_flag_ofProg_spec_within
     flagReg sizeReg roundReg sizeBytesWord roundedAccessEnd flagOld base h_flag_ne_x0
 
 /--
+  Compute the MLOAD access end, round it to the EVM memory word boundary, and
+  compare it against the current memory size.
+-/
+def mload_compute_rounded_access_flag
+    (flagReg sizeReg roundReg endReg offReg : Reg) : Program :=
+  mload_compute_rounded_access_end roundReg endReg offReg ;;
+  mload_compute_expand_flag flagReg sizeReg roundReg
+
+abbrev mload_compute_rounded_access_flag_code
+    (flagReg sizeReg roundReg endReg offReg : Reg) (base : Word) : CodeReq :=
+  (mload_compute_rounded_access_end_code roundReg endReg offReg base).union
+    (mload_compute_expand_flag_code flagReg sizeReg roundReg (base + 12))
+
+theorem mload_compute_rounded_access_flag_code_eq_ofProg
+    (flagReg sizeReg roundReg endReg offReg : Reg) (base : Word) :
+    mload_compute_rounded_access_flag_code flagReg sizeReg roundReg endReg offReg base =
+      CodeReq.ofProg base
+        (mload_compute_rounded_access_flag flagReg sizeReg roundReg endReg offReg) := by
+  unfold mload_compute_rounded_access_flag_code mload_compute_rounded_access_flag
+    mload_compute_rounded_access_end_code mload_compute_expand_flag_code
+    mload_compute_rounded_access_end mload_compute_access_end mload_round_access_end
+    mload_compute_expand_flag mload_compute_access_end_code mload_round_access_end_code
+    ADDI ANDI single seq
+  change ((CodeReq.singleton base (Instr.ADDI endReg offReg 32)).union
+      ((CodeReq.singleton (base + 4) (Instr.ADDI roundReg endReg 31)).union
+        (CodeReq.singleton ((base + 4) + 4)
+          (Instr.ANDI roundReg roundReg (-32))))).union
+      (CodeReq.singleton (base + 12) (Instr.SLTU flagReg sizeReg roundReg)) =
+    CodeReq.ofProg base [Instr.ADDI endReg offReg 32,
+      Instr.ADDI roundReg endReg 31, Instr.ANDI roundReg roundReg (-32),
+      Instr.SLTU flagReg sizeReg roundReg]
+  rw [CodeReq.ofProg_cons, CodeReq.ofProg_cons, CodeReq.ofProg_cons,
+    CodeReq.ofProg_cons, CodeReq.ofProg_nil, CodeReq.union_empty_right]
+  rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega]
+  rw [show (base + 8 : Word) + 4 = base + 12 from by bv_omega]
+  rw [CodeReq.union_assoc, CodeReq.union_assoc]
+
+/--
+  Composed executable bridge for the rounded access-end arithmetic and the
+  unsigned comparison against the current memory size.
+-/
+theorem mload_compute_rounded_access_flag_spec_within
+    (flagReg sizeReg roundReg endReg offReg : Reg)
+    (offset endOld roundOld sizeBytesWord flagOld : Word) (base : Word)
+    (h_end_ne_x0 : endReg ≠ .x0)
+    (h_round_ne_x0 : roundReg ≠ .x0)
+    (h_flag_ne_x0 : flagReg ≠ .x0) :
+    cpsTripleWithin 4 base (base + 16)
+      (mload_compute_rounded_access_flag_code flagReg sizeReg roundReg endReg offReg base)
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ endOld) **
+       (roundReg ↦ᵣ roundOld) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))) **
+       (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ
+        (if BitVec.ult sizeBytesWord
+          (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+         then (1 : Word) else 0))) := by
+  unfold mload_compute_rounded_access_flag_code
+  let roundedAccessEnd :=
+    (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+  have h_rounded :=
+    mload_compute_rounded_access_end_spec_within roundReg endReg offReg
+      offset endOld roundOld base h_end_ne_x0 h_round_ne_x0
+  have h_flag :=
+    mload_compute_expand_flag_spec_within flagReg sizeReg roundReg
+      sizeBytesWord roundedAccessEnd flagOld (base + 12) h_flag_ne_x0
+  rw [show (base + 12 : Word) + 4 = base + 16 from by bv_omega] at h_flag
+  have hd :
+      (mload_compute_rounded_access_end_code roundReg endReg offReg base).Disjoint
+        (mload_compute_expand_flag_code flagReg sizeReg roundReg (base + 12)) := by
+    unfold mload_compute_rounded_access_end_code mload_compute_access_end_code
+      mload_round_access_end_code mload_compute_expand_flag_code
+    exact CodeReq.Disjoint.union_left
+      (CodeReq.Disjoint.singleton (by bv_omega))
+      (CodeReq.Disjoint.union_left
+        (CodeReq.Disjoint.singleton (by bv_omega))
+        (CodeReq.Disjoint.singleton (by bv_omega)))
+  have h_rounded_framed : cpsTripleWithin 3 base (base + 12)
+      (mload_compute_rounded_access_end_code roundReg endReg offReg base)
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ endOld) **
+       (roundReg ↦ᵣ roundOld) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ roundedAccessEnd) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld)) :=
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameR
+        ((sizeReg ↦ᵣ sizeBytesWord) ** (flagReg ↦ᵣ flagOld)) (by pcFree)
+        h_rounded)
+  have h_flag_framed : cpsTripleWithin 1 (base + 12) (base + 16)
+      (mload_compute_expand_flag_code flagReg sizeReg roundReg (base + 12))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ roundedAccessEnd) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ roundedAccessEnd) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ
+        (if BitVec.ult sizeBytesWord roundedAccessEnd then (1 : Word) else 0))) :=
+    cpsTripleWithin_weaken
+      (fun h hp => by xperm_hyp hp)
+      (fun h hp => by xperm_hyp hp)
+      (cpsTripleWithin_frameL
+        ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32))) (by pcFree)
+        h_flag)
+  exact cpsTripleWithin_seq hd h_rounded_framed h_flag_framed
+
+theorem mload_compute_rounded_access_flag_ofProg_spec_within
+    (flagReg sizeReg roundReg endReg offReg : Reg)
+    (offset endOld roundOld sizeBytesWord flagOld : Word) (base : Word)
+    (h_end_ne_x0 : endReg ≠ .x0)
+    (h_round_ne_x0 : roundReg ≠ .x0)
+    (h_flag_ne_x0 : flagReg ≠ .x0) :
+    cpsTripleWithin 4 base (base + 16)
+      (CodeReq.ofProg base
+        (mload_compute_rounded_access_flag flagReg sizeReg roundReg endReg offReg))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ endOld) **
+       (roundReg ↦ᵣ roundOld) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))) **
+       (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ
+        (if BitVec.ult sizeBytesWord
+          (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+         then (1 : Word) else 0))) := by
+  rw [← mload_compute_rounded_access_flag_code_eq_ofProg]
+  exact mload_compute_rounded_access_flag_spec_within
+    flagReg sizeReg roundReg endReg offReg offset endOld roundOld sizeBytesWord flagOld
+    base h_end_ne_x0 h_round_ne_x0 h_flag_ne_x0
+
+/--
   Store a precomputed 32-byte-access expanded high-water mark into the EVM
   memory-size cell. The arithmetic that computes
   `evmMemExpand sizeBytes offset 32` can be supplied by a caller or a later


### PR DESCRIPTION
Stacked on #2058.

Adds mload_compute_rounded_access_flag, its CodeReq/ofProg bridge, and a cpsTripleWithin spec composing the rounded MLOAD access-end computation with the executable SLTU comparison flag against the current memory size.

Refs evm-asm-yph8.2 and GH #99.

Local verification:
- lake build EvmAsm.Evm64.MLoad
- lake build
- scripts/check-file-size.sh --report
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MLoad/Expansion.lean (no matches)

Authored by @pirapira; implemented by Codex.