### PR TITLE
feat(push): prove generic byte-copy bridge

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -3275,8 +3275,42 @@ theorem push_bytes_length (n k : Nat) :
   | succ k ih =>
       unfold push_bytes
       unfold seq
-      rw [Program.length_append, ih, push_one_byte_length]
+      unfold Program at *
+      rw [List.length_append, ih, push_one_byte_length]
       omega
+
+private theorem push_bytes_byte_slice (n k i : Nat) (hi : i < k) :
+    ((push_bytes n k : List Instr).drop (2 * i)).take 2 =
+      (push_one_byte n i : List Instr) := by
+  induction k with
+  | zero =>
+      omega
+  | succ k ih =>
+      unfold push_bytes
+      unfold seq
+      by_cases h_i : i < k
+      · unfold Program at *
+        rw [List.drop_append]
+        rw [push_bytes_length]
+        rw [show 2 * i - 2 * k = 0 by omega]
+        simp only [List.drop_zero]
+        rw [List.take_append_of_le_length
+          (l₁ := (push_bytes n k).drop (2 * i)) (l₂ := push_one_byte n k) (i := 2)
+          (by
+            rw [List.length_drop, push_bytes_length]
+            omega)]
+        exact ih h_i
+      · have h_eq : i = k := by omega
+        subst i
+        unfold Program at *
+        rw [List.drop_append]
+        rw [push_bytes_length]
+        rw [show 2 * k - 2 * k = 0 by omega]
+        simp only [List.drop_zero]
+        rw [show (push_bytes n k).drop (2 * k) = [] by
+          exact List.drop_eq_nil_of_le (by rw [push_bytes_length]; omega)]
+        simp only [List.nil_append]
+        rw [List.take_of_length_le (by rw [push_one_byte_length]; omega)]
 
 /-- Generic PUSHn program.
 
@@ -3299,6 +3333,30 @@ theorem evm_push_length (n : Nat) :
   simp only [Program.length_append, List.length_cons, List.length_nil,
     push_bytes_length]
   omega
+
+/-- The `i`th PUSH byte-copy pair is the two-instruction slice beginning at
+    instruction offset `5 + 2 * i` of the generic `evm_push n` program. -/
+theorem evm_push_byte_slice {n i : Nat} (hi : i < n) :
+    ((evm_push n).drop (5 + 2 * i)).take 2 =
+      (LBU .x7 .x10 (BitVec.ofNat 12 (pushByteSrcOffset i)) ;;
+       SB .x12 .x7 (BitVec.ofNat 12 (pushByteDstOffset n i))) := by
+  unfold evm_push ADDI SD single seq
+  unfold Program at *
+  simp only [List.singleton_append]
+  rw [show 5 + 2 * i = Nat.succ (4 + 2 * i) by omega]
+  simp only [List.drop_succ_cons]
+  rw [show 4 + 2 * i = Nat.succ (3 + 2 * i) by omega]
+  simp only [List.drop_succ_cons]
+  rw [show 3 + 2 * i = Nat.succ (2 + 2 * i) by omega]
+  simp only [List.drop_succ_cons]
+  rw [show 2 + 2 * i = Nat.succ (1 + 2 * i) by omega]
+  simp only [List.drop_succ_cons]
+  rw [show 1 + 2 * i = Nat.succ (2 * i) by omega]
+  simp only [List.drop_succ_cons]
+  repeat rw [List.drop_succ_cons]
+  rw [push_bytes_byte_slice n n i hi]
+  unfold push_one_byte LBU SB single seq
+  rfl
 
 theorem evm_push1_length : (evm_push 1).length = 7 := by
   rw [evm_push_length]

--- a/EvmAsm/Evm64/Push/Spec.lean
+++ b/EvmAsm/Evm64/Push/Spec.lean
@@ -241,4 +241,65 @@ theorem push_one_byte_ofProg_spec_within
     codeDwordAddr dstDwordAddr codeOff dstOff base
     h_code_align h_code_valid h_dst_align h_dst_valid
 
+/-- Lift the one-byte PUSH copy spec under the full generic `evm_push n`
+    program for any byte index `i < n`. -/
+theorem evm_push_one_byte_spec_within
+    (n i : Nat) (hn : n ≤ 32) (hi : i < n)
+    (codePtr sp v7Old codeWord dstWordOld : Word)
+    (codeDwordAddr dstDwordAddr : Word) (base : Word)
+    (h_code_align :
+      alignToDword
+        (codePtr + signExtend12 (BitVec.ofNat 12 (pushByteSrcOffset i))) =
+          codeDwordAddr)
+    (h_code_valid :
+      isValidByteAccess
+        (codePtr + signExtend12 (BitVec.ofNat 12 (pushByteSrcOffset i))) = true)
+    (h_dst_align :
+      alignToDword
+        (sp + signExtend12 (BitVec.ofNat 12 (pushByteDstOffset n i))) =
+          dstDwordAddr)
+    (h_dst_valid :
+      isValidByteAccess
+        (sp + signExtend12 (BitVec.ofNat 12 (pushByteDstOffset n i))) = true) :
+    let codeOff := BitVec.ofNat 12 (pushByteSrcOffset i)
+    let dstOff := BitVec.ofNat 12 (pushByteDstOffset n i)
+    let subBase := base + BitVec.ofNat 64 (4 * (5 + 2 * i))
+    let byteZext :=
+      (extractByte codeWord (byteOffset (codePtr + signExtend12 codeOff))).zeroExtend 64
+    cpsTripleWithin 2 subBase (subBase + 8) (evm_push_code base n)
+      ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7Old) **
+       (codeDwordAddr ↦ₘ codeWord) ** (dstDwordAddr ↦ₘ dstWordOld))
+      ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ byteZext) **
+       (codeDwordAddr ↦ₘ codeWord) **
+       (dstDwordAddr ↦ₘ
+         replaceByte dstWordOld (byteOffset (sp + signExtend12 dstOff))
+           (byteZext.truncate 8))) := by
+  intro codeOff dstOff subBase byteZext
+  have hByte := push_one_byte_ofProg_spec_within
+    codePtr sp v7Old codeWord dstWordOld codeDwordAddr dstDwordAddr
+    codeOff dstOff subBase h_code_align h_code_valid h_dst_align h_dst_valid
+  exact cpsTripleWithin_extend_code (h := hByte) (hmono := by
+    unfold evm_push_code
+    exact CodeReq.ofProg_mono_sub base subBase (evm_push n)
+      (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff) (5 + 2 * i)
+      (by rfl)
+      (by
+        have hlen :
+            (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff).length = 2 := by
+          unfold LBU SB single seq
+          rfl
+        rw [hlen]
+        change ((evm_push n).drop (5 + 2 * i)).take 2 =
+          (LBU .x7 .x10 (BitVec.ofNat 12 (pushByteSrcOffset i)) ;;
+           SB .x12 .x7 (BitVec.ofNat 12 (pushByteDstOffset n i)))
+        rw [evm_push_byte_slice hi])
+      (by
+        rw [evm_push_length]
+        unfold LBU SB single seq
+        simp only [Program.length_append, List.length_cons, List.length_nil]
+        omega)
+      (by
+        rw [evm_push_length]
+        omega))
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Push/Spec.lean
+++ b/EvmAsm/Evm64/Push/Spec.lean
@@ -241,6 +241,37 @@ theorem push_one_byte_ofProg_spec_within
     codeDwordAddr dstDwordAddr codeOff dstOff base
     h_code_align h_code_valid h_dst_align h_dst_valid
 
+@[irreducible]
+def evmPushOneBytePost
+    (n i : Nat) (codePtr sp codeWord dstWordOld : Word)
+    (codeDwordAddr dstDwordAddr : Word) : Assertion :=
+  let codeOff := BitVec.ofNat 12 (pushByteSrcOffset i)
+  let dstOff := BitVec.ofNat 12 (pushByteDstOffset n i)
+  let byteZext :=
+    (extractByte codeWord (byteOffset (codePtr + signExtend12 codeOff))).zeroExtend 64
+  ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ byteZext) **
+   (codeDwordAddr ↦ₘ codeWord) **
+   (dstDwordAddr ↦ₘ
+     replaceByte dstWordOld (byteOffset (sp + signExtend12 dstOff))
+       (byteZext.truncate 8)))
+
+theorem evmPushOneBytePost_unfold
+    (n i : Nat) (codePtr sp codeWord dstWordOld : Word)
+    (codeDwordAddr dstDwordAddr : Word) :
+    evmPushOneBytePost n i codePtr sp codeWord dstWordOld
+      codeDwordAddr dstDwordAddr =
+    let codeOff := BitVec.ofNat 12 (pushByteSrcOffset i)
+    let dstOff := BitVec.ofNat 12 (pushByteDstOffset n i)
+    let byteZext :=
+      (extractByte codeWord (byteOffset (codePtr + signExtend12 codeOff))).zeroExtend 64
+    ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ byteZext) **
+     (codeDwordAddr ↦ₘ codeWord) **
+     (dstDwordAddr ↦ₘ
+       replaceByte dstWordOld (byteOffset (sp + signExtend12 dstOff))
+         (byteZext.truncate 8))) := by
+  delta evmPushOneBytePost
+  rfl
+
 /-- Lift the one-byte PUSH copy spec under the full generic `evm_push n`
     program for any byte index `i < n`. -/
 theorem evm_push_one_byte_spec_within
@@ -261,45 +292,46 @@ theorem evm_push_one_byte_spec_within
     (h_dst_valid :
       isValidByteAccess
         (sp + signExtend12 (BitVec.ofNat 12 (pushByteDstOffset n i))) = true) :
-    let codeOff := BitVec.ofNat 12 (pushByteSrcOffset i)
-    let dstOff := BitVec.ofNat 12 (pushByteDstOffset n i)
-    let subBase := base + BitVec.ofNat 64 (4 * (5 + 2 * i))
-    let byteZext :=
-      (extractByte codeWord (byteOffset (codePtr + signExtend12 codeOff))).zeroExtend 64
-    cpsTripleWithin 2 subBase (subBase + 8) (evm_push_code base n)
+    cpsTripleWithin 2 (base + BitVec.ofNat 64 (4 * (5 + 2 * i)))
+      ((base + BitVec.ofNat 64 (4 * (5 + 2 * i))) + 8)
+      (evm_push_code base n)
       ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ v7Old) **
        (codeDwordAddr ↦ₘ codeWord) ** (dstDwordAddr ↦ₘ dstWordOld))
-      ((.x10 ↦ᵣ codePtr) ** (.x12 ↦ᵣ sp) ** (.x7 ↦ᵣ byteZext) **
-       (codeDwordAddr ↦ₘ codeWord) **
-       (dstDwordAddr ↦ₘ
-         replaceByte dstWordOld (byteOffset (sp + signExtend12 dstOff))
-           (byteZext.truncate 8))) := by
-  intro codeOff dstOff subBase byteZext
+      (evmPushOneBytePost n i codePtr sp codeWord dstWordOld
+        codeDwordAddr dstDwordAddr) := by
+  let codeOff := BitVec.ofNat 12 (pushByteSrcOffset i)
+  let dstOff := BitVec.ofNat 12 (pushByteDstOffset n i)
+  let subBase := base + BitVec.ofNat 64 (4 * (5 + 2 * i))
   have hByte := push_one_byte_ofProg_spec_within
     codePtr sp v7Old codeWord dstWordOld codeDwordAddr dstDwordAddr
     codeOff dstOff subBase h_code_align h_code_valid h_dst_align h_dst_valid
-  exact cpsTripleWithin_extend_code (h := hByte) (hmono := by
-    unfold evm_push_code
-    exact CodeReq.ofProg_mono_sub base subBase (evm_push n)
-      (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff) (5 + 2 * i)
-      (by rfl)
-      (by
-        have hlen :
-            (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff).length = 2 := by
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      rw [evmPushOneBytePost_unfold]
+      exact hp)
+    (cpsTripleWithin_extend_code (h := hByte) (hmono := by
+      unfold evm_push_code
+      exact CodeReq.ofProg_mono_sub base subBase (evm_push n)
+        (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff) (5 + 2 * i)
+        (by rfl)
+        (by
+          have hlen :
+              (LBU .x7 .x10 codeOff ;; SB .x12 .x7 dstOff).length = 2 := by
+            unfold LBU SB single seq
+            rfl
+          rw [hlen]
+          change ((evm_push n).drop (5 + 2 * i)).take 2 =
+            (LBU .x7 .x10 (BitVec.ofNat 12 (pushByteSrcOffset i)) ;;
+             SB .x12 .x7 (BitVec.ofNat 12 (pushByteDstOffset n i)))
+          rw [evm_push_byte_slice hi])
+        (by
+          rw [evm_push_length]
           unfold LBU SB single seq
-          rfl
-        rw [hlen]
-        change ((evm_push n).drop (5 + 2 * i)).take 2 =
-          (LBU .x7 .x10 (BitVec.ofNat 12 (pushByteSrcOffset i)) ;;
-           SB .x12 .x7 (BitVec.ofNat 12 (pushByteDstOffset n i)))
-        rw [evm_push_byte_slice hi])
-      (by
-        rw [evm_push_length]
-        unfold LBU SB single seq
-        simp only [Program.length_append, List.length_cons, List.length_nil]
-        omega)
-      (by
-        rw [evm_push_length]
-        omega))
+          simp only [Program.length_append, List.length_cons, List.length_nil]
+          omega)
+        (by
+          rw [evm_push_length]
+          omega)))
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds a generalized PUSH byte-copy bridge instead of more concrete PUSH-width examples.\n\nSummary:\n- adds evm_push_byte_slice for arbitrary byte index i < n\n- adds evm_push_one_byte_spec_within lifting the existing LBU/SB byte-copy spec under evm_push_code\n\nVerification:\n- lake build EvmAsm.Evm64.Push\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- forbidden-pattern scan on modified PUSH files\n\nRefs: evm-asm-f0f5.9, GH #101.\n\nAuthored by @pirapira; implemented by Codex.