### PR TITLE
feat(rlp): bridge phase3 prefixes to helpers

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase3LongString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3LongString.lean
@@ -33,6 +33,7 @@
     x14 — output: length-of-length counter (= prefix − 0xB7)
 -/
 
+import EvmAsm.EL.RLP.ProgramSpec
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 
@@ -176,6 +177,32 @@ theorem rlp_phase3_long_string_spec_within
     · exact CodeReq.Disjoint.singleton (by bv_omega)
     exact CodeReq.Disjoint.ofProg_nil_right _ _
   exact cpsTripleWithin_seq hd1_23 s1 s23_raw
+
+theorem rlp_phase3_long_string_lenOfLen_of_class_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte) (v11Old v13 v14Old : Word) (base : Word)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx =
+      EvmAsm.EL.RLP.PrefixClass.longBytes) :
+    cpsTripleWithin 3 base (base + 12)
+      (CodeReq.ofProg base rlp_phase3_long_string_prog)
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+       (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14Old))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+       (.x11 ↦ᵣ (0 : Word)) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+       (.x14 ↦ᵣ
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixLongBytesLenOfLen pfx) : Word))) := by
+  have h_add_sub :
+      pfx.zeroExtend 64 + signExtend12 (-(0xB7 : BitVec 12)) =
+        pfx.zeroExtend 64 - (0xB7 : Word) := by
+    native_decide +revert
+  have h_len :=
+    EvmAsm.EL.RLP.rlpPrefixLongBytesLenOfLen_toWord_of_class pfx h_class
+  have h_add :
+      pfx.zeroExtend 64 + signExtend12 (-(0xB7 : BitVec 12)) =
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixLongBytesLenOfLen pfx) : Word) := by
+    rw [h_add_sub, ← h_len]
+  rw [← h_add]
+  exact rlp_phase3_long_string_spec_within (pfx.zeroExtend 64) v11Old v13 v14Old base
 
 theorem rlp_phase3_long_string_spec_at_0xB8_within
     (v11Old v13 v14Old : Word) (base : Word) :

--- a/EvmAsm/Rv64/RLP/Phase3ShortString.lean
+++ b/EvmAsm/Rv64/RLP/Phase3ShortString.lean
@@ -24,6 +24,7 @@
                          first payload byte)
 -/
 
+import EvmAsm.EL.RLP.ProgramSpec
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 
@@ -117,6 +118,30 @@ theorem rlp_phase3_short_string_spec_within (v5 v11Old v13 : Word) (base : Word)
       (fun _ hp => by xperm_hyp hp)
       framed
   exact cpsTripleWithin_seq hd s1 s2
+
+theorem rlp_phase3_short_string_payload_len_of_class_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte) (v11Old v13 : Word) (base : Word)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx =
+      EvmAsm.EL.RLP.PrefixClass.shortBytes) :
+    cpsTripleWithin 2 base (base + 8)
+      (CodeReq.ofProg base rlp_phase3_short_string_prog)
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13))
+      ((.x5 ↦ᵣ pfx.zeroExtend 64) **
+       (.x11 ↦ᵣ
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen pfx) : Word)) **
+       (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12)))) := by
+  have h_add_sub :
+      pfx.zeroExtend 64 + signExtend12 (-(0x80 : BitVec 12)) =
+        pfx.zeroExtend 64 - (0x80 : Word) := by
+    native_decide +revert
+  have h_len :=
+    EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen_toWord_of_class pfx h_class
+  have h_add :
+      pfx.zeroExtend 64 + signExtend12 (-(0x80 : BitVec 12)) =
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixShortBytesPayloadLen pfx) : Word) := by
+    rw [h_add_sub, ← h_len]
+  rw [← h_add]
+  exact rlp_phase3_short_string_spec_within (pfx.zeroExtend 64) v11Old v13 base
 
 theorem rlp_phase3_short_string_spec_at_0x80_within
     (v11Old v13 : Word) (base : Word) :


### PR DESCRIPTION
Adds class-parametric Rv64 Phase 3 bridge specs that expose the semantic payload fields through the pure EL/RLP prefix helpers.\n\nThis covers GH #120 / bead evm-asm-h6mz.8 and avoids adding more concrete at_0x.. Phase 3 examples:\n- short byte-string: x11 = rlpPrefixShortBytesPayloadLen pfx\n- long byte-string: x14 = rlpPrefixLongBytesLenOfLen pfx\n\nLocal verification:\n- lake build EvmAsm.Rv64.RLP\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Rv64/RLP/Phase3ShortString.lean EvmAsm/Rv64/RLP/Phase3LongString.lean\n\nAuthored by @pirapira; implemented by Codex.