### PR TITLE
chore(noshake): flag XPermPure/DropPure tactic-macro imports as false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -16,6 +16,10 @@
   ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.XPerm":
   ["EvmAsm.Rv64.SepLogic"],
+  "EvmAsm.Rv64.Tactics.XPermPure":
+  ["EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.XSimp"],
+  "EvmAsm.Rv64.Tactics.DropPure":
+  ["EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.Tactics.SeqFrame":
   ["EvmAsm.Rv64.Tactics.PerfTrace", "EvmAsm.Rv64.InstructionSpecs"],
   "EvmAsm.Rv64.Tactics.LiftSpec":


### PR DESCRIPTION
Sub-slice of evm-asm-9tq (#1045 import hygiene sweep).

`lake exe shake EvmAsm` flags ExtractPure and XSimp imports as removable in:
- `EvmAsm/Rv64/Tactics/XPermPure.lean`
- `EvmAsm/Rv64/Tactics/DropPure.lean`

Both are false positives — each file expands tactic macros (`extract_pure` from ExtractPure.lean, `xperm_hyp` from XSimp.lean) that shake cannot see. Add four `noshake.json` entries to silence.

Verified:
- `lake build` green.
- `lake exe shake EvmAsm` no longer flags XPermPure or DropPure (other unrelated suggestions remain, tracked in sibling slices).

Refs evm-asm-xuyv, #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).