### PR TITLE
feat(el): add log event model

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -4,6 +4,7 @@
   Root import file for the Execution Layer (EL) specifications.
 -/
 import EvmAsm.EL.RLP
+import EvmAsm.EL.Logs
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.Storage
 import EvmAsm.EL.Transaction

--- a/EvmAsm/EL/Logs.lean
+++ b/EvmAsm/EL/Logs.lean
@@ -1,0 +1,92 @@
+/-
+  EvmAsm.EL.Logs
+
+  Pure LOG0-LOG4 event surface for GH #112.
+-/
+
+import EvmAsm.EL.WorldState
+
+namespace EvmAsm.EL
+
+/-- A LOG topic is a full 256-bit EVM word. -/
+abbrev LogTopic := Word256
+
+/-- One EVM log entry emitted by LOG0 through LOG4. -/
+structure LogEntry where
+  emitter : Address
+  topics : List LogTopic
+  data : List Byte
+  deriving Repr
+
+namespace LogEntry
+
+/-- Topic-count validity for LOG0 through LOG4. -/
+def topicCountOk (entry : LogEntry) : Prop :=
+  entry.topics.length ≤ 4
+
+/-- Construct a log entry when the caller already has the concrete topics/data. -/
+def mkChecked (emitter : Address) (topics : List LogTopic) (data : List Byte) : LogEntry :=
+  { emitter := emitter, topics := topics, data := data }
+
+theorem topicCountOk_iff (entry : LogEntry) :
+    entry.topicCountOk ↔ entry.topics.length ≤ 4 := Iff.rfl
+
+theorem topicCountOk_nil (emitter : Address) (data : List Byte) :
+    (mkChecked emitter [] data).topicCountOk := by
+  simp [topicCountOk, mkChecked]
+
+theorem topicCountOk_single (emitter : Address) (topic : LogTopic) (data : List Byte) :
+    (mkChecked emitter [topic] data).topicCountOk := by
+  simp [topicCountOk, mkChecked]
+
+theorem topicCountOk_two
+    (emitter : Address) (topic0 topic1 : LogTopic) (data : List Byte) :
+    (mkChecked emitter [topic0, topic1] data).topicCountOk := by
+  simp [topicCountOk, mkChecked]
+
+theorem topicCountOk_three
+    (emitter : Address) (topic0 topic1 topic2 : LogTopic) (data : List Byte) :
+    (mkChecked emitter [topic0, topic1, topic2] data).topicCountOk := by
+  simp [topicCountOk, mkChecked]
+
+theorem topicCountOk_four
+    (emitter : Address) (topic0 topic1 topic2 topic3 : LogTopic) (data : List Byte) :
+    (mkChecked emitter [topic0, topic1, topic2, topic3] data).topicCountOk := by
+  simp [topicCountOk, mkChecked]
+
+end LogEntry
+
+/-- Append-only sequence of EVM log entries accumulated during execution. -/
+structure LogState where
+  entries : List LogEntry
+  deriving Repr
+
+namespace LogState
+
+def empty : LogState :=
+  { entries := [] }
+
+/-- Append one log entry to the end of the execution log. -/
+def appendLog (logs : LogState) (entry : LogEntry) : LogState :=
+  { entries := logs.entries ++ [entry] }
+
+@[simp] theorem entries_empty : empty.entries = [] := rfl
+
+@[simp] theorem entries_appendLog (logs : LogState) (entry : LogEntry) :
+    (appendLog logs entry).entries = logs.entries ++ [entry] := rfl
+
+theorem length_appendLog (logs : LogState) (entry : LogEntry) :
+    (appendLog logs entry).entries.length = logs.entries.length + 1 := by
+  simp [appendLog]
+
+theorem appendLog_empty_entries (entry : LogEntry) :
+    (appendLog empty entry).entries = [entry] := rfl
+
+theorem appended_log_topicCountOk
+    (logs : LogState) {entry : LogEntry} (h_topics : entry.topicCountOk) :
+    (appendLog logs entry).entries.getLast (by simp [appendLog]) |>.topicCountOk := by
+  simpa [appendLog] using h_topics
+
+end LogState
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds the first #112 pure LOG0-LOG4 event surface:

- LogTopic
- LogEntry with emitter/topics/data
- LogEntry.topicCountOk for LOG0 through LOG4 arity
- LogState as an append-only event list
- LogState.appendLog and basic length/last-entry/topic-count lemmas

This gives later LOG opcode stack specs a pure EL target before memory-slice and RISC-V bridge work.

Refs Bead evm-asm-molh.1 and GH #112.

Verification:
- lake build EvmAsm.EL.Logs
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/EL/Logs.lean EvmAsm/EL.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.