### PR TITLE
prove(rlp): add one-word HINT_READ spec

### DIFF
--- a/EvmAsm/Rv64/HintSpecs.lean
+++ b/EvmAsm/Rv64/HintSpecs.lean
@@ -13,10 +13,9 @@
   shape as `ecall_halt_spec_gen_within` so the wrapper body can be
   composed with surrounding ALU/branch instructions.
 
-  HINT_READ is intentionally **not** covered here: it requires reasoning
-  about the input-buffer placement convention (memory range owned in
-  the post-state) and is the central work of slice 4 itself. HINT_LEN
-  is purely register-only and can ship now.
+  The first HINT_READ spec below covers the one-output-dword case. The
+  multi-dword buffer spec remains the central work of the full Phase 4
+  slice.
 
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
@@ -99,5 +98,153 @@ theorem ecall_hint_len_spec_gen_own_within
     (fun _ hp => by xperm_hyp hp)
     (fun _ hq => by xperm_hyp hq)
     (ecall_hint_len_spec_gen_within vOld input addr)
+
+-- ============================================================================
+-- HINT_READ ECALL spec (SP1 convention: t0 = 0xF1)
+-- ============================================================================
+
+private theorem holdsFor_sepConj_privateInputIs_setPrivateInput
+    {vals vals' : List (BitVec 8)} {R : Assertion} {s : MachineState}
+    (h : ((privateInputIs vals) ** R).holdsFor s) :
+    ((privateInputIs vals') ** R).holdsFor { s with privateInput := vals' } := by
+  rcases h with ⟨h, hcompat, h1, h2, hd, hunion, hp1, hp2⟩
+  rw [privateInputIs] at hp1
+  subst hp1
+  rw [← hunion] at hcompat
+  have hcompat_parts := (PartialState.CompatibleWith_union hd).mp hcompat
+  have h2_no_private : h2.privateInput = none := by
+    rcases hd with ⟨_, _, _, _, _, hpriv⟩
+    rcases hpriv with hleft | hright
+    · simp [PartialState.singletonPrivateInput] at hleft
+    · exact hright
+  have hd' : (PartialState.singletonPrivateInput vals').Disjoint h2 := by
+    rcases hd with ⟨hr, hm, hc, hpc, hpv, _⟩
+    exact ⟨hr, hm, hc, hpc, hpv, Or.inr h2_no_private⟩
+  have h2compat' : h2.CompatibleWith { s with privateInput := vals' } := by
+    rcases hcompat_parts.2 with ⟨hr, hm, hc, hpc, hpv, hpi⟩
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_⟩
+    · intro r v hv
+      simpa using hr r v hv
+    · intro a v hv
+      simpa using hm a v hv
+    · intro a i hv
+      simpa using hc a i hv
+    · intro v hv
+      simpa using hpc v hv
+    · intro v hv
+      simpa using hpv v hv
+    · intro v hv
+      rw [h2_no_private] at hv
+      simp at hv
+  exact ⟨_, (PartialState.CompatibleWith_union hd').mpr
+    ⟨PartialState.CompatibleWith_singletonPrivateInput.mpr rfl, h2compat'⟩,
+    _, _, hd', rfl, rfl, hp2⟩
+
+/-- `HINT_READ` consumes up to one output dword from the private input stream
+    and writes the consumed bytes to the caller-owned destination dword.
+
+    This is the first reusable Phase 4 syscall bridge: it captures the input
+    consumption and the memory output for `0 < nbytes ≤ 8`. Larger reads are
+    handled by the later multi-dword buffer spec. -/
+@[spec_gen_rv64] theorem ecall_hint_read_one_word_spec_gen_within
+    (buf nbytes oldWord : Word) (input : List (BitVec 8)) (addr : Word)
+    (h_pos : 0 < nbytes.toNat) (h_le8 : nbytes.toNat ≤ 8)
+    (h_suff : nbytes.toNat ≤ input.length) :
+    cpsTripleWithin 1 addr (addr + 4) (CodeReq.singleton addr .ECALL)
+      ((.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) ** (buf ↦ₘ oldWord) **
+        (addr ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) **
+        privateInputIs input)
+      ((.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) **
+        (buf ↦ₘ bytesToWordLE (input.take nbytes.toNat)) **
+        (addr ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) **
+        privateInputIs (input.drop nbytes.toNat)) := by
+  intro R hR s hcr hPR hpc; subst hpc
+  let bytes := input.take nbytes.toNat
+  have hfetch : s.code s.pc = some .ECALL :=
+    CodeReq.singleton_satisfiedBy.mp hcr
+  have hP := holdsFor_sepConj_elim_left hPR
+  have hP_x11 := holdsFor_sepConj_elim_right hP
+  have hP_mem := holdsFor_sepConj_elim_right hP_x11
+  have hP_code := holdsFor_sepConj_elim_right hP_mem
+  have hP_x5_priv := holdsFor_sepConj_elim_right hP_code
+  have hx10 : s.getReg .x10 = buf :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP)
+  have hx11 : s.getReg .x11 = nbytes :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP_x11)
+  have hx5 : s.getReg .x5 = BitVec.ofNat 64 0xF1 :=
+    holdsFor_regIs.mp (holdsFor_sepConj_elim_left hP_x5_priv)
+  have hpi : s.privateInput = input :=
+    holdsFor_privateInputIs.mp (holdsFor_sepConj_elim_right hP_x5_priv)
+  have h_suff_state : (s.getReg .x11).toNat ≤ s.privateInput.length := by
+    rw [hx11, hpi]
+    exact h_suff
+  have hstep := step_ecall_hint_read hfetch hx5 h_suff_state
+  have h_bytes_len : bytes.length = nbytes.toNat := by
+    simp [bytes, List.length_take, h_suff]
+  have h_bytes_take : bytes.take 8 = bytes := by
+    apply List.take_of_length_le
+    rw [h_bytes_len]
+    exact h_le8
+  have h_bytes_drop : bytes.drop 8 = [] := by
+    apply List.drop_eq_nil_of_le
+    rw [h_bytes_len]
+    exact h_le8
+  have h_after_private :
+      ((privateInputIs (input.drop nbytes.toNat)) **
+        (buf ↦ₘ oldWord) ** (.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) **
+          (s.pc ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** R).holdsFor
+          { s with privateInput := input.drop nbytes.toNat } := by
+    have hpre :
+        ((privateInputIs input) **
+          (buf ↦ₘ oldWord) ** (.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) **
+            (s.pc ↦ᵢ .ECALL) ** (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** R).holdsFor s := by
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using hPR
+    exact holdsFor_sepConj_privateInputIs_setPrivateInput
+      (vals := input) (vals' := input.drop nbytes.toNat) hpre
+  have h_after_mem :
+      ((buf ↦ₘ bytesToWordLE bytes) **
+        privateInputIs (input.drop nbytes.toNat) ** (.x10 ↦ᵣ buf) **
+          (.x11 ↦ᵣ nbytes) ** (s.pc ↦ᵢ .ECALL) **
+          (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** R).holdsFor
+          ({ s with privateInput := input.drop nbytes.toNat }.setMem buf
+            (bytesToWordLE bytes)) := by
+    have hpre :
+        ((buf ↦ₘ oldWord) ** privateInputIs (input.drop nbytes.toNat) **
+          (.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) ** (s.pc ↦ᵢ .ECALL) **
+          (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** R).holdsFor
+          { s with privateInput := input.drop nbytes.toNat } := by
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using h_after_private
+    exact holdsFor_sepConj_memIs_setMem (v' := bytesToWordLE bytes) hpre
+  have h_write :
+      ({ s with privateInput := input.drop nbytes.toNat }.writeBytesAsWords buf bytes) =
+        ({ s with privateInput := input.drop nbytes.toNat }.setMem buf
+          (bytesToWordLE bytes)) := by
+    cases h_bytes : bytes with
+    | nil =>
+        have h_zero : nbytes.toNat = 0 := by
+          simpa [h_bytes] using h_bytes_len.symm
+        omega
+    | cons b bs =>
+        simp only [MachineState.writeBytesAsWords]
+        have h_len_cons : (b :: bs).length ≤ 8 := by
+          rw [← h_bytes, h_bytes_len]
+          exact h_le8
+        rw [List.take_of_length_le h_len_cons, List.drop_eq_nil_of_le h_len_cons]
+        simp
+  refine ⟨1, Nat.le_refl 1,
+    (({ s with privateInput := input.drop nbytes.toNat }.writeBytesAsWords buf bytes)).setPC (s.pc + 4),
+    ?_, by simp [MachineState.setPC], ?_⟩
+  · show (step s).bind (stepN 0) = some _
+    rw [hstep]
+    simp only [hx10, hx11, hpi]
+    rfl
+  · have hpost : (((.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ nbytes) **
+        (buf ↦ₘ bytesToWordLE bytes) ** (s.pc ↦ᵢ .ECALL) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) **
+        privateInputIs (input.drop nbytes.toNat)) ** R).holdsFor
+          ({ s with privateInput := input.drop nbytes.toNat }.writeBytesAsWords buf bytes) := by
+      rw [h_write]
+      simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using h_after_mem
+    exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hpost
 
 end EvmAsm.Rv64


### PR DESCRIPTION
Stacked on #2146.

Adds the first reusable HINT_READ CPS bridge for RLP Phase 4: ecall_hint_read_one_word_spec_gen_within in EvmAsm/Rv64/HintSpecs.lean. The theorem covers 0 < nbytes <= 8, owns the destination dword in the precondition, writes bytesToWordLE (input.take nbytes.toNat), and advances privateInput to input.drop nbytes.toNat while preserving x5/x10/x11.

This deliberately does not claim the future multi-dword buffer spec; it is a sound one-output-dword bridge for Phase 4 consumers.

Verification:
- lake build EvmAsm.Rv64.HintSpecs
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Rv64/HintSpecs.lean

Slice: evm-asm-wgr8. GH: #120.

Authored by @pirapira; implemented by Codex.