### PR TITLE
prove(mload): lift prologue under full code

### DIFF
--- a/EvmAsm/Evm64/MLoad/Program.lean
+++ b/EvmAsm/Evm64/MLoad/Program.lean
@@ -156,6 +156,22 @@ theorem evm_mload_length (offReg byteReg accReg addrReg memBaseReg : Reg) :
   simp [evm_mload, LD, ADD, single, seq, Program.length_append,
     mload_one_limb_length]
 
+theorem evm_mload_prologue_slice
+    (offReg byteReg accReg addrReg memBaseReg : Reg) :
+    ((evm_mload offReg byteReg accReg addrReg memBaseReg).drop 0).take
+      (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg).length =
+      (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg) := by
+  simp only [evm_mload, LD, ADD, single, seq, Program, List.drop_zero]
+  let prologue : List Instr :=
+    [Instr.LD offReg .x12 0] ++ [Instr.ADD addrReg memBaseReg offReg]
+  let suffix : List Instr :=
+    mload_one_limb addrReg byteReg accReg 0 ++
+      (mload_one_limb addrReg byteReg accReg 1 ++
+        (mload_one_limb addrReg byteReg accReg 2 ++
+          mload_one_limb addrReg byteReg accReg 3))
+  change List.take prologue.length (prologue ++ suffix) = prologue
+  exact List.take_left
+
 /-- Concrete byte length of `evm_mload` when placed in RV64 code memory. -/
 theorem evm_mload_byte_length (offReg byteReg accReg addrReg memBaseReg : Reg) :
     4 * (evm_mload offReg byteReg accReg addrReg memBaseReg).length = 376 := by

--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -78,6 +78,46 @@ theorem mload_prologue_ofProg_spec_within
   exact mload_prologue_spec_within offReg addrReg memBaseReg
     sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
 
+theorem evm_mload_code_prologue_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i,
+      (CodeReq.ofProg base (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg)) a =
+        some i →
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base) a =
+        some i := by
+  unfold evm_mload_code
+  exact CodeReq.ofProg_mono_sub base base
+    (evm_mload offReg byteReg accReg addrReg memBaseReg)
+    (LD offReg .x12 0 ;; ADD addrReg memBaseReg offReg) 0
+    (by bv_omega)
+    (evm_mload_prologue_slice offReg byteReg accReg addrReg memBaseReg)
+    (by
+      rw [evm_mload_length]
+      change 2 ≤ 94
+      norm_num)
+    (by
+      rw [evm_mload_length]
+      norm_num)
+
+theorem mload_prologue_evm_mload_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mload_code offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  exact cpsTripleWithin_extend_code
+    (h := mload_prologue_ofProg_spec_within offReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    (hmono := evm_mload_code_prologue_sub
+      offReg byteReg accReg addrReg memBaseReg base)
+
 /-- The 256-bit value assembled by MLOAD from four little-endian output limbs. -/
 def mloadLoadedWord (l0 l1 l2 l3 : Word) : EvmWord :=
   EvmWord.fromLimbs fun i : Fin 4 =>


### PR DESCRIPTION
Stacked on #2086.\n\nAdds the MLOAD prologue program-slice bridge and exposes the address prologue spec under evm_mload_code.\n\nChanges:\n- add evm_mload_prologue_slice\n- add evm_mload_code_prologue_sub\n- add mload_prologue_evm_mload_spec_within\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check\n\nRefs evm-asm-vglb, GH #99.\n\nAuthored by @pirapira; implemented by Codex.