### PR TITLE
feat(env): add simple field surface

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -63,6 +63,7 @@ import EvmAsm.Evm64.CallingConvention
 import EvmAsm.Evm64.Environment
 import EvmAsm.Evm64.Environment.Layout
 import EvmAsm.Evm64.Environment.Assertion
+import EvmAsm.Evm64.Env.Field
 
 -- EVM memory model (issue #99)
 import EvmAsm.Evm64.Memory

--- a/EvmAsm/Evm64/Env/Field.lean
+++ b/EvmAsm/Evm64/Env/Field.lean
@@ -1,0 +1,127 @@
+/-
+  EvmAsm.Evm64.Env.Field
+
+  Shared field surface for the simple environment opcodes (GH #103 slice 1).
+  The later `evm_env_load` program/spec can be parameterized by this enum
+  instead of duplicating one opcode-specific setup for each environment field.
+-/
+
+import EvmAsm.Evm64.Environment.Assertion
+
+namespace EvmAsm.Evm64
+namespace Env
+
+open EvmAsm.Rv64
+
+/-- The 13 simple environment opcodes whose result is a 256-bit word stored in
+    the environment block. Address-shaped fields are zero-extended through
+    `EvmEnv.addrAsWord`. -/
+inductive SimpleEnvField where
+  | address
+  | caller
+  | callValue
+  | origin
+  | gasPrice
+  | coinbase
+  | timestamp
+  | number
+  | prevrandao
+  | gasLimit
+  | chainId
+  | baseFee
+  | selfBalance
+  deriving DecidableEq, Repr
+
+namespace SimpleEnvField
+
+/-- Canonical EVM opcode byte for this simple environment field. -/
+def opcodeByte : SimpleEnvField → Nat
+  | address => 0x30
+  | caller => 0x33
+  | callValue => 0x34
+  | origin => 0x32
+  | gasPrice => 0x3a
+  | coinbase => 0x41
+  | timestamp => 0x42
+  | number => 0x43
+  | prevrandao => 0x44
+  | gasLimit => 0x45
+  | chainId => 0x46
+  | baseFee => 0x48
+  | selfBalance => 0x47
+
+/-- Byte offset of the field in the `envIs` block. Every simple env field is
+    represented as a 32-byte slot. -/
+def offset : SimpleEnvField → Nat
+  | address => EvmEnv.addressOff
+  | caller => EvmEnv.callerOff
+  | callValue => EvmEnv.callValueOff
+  | origin => EvmEnv.txOriginOff
+  | gasPrice => EvmEnv.gasPriceOff
+  | coinbase => EvmEnv.blockCoinbaseOff
+  | timestamp => EvmEnv.blockTimestampOff
+  | number => EvmEnv.blockNumberOff
+  | prevrandao => EvmEnv.blockPrevrandaoOff
+  | gasLimit => EvmEnv.blockGasLimitOff
+  | chainId => EvmEnv.chainIdOff
+  | baseFee => EvmEnv.blockBaseFeeOff
+  | selfBalance => EvmEnv.selfBalanceOff
+
+/-- Value pushed by the corresponding simple environment opcode. -/
+def value (field : SimpleEnvField) (env : EvmEnv) : EvmWord :=
+  match field with
+  | address => EvmEnv.addrAsWord env.address
+  | caller => EvmEnv.addrAsWord env.caller
+  | callValue => env.callValue
+  | origin => EvmEnv.addrAsWord env.txOrigin
+  | gasPrice => env.gasPrice
+  | coinbase => EvmEnv.addrAsWord env.blockCoinbase
+  | timestamp => env.blockTimestamp
+  | number => env.blockNumber
+  | prevrandao => env.blockPrevrandao
+  | gasLimit => env.blockGasLimit
+  | chainId => env.chainId
+  | baseFee => env.blockBaseFee
+  | selfBalance => env.selfBalance
+
+/-- Address of this field's 32-byte slot relative to an environment base. -/
+def slotAddr (base : Word) (field : SimpleEnvField) : Word :=
+  base + BitVec.ofNat 64 field.offset
+
+/-- The individual `envIs` cell that an `evm_env_load field` handler will read. -/
+def cellIs (base : Word) (field : SimpleEnvField) (env : EvmEnv) : Assertion :=
+  evmWordIs (slotAddr base field) (field.value env)
+
+theorem offset_align (field : SimpleEnvField) :
+    field.offset % 32 = 0 := by
+  cases field <;> decide
+
+theorem cellIs_unfold (base : Word) (field : SimpleEnvField) (env : EvmEnv) :
+    cellIs base field env =
+      evmWordIs (base + BitVec.ofNat 64 field.offset) (field.value env) := rfl
+
+theorem pcFree_cellIs {base : Word} {field : SimpleEnvField} {env : EvmEnv} :
+    (cellIs base field env).pcFree := by
+  unfold cellIs
+  exact pcFree_evmWordIs
+
+instance (base : Word) (field : SimpleEnvField) (env : EvmEnv) :
+    Assertion.PCFree (cellIs base field env) :=
+  ⟨pcFree_cellIs⟩
+
+theorem value_address (env : EvmEnv) :
+    value address env = EvmEnv.addrAsWord env.address := rfl
+
+theorem value_caller (env : EvmEnv) :
+    value caller env = EvmEnv.addrAsWord env.caller := rfl
+
+theorem value_callValue (env : EvmEnv) :
+    value callValue env = env.callValue := rfl
+
+theorem value_selfBalance (env : EvmEnv) :
+    value selfBalance env = env.selfBalance := rfl
+
+end SimpleEnvField
+
+end Env
+end EvmAsm.Evm64


### PR DESCRIPTION
Implements Bead evm-asm-30td.1 for GH #103.\n\nSummary:\n- add EvmAsm.Evm64.Env.Field with SimpleEnvField for the 13 simple environment opcodes\n- define opcode bytes, env layout offsets, pushed values, and per-field cell assertions\n- prove 32-byte offset alignment and PCFree for field cells\n- wire the module into EvmAsm.Evm64\n\nVerification:\n- lake build EvmAsm.Evm64.Env.Field\n- lake build\n\nAuthored by @pirapira; implemented by Codex.