### PR TITLE
prove(precompile): bound dispatch result gas

### DIFF
--- a/EvmAsm/Evm64/PrecompileDispatch.lean
+++ b/EvmAsm/Evm64/PrecompileDispatch.lean
@@ -80,6 +80,22 @@ theorem dispatch?_fail_of_gasCost?_gt {input : PrecompileInput} {out : List (Bit
   have h_not : ¬ cost ≤ input.gas := Nat.not_le.mpr h_gt
   simp [dispatch?, h_cost, h_not]
 
+theorem dispatch?_preservesGasBound {input : PrecompileInput} {out : List (BitVec 8)}
+    {result : PrecompileResult} (h_dispatch : dispatch? input out = some result) :
+    PrecompileResult.preservesGasBound input result := by
+  unfold dispatch? at h_dispatch
+  cases h_cost : gasCost? input with
+  | none =>
+      simp [h_cost] at h_dispatch
+  | some cost =>
+      by_cases h_le : cost ≤ input.gas
+      · simp [h_cost, h_le] at h_dispatch
+        rw [← h_dispatch]
+        simp [PrecompileResult.preservesGasBound, PrecompileResult.ok]
+      · simp [h_cost, h_le] at h_dispatch
+        rw [← h_dispatch]
+        simp [PrecompileResult.preservesGasBound, PrecompileResult.fail]
+
 theorem dispatchAddress?_none_zero (caller : Address) (payload out : List (BitVec 8))
     (gas : Nat) :
     dispatchAddress? 0 caller payload out gas = none := by


### PR DESCRIPTION
Adds a reusable #116 invariant for known-cost precompile dispatch: if PrecompileDispatch.dispatch? returns a result, the result's remaining gas is bounded by the input gas. This gives CALL-family/precompile bridge work a compact postcondition lemma.\n\nBead: evm-asm-i5pi.5\nRefs: #116\n\nLocal verification:\n- lake build EvmAsm.Evm64.PrecompileDispatch\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes/options in EvmAsm/Evm64/PrecompileDispatch.lean\n\nAuthored by @pirapira; implemented by Codex.