### PR TITLE
prove(exp): add EvmWord zero-base semantics

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -36,18 +36,35 @@ theorem exp_one_left (exponent : EvmWord) : exp 1 exponent = 1 := by
   rw [exp_correct]
   simp
 
+/-- Zero raised to any nonzero EVM exponent remains zero. -/
+theorem exp_zero_left_of_ne_zero (exponent : EvmWord) (h : exponent ≠ 0) :
+    exp 0 exponent = 0 := by
+  apply BitVec.eq_of_toNat_eq
+  rw [exp_correct]
+  have hpos : 0 < exponent.toNat := by
+    by_contra hnot
+    have hz : exponent.toNat = 0 := by omega
+    apply h
+    apply BitVec.eq_of_toNat_eq
+    simp [hz]
+  simp [Nat.zero_pow hpos]
+
 /-- Any base raised to the EVM word one is itself. -/
 theorem exp_one_right (base : EvmWord) : exp base 1 = base := by
   apply BitVec.eq_of_toNat_eq
   rw [exp_correct]
   simp [Nat.mod_eq_of_lt base.isLt]
 
+/-- The GH #92 boundary case `EXP(2, 256)` wraps to zero modulo `2^256`. -/
+theorem exp_two_256 : exp (2 : EvmWord) (256 : EvmWord) = 0 := by
+  native_decide
+
 -- Edge checks required by GH #92's EXP acceptance notes.
 example : exp (0 : EvmWord) (0 : EvmWord) = 1 := by
   native_decide
 
 example : exp (2 : EvmWord) (256 : EvmWord) = 0 := by
-  native_decide
+  exact exp_two_256
 
 end EvmWord
 


### PR DESCRIPTION
Stacked on #2149.

Adds reusable pure EXP semantic lemmas:
- exp_zero_left_of_ne_zero
- exp_two_256

The existing edge check now references the named theorem instead of carrying another anonymous proof.

Slice: evm-asm-3t9n
GH: #92

Local verification:
- lake build EvmAsm.Evm64.EvmWordArith.Exp
- lake build EvmAsm.Evm64.EvmWordArith
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-token scan on EvmAsm/Evm64/EvmWordArith/Exp.lean

Authored by @pirapira; implemented by Codex.