### PR TITLE
prove(mload): add byte-window offset bridge

### DIFF
--- a/EvmAsm/Evm64/MLoad.lean
+++ b/EvmAsm/Evm64/MLoad.lean
@@ -3,5 +3,6 @@ import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Evm64.MLoad.LimbSpec
 import EvmAsm.Evm64.MLoad.LimbSpecEight
 import EvmAsm.Evm64.MLoad.Spec
+import EvmAsm.Evm64.MLoad.ByteWindow
 import EvmAsm.Evm64.MLoad.StackSpec
 import EvmAsm.Evm64.MLoad.Expansion

--- a/EvmAsm/Evm64/MLoad/ByteWindow.lean
+++ b/EvmAsm/Evm64/MLoad/ByteWindow.lean
@@ -1,0 +1,37 @@
+/-
+  EvmAsm.Evm64.MLoad.ByteWindow
+
+  Small semantic bridges for the unaligned MLOAD byte-window helpers in
+  `MLoad.Spec`. These lemmas make explicit that the byte selected from a
+  dword pair is governed by the runtime byte offset and selected dword value;
+  no alignment premise is needed at this pure layer.
+-/
+
+import EvmAsm.Evm64.MLoad.Spec
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+/-- Generic byte-window bridge for MLOAD: once a runtime address has the
+    expected byte offset, the dword-pair byte helper is just `extractByte`
+    from the selected low/high dword value at that runtime offset. -/
+theorem mloadByteFromDwordPair_eq_extractByte_of_byteOffset
+    (loVal hiVal addr : Word) (start i : Nat)
+    (h_byte : byteOffset addr = (start + i) % 8) :
+    mloadByteFromDwordPair loVal hiVal start i =
+      extractByte (mloadDwordPairVal loVal hiVal start i) (byteOffset addr) := by
+  rw [mloadByteFromDwordPair_eq_extractByte_pair, h_byte]
+
+/-- Zero-extended form of `mloadByteFromDwordPair_eq_extractByte_of_byteOffset`
+    for executable specs whose byte loads land in 64-bit registers. -/
+theorem mloadByteFromDwordPair_zeroExtend_eq_extractByte_of_byteOffset
+    (loVal hiVal addr : Word) (start i : Nat)
+    (h_byte : byteOffset addr = (start + i) % 8) :
+    (mloadByteFromDwordPair loVal hiVal start i).zeroExtend 64 =
+      (extractByte (mloadDwordPairVal loVal hiVal start i)
+        (byteOffset addr)).zeroExtend 64 := by
+  rw [mloadByteFromDwordPair_eq_extractByte_of_byteOffset
+    loVal hiVal addr start i h_byte]
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds EvmAsm.Evm64.MLoad.ByteWindow with generic byte-window bridges showing mloadByteFromDwordPair is extractByte from the selected low/high dword value at the runtime byteOffset. This makes the no-alignment premise explicit at the pure helper layer and keeps new lines out of the grandfathered MLoad/Spec.lean file.

Refs evm-asm-rsqq / GH #99.

Verification:
- lake build EvmAsm.Evm64.MLoad
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in the touched files

Authored by @pirapira; implemented by Codex.