### PR TITLE
prove(exp): name mul program layout facts

### DIFF
--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -155,8 +155,17 @@ def evm_mul : Program :=
 -- Instruction count verification
 -- ============================================================================
 
-/-- evm_mul has exactly 63 instructions. -/
-example : evm_mul.length = 63 := by decide
+/-- `evm_mul` has exactly 63 instructions. -/
+theorem evm_mul_length : evm_mul.length = 63 := by decide
+
+/-- The epilogue starts at byte offset 248 within `evm_mul`. -/
+theorem evm_mul_epilogue_byte_off :
+    4 * (mul_col0.length + mul_col1.length + mul_col2.length + mul_col3.length) = 248 := by
+  native_decide
+
+/-- `evm_mul` occupies exactly 252 bytes. -/
+theorem evm_mul_byte_length : 4 * evm_mul.length = 252 := by
+  rw [evm_mul_length]
 
 -- ============================================================================
 -- Test infrastructure


### PR DESCRIPTION
Adds named reusable layout facts for evm_mul in EvmAsm/Evm64/Multiply/Program.lean so EXP call layout proofs can cite stable theorem names instead of anonymous examples.\n\nLocal checks:\n- lake build EvmAsm.Evm64.Multiply\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n\nReferences evm-asm-elqw / GH #92.\n\nAuthored by @pirapira; implemented by Codex.