### PR TITLE
feat(storage): add access outcome surface

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -73,6 +73,7 @@ import EvmAsm.Evm64.Gas
 import EvmAsm.Evm64.Env.Gas
 import EvmAsm.Evm64.StorageGas
 import EvmAsm.Evm64.StorageAccess
+import EvmAsm.Evm64.StorageAccessOutcome
 
 -- Opcode dispatch surface (#106)
 import EvmAsm.Evm64.Dispatch

--- a/EvmAsm/Evm64/StorageAccessOutcome.lean
+++ b/EvmAsm/Evm64/StorageAccessOutcome.lean
@@ -1,0 +1,76 @@
+/-
+  EvmAsm.Evm64.StorageAccessOutcome
+
+  Pure SLOAD/SSTORE access outcomes for issue #119.
+-/
+
+import EvmAsm.Evm64.StorageAccess
+
+namespace EvmAsm.Evm64
+namespace StorageAccessOutcome
+
+/-- Dynamic gas and warm-list state produced by one storage-key access. -/
+structure Outcome where
+  status : StorageGas.StorageAccessStatus
+  cost : Nat
+  accesses : StorageAccess.StorageAccessList
+  deriving Repr
+
+def sloadOutcome
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey) :
+    Outcome :=
+  { status := StorageAccess.accessStatus accesses key
+    cost := StorageAccess.sloadDynamicCostForKey accesses key
+    accesses := StorageAccess.warmKey accesses key }
+
+def sstoreOutcome
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey)
+    (current new : EvmWord) :
+    Outcome :=
+  { status := StorageAccess.accessStatus accesses key
+    cost := StorageAccess.sstoreDynamicCostForKey accesses key current new
+    accesses := StorageAccess.warmKey accesses key }
+
+theorem sloadOutcome_status
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey) :
+    (sloadOutcome accesses key).status = StorageAccess.accessStatus accesses key := rfl
+
+theorem sloadOutcome_cost
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey) :
+    (sloadOutcome accesses key).cost =
+      StorageAccess.sloadDynamicCostForKey accesses key := rfl
+
+theorem sloadOutcome_warms
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey) :
+    StorageAccess.isWarm (sloadOutcome accesses key).accesses key = true := by
+  exact StorageAccess.warmKey_warms accesses key
+
+theorem sstoreOutcome_status
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey)
+    (current new : EvmWord) :
+    (sstoreOutcome accesses key current new).status = StorageAccess.accessStatus accesses key := rfl
+
+theorem sstoreOutcome_cost
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey)
+    (current new : EvmWord) :
+    (sstoreOutcome accesses key current new).cost =
+      StorageAccess.sstoreDynamicCostForKey accesses key current new := rfl
+
+theorem sstoreOutcome_warms
+    (accesses : StorageAccess.StorageAccessList) (key : StorageAccess.StorageAccessKey)
+    (current new : EvmWord) :
+    StorageAccess.isWarm (sstoreOutcome accesses key current new).accesses key = true := by
+  exact StorageAccess.warmKey_warms accesses key
+
+theorem sloadOutcome_nil_cost (key : StorageAccess.StorageAccessKey) :
+    (sloadOutcome [] key).cost = StorageGas.coldSloadCost := by
+  simp [sloadOutcome]
+
+theorem sstoreOutcome_nil_cost
+    (key : StorageAccess.StorageAccessKey) (current new : EvmWord) :
+    (sstoreOutcome [] key current new).cost =
+      StorageGas.coldSloadCost + StorageGas.sstoreWriteCost current new := by
+  simp [sstoreOutcome]
+
+end StorageAccessOutcome
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds #119 SLOAD/SSTORE access outcome helpers bundling pre-access status, dynamic gas cost, and post-access warm-list state. This gives later SLOAD/SSTORE handler specs one surface for cost plus access-list update.

Refs Bead evm-asm-6sjn.6 and GH #119.

Verification:
- lake build EvmAsm.Evm64.StorageAccessOutcome
- scripts/check-file-size.sh
- scripts/check-unimported.sh
- rg forbidden proof escapes in EvmAsm/Evm64/StorageAccessOutcome.lean and EvmAsm/Evm64.lean
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.