### PR TITLE
feat(call): add stack arity helpers

### DIFF
--- a/EvmAsm/Evm64/CallArgs.lean
+++ b/EvmAsm/Evm64/CallArgs.lean
@@ -53,6 +53,10 @@ def argumentCount : Kind → Nat
   | .staticcall => 6
   | .delegatecall => 6
 
+def resultCount (_kind : Kind) : Nat := 1
+
+def memoryRangeCount (_kind : Kind) : Nat := 2
+
 def hasValueArgument : Kind → Bool
   | .call => true
   | .staticcall => false
@@ -76,6 +80,16 @@ theorem staticcallArgumentCount :
 
 theorem delegatecallArgumentCount :
     argumentCount .delegatecall = 6 := rfl
+
+theorem resultCount_eq_one (kind : Kind) :
+    resultCount kind = 1 := rfl
+
+theorem memoryRangeCount_eq_two (kind : Kind) :
+    memoryRangeCount kind = 2 := rfl
+
+theorem argumentCount_eq_six_plus_value (kind : Kind) :
+    argumentCount kind = 6 + if hasValueArgument kind then 1 else 0 := by
+  cases kind <;> rfl
 
 theorem callHasValue :
     hasValueArgument .call = true := rfl


### PR DESCRIPTION
Adds #114 pure CALL-family stack arity helpers in EvmAsm/Evm64/CallArgs.lean: resultCount, memoryRangeCount, and argumentCount_eq_six_plus_value tying argumentCount to the value-argument flag.\n\nBead: evm-asm-b37o.3\nRefs: #114\n\nLocal verification:\n- lake build EvmAsm.Evm64.CallArgs\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes/options in EvmAsm/Evm64/CallArgs.lean\n\nAuthored by @pirapira; implemented by Codex.