### PR TITLE
chore(noshake): silence Phase2LongLoop chained-iteration false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -110,4 +110,11 @@
  "EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation":
   ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.CompensationCases", "EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback", "EvmAsm.Evm64.EvmWordArith.ModBridgeUtop"],
  "EvmAsm.Evm64.DivMod.Spec.Dispatcher":
-  ["EvmAsm.Evm64.DivMod.Spec.Base", "EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge"]}}
+  ["EvmAsm.Evm64.DivMod.Spec.Base", "EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopTwo":   ["EvmAsm.Rv64.RLP.Phase2LongLoopOne"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopThree": ["EvmAsm.Rv64.RLP.Phase2LongLoopTwo"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopFour":  ["EvmAsm.Rv64.RLP.Phase2LongLoopThree"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopFive":  ["EvmAsm.Rv64.RLP.Phase2LongLoopFour"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopSix":   ["EvmAsm.Rv64.RLP.Phase2LongLoopFive"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopSeven": ["EvmAsm.Rv64.RLP.Phase2LongLoopSix"],
+ "EvmAsm.Rv64.RLP.Phase2LongLoopEight": ["EvmAsm.Rv64.RLP.Phase2LongLoopSeven"]}}


### PR DESCRIPTION
Slice of evm-asm-85m8 (parent evm-asm-9tq / GH #1045 import hygiene sweep).

`lake exe shake EvmAsm` flags `EvmAsm/Rv64/RLP/Phase2LongLoop{Two,Three,Four,Five,Six,Seven,Eight}.lean` as importing the previous `Phase2LongLoop{N-1}` module unnecessarily, suggesting that each be replaced with `Phase2LongLoopBody`. The suggestion is a false positive:

- Each `LoopN.lean` references `rlp_phase2_long_loop_{N-1}_byte_spec_within` and `_post_unfold` defined only in `LoopN-1.lean` (e.g. `Phase2LongLoopThree.lean:110` calls `rlp_phase2_long_loop_two_byte_spec_within`).
- `Phase2LongLoopBody.lean` does not define any `rlp_phase2_long_loop_<word>_byte` specs — it only defines the generic body lemmas.
- Same chained-iteration false-positive pattern documented in evm-asm-o6y / -pic and previously closed as won't-do in evm-asm-8qy / evm-asm-0lh0 without silencing the suggestion.

Add explicit `noshake.json` entries for all seven files so shake stops re-flagging them.

Verification:
- `lake build`: green
- `lake exe shake EvmAsm`: the seven `Phase2LongLoop{N}.lean` blocks are gone from the output

Refs evm-asm-85m8, evm-asm-9tq, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).