### PR TITLE
chore(shake): drop unused Common import in EvmWordArith/SignExtend

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SignExtend.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SignExtend.lean
@@ -4,7 +4,7 @@
   SIGNEXTEND correctness: limb-level sign-extension definitions and getLimb lemmas.
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Common
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/SignExtend/Compose.lean
+++ b/EvmAsm/Evm64/SignExtend/Compose.lean
@@ -10,6 +10,7 @@
 
 -- `SignExtend.LimbSpec` transitively imports `Rv64.AddrNorm`.
 import EvmAsm.Evm64.SignExtend.LimbSpec
+import EvmAsm.Evm64.EvmWordArith.Common
 import EvmAsm.Evm64.EvmWordArith.SignExtend
 
 open EvmAsm.Rv64.Tactics


### PR DESCRIPTION
Sub-slice of evm-asm-9tq (#1045 import hygiene sweep).

EvmWordArith/SignExtend.lean references no names from EvmWordArith.Common (verified by grep: no `bv_or_eq_zero` / `ult_one_eq_zero` / `toNat_eq_limb_sum` / `eq_zero_iff_limbs` / `xor_eq_zero_imp`). Replace the import with the more specific `EvmAsm.Evm64.Basic` dependency that it actually needs.

SignExtend/Compose.lean transitively pulled Common via SignExtend and uses `toNat_eq_limb_sum` at line 794, so add the explicit import there.

Verified locally:
- `lake build` succeeds (1535 jobs ✔)
- `lake exe shake EvmAsm` flags clean for both files
- `scripts/check-unimported.sh` passes

Refs beads evm-asm-clhw (parent evm-asm-9tq), GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).