### PR TITLE
prove(mstore): add full executable skeleton

### DIFF
--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -460,4 +460,32 @@ theorem mstore_epilogue_evm_mstore_frame_spec_within
     (mstore_epilogue_evm_mstore_spec_within
       offReg valReg byteReg accReg addrReg memBaseReg sp base)
 
+theorem mstore_full_evm_mstore_spec_within
+    {nBody : Nat} {FPre FPost : Assertion}
+    (offReg valReg byteReg accReg addrReg memBaseReg : Reg)
+    (sp offset offOld addrOld memBase : Word) (base : Word)
+    (hFPre : FPre.pcFree) (hFPost : FPost.pcFree)
+    (h_off_ne_x0 : offReg ≠ .x0)
+    (h_addr_ne_x0 : addrReg ≠ .x0)
+    (hBody :
+      cpsTripleWithin nBody (base + 8) (base + 280)
+        (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+        ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offset) **
+          (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ (memBase + offset)) **
+          (sp ↦ₘ offset)) ** FPre)
+        (((.x12 : Reg) ↦ᵣ sp) ** FPost)) :
+    cpsTripleWithin (2 + nBody + 1) base (base + 284)
+      (evm_mstore_code offReg valReg byteReg accReg addrReg memBaseReg base)
+      ((((.x12 : Reg) ↦ᵣ sp) ** (offReg ↦ᵣ offOld) **
+        (memBaseReg ↦ᵣ memBase) ** (addrReg ↦ᵣ addrOld) **
+        (sp ↦ₘ offset)) ** FPre)
+      (((.x12 : Reg) ↦ᵣ (sp + 64)) ** FPost) := by
+  exact cpsTripleWithin_seq_same_cr
+    (mstore_prologue_body_evm_mstore_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg
+      sp offset offOld addrOld memBase base FPre hFPre
+      h_off_ne_x0 h_addr_ne_x0 hBody)
+    (mstore_epilogue_evm_mstore_frame_spec_within
+      offReg valReg byteReg accReg addrReg memBaseReg sp base FPost hFPost)
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2129.\n\nAdds a reusable full MSTORE executable skeleton that sequences framed prologue, arbitrary body, and framed epilogue over evm_mstore_code. This is the final shell needed before plugging in the concrete four-limb body postcondition.\n\nVerification:\n- lake build EvmAsm.Evm64.MStore\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes in edited file\n\nRefs evm-asm-vowy, evm-asm-k655, GH #99.\n\nAuthored by @pirapira; implemented by Codex.