### PR TITLE
chore(noshake): silence false-positive imports in RLP/Phase3SingleByte

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -8,6 +8,8 @@
   ["Mathlib.Tactic.IntervalCases", "Mathlib.Tactic.FinCases", "Mathlib.Data.Fintype.Basic"],
   "EvmAsm.Rv64.RLP.Phase1":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.ExtractPure"],
+  "EvmAsm.Rv64.RLP.Phase3SingleByte":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE2": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE3": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],
   "EvmAsm.Rv64.RLP.Phase1CascadePrefixE4": ["EvmAsm.Rv64.RLP.Phase1Disjoint"],


### PR DESCRIPTION
Shake flags `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.XSimp` as removable in `EvmAsm/Rv64/RLP/Phase3SingleByte.lean`, but both are genuinely required:
- `addi_spec_gen_within` (used in the spec's body) is defined in `EvmAsm.Rv64.SyscallSpecs`.
- the proof invokes the `xsimp` tactic, which is provided by `EvmAsm.Rv64.Tactics.XSimp`.

Replacing with `EvmAsm.Rv64.CPSSpec` breaks the build (verified locally: `addi_spec_gen_within` becomes unknown and the `xsimp` invocation errors).

This PR adds a `noshake.json` entry for `EvmAsm.Rv64.RLP.Phase3SingleByte` mirroring the existing pattern for `EvmAsm.Rv64.RLP.Phase1`. `lake build` is green and `lake exe shake EvmAsm` no longer flags this file.

Refs #1045 (beads evm-asm-tszg).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).