### PR TITLE
feat(el): add create request model

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -4,6 +4,7 @@
   Root import file for the Execution Layer (EL) specifications.
 -/
 import EvmAsm.EL.RLP
+import EvmAsm.EL.Create
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.Storage
 import EvmAsm.EL.Transaction

--- a/EvmAsm/EL/Create.lean
+++ b/EvmAsm/EL/Create.lean
@@ -1,0 +1,155 @@
+/-
+  EvmAsm.EL.Create
+
+  Pure contract-creation request surface for GH #115.
+-/
+
+import EvmAsm.EL.WorldState
+
+namespace EvmAsm.EL
+
+/-- CREATE-family opcode variant. -/
+inductive CreateKind where
+  | create
+  | create2
+  deriving DecidableEq, Repr
+
+namespace CreateKind
+
+def usesSalt : CreateKind → Bool
+  | create => false
+  | create2 => true
+
+theorem usesSalt_create : usesSalt create = false := rfl
+theorem usesSalt_create2 : usesSalt create2 = true := rfl
+
+end CreateKind
+
+/-- Pure input request for a CREATE or CREATE2 operation. -/
+structure CreateRequest where
+  kind : CreateKind
+  creator : Address
+  value : Word256
+  initcode : List Byte
+  gas : Nat
+  salt? : Option Word256
+  deriving Repr
+
+namespace CreateRequest
+
+def forCreate
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat) :
+    CreateRequest :=
+  { kind := .create
+    creator := creator
+    value := value
+    initcode := initcode
+    gas := gas
+    salt? := none }
+
+def forCreate2
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat)
+    (salt : Word256) : CreateRequest :=
+  { kind := .create2
+    creator := creator
+    value := value
+    initcode := initcode
+    gas := gas
+    salt? := some salt }
+
+def isCreate2 (request : CreateRequest) : Prop :=
+  request.kind = .create2
+
+def hasSalt (request : CreateRequest) : Prop :=
+  request.salt?.isSome
+
+theorem kind_forCreate
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat) :
+    (forCreate creator value initcode gas).kind = .create := rfl
+
+theorem kind_forCreate2
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat)
+    (salt : Word256) :
+    (forCreate2 creator value initcode gas salt).kind = .create2 := rfl
+
+theorem salt?_forCreate
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat) :
+    (forCreate creator value initcode gas).salt? = none := rfl
+
+theorem salt?_forCreate2
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat)
+    (salt : Word256) :
+    (forCreate2 creator value initcode gas salt).salt? = some salt := rfl
+
+theorem hasSalt_forCreate2
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat)
+    (salt : Word256) :
+    (forCreate2 creator value initcode gas salt).hasSalt := by
+  unfold hasSalt
+  rfl
+
+theorem not_hasSalt_forCreate
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat) :
+    ¬ (forCreate creator value initcode gas).hasSalt := by
+  simp [hasSalt, forCreate]
+
+theorem isCreate2_forCreate2
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat)
+    (salt : Word256) :
+    (forCreate2 creator value initcode gas salt).isCreate2 := rfl
+
+theorem not_isCreate2_forCreate
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas : Nat) :
+    ¬ (forCreate creator value initcode gas).isCreate2 := by
+  simp [isCreate2, forCreate]
+
+end CreateRequest
+
+/-- Coarse result status for CREATE and CREATE2. -/
+inductive CreateStatus where
+  | deployed
+  | reverted
+  | failed
+  deriving DecidableEq, Repr
+
+/-- Pure output of a CREATE-family operation. -/
+structure CreateResult where
+  status : CreateStatus
+  address? : Option Address
+  state : WorldState
+  returndata : List Byte
+  gasRemaining : Nat
+
+namespace CreateResult
+
+def deployed (result : CreateResult) : Prop :=
+  result.status = .deployed
+
+def reverted (result : CreateResult) : Prop :=
+  result.status = .reverted
+
+def failed (result : CreateResult) : Prop :=
+  result.status = .failed
+
+theorem deployed_mk
+    (address : Address) (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    deployed
+      { status := .deployed
+        address? := some address
+        state := state
+        returndata := returndata
+        gasRemaining := gasRemaining } := rfl
+
+theorem not_deployed_failed
+    (state : WorldState) (returndata : List Byte) (gasRemaining : Nat) :
+    ¬ deployed
+      { status := .failed
+        address? := none
+        state := state
+        returndata := returndata
+        gasRemaining := gasRemaining } := by
+  simp [deployed]
+
+end CreateResult
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds the first #115 pure CREATE/CREATE2 surface:

- CreateKind with CREATE/CREATE2 salt classification
- CreateRequest with forCreate and forCreate2 constructors
- salt/isCreate2 predicates and constructor lemmas
- CreateStatus and CreateResult status predicates

Address derivation and world-state mutation are intentionally left for later slices so this PR gives opcode and state-transition work a stable request/result model first.

Refs Bead evm-asm-dtys.1 and GH #115.

Verification:
- lake build EvmAsm.EL.Create
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/EL/Create.lean EvmAsm/EL.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.