### PR TITLE
feat(mload): add size-select copy path

### DIFF
--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -491,6 +491,33 @@ theorem mload_select_expanded_size_ofProg_spec_within
     sizeReg roundReg flagReg sizeOld roundedAccessEnd flagVal base
 
 /--
+  Fall-through copy step for `mload_select_expanded_size`: when the dispatch
+  does not branch, this instruction copies the rounded access end into the
+  size register.
+-/
+theorem mload_select_expanded_size_copy_spec_within
+    (sizeReg roundReg flagReg : Reg)
+    (sizeOld roundedAccessEnd flagVal : Word) (base : Word)
+    (h_size_ne_x0 : sizeReg ≠ .x0) :
+    cpsTripleWithin 1 (base + 4) (base + 8)
+      (CodeReq.singleton (base + 4) (Instr.ADDI sizeReg roundReg 0))
+      ((flagReg ↦ᵣ flagVal) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sizeReg ↦ᵣ sizeOld) ** (roundReg ↦ᵣ roundedAccessEnd))
+      ((flagReg ↦ᵣ flagVal) ** (.x0 ↦ᵣ (0 : Word)) **
+       (sizeReg ↦ᵣ (roundedAccessEnd + 0)) ** (roundReg ↦ᵣ roundedAccessEnd)) := by
+  have haddi :=
+    addi_spec_gen_within sizeReg roundReg sizeOld roundedAccessEnd
+      (0 : BitVec 12) (base + 4) h_size_ne_x0
+  simp only [signExtend12_0] at haddi
+  rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at haddi
+  exact cpsTripleWithin_weaken
+    (fun h hp => by xperm_hyp hp)
+    (fun h hp => by xperm_hyp hp)
+    (cpsTripleWithin_frameL
+      ((flagReg ↦ᵣ flagVal) ** (.x0 ↦ᵣ (0 : Word))) (by pcFree)
+      haddi)
+
+/--
   Store a precomputed 32-byte-access expanded high-water mark into the EVM
   memory-size cell. The arithmetic that computes
   `evmMemExpand sizeBytes offset 32` can be supplied by a caller or a later

--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Memory
+import EvmAsm.Rv64.AddrNorm
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.XSimp
@@ -504,11 +505,12 @@ theorem mload_select_expanded_size_copy_spec_within
       ((flagReg ↦ᵣ flagVal) ** (.x0 ↦ᵣ (0 : Word)) **
        (sizeReg ↦ᵣ sizeOld) ** (roundReg ↦ᵣ roundedAccessEnd))
       ((flagReg ↦ᵣ flagVal) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sizeReg ↦ᵣ (roundedAccessEnd + 0)) ** (roundReg ↦ᵣ roundedAccessEnd)) := by
+       (sizeReg ↦ᵣ roundedAccessEnd) ** (roundReg ↦ᵣ roundedAccessEnd)) := by
   have haddi :=
     addi_spec_gen_within sizeReg roundReg sizeOld roundedAccessEnd
       (0 : BitVec 12) (base + 4) h_size_ne_x0
   simp only [signExtend12_0] at haddi
+  rw [EvmAsm.Rv64.AddrNorm.word_add_zero] at haddi
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at haddi
   exact cpsTripleWithin_weaken
     (fun h hp => by xperm_hyp hp)


### PR DESCRIPTION
Stacked on #2060.

Adds mload_select_expanded_size_copy_spec_within for the fall-through ADDI of mload_select_expanded_size. This proves the copy path writes roundedAccessEnd + 0 into the size register while preserving the flag/x0 context.

Refs evm-asm-yph8.4 and GH #99.

Local verification:
- lake build EvmAsm.Evm64.MLoad
- lake build
- scripts/check-file-size.sh --report
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MLoad/Expansion.lean (no matches)

Authored by @pirapira; implemented by Codex.