### PR TITLE
feat(log): add dynamic gas helpers

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -86,6 +86,7 @@ import EvmAsm.Evm64.PrecompileDispatch
 -- EVM memory model (issue #99)
 import EvmAsm.Evm64.Memory
 import EvmAsm.Evm64.MemoryGas
+import EvmAsm.Evm64.LogGas
 import EvmAsm.Evm64.EvmState
 import EvmAsm.Evm64.Termination
 import EvmAsm.Evm64.MSize

--- a/EvmAsm/Evm64/LogGas.lean
+++ b/EvmAsm/Evm64/LogGas.lean
@@ -1,0 +1,75 @@
+/-
+  EvmAsm.Evm64.LogGas
+
+  Pure dynamic gas helpers for LOG0 through LOG4 (GH #112 / #118).
+-/
+
+import EvmAsm.Evm64.LogArgs
+import EvmAsm.Evm64.MemoryGas
+
+namespace EvmAsm.Evm64
+namespace LogGas
+
+/-- Dynamic gas charged per LOG topic. -/
+def logGasPerTopic : Nat := 375
+
+/-- Dynamic gas charged per byte of LOG data. -/
+def logGasPerDataByte : Nat := 8
+
+/-- Topic-dependent dynamic gas for LOG0 through LOG4. -/
+def logTopicDynamicCost (kind : LogArgs.Kind) : Nat :=
+  logGasPerTopic * LogArgs.topicCount kind
+
+/-- Data-byte dynamic gas for LOG input data. -/
+def logDataDynamicCost (length : Nat) : Nat :=
+  logGasPerDataByte * length
+
+/--
+  LOG dynamic gas: topic charge, data-byte charge, and memory expansion for
+  the logged byte range. The opcode base cost is tracked separately by the
+  static gas table.
+-/
+def logDynamicCost
+    (kind : LogArgs.Kind) (sizeBytes offset length : Nat) : Nat :=
+  logTopicDynamicCost kind + logDataDynamicCost length +
+    MemoryGas.memoryAccessExpansionCost sizeBytes offset length
+
+@[simp] theorem logTopicDynamicCost_log0 :
+    logTopicDynamicCost .log0 = 0 := rfl
+
+theorem logTopicDynamicCost_log4 :
+    logTopicDynamicCost .log4 = 1500 := rfl
+
+@[simp] theorem logDataDynamicCost_zero :
+    logDataDynamicCost 0 = 0 := by
+  simp [logDataDynamicCost, logGasPerDataByte]
+
+theorem logDynamicCost_eq
+    (kind : LogArgs.Kind) (sizeBytes offset length : Nat) :
+    logDynamicCost kind sizeBytes offset length =
+      logTopicDynamicCost kind + logDataDynamicCost length +
+        MemoryGas.memoryExpansionCost sizeBytes
+          (evmMemExpand sizeBytes offset length) := rfl
+
+theorem logDynamicCost_eq_charges_of_no_growth
+    {kind : LogArgs.Kind} {sizeBytes offset length : Nat}
+    (h_no_growth : evmMemExpand sizeBytes offset length = sizeBytes) :
+    logDynamicCost kind sizeBytes offset length =
+      logTopicDynamicCost kind + logDataDynamicCost length := by
+  simp [logDynamicCost,
+    MemoryGas.memoryAccessExpansionCost_eq_zero_of_no_growth h_no_growth]
+
+theorem logDynamicCost_eq_charges_of_access_le
+    {kind : LogArgs.Kind} {sizeBytes offset length : Nat}
+    (h_access : roundUpTo32 (offset + length) ≤ sizeBytes) :
+    logDynamicCost kind sizeBytes offset length =
+      logTopicDynamicCost kind + logDataDynamicCost length := by
+  exact logDynamicCost_eq_charges_of_no_growth
+    (evmMemExpand_eq_old_of_access_le sizeBytes offset length h_access)
+
+@[simp] theorem logDynamicCost_log0_zero_length (sizeBytes offset : Nat) :
+    logDynamicCost .log0 sizeBytes offset 0 = 0 := by
+  simp [logDynamicCost]
+
+end LogGas
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds EvmAsm.Evm64.LogGas for LOG0-LOG4 dynamic gas under #112/#118: topic charge, data-byte charge, and memory expansion for the logged byte range. Wires the module into EvmAsm.Evm64.\n\nBead: evm-asm-molh.4\n\nLocal verification:\n- lake build EvmAsm.Evm64.LogGas\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden proof-escape scan on EvmAsm/Evm64/LogGas.lean and EvmAsm/Evm64.lean\n\nAuthored by @pirapira; implemented by Codex.