### PR TITLE
chore: drop stale file-size-exception references in three Spec headers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
@@ -14,7 +14,7 @@
   - `c3_eq_u4_plus_one_from_double_mulsub_addback_bounds`
   - `abPrime_val_eq_amod_pow_s_pure_nat`
 
-  Extracted from `Spec/CallAddback.lean` (file-size-exception, #1078).
+  Extracted from `Spec/CallAddback.lean` (#1078 split).
   No external Lean expression depends on these names other than the
   consumers in `CallAddback.lean` (the docstrings in `SpecCallAddbackBeq/`
   cross-reference them by name only). See evm-asm-rfl / sub-slice of

--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackSubStubs.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackSubStubs.lean
@@ -1,4 +1,3 @@
--- file-size-exception NOT required: this sibling file lives below cap.
 /-
   EvmAsm.Evm64.DivMod.Spec.CallAddbackSubStubs
 

--- a/EvmAsm/Evm64/DivMod/Spec/CallSkipOverestimateBridge.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallSkipOverestimateBridge.lean
@@ -10,7 +10,7 @@
   (`qHat = div128Quot u4 u3 b3'`).
 
   Originally lived in `Spec.CallSkip`; extracted to keep that file under
-  the 1500-line cap (file-size-exception cleanup, GH #1078).
+  the 1500-line cap (#1078 split).
 
   Theorems exported:
     - c3_un_zero_of_qHat_mul_le


### PR DESCRIPTION
Three sibling files extracted out of `CallAddback.lean` / `CallSkip.lean` during the #1078 split (`CallAddbackPureNat.lean`, `CallAddbackSubStubs.lean`, `CallSkipOverestimateBridge.lean`) carry doc-comment references to *file-size-exception* that no longer apply — each is well below the 1500-line cap (454 / 700 / 511 lines) and carries no actual exception marker (those are detected at column 0 as `-- file-size-exception: ...`).

Reword the three doc comments to drop the stale terminology, and remove the stray `-- file-size-exception NOT required: ...` comment at the top of `CallAddbackSubStubs.lean` (it served only to reassure a reader).

`scripts/check-file-size.sh` stays green (342 files, 2 exempted: `CallAddback.lean` and `MLoad/Spec.lean`, each tracked separately by evm-asm-ry8 / evm-asm-qgjp).

No proof / behaviour changes.

Refs evm-asm-lb1i (sub-slice of evm-asm-0lq / GH #1078).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).