### PR TITLE
feat(env): add opcode value bridge

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -64,6 +64,7 @@ import EvmAsm.Evm64.Environment
 import EvmAsm.Evm64.Environment.Layout
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.Env.Field
+import EvmAsm.Evm64.Env.Semantics
 
 -- Static gas schedule (#117)
 import EvmAsm.Evm64.Gas

--- a/EvmAsm/Evm64/Env/Semantics.lean
+++ b/EvmAsm/Evm64/Env/Semantics.lean
@@ -1,0 +1,39 @@
+/-
+  EvmAsm.Evm64.Env.Semantics
+
+  Pure semantic bridge for simple environment opcode bytes (GH #103 slice 3).
+-/
+
+import EvmAsm.Evm64.Env.Field
+
+namespace EvmAsm.Evm64
+namespace Env
+
+/-- Value pushed by a simple environment opcode byte, when the byte is supported. -/
+def simpleEnvOpcodeValue? (opcode : Nat) (env : EvmEnv) : Option EvmWord :=
+  (SimpleEnvField.ofOpcodeByte? opcode).map (fun field => field.value env)
+
+theorem simpleEnvOpcodeValue?_of_decoded {opcode : Nat} {field : SimpleEnvField}
+    (env : EvmEnv) (h_decode : SimpleEnvField.ofOpcodeByte? opcode = some field) :
+    simpleEnvOpcodeValue? opcode env = some (field.value env) := by
+  simp [simpleEnvOpcodeValue?, h_decode]
+
+theorem simpleEnvOpcodeValue?_of_opcodeByte (field : SimpleEnvField) (env : EvmEnv) :
+    simpleEnvOpcodeValue? field.opcodeByte env = some (field.value env) := by
+  exact simpleEnvOpcodeValue?_of_decoded env (SimpleEnvField.ofOpcodeByte?_opcodeByte field)
+
+theorem simpleEnvOpcodeValue?_of_unknown {opcode : Nat} (env : EvmEnv)
+    (h_decode : SimpleEnvField.ofOpcodeByte? opcode = none) :
+    simpleEnvOpcodeValue? opcode env = none := by
+  simp [simpleEnvOpcodeValue?, h_decode]
+
+@[simp] theorem simpleEnvOpcodeValue?_balance (env : EvmEnv) :
+    simpleEnvOpcodeValue? 0x31 env = none := by
+  exact simpleEnvOpcodeValue?_of_unknown env SimpleEnvField.ofOpcodeByte?_balance
+
+@[simp] theorem simpleEnvOpcodeValue?_unknown_ff (env : EvmEnv) :
+    simpleEnvOpcodeValue? 0xff env = none := by
+  exact simpleEnvOpcodeValue?_of_unknown env SimpleEnvField.ofOpcodeByte?_unknown_ff
+
+end Env
+end EvmAsm.Evm64


### PR DESCRIPTION
Implements Bead evm-asm-30td.3 for GH #103.

Summary:
- add EvmAsm.Evm64.Env.Semantics
- map simple environment opcode bytes to their EvmEnv EvmWord result
- add decoded-field, opcode-byte round-trip, and unknown-byte lemmas for later dispatch/handler specs

Verification:
- lake build EvmAsm.Evm64.Env.Semantics
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.