### PR TITLE
feat(storage): add SSTORE access gas bridge

### DIFF
--- a/EvmAsm/Evm64/StorageAccess.lean
+++ b/EvmAsm/Evm64/StorageAccess.lean
@@ -90,5 +90,39 @@ theorem sloadDynamicCostForKey_after_warmKey
       StorageGas.warmStorageReadCost := by
   simp [sloadDynamicCostForKey, accessStatus_after_warmKey]
 
+/-- Dynamic SSTORE gas for a key under the current access list. -/
+def sstoreDynamicCostForKey
+    (accesses : StorageAccessList) (key : StorageAccessKey) (current new : EvmWord) : Nat :=
+  StorageGas.sstoreDynamicCost (accessStatus accesses key) current new
+
+theorem sstoreDynamicCostForKey_of_warm
+    {accesses : StorageAccessList} {key : StorageAccessKey} {current new : EvmWord}
+    (h_warm : isWarm accesses key = true) :
+    sstoreDynamicCostForKey accesses key current new =
+      StorageGas.sstoreWriteCost current new := by
+  simp [sstoreDynamicCostForKey, accessStatus_of_warm h_warm,
+    StorageGas.sstoreDynamicCost_warm]
+
+theorem sstoreDynamicCostForKey_of_cold
+    {accesses : StorageAccessList} {key : StorageAccessKey} {current new : EvmWord}
+    (h_cold : isWarm accesses key = false) :
+    sstoreDynamicCostForKey accesses key current new =
+      StorageGas.coldSloadCost + StorageGas.sstoreWriteCost current new := by
+  simp [sstoreDynamicCostForKey, accessStatus_of_cold h_cold,
+    StorageGas.sstoreDynamicCost_cold]
+
+@[simp] theorem sstoreDynamicCostForKey_nil
+    (key : StorageAccessKey) (current new : EvmWord) :
+    sstoreDynamicCostForKey [] key current new =
+      StorageGas.coldSloadCost + StorageGas.sstoreWriteCost current new := by
+  simp [sstoreDynamicCostForKey, StorageGas.sstoreDynamicCost_cold]
+
+theorem sstoreDynamicCostForKey_after_warmKey
+    (accesses : StorageAccessList) (key : StorageAccessKey) (current new : EvmWord) :
+    sstoreDynamicCostForKey (warmKey accesses key) key current new =
+      StorageGas.sstoreWriteCost current new := by
+  simp [sstoreDynamicCostForKey, accessStatus_after_warmKey,
+    StorageGas.sstoreDynamicCost_warm]
+
 end StorageAccess
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2188.

Implements Bead evm-asm-6sjn.5 for GH #119.

Summary:
- add sstoreDynamicCostForKey over StorageAccessList
- bridge accessStatus to StorageGas.sstoreDynamicCost
- add warm/cold/nil/after-warm lemmas for later SSTORE handler specs

Verification:
- lake build EvmAsm.Evm64.StorageAccess
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.