### PR TITLE
chore(shake): drop heavier imports in CallArgs/LogArgs/Calldata.Size

### DIFF
--- a/EvmAsm/Evm64/CallArgs.lean
+++ b/EvmAsm/Evm64/CallArgs.lean
@@ -4,7 +4,7 @@
   Pure stack-argument records for CALL-family opcodes (GH #114).
 -/
 
-import EvmAsm.Evm64.Environment
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Calldata/Size.lean
+++ b/EvmAsm/Evm64/Calldata/Size.lean
@@ -4,7 +4,7 @@
   Pure CALLDATASIZE semantics for issue #104.
 -/
 
-import EvmAsm.Evm64.Calldata.Basic
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 namespace Calldata

--- a/EvmAsm/Evm64/LogArgs.lean
+++ b/EvmAsm/Evm64/LogArgs.lean
@@ -4,7 +4,7 @@
   Pure stack-argument records for LOG0 through LOG4 (GH #112).
 -/
 
-import EvmAsm.Evm64.Environment
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Three pure data-record files only need `EvmWord` (defined in `EvmAsm.Evm64.Basic`), but they imported heavier modules that transitively reached it. Suggested by `lake exe shake EvmAsm`.

- `EvmAsm/Evm64/CallArgs.lean`: `Environment` → `Basic`
- `EvmAsm/Evm64/LogArgs.lean`: `Environment` → `Basic`
- `EvmAsm/Evm64/Calldata/Size.lean`: `Calldata.Basic` → `Basic`

`lake build` green.

Refs evm-asm-08f2, parent #1045 (evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).