### PR TITLE
feat(exp): lift loop-back spec to loop code

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -444,4 +444,19 @@ theorem expOneIterCode_loop_sub {base : Word}
           exact expLoopCode_loop_back_sub a _ (by assumption)
         · simp_all [CodeReq.empty]
 
+theorem exp_loop_back_loop_spec_within (c : Word)
+    (mulOff : BitVec 21) (skipOff backOff : BitVec 13)
+    (base target : Word)
+    (htarget : ((base + 24) + 4 : Word) + signExtend13 backOff = target) :
+    let cNew := c + signExtend12 ((-1 : BitVec 12))
+    cpsBranchWithin 2 (base + 24)
+      (expLoopCode base mulOff skipOff backOff)
+      ((.x9 ↦ᵣ c) ** (.x0 ↦ᵣ (0 : Word)))
+      target ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew ≠ 0⌝)
+      (base + 32) ((.x9 ↦ᵣ cNew) ** (.x0 ↦ᵣ (0 : Word)) ** ⌜cNew = 0⌝) := by
+  have h := EvmAsm.Evm64.exp_loop_back_spec_within c backOff (base + 24) target htarget
+  have hnext : ((base + 24 : Word) + 8) = base + 32 := by bv_omega
+  rw [hnext] at h
+  exact cpsBranchWithin_extend_code (h := h) (hmono := expLoopCode_loop_back_sub)
+
 end EvmAsm.Evm64.Exp.Compose


### PR DESCRIPTION
Adds exp_loop_back_loop_spec_within, extending the verified exp_loop_back branch spec over the concrete expLoopCode via expLoopCode_loop_back_sub. This gives later EXP loop composition a reusable taken/exit branch spec under the full one-iteration program CodeReq.\n\nVerification:\n- lake build EvmAsm.Evm64.Exp\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/Exp/Compose/Base.lean\n\nBead: evm-asm-6bti\nRefs: GH #92\n\nAuthored by @pirapira; implemented by Codex.