### PR TITLE
prove(rlp): expose nonempty decode fuel

### DIFF
--- a/EvmAsm/EL/RLP/Decode.lean
+++ b/EvmAsm/EL/RLP/Decode.lean
@@ -97,4 +97,11 @@ end
 def decode (bs : List Byte) : Option (RLPItem × List Byte) :=
   decodeAux (2 * bs.length) bs
 
+/-- Top-level decode on a nonempty stream uses two fuel units for the head byte
+    plus twice the tail length. -/
+theorem decode_cons_eq_decodeAux_fuel (pfx : Byte) (rest : List Byte) :
+    decode (pfx :: rest) = decodeAux (2 * rest.length + 2) (pfx :: rest) := by
+  unfold decode
+  simp [Nat.mul_succ]
+
 end EvmAsm.EL.RLP


### PR DESCRIPTION
Adds decode_cons_eq_decodeAux_fuel in EvmAsm/EL/RLP/Decode.lean, rewriting decode (pfx :: rest) to the exact decodeAux fuel 2 * rest.length + 2.

This is a generic executable-spec bridge for nonempty RLP streams and prefix-dispatch proofs, not another concrete decode example.

Local verification:
- lake build EvmAsm.EL.RLP.Decode
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escape scan on EvmAsm/EL/RLP/Decode.lean

Refs evm-asm-khqz / GH #120.

Authored by @pirapira; implemented by Codex.