### PR TITLE
feat(mstore): bridge prologue epilogue to program

### DIFF
--- a/EvmAsm/Evm64/MStore/Program.lean
+++ b/EvmAsm/Evm64/MStore/Program.lean
@@ -135,6 +135,23 @@ private theorem mstore_one_limb_length
   rw [Program.length_append, mstore_byte_unpack_7_length]
   rfl
 
+private def evm_mstore_prefix
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) : Program :=
+  let _ := valReg
+  LD offReg .x12 0 ;;
+  ADD addrReg memBaseReg offReg ;;
+  mstore_one_limb addrReg byteReg accReg 0 ;;
+  mstore_one_limb addrReg byteReg accReg 1 ;;
+  mstore_one_limb addrReg byteReg accReg 2 ;;
+  mstore_one_limb addrReg byteReg accReg 3
+
+private theorem evm_mstore_prefix_length
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
+    (evm_mstore_prefix offReg valReg byteReg accReg addrReg memBaseReg).length =
+      70 := by
+  simp [evm_mstore_prefix, LD, ADD, single, seq, Program.length_append,
+    mstore_one_limb_length]
+
 /-- 256-bit EVM `MSTORE` program.
 
     Pops a 32-byte `offset` from the EVM stack at `x12 + 0`, a 32-byte
@@ -150,13 +167,7 @@ private theorem mstore_one_limb_length
     without changing call sites. -/
 def evm_mstore (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
     Program :=
-  let _ := valReg
-  LD offReg .x12 0 ;;
-  ADD addrReg memBaseReg offReg ;;
-  mstore_one_limb addrReg byteReg accReg 0 ;;
-  mstore_one_limb addrReg byteReg accReg 1 ;;
-  mstore_one_limb addrReg byteReg accReg 2 ;;
-  mstore_one_limb addrReg byteReg accReg 3 ;;
+  evm_mstore_prefix offReg valReg byteReg accReg addrReg memBaseReg ;;
   ADDI .x12 .x12 (BitVec.ofNat 12 64)
 
 /-- `CodeReq` for `evm_mstore` placed at `base`. -/
@@ -169,8 +180,48 @@ abbrev evm_mstore_code
 theorem evm_mstore_length
     (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
     (evm_mstore offReg valReg byteReg accReg addrReg memBaseReg).length = 71 := by
-  simp [evm_mstore, LD, ADD, ADDI, single, seq, Program.length_append,
-    mstore_one_limb_length]
+  simp [evm_mstore, ADDI, single, seq, Program.length_append,
+    evm_mstore_prefix_length]
+
+theorem evm_mstore_prologue_slice
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
+    ((evm_mstore offReg valReg byteReg accReg addrReg memBaseReg).drop 0).take
+      (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg).length =
+      (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg) := by
+  simp only [evm_mstore, evm_mstore_prefix, LD, ADD, single, seq, Program,
+    List.drop_zero]
+  let prologue : List Instr :=
+    [Instr.LD offReg .x12 0] ++ [Instr.ADD addrReg memBaseReg offReg]
+  let suffix : List Instr :=
+    (mstore_one_limb addrReg byteReg accReg 0 ++
+      (mstore_one_limb addrReg byteReg accReg 1 ++
+        (mstore_one_limb addrReg byteReg accReg 2 ++
+          mstore_one_limb addrReg byteReg accReg 3))) ++
+      ADDI .x12 .x12 (BitVec.ofNat 12 64)
+  change List.take prologue.length (prologue ++ suffix) = prologue
+  exact List.take_left
+
+theorem evm_mstore_epilogue_slice
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
+    ((evm_mstore offReg valReg byteReg accReg addrReg memBaseReg).drop 70).take
+        (ADDI .x12 .x12 (BitVec.ofNat 12 64)).length =
+      (ADDI .x12 .x12 (BitVec.ofNat 12 64)) := by
+  unfold evm_mstore
+  simp only [seq, Program, ADDI, single]
+  let pre : List Instr := evm_mstore_prefix offReg valReg byteReg accReg addrReg memBaseReg
+  let suffix : List Instr := [Instr.ADDI .x12 .x12 (BitVec.ofNat 12 64)]
+  change List.take suffix.length
+      (List.drop 70 (pre ++ suffix)) = suffix
+  have hdrop :
+      List.drop 70 (pre ++ suffix) =
+        suffix := by
+    have hpre_len : pre.length = 70 := by
+      dsimp [pre]
+      exact evm_mstore_prefix_length offReg valReg byteReg accReg addrReg memBaseReg
+    rw [← hpre_len]
+    exact List.drop_left
+  rw [hdrop]
+  simp
 
 /-- Concrete byte length of `evm_mstore` when placed in RV64 code memory. -/
 theorem evm_mstore_byte_length

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -4,6 +4,7 @@
   Stack-level building blocks for the 256-bit EVM MSTORE program.
 -/
 
+import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore.LimbSpec
 
 namespace EvmAsm.Evm64
@@ -94,6 +95,46 @@ theorem mstore_prologue_ofProg_spec_within
   exact mstore_prologue_spec_within offReg addrReg memBaseReg
     sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
 
+theorem evm_mstore_code_prologue_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (CodeReq.ofProg base (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg)) a =
+        some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a =
+        some i := by
+  unfold evm_mstore_code
+  exact CodeReq.ofProg_mono_sub base base
+    (evm_mstore offReg valReg byteReg accReg addrReg memBaseReg)
+    (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg) 0
+    (by bv_omega)
+    (evm_mstore_prologue_slice offReg valReg byteReg accReg addrReg memBaseReg)
+    (by
+      rw [evm_mstore_length]
+      change 2 ≤ 71
+      norm_num)
+    (by
+      rw [evm_mstore_length]
+      norm_num)
+
+theorem mstore_prologue_evm_mstore_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  exact cpsTripleWithin_extend_code
+    (h := mstore_prologue_ofProg_spec_within offReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    (hmono := evm_mstore_code_prologue_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
+
 /-- CodeReq for the final MSTORE stack-pop epilogue. -/
 def mstoreEpilogueCode (base : Word) : CodeReq :=
   CodeReq.singleton base (.ADDI .x12 .x12 64)
@@ -120,6 +161,40 @@ theorem mstore_epilogue_ofProg_spec_within (sp : Word) (base : Word) :
       (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
   rw [← mstoreEpilogueCode_eq_ofProg]
   exact mstore_epilogue_spec_within sp base
+
+theorem evm_mstore_code_epilogue_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (CodeReq.ofProg (base + 280) (ADDI .x12 .x12 (BitVec.ofNat 12 64))) a =
+        some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a =
+        some i := by
+  unfold evm_mstore_code
+  exact CodeReq.ofProg_mono_sub base (base + 280)
+    (evm_mstore offReg valReg byteReg accReg addrReg memBaseReg)
+    (ADDI .x12 .x12 (BitVec.ofNat 12 64)) 70
+    (by bv_omega)
+    (evm_mstore_epilogue_slice offReg valReg byteReg accReg addrReg memBaseReg)
+    (by
+      rw [evm_mstore_length]
+      simp [ADDI, single])
+    (by
+      rw [evm_mstore_length]
+      norm_num)
+
+theorem mstore_epilogue_evm_mstore_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp : Word) (base : Word) :
+    cpsTripleWithin 1 (base + 280) (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp))
+      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
+  have h := mstore_epilogue_ofProg_spec_within sp (base + 280)
+  rw [show (base + 280 : Word) + 4 = base + 284 from by bv_addr] at h
+  exact cpsTripleWithin_extend_code
+    (h := h)
+    (hmono := evm_mstore_code_epilogue_sub
+      offReg valReg byteReg accReg addrReg memBaseReg base)
 
 /-- Compact CodeReq for the full MSTORE program, split into prologue, four
     one-limb byte-unpack blocks, and the final stack-pop epilogue. -/


### PR DESCRIPTION
Adds actual evm_mstore_code prologue and epilogue bridge specs for bead evm-asm-k655.2 / GH #99.\n\nThis avoids adding more concrete examples and gives downstream MSTORE stack composition executable-program handles for the prologue and final stack-pop epilogue.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden-pattern scan on edited MSTORE files\n\nAuthored by @pirapira; implemented by Codex.