### PR TITLE
prove(exp): bridge boundary code to program

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -165,6 +165,20 @@ theorem expBoundaryProgram_byte_len : 4 * expBoundaryProgram.length = 60 := by
 abbrev expBoundaryProgramCode (base : Word) : CodeReq :=
   CodeReq.ofProg base expBoundaryProgram
 
+/-- The structural boundary-code union is exactly the executable boundary
+    program's `CodeReq.ofProg` handle. -/
+theorem expBoundaryCode_eq_programCode (base : Word) :
+    expBoundaryCode base = expBoundaryProgramCode base := by
+  unfold expBoundaryCode expBoundaryProgramCode expBoundaryProgram
+  simp only [CodeReq.unionAll_cons, CodeReq.unionAll_nil,
+    CodeReq.union_empty_right, EvmAsm.Rv64.seq]
+  rw [show (base + 24 : Word) =
+      base + BitVec.ofNat 64 (4 * EvmAsm.Evm64.exp_prologue.length) by
+    rw [exp_prologue_len]
+    bv_omega]
+  rw [← CodeReq.ofProg_append]
+  rfl
+
 theorem expBoundaryProgramCode_prologue_sub {base : Word} :
     ∀ a i, (CodeReq.ofProg base EvmAsm.Evm64.exp_prologue) a = some i →
       (expBoundaryProgramCode base) a = some i := by


### PR DESCRIPTION
Adds expBoundaryCode_eq_programCode, proving the structural EXP boundary CodeReq union equals the executable expBoundaryProgram CodeReq.ofProg handle.

Local verification:
- lake build EvmAsm.Evm64.Exp.Compose.Base
- lake build EvmAsm.Evm64.Exp
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check

Slice: evm-asm-886y. GH: #92.

Authored by @pirapira; implemented by Codex.