### PR TITLE
prove(mstore): bridge stack code to executable

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -4,6 +4,7 @@
   Stack-level building blocks for the 256-bit EVM MSTORE program.
 -/
 
+import EvmAsm.Evm64.MStore.Program
 import EvmAsm.Evm64.MStore.LimbSpec
 
 namespace EvmAsm.Evm64
@@ -251,6 +252,21 @@ theorem mstoreStackCode_eq_ofProg
       rfl]
     exact (CodeReq.ofProg_append (base := base) (p1 := p0) (p2 := p1 ++ p2)).symm
   exact h012
+
+theorem mstoreStackProg_eq_evm_mstore
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) :
+    mstoreStackProg offReg byteReg accReg addrReg memBaseReg =
+      evm_mstore offReg valReg byteReg accReg addrReg memBaseReg := by
+  unfold mstoreStackProg mstoreFourLimbsProg mstoreOneLimbProg
+    mstoreByteUnpackEightProg evm_mstore
+  rfl
+
+theorem mstoreStackCode_eq_evm_mstore_code
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :
+    mstoreStackCode offReg byteReg accReg addrReg memBaseReg base =
+      evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base := by
+  rw [mstoreStackCode_eq_ofProg,
+    mstoreStackProg_eq_evm_mstore offReg valReg byteReg accReg addrReg memBaseReg]
 
 theorem mstoreStackCode_prologue_sub
     (offReg byteReg accReg addrReg memBaseReg : Reg) (base : Word) :


### PR DESCRIPTION
Stacked on #2111.

Adds public equalities connecting the public stack-helper program/code to the actual executable MSTORE opcode handler:
- mstoreStackProg_eq_evm_mstore
- mstoreStackCode_eq_evm_mstore_code

Refs evm-asm-saap and GH #99.

Verification:
- lake build EvmAsm.Evm64.MStore
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/Evm64/MStore/Spec.lean