### PR TITLE
prove(exp): fold boundary result into stack tail

### DIFF
--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -117,6 +117,39 @@ theorem exp_boundary_result_one_stack_spec_within
     (exp_boundary_stack_spec_within sp evmSp cOld tOld m0 m1 m2 m3 base
       baseWord exponentWord rest)
 
+/-- Boundary bridge with the produced one-word result folded into the visible
+    stack tail. The old base operand cell is still framed explicitly because
+    the boundary mini-program is only the prologue/epilogue skeleton, not the
+    final EXP loop that consumes both operands semantically. -/
+theorem exp_boundary_result_one_stack_tail_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmWordIs evmSp baseWord **
+       evmWordIs (evmSp + 32) exponentWord **
+       evmStackIs (evmSp + 64) rest)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ ((0 : Word) + signExtend12 (256 : BitVec 12))) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmWordIs evmSp baseWord **
+       evmStackIs (evmSp + 32) ((1 : EvmWord) :: rest)) := by
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      rw [evmStackIs_cons]
+      rw [show (evmSp + 32 : Word) + 32 = evmSp + 64 from by bv_addr]
+      xperm_hyp hp)
+    (exp_boundary_result_one_stack_spec_within sp evmSp cOld tOld m0 m1 m2 m3 base
+      baseWord exponentWord rest)
+
 -- Placeholder: `evm_exp_stack_spec_within` lands in slice 6 (evm-asm-6snn).
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2099.

Adds exp_boundary_result_one_stack_tail_spec_within, folding the boundary output slot plus rest into evmStackIs (evmSp + 32) ((1 : EvmWord) :: rest) while keeping the old base operand cell framed explicitly.

Refs evm-asm-25x6 / GH #92.

Verification:
- lake build EvmAsm.Evm64.Exp
- lake build
- scripts/check-file-size.sh --report
- git diff --check
- rg forbidden proof escapes in EvmAsm/Evm64/Exp/Spec.lean

Authored by @pirapira; implemented by Codex.