### PR TITLE
chore(shake): drop Stack import in Shift/Byte/SignExtend/Multiply/Exp/MSize/MLoad Program.lean (#1045)

### DIFF
--- a/EvmAsm/Evm64/Byte/Program.lean
+++ b/EvmAsm/Evm64/Byte/Program.lean
@@ -36,7 +36,7 @@
     Exit point: offset 180
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Byte/Spec.lean
+++ b/EvmAsm/Evm64/Byte/Spec.lean
@@ -15,6 +15,7 @@
 
 -- `Byte.LimbSpec → Byte.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Byte.LimbSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.EvmWordArith.ByteOps
 import EvmAsm.Rv64.AddrNorm
 import Mathlib.Tactic.Set

--- a/EvmAsm/Evm64/Exp/LimbSpec.lean
+++ b/EvmAsm/Evm64/Exp/LimbSpec.lean
@@ -11,6 +11,7 @@
 -/
 
 import EvmAsm.Evm64.Exp.Program
+import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.XSimp
 import EvmAsm.Rv64.Tactics.RunBlock

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -18,7 +18,7 @@
   it without breaking the umbrella import graph.
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/MLoad/Program.lean
+++ b/EvmAsm/Evm64/MLoad/Program.lean
@@ -60,7 +60,7 @@
   Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/MLoad/Spec.lean
+++ b/EvmAsm/Evm64/MLoad/Spec.lean
@@ -11,6 +11,7 @@
 -- file-size-exception: temporary bridge-file overage; split tracked by evm-asm-qgjp.
 
 import EvmAsm.Evm64.MLoad.LimbSpecEight
+import EvmAsm.Evm64.Stack
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/MSize/Program.lean
+++ b/EvmAsm/Evm64/MSize/Program.lean
@@ -28,7 +28,7 @@
   (evm-hermes).
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -39,7 +39,7 @@
     Exit point: offset 252
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Multiply/Spec.lean
+++ b/EvmAsm/Evm64/Multiply/Spec.lean
@@ -15,6 +15,7 @@
 
 -- `Multiply.LimbSpec → Multiply.Program → Stack`.
 import EvmAsm.Evm64.Multiply.LimbSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.EvmWordArith.MulCorrect
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Evm64/Shift/Compose.lean
+++ b/EvmAsm/Evm64/Shift/Compose.lean
@@ -9,6 +9,7 @@
 
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.ComposeBase
+import EvmAsm.Evm64.Stack
 import Mathlib.Tactic.Set
 
 open EvmAsm.Rv64.Tactics

--- a/EvmAsm/Evm64/Shift/Program.lean
+++ b/EvmAsm/Evm64/Shift/Program.lean
@@ -32,7 +32,7 @@
     Exit point: offset 360
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/SarCompose.lean
+++ b/EvmAsm/Evm64/Shift/SarCompose.lean
@@ -11,6 +11,7 @@
 
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.SarSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ComposeBase
 import Mathlib.Tactic.Set
 

--- a/EvmAsm/Evm64/Shift/ShlCompose.lean
+++ b/EvmAsm/Evm64/Shift/ShlCompose.lean
@@ -11,6 +11,7 @@
 
 -- `Shift.ComposeBase → Shift.LimbSpec → Shift.Program → Evm64.Stack → SpAddr`.
 import EvmAsm.Evm64.Shift.ShlSpec
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Shift.ComposeBase
 import Mathlib.Tactic.Set
 

--- a/EvmAsm/Evm64/SignExtend/Program.lean
+++ b/EvmAsm/Evm64/SignExtend/Program.lean
@@ -34,7 +34,7 @@
     Exit point: offset 192
 -/
 
-import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/SignExtend/Spec.lean
+++ b/EvmAsm/Evm64/SignExtend/Spec.lean
@@ -8,6 +8,7 @@
 
 -- `SignExtend.Compose → SignExtend.LimbSpec → SignExtend.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.SignExtend.Compose
+import EvmAsm.Evm64.Stack
 
 open EvmAsm.Rv64.Tactics
 


### PR DESCRIPTION
Replace the heavy `import EvmAsm.Evm64.Stack` in seven opcode `Program.lean` files with the narrow `import EvmAsm.Rv64.SepLogic` (or `EvmAsm.Rv64.Program`) that they actually need (`Program`, `CodeReq.ofProg`, `loadProgram`, `stepN`). Where the corresponding `Spec`/`Compose`/`LimbSpec` consumer transitively relied on `Stack` through the `Program` file, add the explicit `import EvmAsm.Evm64.Stack` there so the upstream narrowing is invisible to actual stack-spec consumers.

`lake build` green.

Analog of #1454 / #1741 / #1711 / #2250 / #2258. Refs #1045; beads evm-asm-80xn (slice of evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).