### PR TITLE
prove(exp): normalize boundary stack pointer

### DIFF
--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -220,6 +220,11 @@ theorem exp_boundary_counter_256 :
   unfold signExtend12
   bv_decide
 
+/-- The EXP boundary epilogue advances the EVM stack pointer by one word. -/
+theorem exp_boundary_stack_pointer_advance_32 (evmSp : Word) :
+    evmSp + signExtend12 (32 : BitVec 12) = evmSp + 32 := by
+  rw [signExtend12_32]
+
 /-- Boundary bridge with the stack-shaped postcondition and the loop counter
     exposed as the plain word `256`. -/
 theorem exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within
@@ -241,6 +246,29 @@ theorem exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within
        evmStackIs evmSp (baseWord :: (1 : EvmWord) :: rest)) := by
   rw [← exp_boundary_counter_256]
   exact exp_boundary_result_one_full_post_stack_shape_spec_within
+    sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
+/-- Boundary bridge with the stack-shaped postcondition and register values
+    exposed in their plain consumer-facing forms. -/
+theorem exp_boundary_result_one_full_post_stack_shape_clean_regs_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp (baseWord :: (1 : EvmWord) :: rest)) := by
+  rw [← exp_boundary_stack_pointer_advance_32 evmSp]
+  exact exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within
     sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
 
 -- Placeholder: `evm_exp_stack_spec_within` lands in slice 6 (evm-asm-6snn).


### PR DESCRIPTION
Stacked on #2113.

Adds exp_boundary_stack_pointer_advance_32 and exp_boundary_result_one_full_post_stack_shape_clean_regs_spec_within, exposing the EXP boundary postcondition with plain consumer-facing register values.

Verification:
- lake build EvmAsm.Evm64.Exp
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check

References evm-asm-14t9 and GH #92.

Authored by @pirapira; implemented by Codex.