### PR TITLE
feat(gas): add calldata opcode costs

### DIFF
--- a/EvmAsm/Evm64/Dispatch.lean
+++ b/EvmAsm/Evm64/Dispatch.lean
@@ -38,6 +38,9 @@ def decodeByte? : Nat → Option EvmOpcode
   | 0x1b => some SHL
   | 0x1c => some SHR
   | 0x1d => some SAR
+  | 0x35 => some CALLDATALOAD
+  | 0x36 => some CALLDATASIZE
+  | 0x37 => some CALLDATACOPY
   | 0x50 => some POP
   | 0x51 => some MLOAD
   | 0x52 => some MSTORE
@@ -117,6 +120,9 @@ def modeledByte (b : Nat) : Prop :=
 
 theorem decodeByte?_ADD : decodeByte? 0x01 = some ADD := rfl
 theorem decodeByte?_EXP : decodeByte? 0x0a = some EXP := rfl
+theorem decodeByte?_CALLDATALOAD : decodeByte? 0x35 = some CALLDATALOAD := rfl
+theorem decodeByte?_CALLDATASIZE : decodeByte? 0x36 = some CALLDATASIZE := rfl
+theorem decodeByte?_CALLDATACOPY : decodeByte? 0x37 = some CALLDATACOPY := rfl
 theorem decodeByte?_MLOAD : decodeByte? 0x51 = some MLOAD := rfl
 theorem decodeByte?_PUSH0 : decodeByte? 0x5f = some PUSH0 := rfl
 theorem decodeByte?_PUSH1 : decodeByte? 0x60 = some (PUSH 1) := rfl
@@ -128,6 +134,18 @@ theorem decodeByte?_SWAP16 : decodeByte? 0x9f = some (SWAP 16) := rfl
 
 theorem byte?_roundtrip_ADD :
     byte? ADD = some 0x01 ∧ decodeByte? 0x01 = some ADD := by
+  exact ⟨rfl, rfl⟩
+
+theorem byte?_roundtrip_CALLDATALOAD :
+    byte? CALLDATALOAD = some 0x35 ∧ decodeByte? 0x35 = some CALLDATALOAD := by
+  exact ⟨rfl, rfl⟩
+
+theorem byte?_roundtrip_CALLDATASIZE :
+    byte? CALLDATASIZE = some 0x36 ∧ decodeByte? 0x36 = some CALLDATASIZE := by
+  exact ⟨rfl, rfl⟩
+
+theorem byte?_roundtrip_CALLDATACOPY :
+    byte? CALLDATACOPY = some 0x37 ∧ decodeByte? 0x37 = some CALLDATACOPY := by
   exact ⟨rfl, rfl⟩
 
 theorem byte?_roundtrip_PUSH32 :

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -42,6 +42,9 @@ inductive EvmOpcode where
   | MSTORE
   | MSTORE8
   | MSIZE
+  | CALLDATALOAD
+  | CALLDATASIZE
+  | CALLDATACOPY
   | PUSH0
   | PUSH (n : Nat)
   | DUP (n : Nat)
@@ -92,6 +95,9 @@ def byte? : EvmOpcode → Option Nat
   | MSTORE => some 0x52
   | MSTORE8 => some 0x53
   | MSIZE => some 0x59
+  | CALLDATALOAD => some 0x35
+  | CALLDATASIZE => some 0x36
+  | CALLDATACOPY => some 0x37
   | PUSH0 => some 0x5f
   | PUSH n => if validPushWidth n then some (0x5f + n) else none
   | DUP n => if validDupIndex n then some (0x7f + n) else none
@@ -126,6 +132,9 @@ def staticGasCost : EvmOpcode → Nat
   | MSTORE => 3
   | MSTORE8 => 3
   | MSIZE => 2
+  | CALLDATALOAD => 3
+  | CALLDATASIZE => 2
+  | CALLDATACOPY => 3
   | PUSH0 => 2
   | PUSH _ => 3
   | DUP _ => 3
@@ -157,6 +166,12 @@ theorem byte?_PUSH0 : byte? PUSH0 = some 0x5f := rfl
 theorem staticGasCost_push0 : staticGasCost PUSH0 = 2 := rfl
 
 theorem staticGasCost_msize : staticGasCost MSIZE = 2 := rfl
+
+theorem staticGasCost_calldataLoad : staticGasCost CALLDATALOAD = 3 := rfl
+
+theorem staticGasCost_calldataSize : staticGasCost CALLDATASIZE = 2 := rfl
+
+theorem staticGasCost_calldataCopyBase : staticGasCost CALLDATACOPY = 3 := rfl
 
 theorem staticGasCost_expBase : staticGasCost EXP = 10 := rfl
 


### PR DESCRIPTION
Implements Bead evm-asm-y6gx.3 for GH #117, supporting GH #104 and GH #106.

Summary:
- add CALLDATALOAD, CALLDATASIZE, and CALLDATACOPY to EvmOpcode
- add byte? cases and Dispatch.decodeByte? cases for 0x35/0x36/0x37
- add Shanghai static/base gas costs and round-trip lemmas

Verification:
- lake build EvmAsm.Evm64.Gas
- lake build EvmAsm.Evm64.Dispatch
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.