### PR TITLE
feat(gas): add call static costs

### DIFF
--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -10,6 +10,7 @@
 -/
 
 import EvmAsm.Evm64.LogArgs
+import EvmAsm.Evm64.CallArgs
 
 namespace EvmAsm.Evm64
 
@@ -62,6 +63,9 @@ inductive EvmOpcode where
   | SELFBALANCE
   | BASEFEE
   | LOG (kind : LogArgs.Kind)
+  | CALL
+  | DELEGATECALL
+  | STATICCALL
   | RETURN
   | REVERT
   | INVALID
@@ -133,6 +137,9 @@ def byte? : EvmOpcode → Option Nat
   | SELFBALANCE => some 0x47
   | BASEFEE => some 0x48
   | LOG kind => some (0xa0 + LogArgs.topicCount kind)
+  | CALL => some 0xf1
+  | DELEGATECALL => some 0xf4
+  | STATICCALL => some 0xfa
   | RETURN => some 0xf3
   | REVERT => some 0xfd
   | INVALID => some 0xfe
@@ -188,6 +195,9 @@ def staticGasCost : EvmOpcode → Nat
   | SELFBALANCE => 5
   | BASEFEE => 2
   | LOG _ => 375
+  | CALL => 700
+  | DELEGATECALL => 700
+  | STATICCALL => 700
   | RETURN => 0
   | REVERT => 0
   | INVALID => 0
@@ -238,6 +248,19 @@ theorem byte?_LOG0 : byte? (LOG .log0) = some 0xa0 := rfl
 
 theorem byte?_LOG4 : byte? (LOG .log4) = some 0xa4 := rfl
 
+def ofCallKind : CallArgs.Kind → EvmOpcode
+  | .call => CALL
+  | .delegatecall => DELEGATECALL
+  | .staticcall => STATICCALL
+
+theorem byte?_ofCallKind (kind : CallArgs.Kind) :
+    byte? (ofCallKind kind) =
+      match kind with
+      | .call => some 0xf1
+      | .delegatecall => some 0xf4
+      | .staticcall => some 0xfa := by
+  cases kind <;> rfl
+
 theorem staticGasCost_stop : staticGasCost STOP = 0 := rfl
 
 theorem staticGasCost_push0 : staticGasCost PUSH0 = 2 := rfl
@@ -262,6 +285,10 @@ theorem staticGasCost_LOG (kind : LogArgs.Kind) :
 theorem staticGasCost_log0Base : staticGasCost (LOG .log0) = 375 := rfl
 
 theorem staticGasCost_log4Base : staticGasCost (LOG .log4) = 375 := rfl
+
+theorem staticGasCost_ofCallKind (kind : CallArgs.Kind) :
+    staticGasCost (ofCallKind kind) = 700 := by
+  cases kind <;> rfl
 
 theorem staticGasCost_returnBase : staticGasCost RETURN = 0 := rfl
 


### PR DESCRIPTION
Stacked on #2223.\n\nAdds #114 CALL-family opcode entries to the #117 static gas table in EvmAsm/Evm64/Gas.lean: CALL, DELEGATECALL, and STATICCALL with canonical opcode bytes and static/base cost 700. Includes a compact CallArgs.Kind bridge rather than per-variant example sprawl.\n\nBead: evm-asm-y6gx.8\nRefs: #117, #114\n\nLocal verification:\n- lake build EvmAsm.Evm64.Gas\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes/options in EvmAsm/Evm64/Gas.lean\n\nAuthored by @pirapira; implemented by Codex.