### PR TITLE
prove(memory): expose byte expansion equation

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -397,6 +397,13 @@ theorem evmMemExpand_word_eq (sizeBytes offset : Nat) :
   unfold evmMemExpand
   simp
 
+/-- Byte-granular memory writes such as MSTORE8 access one EVM memory byte. -/
+theorem evmMemExpand_byte_eq (sizeBytes offset : Nat) :
+    evmMemExpand sizeBytes offset 1 =
+      max sizeBytes (roundUpTo32 (offset + 1)) := by
+  unfold evmMemExpand
+  simp
+
 theorem bitvec_select_word_eq_ofNat_max
     (sizeBytes rounded : Nat)
     (h_size : sizeBytes < 2^64)


### PR DESCRIPTION
Adds evmMemExpand_byte_eq in EvmAsm/Evm64/Memory.lean, exposing the generic one-byte memory expansion equation evmMemExpand sizeBytes offset 1 = max sizeBytes (roundUpTo32 (offset + 1)).

This lifts the byte-access expansion fact into the memory model for MSTORE8 and future byte-granular specs.

Local verification:
- lake build EvmAsm.Evm64.Memory
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escape scan on EvmAsm/Evm64/Memory.lean

Refs evm-asm-jmcd / GH #99.

Authored by @pirapira; implemented by Codex.