### PR TITLE
chore(shake): drop CPSSpec import in Slt/Program.lean

### DIFF
--- a/EvmAsm/Evm64/Slt/Program.lean
+++ b/EvmAsm/Evm64/Slt/Program.lean
@@ -4,7 +4,7 @@
   256-bit EVM SLT program definition.
 -/
 
-import EvmAsm.Rv64.CPSSpec
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Slt/Program.lean only constructs the `evm_slt` RV64 program (uses `single`/`LD`/`SD`/`ADDI`/`;;` notation from `Rv64.Program`); it never references any identifier from `Rv64.CPSSpec`. Replace `import EvmAsm.Rv64.CPSSpec` with the lighter `import EvmAsm.Rv64.Program`.

Verified via:
- `lake build` — 1535 jobs green, no new sorry.
- `lake exe shake EvmAsm` — flagged suggestion is gone.

Refs #1045 (import hygiene sweep). Beads: evm-asm-ug24.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).