### PR TITLE
prove(exp): name mul callable layout facts

### DIFF
--- a/EvmAsm/Evm64/Multiply/Callable.lean
+++ b/EvmAsm/Evm64/Multiply/Callable.lean
@@ -41,7 +41,13 @@ open EvmAsm.Rv64
 def mul_callable : Program := evm_mul ;; cc_ret
 
 /-- 63 (`evm_mul`) + 1 (`cc_ret`) = 64 instructions. -/
-example : mul_callable.length = 64 := by decide
+theorem mul_callable_length : mul_callable.length = 64 := by decide
+
+theorem mul_callable_ret_byte_off : 4 * (evm_mul).length = 252 := by
+  native_decide
+
+theorem mul_callable_byte_length : 4 * mul_callable.length = 256 := by
+  rw [mul_callable_length]
 
 -- ============================================================================
 -- Code-region helper


### PR DESCRIPTION
Adds public MUL callable layout facts for bead evm-asm-j594 / GH #92.\n\nThis replaces the anonymous length example with named theorems EXP layout proofs can cite when pinning JAL/return offsets:\n- mul_callable_length\n- mul_callable_ret_byte_off\n- mul_callable_byte_length\n\nLocal verification:\n- lake build EvmAsm.Evm64.Multiply.Callable\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden-pattern scan on edited file\n\nAuthored by @pirapira; implemented by Codex.