### PR TITLE
feat(call): add stack argument records

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -65,6 +65,7 @@ import EvmAsm.Evm64.Environment.Layout
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.Env.Field
 import EvmAsm.Evm64.Env.Semantics
+import EvmAsm.Evm64.CallArgs
 
 -- Static gas schedule (#117)
 import EvmAsm.Evm64.Gas

--- a/EvmAsm/Evm64/CallArgs.lean
+++ b/EvmAsm/Evm64/CallArgs.lean
@@ -1,0 +1,97 @@
+/-
+  EvmAsm.Evm64.CallArgs
+
+  Pure stack-argument records for CALL-family opcodes (GH #114).
+-/
+
+import EvmAsm.Evm64.Environment
+
+namespace EvmAsm.Evm64
+
+namespace CallArgs
+
+/-- Memory slice described by an EVM offset and byte size. -/
+structure MemoryRange where
+  offset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+/-- CALL stack arguments: gas, target, value, input range, and output range. -/
+structure Call where
+  gas : EvmWord
+  to : EvmWord
+  value : EvmWord
+  input : MemoryRange
+  output : MemoryRange
+  deriving Repr
+
+/-- STATICCALL stack arguments: no value transfer argument. -/
+structure StaticCall where
+  gas : EvmWord
+  to : EvmWord
+  input : MemoryRange
+  output : MemoryRange
+  deriving Repr
+
+/-- DELEGATECALL stack arguments: caller/value context is inherited. -/
+structure DelegateCall where
+  gas : EvmWord
+  to : EvmWord
+  input : MemoryRange
+  output : MemoryRange
+  deriving Repr
+
+/-- Opcode family classifier for stack argument decoding. -/
+inductive Kind where
+  | call
+  | staticcall
+  | delegatecall
+  deriving DecidableEq, Repr
+
+def argumentCount : Kind → Nat
+  | .call => 7
+  | .staticcall => 6
+  | .delegatecall => 6
+
+def hasValueArgument : Kind → Bool
+  | .call => true
+  | .staticcall => false
+  | .delegatecall => false
+
+def isStatic : Kind → Bool
+  | .call => false
+  | .staticcall => true
+  | .delegatecall => false
+
+def preservesCallerContext : Kind → Bool
+  | .call => false
+  | .staticcall => false
+  | .delegatecall => true
+
+theorem callArgumentCount :
+    argumentCount .call = 7 := rfl
+
+theorem staticcallArgumentCount :
+    argumentCount .staticcall = 6 := rfl
+
+theorem delegatecallArgumentCount :
+    argumentCount .delegatecall = 6 := rfl
+
+theorem callHasValue :
+    hasValueArgument .call = true := rfl
+
+theorem staticcallHasNoValue :
+    hasValueArgument .staticcall = false := rfl
+
+theorem delegatecallHasNoValue :
+    hasValueArgument .delegatecall = false := rfl
+
+theorem staticcallIsStatic :
+    isStatic .staticcall = true := rfl
+
+theorem delegatecallPreservesCallerContext :
+    preservesCallerContext .delegatecall = true := rfl
+
+end CallArgs
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds #114 CALL-family stack argument records and kind classification for CALL, STATICCALL, and DELEGATECALL. This is a pure argument-surface precursor for later executable CALL-family specs.

Refs Bead evm-asm-b37o.1 and GH #114.

Verification:
- lake build EvmAsm.Evm64.CallArgs
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/Evm64/CallArgs.lean and EvmAsm/Evm64.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.