### PR TITLE
prove(exp): expose mul callable code blocks

### DIFF
--- a/EvmAsm/Evm64/Multiply/Callable.lean
+++ b/EvmAsm/Evm64/Multiply/Callable.lean
@@ -70,6 +70,27 @@ private theorem mul_callable_codes_disjoint (base : Word) :
   unfold mul_col0 mul_col1 mul_col2 mul_col3
   crDisjoint
 
+theorem mul_callable_code_mul_sub (base : Word) :
+    ∀ a i, (evm_mul_code base) a = some i →
+      (mul_callable_code base) a = some i := by
+  unfold mul_callable_code
+  exact CodeReq.union_mono_left
+
+theorem mul_callable_code_ret_sub (base : Word) :
+    ∀ a i, (cc_ret_code (base + 252)) a = some i →
+      (mul_callable_code base) a = some i := by
+  unfold mul_callable_code
+  apply CodeReq.mono_union_right (mul_callable_codes_disjoint base)
+  intro a i h
+  exact h
+
+theorem mul_callable_code_block_subs (base : Word) :
+    (∀ a i, (evm_mul_code base) a = some i →
+      (mul_callable_code base) a = some i) ∧
+    (∀ a i, (cc_ret_code (base + 252)) a = some i →
+      (mul_callable_code base) a = some i) := by
+  exact ⟨mul_callable_code_mul_sub base, mul_callable_code_ret_sub base⟩
+
 -- ============================================================================
 -- Callable spec
 -- ============================================================================


### PR DESCRIPTION
Stacked on #2080.\n\nAdds public MUL callable CodeReq block inclusion lemmas for bead evm-asm-yqmt / GH #92:\n- mul_callable_code_mul_sub\n- mul_callable_code_ret_sub\n- mul_callable_code_block_subs\n\nThese expose the evm_mul body and cc_ret tail under mul_callable_code for future EXP call composition without exposing the private disjointness proof.\n\nLocal verification:\n- lake build EvmAsm.Evm64.Multiply.Callable\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg forbidden-pattern scan on edited file\n\nAuthored by @pirapira; implemented by Codex.