### PR TITLE
prove(rlp): expose decode wrapper fuel

### DIFF
--- a/EvmAsm/EL/RLP/Decode.lean
+++ b/EvmAsm/EL/RLP/Decode.lean
@@ -97,6 +97,11 @@ end
 def decode (bs : List Byte) : Option (RLPItem × List Byte) :=
   decodeAux (2 * bs.length) bs
 
+/-- Expose the exact fuel budget used by the top-level decode wrapper. -/
+theorem decode_eq_decodeAux_length (bs : List Byte) :
+    decode bs = decodeAux (2 * bs.length) bs := by
+  rfl
+
 /-- Top-level decode on a nonempty stream uses two fuel units for the head byte
     plus twice the tail length. -/
 theorem decode_cons_eq_decodeAux_fuel (pfx : Byte) (rest : List Byte) :


### PR DESCRIPTION
Stacked on #2117.

Adds decode_eq_decodeAux_length in EvmAsm/EL/RLP/Decode.lean, exposing the top-level decode wrapper as decodeAux (2 * bs.length) bs for arbitrary byte streams.

This is a generic executable-spec bridge for downstream decoder proofs, not a concrete decode example.

Local verification:
- lake build EvmAsm.EL.RLP.Decode
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escape scan on EvmAsm/EL/RLP/Decode.lean

Refs evm-asm-1x2a / GH #120.

Authored by @pirapira; implemented by Codex.