### PR TITLE
feat(mstore): add ofProg bridge specs

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -38,6 +38,17 @@ def mstorePrologueCode
   (CodeReq.singleton base (.LD offReg .x12 0)).union
     (CodeReq.singleton (base + 4) (.ADD addrReg memBaseReg offReg))
 
+theorem mstorePrologueCode_eq_ofProg
+    (offReg addrReg memBaseReg : Reg) (base : Word) :
+    mstorePrologueCode offReg addrReg memBaseReg base =
+      CodeReq.ofProg base
+        (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg) := by
+  unfold mstorePrologueCode LD ADD single seq
+  change _ =
+    CodeReq.ofProg base
+      [.LD offReg .x12 0, .ADD addrReg memBaseReg offReg]
+  rw [CodeReq.ofProg_cons, CodeReq.ofProg_singleton]
+
 /--
   MSTORE prologue spec: load the low 64-bit offset limb from the EVM stack and
   compute the concrete byte address `memBase + offset` used by the four
@@ -65,9 +76,33 @@ theorem mstore_prologue_spec_within
   rw [show (base + 4 : Word) + 4 = base + 8 from by bv_omega] at h_add
   runBlock h_ld h_add
 
+theorem mstore_prologue_ofProg_spec_within
+    (offReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (CodeReq.ofProg base
+        (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  rw [← mstorePrologueCode_eq_ofProg]
+  exact mstore_prologue_spec_within offReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+
 /-- CodeReq for the final MSTORE stack-pop epilogue. -/
 def mstoreEpilogueCode (base : Word) : CodeReq :=
   CodeReq.singleton base (.ADDI .x12 .x12 64)
+
+theorem mstoreEpilogueCode_eq_ofProg (base : Word) :
+    mstoreEpilogueCode base =
+      CodeReq.ofProg base (ADDI .x12 .x12 64) := by
+  unfold mstoreEpilogueCode ADDI single
+  rw [CodeReq.ofProg_singleton]
 
 /-- MSTORE epilogue spec: pop the offset and value words from the EVM stack. -/
 theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
@@ -77,6 +112,14 @@ theorem mstore_epilogue_spec_within (sp : Word) (base : Word) :
       (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
   unfold mstoreEpilogueCode
   exact addi_spec_gen_same_within (.x12 : Reg) sp 64 base (by nofun)
+
+theorem mstore_epilogue_ofProg_spec_within (sp : Word) (base : Word) :
+    cpsTripleWithin 1 base (base + 4)
+      (CodeReq.ofProg base (ADDI .x12 .x12 64))
+      (((.x12 : Reg) ↦ᵣ sp))
+      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
+  rw [← mstoreEpilogueCode_eq_ofProg]
+  exact mstore_epilogue_spec_within sp base
 
 /-- Compact CodeReq for the full MSTORE program, split into prologue, four
     one-limb byte-unpack blocks, and the final stack-pop epilogue. -/


### PR DESCRIPTION
Adds CodeReq.ofProg equality bridges and consumer-facing ofProg specs for the MSTORE address prologue and stack-pop epilogue.\n\nThis is a narrow executable-spec bridge for GH #99 / bead evm-asm-k655.1, intended to support later MSTORE stack composition without adding more concrete one-off examples.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MStore/Spec.lean\n\nAuthored by @pirapira; implemented by Codex.