### PR TITLE
feat(tx): add execution hook surface

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -15,4 +15,5 @@ import EvmAsm.EL.MessageCall
 import EvmAsm.EL.MessageCallExecution
 import EvmAsm.EL.CallArgsBridge
 import EvmAsm.EL.TransactionCall
+import EvmAsm.EL.TransactionExecution
 import EvmAsm.EL.Block

--- a/EvmAsm/EL/TransactionExecution.lean
+++ b/EvmAsm/EL/TransactionExecution.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.EL.TransactionExecution
+
+  Pure transaction execution hooks for GH #122.
+-/
+
+import EvmAsm.EL.TransactionCall
+import EvmAsm.EL.MessageCallExecution
+
+namespace EvmAsm.EL
+
+namespace TransactionExecution
+
+/-- Inputs needed to run one already-validated transaction. -/
+structure TransactionExecutionInput where
+  state : WorldState
+  tx : Transaction
+  baseFee : Nat
+  blockGasRemaining : Nat
+
+/-- Caller-visible execution output for ordinary message-call transactions. -/
+structure TransactionExecutionResult where
+  status : CallStatus
+  state : WorldState
+  output : List Byte
+  gasRemaining : Nat
+
+def transactionCallerVisible
+    (callInput : MessageCallExecution.CallExecutionInput) (callResult : CallResult) :
+    TransactionExecutionResult :=
+  let visible := MessageCallExecution.toCallerVisible callInput callResult
+  { status := visible.status
+    state := visible.state
+    output := visible.output
+    gasRemaining := visible.gasRemaining }
+
+/-- Execute an ordinary transaction through the supplied message-call executor.
+    Contract-creation transactions return `none` here and are handled by #115. -/
+def execute? (executor : MessageCallExecution.CallExecutor)
+    (input : TransactionExecutionInput) : Option TransactionExecutionResult :=
+  match input.tx.toCallFrame? with
+  | none => none
+  | some frame =>
+      let callInput : MessageCallExecution.CallExecutionInput :=
+        { state := input.state, frame := frame }
+      some (transactionCallerVisible callInput (executor callInput))
+
+def validatesInput (input : TransactionExecutionInput) : Prop :=
+  input.tx.validatesAgainst input.state input.baseFee input.blockGasRemaining
+
+theorem execute?_create_none
+    (executor : MessageCallExecution.CallExecutor) (input : TransactionExecutionInput)
+    (h_to : input.tx.to = none) :
+    execute? executor input = none := by
+  simp [execute?, Transaction.toCallFrame?_create input.tx h_to]
+
+theorem execute?_some_call
+    (executor : MessageCallExecution.CallExecutor) (input : TransactionExecutionInput)
+    {callee : Address} (h_to : input.tx.to = some callee) :
+    execute? executor input =
+      let frame := CallFrame.forCall input.tx.sender callee input.tx.value input.tx.data
+        input.tx.gasLimit false
+      let callInput : MessageCallExecution.CallExecutionInput :=
+        { state := input.state, frame := frame }
+      some (transactionCallerVisible callInput (executor callInput)) := by
+  simp [execute?, Transaction.toCallFrame?_some input.tx h_to]
+
+theorem transactionCallerVisible_status
+    (callInput : MessageCallExecution.CallExecutionInput) (callResult : CallResult) :
+    (transactionCallerVisible callInput callResult).status = callResult.status := rfl
+
+theorem transactionCallerVisible_state
+    (callInput : MessageCallExecution.CallExecutionInput) (callResult : CallResult) :
+    (transactionCallerVisible callInput callResult).state =
+      MessageCallExecution.committedState callInput callResult := rfl
+
+theorem transactionCallerVisible_output
+    (callInput : MessageCallExecution.CallExecutionInput) (callResult : CallResult) :
+    (transactionCallerVisible callInput callResult).output =
+      MessageCallExecution.propagatedOutput callResult := rfl
+
+theorem validatesInput_iff (input : TransactionExecutionInput) :
+    validatesInput input ↔
+      input.tx.validatesAgainst input.state input.baseFee input.blockGasRemaining := Iff.rfl
+
+end TransactionExecution
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds #122 transaction execution hooks connecting validated ordinary transactions to message-call executors: TransactionExecutionInput, TransactionExecutionResult, transactionCallerVisible, execute?, validatesInput, and create/ordinary-call lemmas. Contract creation remains none here for the #115 CREATE path.

Refs Bead evm-asm-py9u.3 and GH #122.

Verification:
- lake build EvmAsm.EL.TransactionExecution
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/EL/TransactionExecution.lean and EvmAsm/EL.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.