### PR TITLE
prove(rlp): bridge e5 full path to long-list class

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase1E5FullPath.lean
+++ b/EvmAsm/Rv64/RLP/Phase1E5FullPath.lean
@@ -117,4 +117,67 @@ theorem rlp_phase1_e5_full_path_spec'_within
     v5 v10 v11Old v13 v14Old off1 off2 off3 off4 base
     hv5_lo hv5_2 hv5_3 hv5_hi hd_phase3
 
+/--
+  Class-level long-list wrapper for the full Phase 1 → Phase 3 e5 path.
+  The output length-of-length counter is restated as the pure RLP
+  `rlpPrefixLongListLenOfLen` value.
+-/
+theorem rlp_phase1_e5_full_path_lenOfLen_of_class_spec_within
+    (pfx : EvmAsm.EL.RLP.Byte) (v10 v11Old v13 v14Old : Word)
+    (off1 off2 off3 off4 : BitVec 13) (base : Word)
+    (h_class : EvmAsm.EL.RLP.classifyPrefix pfx =
+      EvmAsm.EL.RLP.PrefixClass.longList)
+    (hd_phase3 :
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24)))))).Disjoint
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog)) :
+    cpsTripleWithin 11 base (base + 44)
+      (((rlp_phase1_step_code 0x80 off1 base).union
+        ((rlp_phase1_step_code 0xB8 off2 (base + 8)).union
+          ((rlp_phase1_step_code 0xC0 off3 (base + 16)).union
+            (rlp_phase1_step_code 0xF8 off4 (base + 24))))).union
+        (CodeReq.ofProg (base + 32) rlp_phase3_long_list_prog))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) ** (.x10 ↦ᵣ v10) **
+        (.x11 ↦ᵣ v11Old) ** (.x13 ↦ᵣ v13) ** (.x14 ↦ᵣ v14Old))
+      ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ pfx.zeroExtend 64) **
+        (.x10 ↦ᵣ ((0 : Word) + signExtend12 (0xF8 : BitVec 12))) **
+        (.x11 ↦ᵣ (0 : Word)) **
+        (.x13 ↦ᵣ (v13 + signExtend12 (1 : BitVec 12))) **
+        (.x14 ↦ᵣ
+          (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixLongListLenOfLen pfx) : Word))) := by
+  have h_range :=
+    (EvmAsm.EL.RLP.classifyPrefix_longList_iff pfx).mp h_class
+  have hv5_lo :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0x80 : BitVec 12)) := by
+    native_decide +revert
+  have hv5_2 :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xB8 : BitVec 12)) := by
+    native_decide +revert
+  have hv5_3 :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xC0 : BitVec 12)) := by
+    native_decide +revert
+  have hv5_hi :
+      ¬ BitVec.ult (pfx.zeroExtend 64)
+        ((0 : Word) + signExtend12 (0xF8 : BitVec 12)) := by
+    native_decide +revert
+  have h_add_sub :
+      pfx.zeroExtend 64 + signExtend12 (-(0xF7 : BitVec 12)) =
+        pfx.zeroExtend 64 - (0xF7 : Word) := by
+    native_decide +revert
+  have h_len :=
+    EvmAsm.EL.RLP.rlpPrefixLongListLenOfLen_toWord_of_class pfx h_class
+  have h_add :
+      pfx.zeroExtend 64 + signExtend12 (-(0xF7 : BitVec 12)) =
+        (BitVec.ofNat 64 (EvmAsm.EL.RLP.rlpPrefixLongListLenOfLen pfx) : Word) := by
+    rw [h_add_sub, ← h_len]
+  rw [← h_add]
+  exact rlp_phase1_e5_full_path_spec'_within
+    (pfx.zeroExtend 64) v10 v11Old v13 v14Old off1 off2 off3 off4 base
+    hv5_lo hv5_2 hv5_3 hv5_hi hd_phase3
+
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Stacked on #2090.\n\nAdds rlp_phase1_e5_full_path_lenOfLen_of_class_spec_within, a class-level wrapper for the executable Phase 1 to Phase 3 e5 long-list path. The theorem takes classifyPrefix pfx = PrefixClass.longList and exposes x14 as rlpPrefixLongListLenOfLen pfx.\n\nBeads: evm-asm-klut\nGH: #120\n\nLocal verification:\n- lake build EvmAsm.Rv64.RLP\n- lake build\n- scripts/check-file-size.sh --report\n- git diff --check