### PR TITLE
chore(shake): drop Stack import in Push/Program.lean

### DIFF
--- a/EvmAsm/Evm64/Push/Program.lean
+++ b/EvmAsm/Evm64/Push/Program.lean
@@ -22,7 +22,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Push/Spec.lean
+++ b/EvmAsm/Evm64/Push/Spec.lean
@@ -17,6 +17,7 @@
 -/
 
 import EvmAsm.Evm64.Push.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.XSimp


### PR DESCRIPTION
Sub-slice of #1045 (evm-asm-8k4k). `lake exe shake EvmAsm` flags `import EvmAsm.Evm64.Stack` in `EvmAsm/Evm64/Push/Program.lean` as unused — the file references no `Stack` declarations. Replaced with `import EvmAsm.Rv64.SepLogic` (the actually-used dependency for program-construction sugar). Side effect: `Push/Spec.lean` transitively pulled `Stack` via `Push/Program`; added an explicit import there.

Analog of PR #1454 (Pop/Push0/Dup/Swap) and evm-asm-h2kr.

Verification:
- `lake build` green (1535/1535)
- `lake exe shake EvmAsm | scripts/shake-filter.py` no longer suggests removing this import.

Refs #1045, evm-asm-8k4k.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).