### PR TITLE
prove(exp): normalize boundary counter

### DIFF
--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -212,6 +212,37 @@ theorem exp_boundary_result_one_full_post_stack_shape_spec_within
     (exp_boundary_result_one_full_stack_shape_spec_within sp evmSp cOld tOld m0 m1 m2 m3 base
       baseWord exponentWord rest)
 
+/-- The EXP boundary prologue initializes the loop counter to the semantic word
+    value `256`; this lemma hides the raw ADDI/sign-extension spelling from
+    stack-level consumers. -/
+theorem exp_boundary_counter_256 :
+    ((0 : Word) + signExtend12 (256 : BitVec 12)) = (256 : Word) := by
+  unfold signExtend12
+  bv_decide
+
+/-- Boundary bridge with the stack-shaped postcondition and the loop counter
+    exposed as the plain word `256`. -/
+theorem exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + signExtend12 (32 : BitVec 12))) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp (baseWord :: (1 : EvmWord) :: rest)) := by
+  rw [← exp_boundary_counter_256]
+  exact exp_boundary_result_one_full_post_stack_shape_spec_within
+    sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
 -- Placeholder: `evm_exp_stack_spec_within` lands in slice 6 (evm-asm-6snn).
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2108.

Adds exp_boundary_counter_256 and exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within, exposing the EXP boundary loop counter as the plain word 256 in the stack-shaped postcondition. This is a generic surface bridge for later EXP composition, not a concrete example case.

Refs evm-asm-b26w / GH #92.

Verification:
- lake build EvmAsm.Evm64.Exp
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in EvmAsm/Evm64/Exp/Spec.lean

Authored by @pirapira; implemented by Codex.