### PR TITLE
prove(memory): expose byte growth bridge

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -445,6 +445,13 @@ theorem evmMemExpand_byte_eq_old_of_end_le
   rw [evmMemExpand_byte_eq]
   exact max_eq_left (roundUpTo32_le_of_le_dvd h_end h_size_dvd)
 
+theorem evmMemExpand_byte_eq_rounded_of_old_le
+    (sizeBytes offset : Nat)
+    (h_old : sizeBytes ≤ roundUpTo32 (offset + 1)) :
+    evmMemExpand sizeBytes offset 1 = roundUpTo32 (offset + 1) := by
+  rw [evmMemExpand_byte_eq]
+  exact max_eq_right h_old
+
 /--
   Named size-cell postcondition for a 32-byte MLOAD/MSTORE-style access.
   This keeps opcode specs from repeating the high-water expression in every
@@ -513,6 +520,14 @@ theorem evmMemSizeIsByteExpanded_eq_current_of_mstore8_within
       evmMemSizeIs sizeLoc sizeBytes := by
   rw [evmMemSizeIsByteExpanded_unfold,
     evmMemExpand_byte_eq_old_of_end_le sizeBytes offset h_end h_size_dvd]
+
+theorem evmMemSizeIsByteExpanded_eq_rounded_of_mstore8_within
+    {sizeLoc : Word} {sizeBytes offset : Nat}
+    (h_old : sizeBytes ≤ roundUpTo32 (offset + 1)) :
+    evmMemSizeIsByteExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc (roundUpTo32 (offset + 1)) := by
+  rw [evmMemSizeIsByteExpanded_unfold,
+    evmMemExpand_byte_eq_rounded_of_old_le sizeBytes offset h_old]
 
 theorem pcFree_evmMemSizeIsByteExpanded
     {sizeLoc : Word} {sizeBytes offset : Nat} :


### PR DESCRIPTION
Stacked on #2123.

Adds evmMemExpand_byte_eq_rounded_of_old_le and evmMemSizeIsByteExpanded_eq_rounded_of_mstore8_within, the growth-side rewrite helpers for one-byte MSTORE8-style memory expansion.

Verification:
- lake build EvmAsm.Evm64.Memory
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check

References evm-asm-py9f and GH #99.

Authored by @pirapira; implemented by Codex.