### PR TITLE
prove(rlp): specialize HINT_READ syscall whole input

### DIFF
--- a/EvmAsm/Rv64/HintSpecs.lean
+++ b/EvmAsm/Rv64/HintSpecs.lean
@@ -247,4 +247,29 @@ private theorem holdsFor_sepConj_privateInputIs_setPrivateInput
       simpa only [sepConj_assoc', sepConj_comm', sepConj_left_comm'] using h_after_mem
     exact holdsFor_pcFree_setPC (pcFree_sepConj (by pcFree) hR) hpost
 
+/-- Whole-input specialization of the one-dword HINT_READ syscall spec.
+    This is the low-level bridge used by Phase 4 wrappers when the private
+    input fits in a single output dword. -/
+theorem ecall_hint_read_whole_one_word_spec_gen_within
+    (buf oldWord : Word) (input : List (BitVec 8)) (addr : Word)
+    (h_pos : 0 < input.length) (h_le8 : input.length ≤ 8) :
+    cpsTripleWithin 1 addr (addr + 4) (CodeReq.singleton addr .ECALL)
+      ((.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ (BitVec.ofNat 64 input.length)) **
+        (buf ↦ₘ oldWord) ** (addr ↦ᵢ .ECALL) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** privateInputIs input)
+      ((.x10 ↦ᵣ buf) ** (.x11 ↦ᵣ (BitVec.ofNat 64 input.length)) **
+        (buf ↦ₘ bytesToWordLE input) ** (addr ↦ᵢ .ECALL) **
+        (.x5 ↦ᵣ (BitVec.ofNat 64 0xF1)) ** privateInputIs []) := by
+  have h_len_lt : input.length < 2^64 := by omega
+  have h_toNat : (BitVec.ofNat 64 input.length).toNat = input.length := by
+    simp only [BitVec.toNat_ofNat]
+    exact Nat.mod_eq_of_lt h_len_lt
+  have hread := ecall_hint_read_one_word_spec_gen_within
+    buf (BitVec.ofNat 64 input.length) oldWord input addr
+    (by simpa [h_toNat] using h_pos)
+    (by simpa [h_toNat] using h_le8)
+    (by simp [h_toNat])
+  simpa [h_toNat, List.take_of_length_le (Nat.le_refl input.length),
+    List.drop_eq_nil_of_le (Nat.le_refl input.length)] using hread
+
 end EvmAsm.Rv64


### PR DESCRIPTION
Stacked on #2155.

Adds ecall_hint_read_whole_one_word_spec_gen_within, a reusable syscall-level specialization of HINT_READ for whole private inputs fitting in one output dword (0 < input.length <= 8).

This gives Phase 4 wrappers a lower-level bridge for the BitVec.ofNat input.length, take, and drop plumbing, without adding more concrete byte-count examples.

Local checks:
- lake build EvmAsm.Rv64.HintSpecs
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-pattern scan on EvmAsm/Rv64/HintSpecs.lean

Refs evm-asm-rcp0; parent evm-asm-h6mz / GH #120.

Authored by @pirapira; implemented by Codex.