### PR TITLE
prove(memory): define byte-expanded size assertion

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -438,6 +438,13 @@ theorem evmMemExpand_word_eq_old_of_end_le
   rw [evmMemExpand_word_eq]
   exact max_eq_left (roundUpTo32_le_of_le_dvd h_end h_size_dvd)
 
+theorem evmMemExpand_byte_eq_old_of_end_le
+    (sizeBytes offset : Nat) (h_end : offset + 1 ≤ sizeBytes)
+    (h_size_dvd : 32 ∣ sizeBytes) :
+    evmMemExpand sizeBytes offset 1 = sizeBytes := by
+  rw [evmMemExpand_byte_eq]
+  exact max_eq_left (roundUpTo32_le_of_le_dvd h_end h_size_dvd)
+
 /--
   Named size-cell postcondition for a 32-byte MLOAD/MSTORE-style access.
   This keeps opcode specs from repeating the high-water expression in every
@@ -498,6 +505,14 @@ theorem evmMemSizeIsByteExpanded_unfold_max
     evmMemSizeIsByteExpanded sizeLoc sizeBytes offset =
       evmMemSizeIs sizeLoc (max sizeBytes (roundUpTo32 (offset + 1))) := by
   rw [evmMemSizeIsByteExpanded_unfold, evmMemExpand_byte_eq]
+
+theorem evmMemSizeIsByteExpanded_eq_current_of_mstore8_within
+    {sizeLoc : Word} {sizeBytes offset : Nat}
+    (h_end : offset + 1 ≤ sizeBytes) (h_size_dvd : 32 ∣ sizeBytes) :
+    evmMemSizeIsByteExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc sizeBytes := by
+  rw [evmMemSizeIsByteExpanded_unfold,
+    evmMemExpand_byte_eq_old_of_end_le sizeBytes offset h_end h_size_dvd]
 
 theorem pcFree_evmMemSizeIsByteExpanded
     {sizeLoc : Word} {sizeBytes offset : Nat} :

--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -478,6 +478,37 @@ instance (sizeLoc : Word) (sizeBytes offset : Nat) :
     Assertion.PCFree (evmMemSizeIsWordExpanded sizeLoc sizeBytes offset) :=
   ⟨pcFree_evmMemSizeIsWordExpanded⟩
 
+/--
+  Named size-cell postcondition for a one-byte MSTORE8-style access.
+  This mirrors `evmMemSizeIsWordExpanded` for byte-granular memory updates.
+-/
+@[irreducible]
+def evmMemSizeIsByteExpanded (sizeLoc : Word) (sizeBytes offset : Nat) : Assertion :=
+  evmMemSizeIs sizeLoc (evmMemExpand sizeBytes offset 1)
+
+theorem evmMemSizeIsByteExpanded_unfold
+    {sizeLoc : Word} {sizeBytes offset : Nat} :
+    evmMemSizeIsByteExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc (evmMemExpand sizeBytes offset 1) := by
+  delta evmMemSizeIsByteExpanded
+  rfl
+
+theorem evmMemSizeIsByteExpanded_unfold_max
+    {sizeLoc : Word} {sizeBytes offset : Nat} :
+    evmMemSizeIsByteExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc (max sizeBytes (roundUpTo32 (offset + 1))) := by
+  rw [evmMemSizeIsByteExpanded_unfold, evmMemExpand_byte_eq]
+
+theorem pcFree_evmMemSizeIsByteExpanded
+    {sizeLoc : Word} {sizeBytes offset : Nat} :
+    (evmMemSizeIsByteExpanded sizeLoc sizeBytes offset).pcFree := by
+  rw [evmMemSizeIsByteExpanded_unfold]
+  exact pcFree_evmMemSizeIs
+
+instance (sizeLoc : Word) (sizeBytes offset : Nat) :
+    Assertion.PCFree (evmMemSizeIsByteExpanded sizeLoc sizeBytes offset) :=
+  ⟨pcFree_evmMemSizeIsByteExpanded⟩
+
 /-- MLOAD is a 32-byte byte-addressed access: expansion covers the byte just
     past the requested range for any starting byte offset. -/
 theorem evmMemExpand_mload_ge_end (sizeBytes offset : Nat) :


### PR DESCRIPTION
Stacked on #2119.

Adds evmMemSizeIsByteExpanded plus unfold/max/pcFree lemmas in EvmAsm/Evm64/Memory.lean, mirroring evmMemSizeIsWordExpanded for one-byte memory accesses.

This gives MSTORE8 and future byte-granular specs a reusable memory-size postcondition wrapper.

Local verification:
- lake build EvmAsm.Evm64.Memory
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escape scan on EvmAsm/Evm64/Memory.lean

Refs evm-asm-1nlb / GH #99.

Authored by @pirapira; implemented by Codex.