### PR TITLE
feat(mstore): expose first limb code in bundle

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -23,6 +23,15 @@ def mstoreFourLimbsCode
         (mstoreOneLimbCode addrReg byteReg accReg
           56 0 1 2 3 4 5 6 7 (base + 212))))
 
+theorem mstoreFourLimbsCode_limb0_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        32 24 25 26 27 28 29 30 31 (base + 8)) a = some i →
+      (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  unfold mstoreFourLimbsCode
+  exact CodeReq.union_mono_left
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=


### PR DESCRIPTION
Adds mstoreFourLimbsCode_limb0_sub, exposing the first value-limb mstoreOneLimbCode block under mstoreFourLimbsCode. This is a small structural bridge toward composing the four MSTORE limbs under the bundled code without duplicating the large limb spec.\n\nVerification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MStore/Spec.lean\n\nBead: evm-asm-ovms\nRefs: GH #99\n\nAuthored by @pirapira; implemented by Codex.