### PR TITLE
feat(precompile): add result framing

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -77,6 +77,7 @@ import EvmAsm.Evm64.Dispatch
 
 -- Precompile dispatch surface (#116)
 import EvmAsm.Evm64.Precompile
+import EvmAsm.Evm64.PrecompileResult
 
 -- EVM memory model (issue #99)
 import EvmAsm.Evm64.Memory

--- a/EvmAsm/Evm64/PrecompileResult.lean
+++ b/EvmAsm/Evm64/PrecompileResult.lean
@@ -1,0 +1,77 @@
+/-
+  EvmAsm.Evm64.PrecompileResult
+
+  Pure precompile result framing for GH #116.
+-/
+
+import EvmAsm.Evm64.Precompile
+
+namespace EvmAsm.Evm64
+
+/-- Coarse status returned by a precompile dispatch. -/
+inductive PrecompileStatus where
+  | success
+  | failure
+  deriving DecidableEq, Repr
+
+/-- Pure input surface for a precompile invocation. -/
+structure PrecompileInput where
+  target : Precompile
+  caller : Address
+  input : List (BitVec 8)
+  gas : Nat
+
+/-- Pure output surface for a precompile invocation. -/
+structure PrecompileResult where
+  status : PrecompileStatus
+  output : List (BitVec 8)
+  gasRemaining : Nat
+
+namespace PrecompileResult
+
+def ok (out : List (BitVec 8)) (gasRemaining : Nat) : PrecompileResult :=
+  { status := .success
+    output := out
+    gasRemaining := gasRemaining }
+
+def fail (gasRemaining : Nat) : PrecompileResult :=
+  { status := .failure
+    output := ([] : List (BitVec 8))
+    gasRemaining := gasRemaining }
+
+def succeeded (result : PrecompileResult) : Prop :=
+  result.status = .success
+
+def failed (result : PrecompileResult) : Prop :=
+  result.status = .failure
+
+def preservesGasBound (input : PrecompileInput) (result : PrecompileResult) : Prop :=
+  result.gasRemaining ≤ input.gas
+
+def outputMatches (result : PrecompileResult) (out : List (BitVec 8)) : Prop :=
+  result.status = .success ∧ result.output = out
+
+theorem succeeded_ok (out : List (BitVec 8)) (gasRemaining : Nat) :
+    succeeded (ok out gasRemaining) := rfl
+
+theorem failed_fail (gasRemaining : Nat) :
+    failed (fail gasRemaining) := rfl
+
+theorem output_fail (gasRemaining : Nat) :
+    (fail gasRemaining).output = ([] : List (BitVec 8)) := rfl
+
+theorem outputMatches_ok (out : List (BitVec 8)) (gasRemaining : Nat) :
+    outputMatches (ok out gasRemaining) out := by
+  exact ⟨rfl, rfl⟩
+
+theorem not_succeeded_fail (gasRemaining : Nat) :
+    ¬ succeeded (fail gasRemaining) := by
+  simp [succeeded, fail]
+
+theorem preservesGasBound_same (input : PrecompileInput) :
+    preservesGasBound input (ok ([] : List (BitVec 8)) input.gas) := by
+  simp [preservesGasBound, ok]
+
+end PrecompileResult
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds the next #116 precompile dispatch surface in a separate module from the open gas schedule PR:

- PrecompileStatus success/failure states
- PrecompileInput invocation record
- PrecompileResult output/gas result record
- success/failure constructors and predicates
- output matching and gas-bound hooks for later syscall/executable-spec bridges

Refs Bead evm-asm-i5pi.3 and GH #116.

Verification:
- lake build EvmAsm.Evm64.PrecompileResult
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/Evm64/PrecompileResult.lean EvmAsm/Evm64.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.