### PR TITLE
feat(el): add pure world state model

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -5,3 +5,4 @@
 -/
 import EvmAsm.EL.RLP
 import EvmAsm.EL.WorldState
+import EvmAsm.EL.Transaction

--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -4,3 +4,4 @@
   Root import file for the Execution Layer (EL) specifications.
 -/
 import EvmAsm.EL.RLP
+import EvmAsm.EL.WorldState

--- a/EvmAsm/EL/Transaction.lean
+++ b/EvmAsm/EL/Transaction.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.EL.Transaction
+
+  Pure transaction data and validation predicates (GH #122 slice 1). This is
+  stacked on the pure world-state model from #123 and intentionally stops before
+  message-call execution, refund accounting, or coinbase payment.
+-/
+
+import EvmAsm.EL.WorldState
+
+namespace EvmAsm.EL
+
+/-- EIP-1559-style transaction surface needed by the Shanghai validation
+    checks. Signature recovery is represented by the already-recovered sender
+    address; calldata bytes are kept for later message-call execution. -/
+structure Transaction where
+  sender : Address
+  nonce : Nat
+  gasLimit : Nat
+  maxFeePerGas : Nat
+  maxPriorityFeePerGas : Nat
+  to : Option Address
+  value : Word256
+  data : List Byte
+  deriving Repr
+
+namespace Transaction
+
+/-- Effective priority fee per gas, capped by the transaction's fee headroom
+    over the block base fee. If `maxFeePerGas < baseFee`, validation fails and
+    this helper returns zero. -/
+def effectivePriorityFee (tx : Transaction) (baseFee : Nat) : Nat :=
+  if baseFee ≤ tx.maxFeePerGas then
+    Nat.min tx.maxPriorityFeePerGas (tx.maxFeePerGas - baseFee)
+  else
+    0
+
+/-- Effective gas price paid by the sender before refunds. -/
+def effectiveGasPrice (tx : Transaction) (baseFee : Nat) : Nat :=
+  baseFee + tx.effectivePriorityFee baseFee
+
+/-- Upfront gas budget charged before execution, excluding transferred value. -/
+def upfrontGasCost (tx : Transaction) (baseFee : Nat) : Nat :=
+  tx.gasLimit * tx.effectiveGasPrice baseFee
+
+/-- Total upfront balance requirement: gas budget plus transferred value. -/
+def upfrontCost (tx : Transaction) (baseFee : Nat) : Nat :=
+  tx.upfrontGasCost baseFee + tx.value.toNat
+
+def senderAccount? (state : WorldState) (tx : Transaction) : Option Account :=
+  state.getAccount tx.sender
+
+def nonceMatches (account : Account) (tx : Transaction) : Prop :=
+  account.nonce = tx.nonce
+
+def gasLimitWithinBlock (tx : Transaction) (blockGasRemaining : Nat) : Prop :=
+  tx.gasLimit ≤ blockGasRemaining
+
+def maxFeeCoversBaseFee (tx : Transaction) (baseFee : Nat) : Prop :=
+  baseFee ≤ tx.maxFeePerGas
+
+def senderCanPayUpfront (account : Account) (tx : Transaction) (baseFee : Nat) : Prop :=
+  tx.upfrontCost baseFee ≤ account.balance.toNat
+
+/-- Validation checks that do not execute the transaction. This captures the
+    nonce, block-gas, base-fee, and sender-balance gates from #122. -/
+def validatesAgainst
+    (state : WorldState) (tx : Transaction) (baseFee blockGasRemaining : Nat) : Prop :=
+  ∃ account : Account,
+    senderAccount? state tx = some account ∧
+    nonceMatches account tx ∧
+    gasLimitWithinBlock tx blockGasRemaining ∧
+    maxFeeCoversBaseFee tx baseFee ∧
+    senderCanPayUpfront account tx baseFee
+
+theorem effectivePriorityFee_eq_min_of_base_le
+    (tx : Transaction) {baseFee : Nat} (h_base : baseFee ≤ tx.maxFeePerGas) :
+    tx.effectivePriorityFee baseFee =
+      Nat.min tx.maxPriorityFeePerGas (tx.maxFeePerGas - baseFee) := by
+  simp [effectivePriorityFee, h_base]
+
+theorem effectivePriorityFee_eq_zero_of_base_gt
+    (tx : Transaction) {baseFee : Nat} (h_base : tx.maxFeePerGas < baseFee) :
+    tx.effectivePriorityFee baseFee = 0 := by
+  simp [effectivePriorityFee, show ¬baseFee ≤ tx.maxFeePerGas from by omega]
+
+theorem validatesAgainst_account
+    {state : WorldState} {tx : Transaction} {baseFee blockGasRemaining : Nat}
+    (h_valid : validatesAgainst state tx baseFee blockGasRemaining) :
+    ∃ account : Account, senderAccount? state tx = some account := by
+  rcases h_valid with ⟨account, h_account, _⟩
+  exact ⟨account, h_account⟩
+
+end Transaction
+
+end EvmAsm.EL

--- a/EvmAsm/EL/WorldState.lean
+++ b/EvmAsm/EL/WorldState.lean
@@ -1,0 +1,109 @@
+/-
+  EvmAsm.EL.WorldState
+
+  Pure Ethereum world-state model (GH #123 slice 1). This module deliberately
+  has no RISC-V dependency; later Evm64 storage/syscall slices can bridge this
+  model to concrete ECALL interfaces and separation-logic assertions.
+-/
+
+namespace EvmAsm.EL
+
+abbrev Byte := BitVec 8
+abbrev Address := BitVec 160
+abbrev Word256 := BitVec 256
+abbrev Hash256 := BitVec 256
+abbrev StorageKey := Word256
+
+/-- Ethereum account data relevant to the execution layer. Code bytes are kept
+    with the account so CREATE/CALL-family slices can relate code hashes to the
+    executable code region later. -/
+structure Account where
+  nonce : Nat
+  balance : Word256
+  storageRoot : Hash256
+  codeHash : Hash256
+  code : List Byte
+  deriving Repr
+
+/-- Pure world state: account existence plus per-account storage slots. Missing
+    storage slots read as zero through `getStorage`. -/
+structure WorldState where
+  accounts : Address → Option Account
+  storage : Address → StorageKey → Word256
+
+namespace WorldState
+
+def empty : WorldState :=
+  { accounts := fun _ => none
+    storage := fun _ _ => 0 }
+
+def getAccount (state : WorldState) (addr : Address) : Option Account :=
+  state.accounts addr
+
+def setAccount (state : WorldState) (addr : Address) (account : Account) : WorldState :=
+  { state with accounts := fun addr' => if addr' = addr then some account else state.accounts addr' }
+
+def deleteAccount (state : WorldState) (addr : Address) : WorldState :=
+  { state with accounts := fun addr' => if addr' = addr then none else state.accounts addr' }
+
+def getStorage (state : WorldState) (addr : Address) (key : StorageKey) : Word256 :=
+  state.storage addr key
+
+def setStorage
+    (state : WorldState) (addr : Address) (key : StorageKey) (value : Word256) :
+    WorldState :=
+  { state with storage := fun addr' key' =>
+      if addr' = addr then
+        if key' = key then value else state.storage addr' key'
+      else
+        state.storage addr' key' }
+
+@[simp] theorem getAccount_empty (addr : Address) :
+    getAccount empty addr = none := rfl
+
+@[simp] theorem getStorage_empty (addr : Address) (key : StorageKey) :
+    getStorage empty addr key = 0 := rfl
+
+@[simp] theorem getAccount_setAccount_same
+    (state : WorldState) (addr : Address) (account : Account) :
+    getAccount (setAccount state addr account) addr = some account := by
+  simp [getAccount, setAccount]
+
+theorem getAccount_setAccount_ne
+    (state : WorldState) {addr other : Address} (account : Account)
+    (h_ne : other ≠ addr) :
+    getAccount (setAccount state addr account) other = getAccount state other := by
+  simp [getAccount, setAccount, h_ne]
+
+@[simp] theorem getAccount_deleteAccount_same
+    (state : WorldState) (addr : Address) :
+    getAccount (deleteAccount state addr) addr = none := by
+  simp [getAccount, deleteAccount]
+
+theorem getAccount_deleteAccount_ne
+    (state : WorldState) {addr other : Address} (h_ne : other ≠ addr) :
+    getAccount (deleteAccount state addr) other = getAccount state other := by
+  simp [getAccount, deleteAccount, h_ne]
+
+@[simp] theorem getStorage_setStorage_same
+    (state : WorldState) (addr : Address) (key : StorageKey) (value : Word256) :
+    getStorage (setStorage state addr key value) addr key = value := by
+  simp [getStorage, setStorage]
+
+theorem getStorage_setStorage_addr_ne
+    (state : WorldState) {addr other : Address} (key key' : StorageKey) (value : Word256)
+    (h_ne : other ≠ addr) :
+    getStorage (setStorage state addr key value) other key' =
+      getStorage state other key' := by
+  simp [getStorage, setStorage, h_ne]
+
+theorem getStorage_setStorage_key_ne
+    (state : WorldState) (addr : Address) {key other : StorageKey} (value : Word256)
+    (h_ne : other ≠ key) :
+    getStorage (setStorage state addr key value) addr other =
+      getStorage state addr other := by
+  simp [getStorage, setStorage, h_ne]
+
+end WorldState
+
+end EvmAsm.EL


### PR DESCRIPTION
Implements Bead evm-asm-wus3.1 for GH #123.\n\nSummary:\n- add EvmAsm.EL.WorldState with pure Account and WorldState types\n- model account get/set/delete operations\n- model storage get/set operations with zero default in empty state\n- prove basic same-address/key and different-address/key rewrite theorems\n- wire the module into EvmAsm.EL\n\nVerification:\n- lake build EvmAsm.EL.WorldState\n- lake build\n\nAuthored by @pirapira; implemented by Codex.