### PR TITLE
feat(mload): add compute-select ofProg bridge

### DIFF
--- a/EvmAsm/Evm64/MLoad/Expansion.lean
+++ b/EvmAsm/Evm64/MLoad/Expansion.lean
@@ -631,6 +631,26 @@ abbrev mload_compute_select_expanded_size_code
   (mload_compute_rounded_access_flag_code flagReg sizeReg roundReg endReg offReg base).union
     (mload_select_expanded_size_code sizeReg roundReg flagReg (base + 16))
 
+theorem mload_compute_select_expanded_size_code_eq_ofProg
+    (flagReg sizeReg roundReg endReg offReg : Reg) (base : Word) :
+    mload_compute_select_expanded_size_code flagReg sizeReg roundReg endReg offReg base =
+      CodeReq.ofProg base
+        (mload_compute_select_expanded_size flagReg sizeReg roundReg endReg offReg) := by
+  unfold mload_compute_select_expanded_size_code mload_compute_select_expanded_size
+  rw [mload_compute_rounded_access_flag_code_eq_ofProg,
+    mload_select_expanded_size_code_eq_ofProg]
+  unfold seq
+  rw [show base + 16 =
+      base + BitVec.ofNat 64
+        (4 * (mload_compute_rounded_access_flag flagReg sizeReg roundReg endReg offReg).length) by
+    unfold mload_compute_rounded_access_flag mload_compute_rounded_access_end
+      mload_compute_access_end mload_round_access_end mload_compute_expand_flag
+      ADDI ANDI single seq
+    rfl]
+  exact (CodeReq.ofProg_append (base := base)
+    (p1 := mload_compute_rounded_access_flag flagReg sizeReg roundReg endReg offReg)
+    (p2 := mload_select_expanded_size sizeReg roundReg flagReg)).symm
+
 /--
   Composed executable bridge for MLOAD memory expansion arithmetic through the
   high-water select stage. The selected size is the rounded access end exactly
@@ -731,6 +751,36 @@ theorem mload_compute_select_expanded_size_spec_within
         ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32))) (by pcFree)
         h_select)
   exact cpsTripleWithin_seq hd h_flag_framed h_select_framed
+
+theorem mload_compute_select_expanded_size_ofProg_spec_within
+    (flagReg sizeReg roundReg endReg offReg : Reg)
+    (offset endOld roundOld sizeBytesWord flagOld : Word) (base : Word)
+    (h_end_ne_x0 : endReg ≠ .x0)
+    (h_round_ne_x0 : roundReg ≠ .x0)
+    (h_flag_ne_x0 : flagReg ≠ .x0)
+    (h_size_ne_x0 : sizeReg ≠ .x0) :
+    cpsTripleWithin 6 base (base + 24)
+      (CodeReq.ofProg base
+        (mload_compute_select_expanded_size flagReg sizeReg roundReg endReg offReg))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ endOld) **
+       (roundReg ↦ᵣ roundOld) ** (sizeReg ↦ᵣ sizeBytesWord) **
+       (flagReg ↦ᵣ flagOld) ** (.x0 ↦ᵣ (0 : Word)))
+      ((offReg ↦ᵣ offset) ** (endReg ↦ᵣ (offset + 32)) **
+       (roundReg ↦ᵣ (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))) **
+       (sizeReg ↦ᵣ
+        (if BitVec.ult sizeBytesWord
+          (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+         then (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+         else sizeBytesWord)) **
+       (flagReg ↦ᵣ
+        (if BitVec.ult sizeBytesWord
+          (((offset + 32) + 31) &&& signExtend12 (-32 : BitVec 12))
+         then (1 : Word) else 0)) **
+       (.x0 ↦ᵣ (0 : Word))) := by
+  rw [← mload_compute_select_expanded_size_code_eq_ofProg]
+  exact mload_compute_select_expanded_size_spec_within
+    flagReg sizeReg roundReg endReg offReg offset endOld roundOld sizeBytesWord
+    flagOld base h_end_ne_x0 h_round_ne_x0 h_flag_ne_x0 h_size_ne_x0
 
 /--
   Store a precomputed 32-byte-access expanded high-water mark into the EVM


### PR DESCRIPTION
Stacked on #2063.\n\nAdds mload_compute_select_expanded_size_code_eq_ofProg and mload_compute_select_expanded_size_ofProg_spec_within so the MLOAD compute+select helper can be consumed through CodeReq.ofProg in downstream executable composition.\n\nVerification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MLoad/Expansion.lean (no matches)\n\nRefs evm-asm-ft28.\nAuthored by @pirapira; implemented by Codex.