### PR TITLE
prove(mload): lift prologue under stack code

### DIFF
--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -1520,4 +1520,25 @@ theorem mloadLoadedWordFromBytes_evmWordIs_fold
         b24 b25 b26 b27 b28 b29 b30 b31) := by
   rw [mloadLoadedWordFromBytes, mloadLoadedWord_evmWordIs_fold]
 
+/-- Fold the byte-window MLOAD result and existing stack tail into one stack assertion. -/
+theorem mloadLoadedWordFromBytes_evmStackIs_fold
+    (sp : Word) (rest : List EvmWord)
+    (b00 b01 b02 b03 b04 b05 b06 b07 : BitVec 8)
+    (b08 b09 b10 b11 b12 b13 b14 b15 : BitVec 8)
+    (b16 b17 b18 b19 b20 b21 b22 b23 : BitVec 8)
+    (b24 b25 b26 b27 b28 b29 b30 b31 : BitVec 8) :
+    (((sp ↦ₘ mloadPackedLimb b24 b25 b26 b27 b28 b29 b30 b31) **
+      ((sp + 8) ↦ₘ mloadPackedLimb b16 b17 b18 b19 b20 b21 b22 b23) **
+      ((sp + 16) ↦ₘ mloadPackedLimb b08 b09 b10 b11 b12 b13 b14 b15) **
+      ((sp + 24) ↦ₘ mloadPackedLimb b00 b01 b02 b03 b04 b05 b06 b07)) **
+      evmStackIs (sp + 32) rest) =
+    evmStackIs sp
+      ((mloadLoadedWordFromBytes
+        b00 b01 b02 b03 b04 b05 b06 b07
+        b08 b09 b10 b11 b12 b13 b14 b15
+        b16 b17 b18 b19 b20 b21 b22 b23
+        b24 b25 b26 b27 b28 b29 b30 b31) :: rest) := by
+  rw [mloadLoadedWordFromBytes_evmWordIs_fold]
+  rfl
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -10,6 +10,51 @@ namespace EvmAsm.Evm64
 
 open EvmAsm.Rv64
 
+/-- CodeReq for all four MLOAD output-limb byte-pack blocks, placed after the
+    two-instruction address prologue. -/
+def mloadFourLimbsCode
+    (addrReg byteReg accReg : Reg) (base : Word) : CodeReq :=
+  (mloadOneLimbCode addrReg byteReg accReg
+      24 25 26 27 28 29 30 31 0 (base + 8)).union
+    ((mloadOneLimbCode addrReg byteReg accReg
+        16 17 18 19 20 21 22 23 8 (base + 100)).union
+      ((mloadOneLimbCode addrReg byteReg accReg
+          8 9 10 11 12 13 14 15 16 (base + 192)).union
+        (mloadOneLimbCode addrReg byteReg accReg
+          0 1 2 3 4 5 6 7 24 (base + 284))))
+
+/-- Compact CodeReq for the full MLOAD program: address prologue followed by
+    the four unaligned output-limb blocks. -/
+def mloadStackCode
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
+  (mloadPrologueCode offReg addrReg memBaseReg base).union
+    (mloadFourLimbsCode addrReg byteReg accReg base)
+
+theorem mloadStackCode_prologue_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i, (mloadPrologueCode offReg addrReg memBaseReg base) a = some i →
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  unfold mloadStackCode
+  exact CodeReq.union_mono_left
+
+theorem mload_prologue_stack_spec_within
+    (offReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (mloadStackCode offReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  exact cpsTripleWithin_extend_code
+    (h := mload_prologue_spec_within offReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+    (hmono := mloadStackCode_prologue_sub offReg byteReg accReg addrReg memBaseReg base)
+
 /--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack


### PR DESCRIPTION
Stacked on #2083.

Adds mloadFourLimbsCode and mloadStackCode as the generic full-code target for MLOAD, then lifts the existing MLOAD prologue proof through that stack CodeReq. This is a precursor for the final unaligned evm_mload_stack_spec_within proof without adding per-offset examples.

Refs evm-asm-qqoi / GH #99. Precursor for evm-asm-bnj9.

Verification:
- lake build EvmAsm.Evm64.MLoad
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in EvmAsm/Evm64/MLoad/StackSpec.lean

Authored by @pirapira; implemented by Codex.