### PR TITLE
feat(mload): fold five-dword output into stack

### DIFF
--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -488,6 +488,17 @@ theorem mloadLoadedWordFromFiveDwords_evmWordIs_fold
   rw [mloadLoadedWordFromFiveDwords_eq_mloadLoadedWordFromDwordPairs]
   rw [mloadLoadedWordFromDwordPairs_evmWordIs_fold]
 
+theorem mloadLoadedWordFromFiveDwords_evmStackIs_fold
+    (sp d0 d1 d2 d3 d4 : Word) (start : Nat) (rest : List EvmWord) :
+    (((sp ↦ₘ mloadPackedLimbFromDwordPair d3 d4 start) **
+      ((sp + 8) ↦ₘ mloadPackedLimbFromDwordPair d2 d3 start) **
+      ((sp + 16) ↦ₘ mloadPackedLimbFromDwordPair d1 d2 start) **
+      ((sp + 24) ↦ₘ mloadPackedLimbFromDwordPair d0 d1 start)) **
+      evmStackIs (sp + 32) rest) =
+    evmStackIs sp (mloadLoadedWordFromFiveDwords d0 d1 d2 d3 d4 start :: rest) := by
+  rw [mloadLoadedWordFromFiveDwords_evmWordIs_fold]
+  rfl
+
 /--
   Compact stack postcondition for the five-dword unaligned MLOAD source shape.
 -/

--- a/EvmAsm/Evm64/MLoad/StackSpec.lean
+++ b/EvmAsm/Evm64/MLoad/StackSpec.lean
@@ -524,4 +524,12 @@ theorem mloadStackOutputPostFiveDwords_evmWordIs_fold
   rw [mloadStackOutputPostFiveDwords_unfold]
   rw [mloadLoadedWordFromFiveDwords_evmWordIs_fold]
 
+theorem mloadStackOutputPostFiveDwords_evmStackIs_fold
+    (sp d0 d1 d2 d3 d4 : Word) (start : Nat) (rest : List EvmWord) :
+    (mloadStackOutputPostFiveDwords sp d0 d1 d2 d3 d4 start **
+      evmStackIs (sp + 32) rest) =
+    evmStackIs sp (mloadLoadedWordFromFiveDwords d0 d1 d2 d3 d4 start :: rest) := by
+  rw [mloadStackOutputPostFiveDwords_unfold]
+  rfl
+
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2152.\n\nAdds mloadLoadedWordFromFiveDwords_evmStackIs_fold for evm-asm-nibt / evm-asm-bnj9 / GH #99. This is the generic final-postcondition bridge for unaligned MLOAD: it folds the five-dword output limb cells plus evmStackIs (sp + 32) rest into evmStackIs sp (mloadLoadedWordFromFiveDwords ... :: rest). No concrete examples are added.\n\nLocal verification:\n- lake build EvmAsm.Evm64.MLoad.StackSpec\n- lake build EvmAsm.Evm64.MLoad\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden-pattern scan on EvmAsm/Evm64/MLoad/StackSpec.lean\n\nAuthored by @pirapira; implemented by Codex.