### PR TITLE
prove(rlp): add generic short byte encoding

### DIFF
--- a/EvmAsm/EL/RLP/Basic.lean
+++ b/EvmAsm/EL/RLP/Basic.lean
@@ -70,6 +70,19 @@ def encodeBytes (data : List Byte) : List Byte :=
       let lenBytes := Nat.toBytesBE len
       [BitVec.ofNat 8 (0xB7 + lenBytes.length)] ++ lenBytes ++ data
 
+/-- Generic short byte-string encoding, excluding the singleton special case. -/
+theorem encodeBytes_short_of_length_ne_one (data : List Byte)
+    (hLen : data.length ≤ 55) (hNeOne : data.length ≠ 1) :
+    encodeBytes data = [BitVec.ofNat 8 (0x80 + data.length)] ++ data := by
+  cases data with
+  | nil => simp [encodeBytes]
+  | cons a tail =>
+      cases tail with
+      | nil => exact False.elim (hNeOne rfl)
+      | cons b tail =>
+          have hLen' : tail.length + 1 + 1 ≤ 55 := by simpa using hLen
+          simp [encodeBytes, hLen']
+
 /-- Encode an RLP item to bytes. -/
 def encode : RLPItem → List Byte
   | .bytes data => encodeBytes data


### PR DESCRIPTION
Adds `encodeBytes_short_of_length_ne_one` in `EvmAsm/EL/RLP/Basic.lean`, proving the generic short byte-string encoding shape `[0x80 + data.length] ++ data` for every byte list with `data.length <= 55` and `data.length != 1`.

This gives downstream RLP proofs a reusable theorem instead of adding more length-specific examples.

Local checks:
- `lake build EvmAsm.EL.RLP.Basic`
- `lake build`
- `scripts/check-file-size.sh --report`
- `scripts/check-unimported.sh`
- `git diff --check`
- forbidden proof-escape scan on `EvmAsm/EL/RLP/Basic.lean`

Refs evm-asm-9nq7 and GH #120.

Authored by @pirapira; implemented by Codex.