### PR TITLE
prove(memory): add word-expanded growth bridge

### DIFF
--- a/EvmAsm/Evm64/Memory.lean
+++ b/EvmAsm/Evm64/Memory.lean
@@ -431,6 +431,13 @@ theorem evmMemExpand_word_eq_old_of_end_le
   rw [evmMemExpand_word_eq]
   exact max_eq_left (roundUpTo32_le_of_le_dvd h_end h_size_dvd)
 
+theorem evmMemExpand_word_eq_rounded_of_old_le
+    (sizeBytes offset : Nat)
+    (h_old : sizeBytes ≤ roundUpTo32 (offset + 32)) :
+    evmMemExpand sizeBytes offset 32 = roundUpTo32 (offset + 32) := by
+  rw [evmMemExpand_word_eq]
+  exact max_eq_right h_old
+
 /--
   Named size-cell postcondition for a 32-byte MLOAD/MSTORE-style access.
   This keeps opcode specs from repeating the high-water expression in every
@@ -460,6 +467,14 @@ theorem evmMemSizeIsWordExpanded_eq_current_of_mload_within
       evmMemSizeIs sizeLoc sizeBytes := by
   rw [evmMemSizeIsWordExpanded_unfold,
     evmMemExpand_word_eq_old_of_end_le sizeBytes offset h_end h_size_dvd]
+
+theorem evmMemSizeIsWordExpanded_eq_rounded_of_mload_within
+    {sizeLoc : Word} {sizeBytes offset : Nat}
+    (h_old : sizeBytes ≤ roundUpTo32 (offset + 32)) :
+    evmMemSizeIsWordExpanded sizeLoc sizeBytes offset =
+      evmMemSizeIs sizeLoc (roundUpTo32 (offset + 32)) := by
+  rw [evmMemSizeIsWordExpanded_unfold,
+    evmMemExpand_word_eq_rounded_of_old_le sizeBytes offset h_old]
 
 theorem pcFree_evmMemSizeIsWordExpanded
     {sizeLoc : Word} {sizeBytes offset : Nat} :


### PR DESCRIPTION
Adds generic 32-byte Memory expansion growth bridges for MLOAD/MSTORE-sized accesses, complementing the existing no-growth word bridge without adding opcode-specific examples.

Verification:
- lake build EvmAsm.Evm64.Memory
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Evm64/Memory.lean

Refs evm-asm-i2g7; GH #99.

Authored by @pirapira; implemented by Codex.