### PR TITLE
prove(mstore): lift four-limb body under stack code

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -428,6 +428,96 @@ theorem mstore_four_limb_sequence_spec_within
       h2)
     h3
 
+/-- Pure five-dword fold for the full 32-byte MSTORE body. The executable
+    code stores source offsets 32, 40, 48, and 56 in that order, so adjacent
+    dword pairs overlap and must be threaded through the fold. -/
+def mstoreFourLimbStore
+    (d0 d1 d2 d3 d4 limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    Word × Word × Word × Word × Word :=
+  let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+  let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+  let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+  let p3 := MStore.mstoreDwordPairStoreLimb d0 p2.1 limb56 start
+  (p3.1, p3.2, p2.2, p1.2, p0.2)
+
+theorem mstoreFourLimbStore_unfold
+    (d0 d1 d2 d3 d4 limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    mstoreFourLimbStore d0 d1 d2 d3 d4 limb32 limb40 limb48 limb56 start =
+      (let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+       let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+       let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+       let p3 := MStore.mstoreDwordPairStoreLimb d0 p2.1 limb56 start
+       (p3.1, p3.2, p2.2, p1.2, p0.2)) := by
+  rfl
+
+@[irreducible]
+def mstoreFourLimbBodyPre
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) : Assertion :=
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+  (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ d2) **
+  (d3Addr ↦ₘ d3) ** (d4Addr ↦ₘ d4) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+
+theorem mstoreFourLimbBodyPre_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) :
+    mstoreFourLimbBodyPre addrReg byteReg accReg
+        addrPtr byteOld accOld d0 d1 d2 d3 d4
+        d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56 =
+      ((addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ byteOld) ** (accReg ↦ᵣ accOld) **
+       (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ d2) **
+       (d3Addr ↦ₘ d3) ** (d4Addr ↦ₘ d4) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)) := by
+  delta mstoreFourLimbBodyPre
+  rfl
+
+@[irreducible]
+def mstoreFourLimbBodyPost
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) : Assertion :=
+  let stored := mstoreFourLimbStore d0 d1 d2 d3 d4 limb32 limb40 limb48 limb56 start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb56) ** (accReg ↦ᵣ limb56) **
+  (d0Addr ↦ₘ stored.1) ** (d1Addr ↦ₘ stored.2.1) **
+  (d2Addr ↦ₘ stored.2.2.1) ** (d3Addr ↦ₘ stored.2.2.2.1) **
+  (d4Addr ↦ₘ stored.2.2.2.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+
+theorem mstoreFourLimbBodyPost_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    mstoreFourLimbBodyPost addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start =
+      (let stored := mstoreFourLimbStore d0 d1 d2 d3 d4 limb32 limb40 limb48 limb56 start
+       (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb56) ** (accReg ↦ᵣ limb56) **
+       (d0Addr ↦ₘ stored.1) ** (d1Addr ↦ₘ stored.2.1) **
+       (d2Addr ↦ₘ stored.2.2.1) ** (d3Addr ↦ₘ stored.2.2.2.1) **
+       (d4Addr ↦ₘ stored.2.2.2.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)) := by
+  delta mstoreFourLimbBodyPost
+  rfl
+
 theorem mstore_limb0_four_code_spec_within
     (addrReg byteReg accReg : Reg)
     (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -342,6 +342,71 @@ theorem mstore_four_limb_sequence_spec_within
       h2)
     h3
 
+theorem mstore_limb0_four_code_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 (24 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 (24 : BitVec 12)) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 (24 : BitVec 12)) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 (25 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 (25 : BitVec 12)) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 (25 : BitVec 12)) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 (26 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 (26 : BitVec 12)) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 (26 : BitVec 12)) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 (27 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 (27 : BitVec 12)) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 (27 : BitVec 12)) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 (28 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 (28 : BitVec 12)) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 (28 : BitVec 12)) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 (29 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 (29 : BitVec 12)) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 (29 : BitVec 12)) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 (30 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 (30 : BitVec 12)) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 (30 : BitVec 12)) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 (31 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 (31 : BitVec 12)) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 (31 : BitVec 12)) = (start + 7) % 8) :
+    cpsTripleWithin 17 (base + 8) (base + 76)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (32 : BitVec 12))
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start (32 : BitVec 12)) := by
+  have h := cpsTripleWithin_extend_code
+    (hmono := mstoreFourLimbsCode_limb0_sub addrReg byteReg accReg base)
+    (h := mstore_one_limb_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+      start (32 : BitVec 12) (24 : BitVec 12) (25 : BitVec 12) (26 : BitVec 12)
+      (27 : BitVec 12) (28 : BitVec 12) (29 : BitVec 12) (30 : BitVec 12)
+      (31 : BitVec 12) (base + 8) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
+      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
+      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
+      h_align7 h_valid7 h_byte7)
+  rw [show (base + 8 : Word) + 68 = base + 76 from by bv_addr] at h
+  exact h
+
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
     ∀ a i, (mstoreEpilogueCode (base + 280)) a = some i →

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -793,6 +793,44 @@ theorem mstore_four_limb_body_sequence_spec_within
   exact mstore_four_limb_sequence_spec_within addrReg byteReg accReg base
     h0Body h1Body h2Body h3Body
 
+/-- Side conditions for one eight-byte MSTORE limb window. The destination
+    byte offsets may cross from `loAddr` into `hiAddr` depending on `start`. -/
+def mstoreLimbWindowOk
+    (addrPtr loAddr hiAddr : Word) (start : Nat)
+    (off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) : Prop :=
+  alignToDword (addrPtr + signExtend12 off0) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 0 ∧
+  isValidByteAccess (addrPtr + signExtend12 off0) = true ∧
+  byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off1) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 1 ∧
+  isValidByteAccess (addrPtr + signExtend12 off1) = true ∧
+  byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off2) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 2 ∧
+  isValidByteAccess (addrPtr + signExtend12 off2) = true ∧
+  byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off3) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 3 ∧
+  isValidByteAccess (addrPtr + signExtend12 off3) = true ∧
+  byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off4) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 4 ∧
+  isValidByteAccess (addrPtr + signExtend12 off4) = true ∧
+  byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off5) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 5 ∧
+  isValidByteAccess (addrPtr + signExtend12 off5) = true ∧
+  byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off6) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 6 ∧
+  isValidByteAccess (addrPtr + signExtend12 off6) = true ∧
+  byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off7) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 7 ∧
+  isValidByteAccess (addrPtr + signExtend12 off7) = true ∧
+  byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8
+
 theorem mstore_limb0_four_code_spec_within
     (addrReg byteReg accReg : Reg)
     (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
@@ -1052,6 +1090,78 @@ theorem mstore_limb3_four_code_spec_within
       h_align7 h_valid7 h_byte7)
   rw [show (base + 212 : Word) + 68 = base + 280 from by bv_addr] at h
   exact h
+
+theorem mstore_four_limb_body_concrete_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h32 : mstoreLimbWindowOk addrPtr d3Addr d4Addr start
+      24 25 26 27 28 29 30 31)
+    (h40 : mstoreLimbWindowOk addrPtr d2Addr d3Addr start
+      16 17 18 19 20 21 22 23)
+    (h48 : mstoreLimbWindowOk addrPtr d1Addr d2Addr start
+      8 9 10 11 12 13 14 15)
+    (h56 : mstoreLimbWindowOk addrPtr d0Addr d1Addr start
+      0 1 2 3 4 5 6 7) :
+    cpsTripleWithin 68 (base + 8) (base + 280)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreFourLimbBodyPre addrReg byteReg accReg
+        addrPtr byteOld accOld d0 d1 d2 d3 d4
+        d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56)
+      (mstoreFourLimbBodyPost addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start) := by
+  obtain ⟨h32a0, h32v0, h32b0, h32a1, h32v1, h32b1, h32a2, h32v2, h32b2,
+    h32a3, h32v3, h32b3, h32a4, h32v4, h32b4, h32a5, h32v5, h32b5,
+    h32a6, h32v6, h32b6, h32a7, h32v7, h32b7⟩ := h32
+  obtain ⟨h40a0, h40v0, h40b0, h40a1, h40v1, h40b1, h40a2, h40v2, h40b2,
+    h40a3, h40v3, h40b3, h40a4, h40v4, h40b4, h40a5, h40v5, h40b5,
+    h40a6, h40v6, h40b6, h40a7, h40v7, h40b7⟩ := h40
+  obtain ⟨h48a0, h48v0, h48b0, h48a1, h48v1, h48b1, h48a2, h48v2, h48b2,
+    h48a3, h48v3, h48b3, h48a4, h48v4, h48b4, h48a5, h48v5, h48b5,
+    h48a6, h48v6, h48b6, h48a7, h48v7, h48b7⟩ := h48
+  obtain ⟨h56a0, h56v0, h56b0, h56a1, h56v1, h56b1, h56a2, h56v2, h56b2,
+    h56a3, h56v3, h56b3, h56a4, h56v4, h56b4, h56a5, h56v5, h56b5,
+    h56a6, h56v6, h56b6, h56a7, h56v7, h56b7⟩ := h56
+  have h := mstore_four_limb_body_sequence_spec_within
+    addrReg byteReg accReg addrPtr byteOld accOld d0 d1 d2 d3 d4
+    d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56
+    start base
+    (mstore_limb0_four_code_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld d3 d4 d3Addr d4Addr sp limb32
+      start base h_byte_ne_x0 h_acc_ne_x0 h32a0 h32v0 h32b0 h32a1 h32v1 h32b1
+      h32a2 h32v2 h32b2 h32a3 h32v3 h32b3 h32a4 h32v4 h32b4 h32a5 h32v5
+      h32b5 h32a6 h32v6 h32b6 h32a7 h32v7 h32b7)
+    (mstore_limb1_four_code_spec_within
+      addrReg byteReg accReg addrPtr limb32 limb32 d2
+      (MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start).1
+      d2Addr d3Addr sp limb40 start base h_byte_ne_x0 h_acc_ne_x0
+      h40a0 h40v0 h40b0 h40a1 h40v1 h40b1 h40a2 h40v2 h40b2
+      h40a3 h40v3 h40b3 h40a4 h40v4 h40b4 h40a5 h40v5 h40b5
+      h40a6 h40v6 h40b6 h40a7 h40v7 h40b7)
+    (mstore_limb2_four_code_spec_within
+      addrReg byteReg accReg addrPtr limb40 limb40 d1
+      (MStore.mstoreDwordPairStoreLimb d2
+        (MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start).1 limb40 start).1
+      d1Addr d2Addr sp limb48 start base h_byte_ne_x0 h_acc_ne_x0
+      h48a0 h48v0 h48b0 h48a1 h48v1 h48b1 h48a2 h48v2 h48b2
+      h48a3 h48v3 h48b3 h48a4 h48v4 h48b4 h48a5 h48v5 h48b5
+      h48a6 h48v6 h48b6 h48a7 h48v7 h48b7)
+    (mstore_limb3_four_code_spec_within
+      addrReg byteReg accReg addrPtr limb48 limb48 d0
+      (MStore.mstoreDwordPairStoreLimb d1
+        (MStore.mstoreDwordPairStoreLimb d2
+          (MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start).1 limb40 start).1
+        limb48 start).1
+      d0Addr d1Addr sp limb56 start base h_byte_ne_x0 h_acc_ne_x0
+      h56a0 h56v0 h56b0 h56a1 h56v1 h56b1 h56a2 h56v2 h56b2
+      h56a3 h56v3 h56b3 h56a4 h56v4 h56b4 h56a5 h56v5 h56b5
+      h56a6 h56v6 h56b6 h56a7 h56v7 h56b7)
+  simpa using h
 
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -341,6 +341,24 @@ theorem mstore_prologue_stack_spec_within
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
     (hmono := mstoreStackCode_prologue_sub offReg byteReg accReg addrReg memBaseReg base)
 
+theorem mstore_prologue_evm_mstore_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+       (sp ↦ₘ offset))
+      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+       (sp ↦ₘ offset)) := by
+  rw [← mstoreStackCode_eq_evm_mstore_code
+    offReg valReg byteReg accReg addrReg memBaseReg base]
+  exact mstore_prologue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
+    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
+
 theorem mstore_epilogue_stack_spec_within
     (offReg byteReg accReg addrReg memBaseReg : Reg)
     (sp : Word) (base : Word) :
@@ -353,5 +371,17 @@ theorem mstore_epilogue_stack_spec_within
     (hmono := mstoreStackCode_epilogue_sub offReg byteReg accReg addrReg memBaseReg base)
   rw [show (base + 280 : Word) + 4 = base + 284 from by bv_addr] at h
   exact h
+
+theorem mstore_epilogue_evm_mstore_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp : Word) (base : Word) :
+    cpsTripleWithin 1 (base + 280) (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp))
+      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
+  rw [← mstoreStackCode_eq_evm_mstore_code
+    offReg valReg byteReg accReg addrReg memBaseReg base]
+  exact mstore_epilogue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
+    sp base
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -398,6 +398,32 @@ theorem mstore_prologue_evm_mstore_frame_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
 
+theorem mstore_prologue_body_evm_mstore_spec_within
+    {nBody : Nat} {R : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hBody :
+      cpsTripleWithin nBody (base + 8) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        R) :
+    cpsTripleWithin (2 + nBody) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      R := by
+  exact cpsTripleWithin_seq_same_cr
+    (mstore_prologue_evm_mstore_frame_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF h_off_ne_x0 h_addr_ne_x0)
+    hBody
+
 theorem mstore_epilogue_stack_spec_within
     (offReg byteReg accReg addrReg memBaseReg : Reg)
     (sp : Word) (base : Word) :

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -1163,6 +1163,37 @@ theorem mstore_four_limb_body_concrete_spec_within
       h56a6 h56v6 h56b6 h56a7 h56v7 h56b7)
   simpa using h
 
+theorem mstore_four_limb_body_evm_mstore_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (addrPtr byteOld accOld d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h32 : mstoreLimbWindowOk addrPtr d3Addr d4Addr start
+      24 25 26 27 28 29 30 31)
+    (h40 : mstoreLimbWindowOk addrPtr d2Addr d3Addr start
+      16 17 18 19 20 21 22 23)
+    (h48 : mstoreLimbWindowOk addrPtr d1Addr d2Addr start
+      8 9 10 11 12 13 14 15)
+    (h56 : mstoreLimbWindowOk addrPtr d0Addr d1Addr start
+      0 1 2 3 4 5 6 7) :
+    cpsTripleWithin 68 (base + 8) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (mstoreFourLimbBodyPre addrReg byteReg accReg
+        addrPtr byteOld accOld d0 d1 d2 d3 d4
+        d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56)
+      (mstoreFourLimbBodyPost addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start) :=
+  mstore_four_limbs_evm_mstore_spec_within
+    offReg valReg byteReg accReg addrReg memBaseReg base
+    (mstore_four_limb_body_concrete_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld d0 d1 d2 d3 d4
+      d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56
+      start base h_byte_ne_x0 h_acc_ne_x0 h32 h40 h48 h56)
+
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
     ∀ a i, (mstoreEpilogueCode (base + 280)) a = some i →

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -460,4 +460,32 @@ theorem mstore_epilogue_evm_mstore_frame_spec_within
     (mstore_epilogue_evm_mstore_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg sp base)
 
+theorem mstore_full_evm_mstore_spec_within
+    {nBody : Nat} {FPre FPost : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (hFPre : FPre.pcFree) (hFPost : FPost.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hBody :
+      cpsTripleWithin nBody (base + 8) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** FPre)
+        (((.x12 : Reg) ↦ᵣ sp) ** FPost)) :
+    cpsTripleWithin (2 + nBody + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** FPre)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) ** FPost) := by
+  exact cpsTripleWithin_seq_same_cr
+    (mstore_prologue_body_evm_mstore_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base FPre hFPre
+      h_off_ne_x0 h_addr_ne_x0 hBody)
+    (mstore_epilogue_evm_mstore_frame_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg sp base FPost hFPost)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -299,6 +299,26 @@ theorem mstoreStackCode_four_limbs_sub
       rw [mstoreStackProg_length]
       omega)
 
+theorem evm_mstore_code_four_limbs_sub
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i, (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i →
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  rw [← mstoreStackCode_eq_evm_mstore_code
+    offReg valReg byteReg accReg addrReg memBaseReg base]
+  exact mstoreStackCode_four_limbs_sub offReg byteReg accReg addrReg memBaseReg base
+
+theorem mstore_four_limbs_evm_mstore_spec_within
+    {nSteps : Nat} {P Q : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word)
+    (h :
+      cpsTripleWithin nSteps (base + 8) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P Q) :
+    cpsTripleWithin nSteps (base + 8) (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base) P Q :=
+  cpsTripleWithin_extend_code
+    (evm_mstore_code_four_limbs_sub offReg valReg byteReg accReg addrReg memBaseReg base)
+    h
+
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
     ∀ a i, (mstoreEpilogueCode (base + 280)) a = some i →

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -130,6 +130,35 @@ theorem mstoreFourLimbsCode_limb1_sub
       rw [mstoreFourLimbsProg_length]
       omega)
 
+theorem mstoreFourLimbsCode_limb2_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        48 8 9 10 11 12 13 14 15 (base + 144)) a = some i →
+      (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  rw [mstoreFourLimbsCode_eq_ofProg, mstoreOneLimbCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub (base + 8) (base + 144)
+    (mstoreFourLimbsProg addrReg byteReg accReg)
+    (mstoreOneLimbProg addrReg byteReg accReg 48 8 9 10 11 12 13 14 15)
+    34
+    (by bv_addr)
+    (by
+      change ((mstoreFourLimbsProg addrReg byteReg accReg).drop 34).take 17 =
+        mstoreOneLimbProg addrReg byteReg accReg 48 8 9 10 11 12 13 14 15
+      unfold mstoreFourLimbsProg mstoreOneLimbProg mstoreByteUnpackEightProg
+        LD SRLI SB single seq
+      rfl)
+    (by
+      rw [show (mstoreOneLimbProg addrReg byteReg accReg
+          48 8 9 10 11 12 13 14 15).length = 17 by
+        unfold mstoreOneLimbProg mstoreByteUnpackEightProg LD SRLI SB single seq
+        rfl]
+      rw [mstoreFourLimbsProg_length]
+      omega)
+    (by
+      rw [mstoreFourLimbsProg_length]
+      omega)
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
@@ -499,6 +528,71 @@ theorem mstore_limb1_four_code_spec_within
       h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
       h_align7 h_valid7 h_byte7)
   rw [show (base + 76 : Word) + 68 = base + 144 from by bv_addr] at h
+  exact h
+
+theorem mstore_limb2_four_code_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 (8 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 (8 : BitVec 12)) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 (8 : BitVec 12)) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 (9 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 (9 : BitVec 12)) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 (9 : BitVec 12)) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 (10 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 (10 : BitVec 12)) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 (10 : BitVec 12)) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 (11 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 (11 : BitVec 12)) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 (11 : BitVec 12)) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 (12 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 (12 : BitVec 12)) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 (12 : BitVec 12)) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 (13 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 (13 : BitVec 12)) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 (13 : BitVec 12)) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 (14 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 (14 : BitVec 12)) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 (14 : BitVec 12)) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 (15 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 (15 : BitVec 12)) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 (15 : BitVec 12)) = (start + 7) % 8) :
+    cpsTripleWithin 17 (base + 144) (base + 212)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (48 : BitVec 12))
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start (48 : BitVec 12)) := by
+  have h := cpsTripleWithin_extend_code
+    (hmono := mstoreFourLimbsCode_limb2_sub addrReg byteReg accReg base)
+    (h := mstore_one_limb_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+      start (48 : BitVec 12) (8 : BitVec 12) (9 : BitVec 12) (10 : BitVec 12)
+      (11 : BitVec 12) (12 : BitVec 12) (13 : BitVec 12) (14 : BitVec 12)
+      (15 : BitVec 12) (base + 144) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
+      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
+      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
+      h_align7 h_valid7 h_byte7)
+  rw [show (base + 144 : Word) + 68 = base + 212 from by bv_addr] at h
   exact h
 
 theorem mstoreStackCode_epilogue_sub

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -101,6 +101,35 @@ theorem mstoreFourLimbsCode_limb0_sub
   unfold mstoreFourLimbsCode
   exact CodeReq.union_mono_left
 
+theorem mstoreFourLimbsCode_limb1_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        40 16 17 18 19 20 21 22 23 (base + 76)) a = some i →
+      (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  rw [mstoreFourLimbsCode_eq_ofProg, mstoreOneLimbCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub (base + 8) (base + 76)
+    (mstoreFourLimbsProg addrReg byteReg accReg)
+    (mstoreOneLimbProg addrReg byteReg accReg 40 16 17 18 19 20 21 22 23)
+    17
+    (by bv_addr)
+    (by
+      change ((mstoreFourLimbsProg addrReg byteReg accReg).drop 17).take 17 =
+        mstoreOneLimbProg addrReg byteReg accReg 40 16 17 18 19 20 21 22 23
+      unfold mstoreFourLimbsProg mstoreOneLimbProg mstoreByteUnpackEightProg
+        LD SRLI SB single seq
+      rfl)
+    (by
+      rw [show (mstoreOneLimbProg addrReg byteReg accReg
+          40 16 17 18 19 20 21 22 23).length = 17 by
+        unfold mstoreOneLimbProg mstoreByteUnpackEightProg LD SRLI SB single seq
+        rfl]
+      rw [mstoreFourLimbsProg_length]
+      omega)
+    (by
+      rw [mstoreFourLimbsProg_length]
+      omega)
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
@@ -405,6 +434,71 @@ theorem mstore_limb0_four_code_spec_within
       h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
       h_align7 h_valid7 h_byte7)
   rw [show (base + 8 : Word) + 68 = base + 76 from by bv_addr] at h
+  exact h
+
+theorem mstore_limb1_four_code_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 (16 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 (16 : BitVec 12)) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 (16 : BitVec 12)) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 (17 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 (17 : BitVec 12)) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 (17 : BitVec 12)) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 (18 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 (18 : BitVec 12)) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 (18 : BitVec 12)) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 (19 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 (19 : BitVec 12)) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 (19 : BitVec 12)) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 (20 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 (20 : BitVec 12)) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 (20 : BitVec 12)) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 (21 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 (21 : BitVec 12)) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 (21 : BitVec 12)) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 (22 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 (22 : BitVec 12)) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 (22 : BitVec 12)) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 (23 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 (23 : BitVec 12)) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 (23 : BitVec 12)) = (start + 7) % 8) :
+    cpsTripleWithin 17 (base + 76) (base + 144)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (40 : BitVec 12))
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start (40 : BitVec 12)) := by
+  have h := cpsTripleWithin_extend_code
+    (hmono := mstoreFourLimbsCode_limb1_sub addrReg byteReg accReg base)
+    (h := mstore_one_limb_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+      start (40 : BitVec 12) (16 : BitVec 12) (17 : BitVec 12) (18 : BitVec 12)
+      (19 : BitVec 12) (20 : BitVec 12) (21 : BitVec 12) (22 : BitVec 12)
+      (23 : BitVec 12) (base + 76) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
+      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
+      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
+      h_align7 h_valid7 h_byte7)
+  rw [show (base + 76 : Word) + 68 = base + 144 from by bv_addr] at h
   exact h
 
 theorem mstoreStackCode_epilogue_sub

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -379,6 +379,25 @@ theorem mstore_prologue_evm_mstore_spec_within
   exact mstore_prologue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
     sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
 
+theorem mstore_prologue_evm_mstore_frame_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0) :
+    cpsTripleWithin 2 base (base + 8)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+        (sp ↦ₘ offset)) ** F) := by
+  exact cpsTripleWithin_frameR F hF
+    (mstore_prologue_evm_mstore_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
+
 theorem mstore_epilogue_stack_spec_within
     (offReg byteReg accReg addrReg memBaseReg : Reg)
     (sp : Word) (base : Word) :

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -626,6 +626,173 @@ theorem mstoreFourLimbBodyPost_unfold
   delta mstoreFourLimbBodyPost
   rfl
 
+theorem mstore_four_limb_body_sequence_spec_within
+    {n0 n1 n2 n3 : Nat}
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word)
+    (start : Nat) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreOneLimbPre addrReg byteReg accReg
+          addrPtr byteOld accOld d3 d4 d3Addr d4Addr sp limb32 (32 : BitVec 12))
+        (mstoreOneLimbPost addrReg byteReg accReg
+          addrPtr d3 d4 d3Addr d4Addr sp limb32 start (32 : BitVec 12)))
+    (h1 :
+      let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreOneLimbPre addrReg byteReg accReg
+          addrPtr limb32 limb32 d2 p0.1 d2Addr d3Addr sp limb40 (40 : BitVec 12))
+        (mstoreOneLimbPost addrReg byteReg accReg
+          addrPtr d2 p0.1 d2Addr d3Addr sp limb40 start (40 : BitVec 12)))
+    (h2 :
+      let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+      let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreOneLimbPre addrReg byteReg accReg
+          addrPtr limb40 limb40 d1 p1.1 d1Addr d2Addr sp limb48 (48 : BitVec 12))
+        (mstoreOneLimbPost addrReg byteReg accReg
+          addrPtr d1 p1.1 d1Addr d2Addr sp limb48 start (48 : BitVec 12)))
+    (h3 :
+      let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+      let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+      let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreOneLimbPre addrReg byteReg accReg
+          addrPtr limb48 limb48 d0 p2.1 d0Addr d1Addr sp limb56 (56 : BitVec 12))
+        (mstoreOneLimbPost addrReg byteReg accReg
+          addrPtr d0 p2.1 d0Addr d1Addr sp limb56 start (56 : BitVec 12))) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 280)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreFourLimbBodyPre addrReg byteReg accReg
+        addrPtr byteOld accOld d0 d1 d2 d3 d4
+        d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56)
+      (mstoreFourLimbBodyPost addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start) := by
+  let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+  let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+  let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+  let rest0 : Assertion :=
+    (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ d2) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+  let h0Framed := cpsTripleWithin_frameR rest0 (by pcFree) h0
+  have h0Body :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreFourLimbBodyPre addrReg byteReg accReg
+          addrPtr byteOld accOld d0 d1 d2 d3 d4
+          d0Addr d1Addr d2Addr d3Addr d4Addr sp limb32 limb40 limb48 limb56)
+        (mstoreFourLimbBodyMid0 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start) := by
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [mstoreFourLimbBodyPre_unfold] at hp
+        rw [mstoreOneLimbPre_unfold]
+        unfold rest0
+        xperm_hyp hp)
+      (fun _ hp => by
+        rw [mstoreOneLimbPost_unfold] at hp
+        rw [mstoreFourLimbBodyMid0_unfold]
+        unfold rest0 at hp
+        dsimp only
+        xperm_hyp hp)
+      h0Framed
+  let rest1 : Assertion :=
+    (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d4Addr ↦ₘ p0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+  let h1Framed := cpsTripleWithin_frameR rest1 (by pcFree) h1
+  have h1Body :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreFourLimbBodyMid0 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start)
+        (mstoreFourLimbBodyMid1 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start) := by
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [mstoreFourLimbBodyMid0_unfold] at hp
+        rw [mstoreOneLimbPre_unfold]
+        unfold rest1 p0
+        xperm_hyp hp)
+      (fun _ hp => by
+        rw [mstoreOneLimbPost_unfold] at hp
+        rw [mstoreFourLimbBodyMid1_unfold]
+        unfold rest1 at hp
+        dsimp only
+        xperm_hyp hp)
+      h1Framed
+  let rest2 : Assertion :=
+    (d0Addr ↦ₘ d0) ** (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+    ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+  let h2Framed := cpsTripleWithin_frameR rest2 (by pcFree) h2
+  have h2Body :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreFourLimbBodyMid1 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start)
+        (mstoreFourLimbBodyMid2 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start) := by
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [mstoreFourLimbBodyMid1_unfold] at hp
+        rw [mstoreOneLimbPre_unfold]
+        unfold rest2 p0 p1
+        xperm_hyp hp)
+      (fun _ hp => by
+        rw [mstoreOneLimbPost_unfold] at hp
+        rw [mstoreFourLimbBodyMid2_unfold]
+        unfold rest2 at hp
+        dsimp only
+        xperm_hyp hp)
+      h2Framed
+  let rest3 : Assertion :=
+    (d2Addr ↦ₘ p2.2) ** (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) **
+    ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+    ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+    ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48)
+  let h3Framed := cpsTripleWithin_frameR rest3 (by pcFree) h3
+  have h3Body :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base)
+        (mstoreFourLimbBodyMid2 addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start)
+        (mstoreFourLimbBodyPost addrReg byteReg accReg
+          addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+          limb32 limb40 limb48 limb56 start) := by
+    exact cpsTripleWithin_weaken
+      (fun _ hp => by
+        rw [mstoreFourLimbBodyMid2_unfold] at hp
+        rw [mstoreOneLimbPre_unfold]
+        unfold rest3 p0 p1 p2
+        xperm_hyp hp)
+      (fun _ hp => by
+        rw [mstoreOneLimbPost_unfold] at hp
+        rw [mstoreFourLimbBodyPost_unfold, mstoreFourLimbStore_unfold]
+        unfold rest3 at hp
+        dsimp only
+        xperm_hyp hp)
+      h3Framed
+  exact mstore_four_limb_sequence_spec_within addrReg byteReg accReg base
+    h0Body h1Body h2Body h3Body
+
 theorem mstore_limb0_four_code_spec_within
     (addrReg byteReg accReg : Reg)
     (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -159,6 +159,34 @@ theorem mstoreFourLimbsCode_limb2_sub
       rw [mstoreFourLimbsProg_length]
       omega)
 
+theorem mstoreFourLimbsCode_limb3_sub
+    (addrReg byteReg accReg : Reg) (base : Word) :
+    ∀ a i,
+      (mstoreOneLimbCode addrReg byteReg accReg
+        56 0 1 2 3 4 5 6 7 (base + 212)) a = some i →
+      (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i := by
+  rw [mstoreFourLimbsCode_eq_ofProg, mstoreOneLimbCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub (base + 8) (base + 212)
+    (mstoreFourLimbsProg addrReg byteReg accReg)
+    (mstoreOneLimbProg addrReg byteReg accReg 56 0 1 2 3 4 5 6 7)
+    51
+    (by bv_addr)
+    (by
+      change ((mstoreFourLimbsProg addrReg byteReg accReg).drop 51).take 17 =
+        mstoreOneLimbProg addrReg byteReg accReg 56 0 1 2 3 4 5 6 7
+      unfold mstoreFourLimbsProg mstoreOneLimbProg mstoreByteUnpackEightProg
+        LD SRLI SB single seq
+      rfl)
+    (by
+      rw [show (mstoreOneLimbProg addrReg byteReg accReg
+          56 0 1 2 3 4 5 6 7).length = 17 by
+        unfold mstoreOneLimbProg mstoreByteUnpackEightProg LD SRLI SB single seq
+        rfl]
+      rw [mstoreFourLimbsProg_length])
+    (by
+      rw [mstoreFourLimbsProg_length]
+      omega)
+
 /-- CodeReq for the two-instruction MSTORE address prologue. -/
 def mstorePrologueCode
     (offReg addrReg memBaseReg : Reg) (base : Word) : CodeReq :=
@@ -593,6 +621,71 @@ theorem mstore_limb2_four_code_spec_within
       h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
       h_align7 h_valid7 h_byte7)
   rw [show (base + 144 : Word) + 68 = base + 212 from by bv_addr] at h
+  exact h
+
+theorem mstore_limb3_four_code_spec_within
+    (addrReg byteReg accReg : Reg)
+    (addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal : Word)
+    (start : Nat) (base : Word)
+    (h_byte_ne_x0 : byteReg ≠ .x0)
+    (h_acc_ne_x0 : accReg ≠ .x0)
+    (h_align0 :
+      alignToDword (addrPtr + signExtend12 (0 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
+    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 (0 : BitVec 12)) = true)
+    (h_byte0 : byteOffset (addrPtr + signExtend12 (0 : BitVec 12)) = (start + 0) % 8)
+    (h_align1 :
+      alignToDword (addrPtr + signExtend12 (1 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
+    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 (1 : BitVec 12)) = true)
+    (h_byte1 : byteOffset (addrPtr + signExtend12 (1 : BitVec 12)) = (start + 1) % 8)
+    (h_align2 :
+      alignToDword (addrPtr + signExtend12 (2 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
+    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 (2 : BitVec 12)) = true)
+    (h_byte2 : byteOffset (addrPtr + signExtend12 (2 : BitVec 12)) = (start + 2) % 8)
+    (h_align3 :
+      alignToDword (addrPtr + signExtend12 (3 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
+    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 (3 : BitVec 12)) = true)
+    (h_byte3 : byteOffset (addrPtr + signExtend12 (3 : BitVec 12)) = (start + 3) % 8)
+    (h_align4 :
+      alignToDword (addrPtr + signExtend12 (4 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
+    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 (4 : BitVec 12)) = true)
+    (h_byte4 : byteOffset (addrPtr + signExtend12 (4 : BitVec 12)) = (start + 4) % 8)
+    (h_align5 :
+      alignToDword (addrPtr + signExtend12 (5 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
+    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 (5 : BitVec 12)) = true)
+    (h_byte5 : byteOffset (addrPtr + signExtend12 (5 : BitVec 12)) = (start + 5) % 8)
+    (h_align6 :
+      alignToDword (addrPtr + signExtend12 (6 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
+    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 (6 : BitVec 12)) = true)
+    (h_byte6 : byteOffset (addrPtr + signExtend12 (6 : BitVec 12)) = (start + 6) % 8)
+    (h_align7 :
+      alignToDword (addrPtr + signExtend12 (7 : BitVec 12)) =
+        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
+    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 (7 : BitVec 12)) = true)
+    (h_byte7 : byteOffset (addrPtr + signExtend12 (7 : BitVec 12)) = (start + 7) % 8) :
+    cpsTripleWithin 17 (base + 212) (base + 280)
+      (mstoreFourLimbsCode addrReg byteReg accReg base)
+      (mstoreOneLimbPre addrReg byteReg accReg
+        addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (56 : BitVec 12))
+      (mstoreOneLimbPost addrReg byteReg accReg
+        addrPtr loVal hiVal loAddr hiAddr sp limbVal start (56 : BitVec 12)) := by
+  have h := cpsTripleWithin_extend_code
+    (hmono := mstoreFourLimbsCode_limb3_sub addrReg byteReg accReg base)
+    (h := mstore_one_limb_spec_within
+      addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
+      start (56 : BitVec 12) (0 : BitVec 12) (1 : BitVec 12) (2 : BitVec 12)
+      (3 : BitVec 12) (4 : BitVec 12) (5 : BitVec 12) (6 : BitVec 12)
+      (7 : BitVec 12) (base + 212) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
+      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
+      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
+      h_align7 h_valid7 h_byte7)
+  rw [show (base + 212 : Word) + 68 = base + 280 from by bv_addr] at h
   exact h
 
 theorem mstoreStackCode_epilogue_sub

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -404,4 +404,15 @@ theorem mstore_epilogue_evm_mstore_spec_within
   exact mstore_epilogue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
     sp base
 
+theorem mstore_epilogue_evm_mstore_frame_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp : Word) (base : Word) (F : Assertion) (hF : F.pcFree) :
+    cpsTripleWithin 1 (base + 280) (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** F)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) ** F) := by
+  exact cpsTripleWithin_frameR F hF
+    (mstore_epilogue_evm_mstore_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg sp base)
+
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -4,6 +4,7 @@
   Stack-level building blocks for the 256-bit EVM MSTORE program.
 -/
 
+import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore.LimbSpec
 
 namespace EvmAsm.Evm64
@@ -251,6 +252,21 @@ theorem mstoreStackCode_eq_ofProg
       rfl]
     exact (CodeReq.ofProg_append (base := base) (p1 := p0) (p2 := p1 ++ p2)).symm
   exact h012
+
+theorem mstoreStackProg_eq_evm_mstore
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
+    mstoreStackProg offReg byteReg accReg addrReg memBaseReg =
+      evm_mstore offReg valReg byteReg accReg addrReg memBaseReg := by
+  unfold mstoreStackProg mstoreFourLimbsProg mstoreOneLimbProg
+    mstoreByteUnpackEightProg evm_mstore
+  rfl
+
+theorem mstoreStackCode_eq_evm_mstore_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    mstoreStackCode offReg byteReg accReg addrReg memBaseReg base =
+      evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base := by
+  rw [mstoreStackCode_eq_ofProg,
+    mstoreStackProg_eq_evm_mstore offReg valReg byteReg accReg addrReg memBaseReg]
 
 theorem mstoreStackCode_prologue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -1310,24 +1310,6 @@ theorem mstore_prologue_stack_spec_within
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
     (hmono := mstoreStackCode_prologue_sub offReg byteReg accReg addrReg memBaseReg base)
 
-theorem mstore_prologue_evm_mstore_spec_within
-    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
-    (sp offset offOld addrOld memBase : Word) (base : Word)
-    (h_off_ne_x0 : offReg ≠ .x0)
-    (h_addr_ne_x0 : addrReg ≠ .x0) :
-    cpsTripleWithin 2 base (base + 8)
-      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
-      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
-       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
-       (sp ↦ₘ offset))
-      (((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
-       (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
-       (sp ↦ₘ offset)) := by
-  rw [← mstoreStackCode_eq_evm_mstore_code
-    offReg valReg byteReg accReg addrReg memBaseReg base]
-  exact mstore_prologue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
-    sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0
-
 theorem mstore_prologue_evm_mstore_frame_spec_within
     (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
     (sp offset offOld addrOld memBase : Word) (base : Word)
@@ -1385,18 +1367,6 @@ theorem mstore_epilogue_stack_spec_within
     (hmono := mstoreStackCode_epilogue_sub offReg byteReg accReg addrReg memBaseReg base)
   rw [show (base + 280 : Word) + 4 = base + 284 from by bv_addr] at h
   exact h
-
-theorem mstore_epilogue_evm_mstore_spec_within
-    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
-    (sp : Word) (base : Word) :
-    cpsTripleWithin 1 (base + 280) (base + 284)
-      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
-      (((.x12 : Reg) ↦ᵣ sp))
-      (((.x12 : Reg) ↦ᵣ (sp + 64))) := by
-  rw [← mstoreStackCode_eq_evm_mstore_code
-    offReg valReg byteReg accReg addrReg memBaseReg base]
-  exact mstore_epilogue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
-    sp base
 
 theorem mstore_epilogue_evm_mstore_frame_spec_within
     (offReg valReg byteReg accReg addrReg memBaseReg : Reg)

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -259,6 +259,30 @@ theorem mstoreStackCode_prologue_sub
   unfold mstoreStackCode
   exact CodeReq.union_mono_left
 
+theorem mstoreStackCode_four_limbs_sub
+    (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    ∀ a i, (mstoreFourLimbsCode addrReg byteReg accReg base) a = some i →
+      (mstoreStackCode offReg byteReg accReg addrReg memBaseReg base) a = some i := by
+  rw [mstoreStackCode_eq_ofProg, mstoreFourLimbsCode_eq_ofProg]
+  exact CodeReq.ofProg_mono_sub base (base + 8)
+    (mstoreStackProg offReg byteReg accReg addrReg memBaseReg)
+    (mstoreFourLimbsProg addrReg byteReg accReg) 2
+    (by
+      change base + 8 = base + 8
+      rfl)
+    (by
+      rw [show (mstoreFourLimbsProg addrReg byteReg accReg).length = 68 from
+        mstoreFourLimbsProg_length addrReg byteReg accReg]
+      unfold mstoreStackProg mstoreFourLimbsProg mstoreOneLimbProg
+        mstoreByteUnpackEightProg LD ADD ADDI SRLI SB single seq
+      rfl)
+    (by
+      rw [mstoreFourLimbsProg_length, mstoreStackProg_length]
+      decide)
+    (by
+      rw [mstoreStackProg_length]
+      omega)
+
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
     ∀ a i, (mstoreEpilogueCode (base + 280)) a = some i →

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -319,6 +319,29 @@ theorem mstore_four_limbs_evm_mstore_spec_within
     (evm_mstore_code_four_limbs_sub offReg valReg byteReg accReg addrReg memBaseReg base)
     h
 
+theorem mstore_four_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 76)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 76) (base + 144)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 144) (base + 212)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 212) (base + 280)
+        (mstoreFourLimbsCode addrReg byteReg accReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 280)
+      (mstoreFourLimbsCode addrReg byteReg accReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
 theorem mstoreStackCode_epilogue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
     ∀ a i, (mstoreEpilogueCode (base + 280)) a = some i →

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -483,6 +483,114 @@ theorem mstoreFourLimbBodyPre_unfold
   rfl
 
 @[irreducible]
+def mstoreFourLimbBodyMid0
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) : Assertion :=
+  let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb32) ** (accReg ↦ᵣ limb32) **
+  (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ d2) **
+  (d3Addr ↦ₘ p0.1) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+
+theorem mstoreFourLimbBodyMid0_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    mstoreFourLimbBodyMid0 addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start =
+      (let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+       (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb32) ** (accReg ↦ᵣ limb32) **
+       (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ d2) **
+       (d3Addr ↦ₘ p0.1) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)) := by
+  delta mstoreFourLimbBodyMid0
+  rfl
+
+@[irreducible]
+def mstoreFourLimbBodyMid1
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) : Assertion :=
+  let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+  let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb40) ** (accReg ↦ᵣ limb40) **
+  (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ p1.1) **
+  (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+
+theorem mstoreFourLimbBodyMid1_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    mstoreFourLimbBodyMid1 addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start =
+      (let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+       let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+       (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb40) ** (accReg ↦ᵣ limb40) **
+       (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ d1) ** (d2Addr ↦ₘ p1.1) **
+       (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)) := by
+  delta mstoreFourLimbBodyMid1
+  rfl
+
+@[irreducible]
+def mstoreFourLimbBodyMid2
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) : Assertion :=
+  let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+  let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+  let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+  (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb48) ** (accReg ↦ᵣ limb48) **
+  (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ p2.1) ** (d2Addr ↦ₘ p2.2) **
+  (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+  ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+  ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+  ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+  ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)
+
+theorem mstoreFourLimbBodyMid2_unfold
+    (addrReg byteReg accReg : Reg)
+    (addrPtr d0 d1 d2 d3 d4 : Word)
+    (d0Addr d1Addr d2Addr d3Addr d4Addr sp : Word)
+    (limb32 limb40 limb48 limb56 : Word) (start : Nat) :
+    mstoreFourLimbBodyMid2 addrReg byteReg accReg
+        addrPtr d0 d1 d2 d3 d4 d0Addr d1Addr d2Addr d3Addr d4Addr sp
+        limb32 limb40 limb48 limb56 start =
+      (let p0 := MStore.mstoreDwordPairStoreLimb d3 d4 limb32 start
+       let p1 := MStore.mstoreDwordPairStoreLimb d2 p0.1 limb40 start
+       let p2 := MStore.mstoreDwordPairStoreLimb d1 p1.1 limb48 start
+       (addrReg ↦ᵣ addrPtr) ** (byteReg ↦ᵣ limb48) ** (accReg ↦ᵣ limb48) **
+       (d0Addr ↦ₘ d0) ** (d1Addr ↦ₘ p2.1) ** (d2Addr ↦ₘ p2.2) **
+       (d3Addr ↦ₘ p1.2) ** (d4Addr ↦ₘ p0.2) ** ((.x12 : Reg) ↦ᵣ sp) **
+       ((sp + signExtend12 (32 : BitVec 12)) ↦ₘ limb32) **
+       ((sp + signExtend12 (40 : BitVec 12)) ↦ₘ limb40) **
+       ((sp + signExtend12 (48 : BitVec 12)) ↦ₘ limb48) **
+       ((sp + signExtend12 (56 : BitVec 12)) ↦ₘ limb56)) := by
+  delta mstoreFourLimbBodyMid2
+  rfl
+
+@[irreducible]
 def mstoreFourLimbBodyPost
     (addrReg byteReg accReg : Reg)
     (addrPtr d0 d1 d2 d3 d4 : Word)


### PR DESCRIPTION
Stacked on #2110.

Adds mstoreStackCode_four_limbs_sub, exposing the four value-limb MSTORE body as a contiguous subrange of mstoreStackCode using the generic ofProg bridge. This replaces the brittle limb-by-limb inclusion direction with one generic body bridge.

Refs evm-asm-zvhc / GH #99.

Verification:
- lake build EvmAsm.Evm64.MStore
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in EvmAsm/Evm64/MStore/Spec.lean

Authored by @pirapira; implemented by Codex.