### PR TITLE
feat(gas): add keccak memory dynamic cost

### DIFF
--- a/EvmAsm/Evm64/MemoryGas.lean
+++ b/EvmAsm/Evm64/MemoryGas.lean
@@ -127,6 +127,43 @@ theorem memoryAccessExpansionCost_mstore8_eq_zero_of_access_le
     memoryAccessExpansionCost sizeBytes offset 1 = 0 := by
   exact memoryAccessExpansionCost_eq_zero_of_access_le h_access
 
+/-- KECCAK256/SHA3 dynamic gas charged per 32-byte input chunk. -/
+def keccakGasPerWord : Nat := 6
+
+/--
+  KECCAK256 dynamic gas: per-word input charge plus memory expansion caused by
+  the input range.
+-/
+def keccakDynamicCost (sizeBytes offset length : Nat) : Nat :=
+  keccakGasPerWord * memoryWords length +
+    memoryAccessExpansionCost sizeBytes offset length
+
+@[simp] theorem keccakDynamicCost_zero_length (sizeBytes offset : Nat) :
+    keccakDynamicCost sizeBytes offset 0 = 0 := by
+  simp [keccakDynamicCost, keccakGasPerWord]
+
+theorem keccakDynamicCost_eq
+    (sizeBytes offset length : Nat) :
+    keccakDynamicCost sizeBytes offset length =
+      keccakGasPerWord * memoryWords length +
+        memoryExpansionCost sizeBytes (evmMemExpand sizeBytes offset length) := rfl
+
+theorem keccakDynamicCost_eq_word_charge_of_no_growth
+    {sizeBytes offset length : Nat}
+    (h_no_growth : evmMemExpand sizeBytes offset length = sizeBytes) :
+    keccakDynamicCost sizeBytes offset length =
+      keccakGasPerWord * memoryWords length := by
+  simp [keccakDynamicCost,
+    memoryAccessExpansionCost_eq_zero_of_no_growth h_no_growth]
+
+theorem keccakDynamicCost_eq_word_charge_of_access_le
+    {sizeBytes offset length : Nat}
+    (h_access : roundUpTo32 (offset + length) ≤ sizeBytes) :
+    keccakDynamicCost sizeBytes offset length =
+      keccakGasPerWord * memoryWords length := by
+  exact keccakDynamicCost_eq_word_charge_of_no_growth
+    (evmMemExpand_eq_old_of_access_le sizeBytes offset length h_access)
+
 /-- Dynamic copy gas charged per 32-byte input chunk for copy-style opcodes. -/
 def copyGasPerWord : Nat := 3
 


### PR DESCRIPTION
Adds pure MemoryGas helpers for KECCAK256/SHA3 dynamic gas under #118/#111: 6 gas per 32-byte input word plus memory expansion for the input byte range.\n\nBead: evm-asm-tl52.7\n\nLocal verification:\n- lake build EvmAsm.Evm64.MemoryGas\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden proof-escape scan on EvmAsm/Evm64/MemoryGas.lean\n\nAuthored by @pirapira; implemented by Codex.