### PR TITLE
chore(shake): flag bv_addr/sep_perm/bv_decide macro false-positives in noshake.json

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -1,7 +1,8 @@
 {"ignoreImport": ["Init", "Lean"],
  "ignore":
  {"EvmAsm.Rv64.ByteOps":
-  ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
+  ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic",
+   "Std.Tactic.BVDecide"],
   "EvmAsm.Rv64.HalfwordOps":
   ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
   "EvmAsm.Rv64.WordOps":
@@ -24,6 +25,12 @@
   "EvmAsm.Rv64.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.RegOpsAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.ByteAlgAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Rv64.Tactics.XCancelStruct":
+  ["EvmAsm.Rv64.SepLogic"],
+  "EvmAsm.Evm64.Basic":
+  ["Std.Tactic.BVDecide"],
+  "EvmAsm.Evm64.SpAddr":
+  ["EvmAsm.Rv64.Tactics.SeqFrame"],
   "EvmAsm.Evm64.Pop.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Push0.Spec":


### PR DESCRIPTION
lake exe shake flagged four imports as removable, but each provides a tactic macro/syntax that elaborates without a leaf identifier shake can track:

- `EvmAsm.Rv64.ByteOps` ← `Std.Tactic.BVDecide` (`bv_decide`)
- `EvmAsm.Evm64.Basic` ← `Std.Tactic.BVDecide` (`bv_decide`)
- `EvmAsm.Evm64.SpAddr` ← `EvmAsm.Rv64.Tactics.SeqFrame` (`bv_addr` macro, defined at SeqFrame.lean:1064)
- `EvmAsm.Rv64.Tactics.XCancelStruct` ← `EvmAsm.Rv64.SepLogic` (`sep_perm` syntax, defined at SepLogic.lean:2762)

Adds the four entries to `scripts/noshake.json`.

Verified locally: `lake build` green (1535 jobs), `lake exe shake EvmAsm` no longer flags these four imports.

Refs #1045, beads evm-asm-nujd (sub-slice of evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).