### PR TITLE
chore(imports): drop EvmAsm.Evm64.Stack import in MStore/MStore8 Program.lean

### DIFF
--- a/EvmAsm/Evm64/MStore/Program.lean
+++ b/EvmAsm/Evm64/MStore/Program.lean
@@ -74,7 +74,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/MStore8/Program.lean
+++ b/EvmAsm/Evm64/MStore8/Program.lean
@@ -42,7 +42,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/MStore8/Spec.lean
+++ b/EvmAsm/Evm64/MStore8/Spec.lean
@@ -24,6 +24,7 @@
 
 import EvmAsm.Evm64.MStore8.Program
 import EvmAsm.Evm64.Memory
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 import EvmAsm.Rv64.Tactics.XSimp


### PR DESCRIPTION
Sub-slice of #1045 (beads evm-asm-7emi) — analog of #h2kr (Push/Program).

`EvmAsm/Evm64/MStore/Program.lean` and `EvmAsm/Evm64/MStore8/Program.lean` do
not reference any name from `EvmAsm.Evm64.Stack` (no `evmWordIs` / `evmStackIs`
or related); they only construct `Program`s of `Rv64` instructions. Replace with
`EvmAsm.Rv64.SepLogic`, the actually-used dependency for the program-construction
sugar.

Side effect: `MStore8/Spec.lean` previously pulled `Stack` transitively via
`MStore8/Program.lean` and uses `evmWordIs`/`evmStackIs` directly, so add an
explicit `import EvmAsm.Evm64.Stack` there. `MStore/Spec.lean` already gets
`Stack` via the `MStore/LimbSpec` chain, so no change needed there.

Verification: `lake build` clean.

Refs #1045, beads evm-asm-7emi.
Authored by @pirapira; implemented by Hermes-bot (evm-hermes).