### PR TITLE
prove(precompile): expose non-address dispatch miss

### DIFF
--- a/EvmAsm/Evm64/PrecompileDispatch.lean
+++ b/EvmAsm/Evm64/PrecompileDispatch.lean
@@ -96,11 +96,17 @@ theorem dispatch?_preservesGasBound {input : PrecompileInput} {out : List (BitVe
         rw [← h_dispatch]
         simp [PrecompileResult.preservesGasBound, PrecompileResult.fail]
 
+theorem dispatchAddress?_none_of_decode?_none {addr caller : Address}
+    {payload out : List (BitVec 8)} {gas : Nat}
+    (h_decode : decode? addr = none) :
+    dispatchAddress? addr caller payload out gas = none := by
+  unfold dispatchAddress?
+  rw [h_decode]
+
 theorem dispatchAddress?_none_zero (caller : Address) (payload out : List (BitVec 8))
     (gas : Nat) :
     dispatchAddress? 0 caller payload out gas = none := by
-  unfold dispatchAddress?
-  rw [decode?_zero]
+  exact dispatchAddress?_none_of_decode?_none decode?_zero
 
 theorem dispatchAddress?_address (p : Precompile) (caller : Address)
     (payload out : List (BitVec 8)) (gas : Nat) :


### PR DESCRIPTION
Stacked on #2226.\n\nAdds a generic #116 negative-path theorem for address-level precompile dispatch: if decode? addr = none, then dispatchAddress? returns none. The existing zero-address miss theorem now derives from this reusable fact.\n\nBead: evm-asm-i5pi.7\nRefs: #116\n\nLocal verification:\n- lake build EvmAsm.Evm64.PrecompileDispatch\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- rg forbidden proof escapes/options in EvmAsm/Evm64/PrecompileDispatch.lean\n\nAuthored by @pirapira; implemented by Codex.