### PR TITLE
feat(push): lift zero-slot spec to push code

### DIFF
--- a/EvmAsm/Evm64/Push/Spec.lean
+++ b/EvmAsm/Evm64/Push/Spec.lean
@@ -99,6 +99,39 @@ theorem push_zero_slot_ofProg_spec_within
   rw [← push_zero_slot_code_eq_ofProg]
   exact push_zero_slot_spec_within sp d0 d1 d2 d3 base
 
+theorem evm_push_zero_slot_code_spec_within
+    (n : Nat) (hn : n ≤ 32) (sp d0 d1 d2 d3 : Word) (base : Word) :
+    let nsp := sp + signExtend12 ((-32 : BitVec 12))
+    cpsTripleWithin 5 base (base + 20) (evm_push_code base n)
+      ((.x12 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((nsp + signExtend12 (0 : BitVec 12)) ↦ₘ d0) **
+       ((nsp + signExtend12 (8 : BitVec 12)) ↦ₘ d1) **
+       ((nsp + signExtend12 (16 : BitVec 12)) ↦ₘ d2) **
+       ((nsp + signExtend12 (24 : BitVec 12)) ↦ₘ d3))
+      ((.x12 ↦ᵣ nsp) ** (.x0 ↦ᵣ (0 : Word)) **
+       ((nsp + signExtend12 (0 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((nsp + signExtend12 (8 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((nsp + signExtend12 (16 : BitVec 12)) ↦ₘ (0 : Word)) **
+       ((nsp + signExtend12 (24 : BitVec 12)) ↦ₘ (0 : Word))) := by
+  intro nsp
+  have hPrefix := push_zero_slot_ofProg_spec_within sp d0 d1 d2 d3 base
+  exact cpsTripleWithin_extend_code (h := hPrefix) (hmono := by
+    unfold evm_push_code
+    exact CodeReq.ofProg_mono_sub base base (evm_push n)
+      (ADDI .x12 .x12 (-32) ;; SD .x12 .x0 0 ;; SD .x12 .x0 8 ;;
+       SD .x12 .x0 16 ;; SD .x12 .x0 24) 0
+      (by bv_omega)
+      (by
+        unfold evm_push ADDI SD single seq
+        rfl)
+      (by
+        change 0 + 5 ≤ (evm_push n).length
+        rw [evm_push_length]
+        omega)
+      (by
+        rw [evm_push_length]
+        omega))
+
 /-- The four zero-filled limbs written by the PUSH allocation prefix fold to
     the EVM word value `0`. -/
 theorem push_zero_slot_word_zero (nsp : Word) :


### PR DESCRIPTION
Adds evm_push_zero_slot_code_spec_within, lifting the existing PUSH allocation/zero-fill prefix proof through evm_push_code for arbitrary PUSH1-32 widths (n ≤ 32). This is the first bridge from the parameterized executable evm_push n program to its verified prefix spec, without adding more concrete offset examples.\n\nVerification:\n- lake build EvmAsm.Evm64.Push\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/Push/Spec.lean\n\nBead: evm-asm-ugd1\nRefs: GH #101\n\nAuthored by @pirapira; implemented by Codex.