### PR TITLE
prove(mstore): frame executable epilogue

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -404,4 +404,15 @@ theorem mstore_epilogue_evm_mstore_spec_within
   exact mstore_epilogue_stack_spec_within offReg byteReg accReg addrReg memBaseReg
     sp base
 
+theorem mstore_epilogue_evm_mstore_frame_spec_within
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp : Word) (base : Word) (F : Assertion) (hF : F.pcFree) :
+    cpsTripleWithin 1 (base + 280) (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      (((.x12 : Reg) ↦ᵣ sp) ** F)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) ** F) := by
+  exact cpsTripleWithin_frameR F hF
+    (mstore_epilogue_evm_mstore_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg sp base)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2126.\n\nAdds a reusable framed executable epilogue spec for MSTORE so downstream full stack composition can pop the consumed offset/value words while preserving any pc-free frame.\n\nVerification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes in edited file\n\nRefs evm-asm-wm7j, evm-asm-k655, GH #99.\n\nAuthored by @pirapira; implemented by Codex.