### PR TITLE
feat(gas): add selfdestruct static cost

### DIFF
--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -74,6 +74,7 @@ inductive EvmOpcode where
   | STATICCALL
   | RETURN
   | REVERT
+  | SELFDESTRUCT
   | INVALID
   | PUSH0
   | PUSH (n : Nat)
@@ -154,6 +155,7 @@ def byte? : EvmOpcode → Option Nat
   | STATICCALL => some 0xfa
   | RETURN => some 0xf3
   | REVERT => some 0xfd
+  | SELFDESTRUCT => some 0xff
   | INVALID => some 0xfe
   | PUSH0 => some 0x5f
   | PUSH n => if validPushWidth n then some (0x5f + n) else none
@@ -218,6 +220,7 @@ def staticGasCost : EvmOpcode → Nat
   | STATICCALL => 700
   | RETURN => 0
   | REVERT => 0
+  | SELFDESTRUCT => 5000
   | INVALID => 0
   | PUSH0 => 2
   | PUSH _ => 3
@@ -252,6 +255,8 @@ theorem byte?_STOP : byte? STOP = some 0x00 := rfl
 theorem byte?_RETURN : byte? RETURN = some 0xf3 := rfl
 
 theorem byte?_REVERT : byte? REVERT = some 0xfd := rfl
+
+theorem byte?_SELFDESTRUCT : byte? SELFDESTRUCT = some 0xff := rfl
 
 theorem byte?_INVALID : byte? INVALID = some 0xfe := rfl
 
@@ -374,6 +379,8 @@ theorem staticGasCost_ofCreateKind (kind : CreateKind) :
 theorem staticGasCost_returnBase : staticGasCost RETURN = 0 := rfl
 
 theorem staticGasCost_revertBase : staticGasCost REVERT = 0 := rfl
+
+theorem staticGasCost_selfdestructBase : staticGasCost SELFDESTRUCT = 5000 := rfl
 
 theorem staticGasCost_invalidBase : staticGasCost INVALID = 0 := rfl
 

--- a/EvmAsm/Evm64/Gas.lean
+++ b/EvmAsm/Evm64/Gas.lean
@@ -50,6 +50,11 @@ inductive EvmOpcode where
   | MSTORE
   | MSTORE8
   | MSIZE
+  | JUMP
+  | JUMPI
+  | PC
+  | GAS
+  | JUMPDEST
   | CALLDATALOAD
   | CALLDATASIZE
   | CALLDATACOPY
@@ -131,6 +136,11 @@ def byte? : EvmOpcode → Option Nat
   | MSTORE => some 0x52
   | MSTORE8 => some 0x53
   | MSIZE => some 0x59
+  | JUMP => some 0x56
+  | JUMPI => some 0x57
+  | PC => some 0x58
+  | GAS => some 0x5a
+  | JUMPDEST => some 0x5b
   | CALLDATALOAD => some 0x35
   | CALLDATASIZE => some 0x36
   | CALLDATACOPY => some 0x37
@@ -196,6 +206,11 @@ def staticGasCost : EvmOpcode → Nat
   | MSTORE => 3
   | MSTORE8 => 3
   | MSIZE => 2
+  | JUMP => 8
+  | JUMPI => 10
+  | PC => 2
+  | GAS => 2
+  | JUMPDEST => 1
   | CALLDATALOAD => 3
   | CALLDATASIZE => 2
   | CALLDATACOPY => 3
@@ -335,6 +350,31 @@ theorem byte?_ofCopyLikeKind (kind : CopyLikeKind) :
       | .returndata => some 0x3e := by
   cases kind <;> rfl
 
+inductive ControlFlowKind where
+  | jump
+  | jumpi
+  | pc
+  | gas
+  | jumpdest
+  deriving DecidableEq, Repr
+
+def ofControlFlowKind : ControlFlowKind → EvmOpcode
+  | .jump => JUMP
+  | .jumpi => JUMPI
+  | .pc => PC
+  | .gas => GAS
+  | .jumpdest => JUMPDEST
+
+theorem byte?_ofControlFlowKind (kind : ControlFlowKind) :
+    byte? (ofControlFlowKind kind) =
+      match kind with
+      | .jump => some 0x56
+      | .jumpi => some 0x57
+      | .pc => some 0x58
+      | .gas => some 0x5a
+      | .jumpdest => some 0x5b := by
+  cases kind <;> rfl
+
 theorem staticGasCost_stop : staticGasCost STOP = 0 := rfl
 
 theorem staticGasCost_push0 : staticGasCost PUSH0 = 2 := rfl
@@ -346,6 +386,16 @@ theorem staticGasCost_calldataLoad : staticGasCost CALLDATALOAD = 3 := rfl
 theorem staticGasCost_calldataSize : staticGasCost CALLDATASIZE = 2 := rfl
 
 theorem staticGasCost_calldataCopyBase : staticGasCost CALLDATACOPY = 3 := rfl
+
+theorem staticGasCost_ofControlFlowKind (kind : ControlFlowKind) :
+    staticGasCost (ofControlFlowKind kind) =
+      match kind with
+      | .jump => 8
+      | .jumpi => 10
+      | .pc => 2
+      | .gas => 2
+      | .jumpdest => 1 := by
+  cases kind <;> rfl
 
 theorem staticGasCost_ofSizeLikeKind (kind : SizeLikeKind) :
     staticGasCost (ofSizeLikeKind kind) = 2 := by


### PR DESCRIPTION
Stacked on #2231.\n\nAdds the #117/#113 SELFDESTRUCT static gas table entry, using opcode byte 0xff and base gas 5000 as reflected by execution-specs GAS_SELF_DESTRUCT.\n\nBead: evm-asm-07iz\n\nLocal verification:\n- lake build EvmAsm.Evm64.Gas\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden scan on EvmAsm/Evm64/Gas.lean\n\nAuthored by @pirapira; implemented by Codex.