### PR TITLE
prove(precompile): bound address dispatch gas

### DIFF
--- a/EvmAsm/Evm64/PrecompileDispatch.lean
+++ b/EvmAsm/Evm64/PrecompileDispatch.lean
@@ -113,6 +113,18 @@ theorem dispatchAddress?_address (p : Precompile) (caller : Address)
         out := by
   simp [dispatchAddress?, decode?_address p]
 
+theorem dispatchAddress?_preservesGasBound {addr caller : Address}
+    {payload out : List (BitVec 8)} {gas : Nat} {result : PrecompileResult}
+    (h_dispatch : dispatchAddress? addr caller payload out gas = some result) :
+    result.gasRemaining ≤ gas := by
+  unfold dispatchAddress? at h_dispatch
+  cases h_decode : decode? addr with
+  | none =>
+      simp [h_decode] at h_dispatch
+  | some target =>
+      simp [h_decode] at h_dispatch
+      exact dispatch?_preservesGasBound h_dispatch
+
 end PrecompileDispatch
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2225.\n\nLifts the #116 precompile dispatch gas-bound invariant to address-level dispatchAddress?: whenever address dispatch returns a result, result.gasRemaining is bounded by the supplied gas.\n\nBead: evm-asm-i5pi.6\nRefs: #116\n\nLocal verification:\n- lake build EvmAsm.Evm64.PrecompileDispatch\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes/options in EvmAsm/Evm64/PrecompileDispatch.lean\n\nAuthored by @pirapira; implemented by Codex.