### PR TITLE
docs(notable-specs): cross-refs from CONTRIBUTING/AGENTS + 5-step refresh procedure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,12 @@ Pitfalls:
 - **RISC-V ISA**: https://riscv.org/technical/specifications/
 - **sail-riscv-lean**: https://github.com/opencompl/sail-riscv-lean (same toolchain)
 - **Lean 4 docs**: https://lean-lang.org/documentation/
+- **Notable Specs Index**: [`docs/notable-specs.md`](docs/notable-specs.md) —
+  curated index of proven specifications (per-opcode stack specs, EvmWord
+  correctness theorems, RLP/ByteOps/calling-convention helpers) with
+  commit-pinned permalinks. Use it to find a spec without grepping. Refresh
+  procedure is documented at the bottom of that page; trigger is closure of a
+  `#61`-class umbrella issue, or quarterly.
 
 ## Frame-automation Tactics
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,13 @@ Start with:
 - [`README.md`](README.md) for the project overview
 - [`AGENTS.md`](AGENTS.md) for build instructions, project structure, and proof guidance
 - [`PLAN.md`](PLAN.md) for the current roadmap and task status
+- [`docs/notable-specs.md`](docs/notable-specs.md) for an index of notable proven
+  specifications (per-opcode stack specs, EvmWord correctness theorems,
+  RLP/ByteOps/calling-convention helpers) with permalinks to the exact theorem
+  statements at a pinned commit. Use it to find a spec without grepping. The
+  index is refreshed whenever a `#61`-class umbrella issue closes or quarterly,
+  whichever comes first; the bottom of that page documents the refresh
+  procedure.
 
 Before sending work for review:
 

--- a/docs/notable-specs.md
+++ b/docs/notable-specs.md
@@ -88,8 +88,50 @@ _TODO (slice 3): index `ByteOps` LBU/SB specs, calling-convention helpers
 ## Maintenance
 
 - See parent backlog: `evm-asm-prwe` / GH issue tracking forthcoming.
-- Refresh procedure: `git rev-parse origin/main` for the new sha, then for each
-  entry re-confirm the line number with `grep -n '<theorem name>'` against the
-  named file. Replace the pinned sha and line numbers and the date in the
-  top-of-page note.
-- Trigger: refresh when a `#61`-class umbrella closes or quarterly.
+- Trigger: refresh when a `#61`-class umbrella closes or quarterly,
+  whichever comes first.
+
+### Refresh procedure (5 steps)
+
+1. **Survey the spec surface.** Grep for the canonical entry-point names so
+   nothing has been added or renamed since the last refresh:
+
+   ```bash
+   rg -n '@\[stack_spec_' EvmAsm/
+   rg -n 'theorem evm_[a-z_]*_stack_spec' EvmAsm/
+   rg -n 'theorem EvmWord\.[a-z_]*_correct' EvmAsm/
+   ```
+
+   Add an entry to the appropriate section for any name not already listed;
+   delete entries whose underlying theorem is gone.
+
+2. **Capture `file:line` for every entry.** For each theorem name, locate
+   its current declaration site:
+
+   ```bash
+   grep -n '<theorem-name>' EvmAsm/<path>.lean
+   ```
+
+   Record the `path:line` pair — both the alias line and (if separate) the
+   underlying proof-bearing theorem line.
+
+3. **Mint commit-pinned permalinks.** Capture the current upstream sha and
+   build URLs against it:
+
+   ```bash
+   SHA=$(git rev-parse origin/main)
+   gh browse <path>:<line> --commit "$SHA" --no-browser
+   # or directly:
+   echo "https://github.com/Verified-zkEVM/evm-asm/blob/$SHA/<path>#L<line>"
+   ```
+
+   Replace each existing permalink in the table cells with the freshly
+   minted one.
+
+4. **Update the top-of-page pin.** Replace the `Permalinks pinned to commit
+   <sha> on <date>` blockquote near the top with the new sha and today's
+   date.
+
+5. **Verify with `lake build`.** Run `lake build` from the repo root to
+   confirm every referenced declaration still elaborates under the pinned
+   sha. Any rename or relocation discovered here loops back to step 1.


### PR DESCRIPTION
Slice 4 of evm-asm-prwe (notable-specs index page).

## Changes

- **CONTRIBUTING.md**: add a 'Start with' bullet pointing at `docs/notable-specs.md` alongside README.md / AGENTS.md / PLAN.md, with a one-line description of what the index covers and the refresh trigger.
- **AGENTS.md** (References section): add a 'Notable Specs Index' bullet so agents see the page when scanning References.
- **docs/notable-specs.md**: replace the one-paragraph maintenance note with an explicit 5-step refresh procedure:
  1. Survey the spec surface (rg for `@[stack_spec_*]`, `evm_*_stack_spec`, `EvmWord.*_correct`)
  2. Capture `file:line` for every entry
  3. Mint commit-pinned permalinks (`gh browse <path>:<line> --commit $SHA`)
  4. Update the top-of-page pin (sha + date)
  5. Verify with `lake build`

Trigger remains: closure of any `#61`-class umbrella issue, or quarterly.

Docs-only change; no Lean files touched.

Refs beads evm-asm-9unx (parent evm-asm-prwe).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).