### PR TITLE
docs(readme): link to docs/notable-specs.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,11 @@ This is a **prototype** demonstrating the approach. Current state:
   sail-riscv-lean for RISC-V spec compliance, connect to EVM specs in Lean,
   testing.
 
+## Documentation
+
+- [Notable proven specifications](docs/notable-specs.md) — index of stack
+  specs and `EvmWord` correctness theorems with commit-pinned permalinks.
+
 ## References
 
 - Kennedy, A., Benton, N., Jensen, J.B., Dagand, P.-E. (2013).


### PR DESCRIPTION
Add a Documentation section to README.md pointing at the notable-specs index page (added in PR #1742) so the index is discoverable from the repo front door.

Closes beads task evm-asm-l83d (slice of evm-asm-prwe).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).