### PR TITLE
feat(exp): expose boundary result as exponent-zero

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -19,6 +19,9 @@ import EvmAsm.Evm64.EvmWordArith.SignExtend
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 
+-- Pure EXP semantic target.
+import EvmAsm.Evm64.EvmWordArith.Exp
+
 -- Div128Shift0 → Div128CallSkipClose → {Div128FinalAssembly +
 -- Div128KnuthLower + Div128QuotientBounds → KnuthTheoremB →
 -- {DivN4Overestimate, MaxTrialVacuity → CLZLemmas → DivN4Lemmas,

--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -1,0 +1,54 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.Exp
+
+  Pure EVM EXP semantics over 256-bit words. This is the semantic target for
+  the executable EXP opcode proof: exponentiation in Nat, reduced modulo 2^256.
+-/
+
+import EvmAsm.Evm64.EvmWordArith.Common
+
+namespace EvmAsm.Evm64
+
+namespace EvmWord
+
+/-- EVM EXP semantics: `base ^ exponent`, reduced modulo `2^256`. -/
+def exp (base exponent : EvmWord) : EvmWord :=
+  BitVec.ofNat 256 (base.toNat ^ exponent.toNat)
+
+/-- `EvmWord.exp` is Nat exponentiation modulo the 256-bit word modulus. -/
+theorem exp_correct (base exponent : EvmWord) :
+    (exp base exponent).toNat = base.toNat ^ exponent.toNat % 2^256 := by
+  simp [exp, BitVec.toNat_ofNat]
+
+/-- EVM's `0^0` case follows Nat exponentiation and returns one. -/
+theorem exp_zero_zero : exp 0 0 = 1 := by
+  native_decide
+
+/-- Any base raised to the zero EVM word is one. -/
+theorem exp_zero_right (base : EvmWord) : exp base 0 = 1 := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp
+
+/-- One raised to any exponent remains one. -/
+theorem exp_one_left (exponent : EvmWord) : exp 1 exponent = 1 := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp
+
+/-- Any base raised to the EVM word one is itself. -/
+theorem exp_one_right (base : EvmWord) : exp base 1 = base := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  simp [Nat.mod_eq_of_lt base.isLt]
+
+-- Edge checks required by GH #92's EXP acceptance notes.
+example : exp (0 : EvmWord) (0 : EvmWord) = 1 := by
+  native_decide
+
+example : exp (2 : EvmWord) (256 : EvmWord) = 0 := by
+  native_decide
+
+end EvmWord
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Exp/Spec.lean
+++ b/EvmAsm/Evm64/Exp/Spec.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Compose.Base
+import EvmAsm.Evm64.EvmWordArith.Exp
 import EvmAsm.Rv64.Tactics.XSimp
 
 namespace EvmAsm.Evm64
@@ -270,6 +271,31 @@ theorem exp_boundary_result_one_full_post_stack_shape_clean_regs_spec_within
   rw [← exp_boundary_stack_pointer_advance_32 evmSp]
   exact exp_boundary_result_one_full_post_stack_shape_clean_counter_spec_within
     sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest
+
+theorem exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within
+    (sp evmSp cOld tOld m0 m1 m2 m3 : Word) (base : Word)
+    (baseWord exponentWord : EvmWord) (rest : List EvmWord) :
+    cpsTripleWithin 15 base (base + 60) (expBoundaryProgramCode base)
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) ** (.x9 ↦ᵣ cOld) **
+       (.x5 ↦ᵣ tOld) ** (.x12 ↦ᵣ evmSp) **
+       ((sp + signExtend12 (0 : BitVec 12)) ↦ₘ m0) **
+       ((sp + signExtend12 (8 : BitVec 12)) ↦ₘ m1) **
+       ((sp + signExtend12 (16 : BitVec 12)) ↦ₘ m2) **
+       ((sp + signExtend12 (24 : BitVec 12)) ↦ₘ m3) **
+       evmStackIs evmSp (baseWord :: exponentWord :: rest))
+      ((.x2 ↦ᵣ sp) ** (.x0 ↦ᵣ (0 : Word)) **
+       (.x9 ↦ᵣ (256 : Word)) **
+       (.x12 ↦ᵣ (evmSp + 32)) **
+       (.x5 ↦ᵣ (0 : Word)) **
+       evmWordIs sp (1 : EvmWord) **
+       evmStackIs evmSp (baseWord :: EvmWord.exp baseWord 0 :: rest)) := by
+  exact cpsTripleWithin_weaken
+    (fun _ hp => hp)
+    (fun _ hp => by
+      rw [EvmWord.exp_zero_right baseWord]
+      exact hp)
+    (exp_boundary_result_one_full_post_stack_shape_clean_regs_spec_within
+      sp evmSp cOld tOld m0 m1 m2 m3 base baseWord exponentWord rest)
 
 -- Placeholder: `evm_exp_stack_spec_within` lands in slice 6 (evm-asm-6snn).
 


### PR DESCRIPTION
Stacked on #2143.\n\nAlso merges #2149's EvmWord.exp helper branch so this bridge can target the semantic EXP helper. Adds exp_boundary_result_exp_zero_full_post_stack_shape_clean_regs_spec_within for evm-asm-7voq / GH #92, rewriting the boundary result word (1 : EvmWord) to EvmWord.exp baseWord 0 in the stack-shaped postcondition. No concrete examples are added.\n\nLocal verification:\n- lake build EvmAsm.Evm64.Exp\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden-pattern scan on EvmAsm/Evm64/Exp/Spec.lean and EvmAsm/Evm64/EvmWordArith/Exp.lean\n\nAuthored by @pirapira; implemented by Codex.