### PR TITLE
feat(mstore): lift prologue spec to stack code

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -77,4 +77,29 @@ def mstoreStackCode
     ((mstoreFourLimbsCode addrReg byteReg accReg base).union
       (mstoreEpilogueCode (base + 280)))
 
+theorem mstoreStackCode_prologue_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i, (mstorePrologueCode offReg addrReg memBaseReg base) a = some i →
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  unfold mstoreStackCode
+  exact CodeReq.union_mono_left
+
+theorem mstore_prologue_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  exact cpsTripleWithin_extend_code
+    (h := mstore_prologue_spec_within offReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    (hmono := mstoreStackCode_prologue_sub offReg byteReg accReg addrReg memBaseReg base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds mstoreStackCode_prologue_sub and mstore_prologue_stack_spec_within, lifting the verified MSTORE two-instruction address prologue into the bundled mstoreStackCode. This is a reusable bridge for the broader evm_mstore_stack_spec_within composition.\n\nVerification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MStore/Spec.lean\n\nBead: evm-asm-673b\nRefs: GH #99\n\nAuthored by @pirapira; implemented by Codex.