### PR TITLE
prove(mstore): compose prologue with body

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -398,6 +398,32 @@ theorem mstore_prologue_evm_mstore_frame_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
 
+theorem mstore_prologue_body_evm_mstore_spec_within
+    {nBody : Nat} {R : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (F : Assertion) (hF : F.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hBody :
+      cpsTripleWithin nBody (base + 8) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** F)
+        R) :
+    cpsTripleWithin (2 + nBody) base (base + 280)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** F)
+      R := by
+  exact cpsTripleWithin_seq_same_cr
+    (mstore_prologue_evm_mstore_frame_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base F hF h_off_ne_x0 h_addr_ne_x0)
+    hBody
+
 theorem mstore_epilogue_stack_spec_within
     (offReg byteReg accReg addrReg memBaseReg : Reg)
     (sp : Word) (base : Word) :


### PR DESCRIPTION
Stacked on #2128.\n\nAdds a reusable executable-code composition bridge that sequences the framed MSTORE prologue with an arbitrary body theorem over evm_mstore_code. This is a direct building block for evm_mstore_stack_spec_within.\n\nVerification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes in edited file\n\nRefs evm-asm-e719, evm-asm-k655, GH #99.\n\nAuthored by @pirapira; implemented by Codex.