### PR TITLE
prove(mload): sequence four limb specs

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -55,6 +55,29 @@ theorem mload_prologue_stack_spec_within
       sp offset offOld addrOld memBase base h_off_ne_x0 h_addr_ne_x0)
     (hmono := mloadStackCode_prologue_sub offReg byteReg accReg addrReg memBaseReg base)
 
+theorem mload_four_limb_sequence_spec_within
+    {n0 n1 n2 n3 : Nat} {P0 P1 P2 P3 P4 : Assertion}
+    (addrReg byteReg accReg : Reg) (base : Word)
+    (h0 :
+      cpsTripleWithin n0 (base + 8) (base + 100)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P0 P1)
+    (h1 :
+      cpsTripleWithin n1 (base + 100) (base + 192)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P1 P2)
+    (h2 :
+      cpsTripleWithin n2 (base + 192) (base + 284)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P2 P3)
+    (h3 :
+      cpsTripleWithin n3 (base + 284) (base + 376)
+        (mloadFourLimbsCode addrReg byteReg accReg base) P3 P4) :
+    cpsTripleWithin (n0 + n1 + n2 + n3) (base + 8) (base + 376)
+      (mloadFourLimbsCode addrReg byteReg accReg base) P0 P4 := by
+  exact cpsTripleWithin_seq_same_cr
+    (cpsTripleWithin_seq_same_cr
+      (cpsTripleWithin_seq_same_cr h0 h1)
+      h2)
+    h3
+
 /--
   The 256-bit value loaded by MLOAD when each output limb is assembled from
   an adjacent low/high dword pair. The four limbs are stored in EVM-stack


### PR DESCRIPTION
Stacked on #2114.

Adds the generic mload_four_limb_sequence_spec_within bridge in EvmAsm/Evm64/MLoad/StackSpec.lean, composing the four 23-instruction MLOAD limb proofs under mloadFourLimbsCode. This is a reusable precursor for evm_mload_stack_spec_within_unaligned_final and avoids adding per-offset examples.

Verification:
- lake build EvmAsm.Evm64.MLoad
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden-pattern scan on EvmAsm/Evm64/MLoad/StackSpec.lean (no matches)

Refs evm-asm-p404, evm-asm-bnj9, GH #99.

Authored by @pirapira; implemented by Codex.