### PR TITLE
feat(exp): add EvmWord exponent semantics

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -19,6 +19,9 @@ import EvmAsm.Evm64.EvmWordArith.SignExtend
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 
+-- Pure EXP semantic target.
+import EvmAsm.Evm64.EvmWordArith.Exp
+
 -- Div128Shift0 → Div128CallSkipClose → {Div128FinalAssembly +
 -- Div128KnuthLower + Div128QuotientBounds → KnuthTheoremB →
 -- {DivN4Overestimate, MaxTrialVacuity → CLZLemmas → DivN4Lemmas,

--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.Exp
+
+  Pure EVM EXP semantics over 256-bit words. This is the semantic target for
+  the executable EXP opcode proof: exponentiation in Nat, reduced modulo 2^256.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.Common
+
+namespace EvmAsm.Evm64
+
+namespace EvmWord
+
+/-- EVM EXP semantics: `base ^ exponent`, reduced modulo `2^256`. -/
+def exp (base exponent : EvmWord) : EvmWord :=
+  BitVec.ofNat 256 (base.toNat ^ exponent.toNat)
+
+/-- `EvmWord.exp` is Nat exponentiation modulo the 256-bit word modulus. -/
+theorem exp_correct (base exponent : EvmWord) :
+    (exp base exponent).toNat = base.toNat ^ exponent.toNat % 2^256 := by
+  simp [exp, BitVec.toNat_ofNat]
+
+/-- EVM's `0^0` case follows Nat exponentiation and returns one. -/
+theorem exp_zero_zero : exp 0 0 = 1 := by
+  native_decide
+
+/-- Any base raised to the zero EVM word is one. -/
+theorem exp_zero_right (base : EvmWord) : exp base 0 = 1 := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp
+
+/-- One raised to any exponent remains one. -/
+theorem exp_one_left (exponent : EvmWord) : exp 1 exponent = 1 := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp
+
+/-- Any base raised to the EVM word one is itself. -/
+theorem exp_one_right (base : EvmWord) : exp base 1 = base := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp [Nat.mod_eq_of_lt base.isLt]
+
+-- Edge checks required by GH #92's EXP acceptance notes.
+example : exp (0 : EvmWord) (0 : EvmWord) = 1 := by
+  native_decide
+
+example : exp (2 : EvmWord) (256 : EvmWord) = 0 := by
+  native_decide
+
+end EvmWord
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds pure EvmWord.exp semantics for GH #92, reducing Nat exponentiation modulo 2^256, with exp_correct and core edge facts for the eventual EXP stack spec.\n\nSlice: evm-asm-bmoe\n\nLocal verification:\n- lake build EvmAsm.Evm64.EvmWordArith.Exp\n- lake build EvmAsm.Evm64.EvmWordArith\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden-pattern scan on edited files\n\nAuthored by @pirapira; implemented by Codex.