### PR TITLE
feat(sdiv,smod): add Evm64/SDiv and Evm64/SMod directory skeletons (#90 slice 2)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -56,6 +56,10 @@ import EvmAsm.Evm64.Exp
 -- DivMod (Knuth Algorithm D)
 import EvmAsm.Evm64.DivMod
 
+-- SDIV / SMOD skeletons (GH #90, signed division/modulo)
+import EvmAsm.Evm64.SDiv
+import EvmAsm.Evm64.SMod
+
 -- Calling convention (LP64)
 import EvmAsm.Evm64.CallingConvention
 

--- a/EvmAsm/Evm64/SDiv.lean
+++ b/EvmAsm/Evm64/SDiv.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.SDiv
+
+  Umbrella for the SDIV opcode subtree (GH #90). Re-exports the
+  top-level spec; downstream consumers should `import EvmAsm.Evm64.SDiv`
+  and not reach into sub-modules directly.
+
+  AddrNormAttr is imported first (per `AGENTS.md` `register_simp_attr`
+  ordering rule) so the `sdiv_addr` attribute exists when later modules
+  attach lemmas to it.
+-/
+
+import EvmAsm.Evm64.SDiv.AddrNormAttr
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Evm64.SDiv.LimbSpec
+import EvmAsm.Evm64.SDiv.AddrNorm
+import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Evm64.SDiv.Spec

--- a/EvmAsm/Evm64/SDiv/AddrNorm.lean
+++ b/EvmAsm/Evm64/SDiv/AddrNorm.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.SDiv.AddrNorm
+
+  Address-normalization simp set for SDIV composition proofs.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). The
+  `@[sdiv_addr, grind =]`-tagged atomic facts will be added once the
+  Compose layer (`SDiv/Compose/...`) starts emitting concrete address
+  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
+  base and the attribute declaration so downstream files can already
+  open the namespace.
+-/
+
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Evm64.SDiv.AddrNormAttr
+
+namespace EvmAsm.Evm64.SDiv.AddrNorm
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.SDiv.AddrNorm

--- a/EvmAsm/Evm64/SDiv/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/SDiv/AddrNormAttr.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.SDiv.AddrNormAttr
+
+  Declares the `sdiv_addr` simp attribute used by `SDiv/AddrNorm.lean`.
+
+  Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code
+  should import `SDiv/AddrNorm.lean` (which imports this file) — not this
+  file directly.
+
+  Skeleton placeholder for GH #90 (SDIV/SMOD opcodes, beads slice
+  evm-asm-kyp6). No tagged lemmas yet; opcode-specific atomic
+  `signExtend12` / `<<<` / `BitVec.toNat` evaluations will be attached as
+  `@[sdiv_addr, grind =]` once the SDIV Compose layer starts emitting
+  concrete address arithmetic.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for SDIV address arithmetic. Will collect atomic evaluations of
+    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+    in SDIV composition proofs. -/
+register_simp_attr sdiv_addr

--- a/EvmAsm/Evm64/SDiv/Compose/Base.lean
+++ b/EvmAsm/Evm64/SDiv/Compose/Base.lean
@@ -1,0 +1,25 @@
+/-
+  EvmAsm.Evm64.SDiv.Compose.Base
+
+  Shared composition infrastructure for SDIV: `sdivCode` (the union of
+  all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
+  back to `sdivCode`, and shared length lemmas.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). Concrete
+  definitions will be added once `evm_sdiv` is laid out (slice
+  evm-asm-01uh) and the per-block specs from `LimbSpec.lean` start
+  composing.
+-/
+
+import EvmAsm.Evm64.SDiv.LimbSpec
+import EvmAsm.Evm64.SDiv.AddrNorm
+
+namespace EvmAsm.Evm64.SDiv.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+-- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
+-- land alongside the Compose/<Phase>.lean files in later slices.
+
+end EvmAsm.Evm64.SDiv.Compose

--- a/EvmAsm/Evm64/SDiv/LimbSpec.lean
+++ b/EvmAsm/Evm64/SDiv/LimbSpec.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.SDiv.LimbSpec
+
+  Per-block / per-limb cpsTriple specs for SDIV sub-blocks (sign
+  extraction, abs negation, callable-divide JAL, sign-correction).
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). Per
+  `OPCODE_TEMPLATE.md`, each sub-block will get exactly one cpsTriple
+  lemma once the Compose layer pins the layout.
+-/
+
+import EvmAsm.Evm64.SDiv.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Per-block specs land in slices evm-asm-01uh and below.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/Program.lean
+++ b/EvmAsm/Evm64/SDiv/Program.lean
@@ -1,0 +1,32 @@
+/-
+  EvmAsm.Evm64.SDiv.Program
+
+  Signed division opcode SDIV (`SDIV(a, b)` = signed-quotient under EVM
+  rules) as a 64-bit RISC-V program.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6).
+
+  The actual `evm_sdiv : Program` will be defined in slice
+  evm-asm-01uh. Per `docs/sdiv-smod-design.md` the algorithm is
+
+      1. extract sign of each operand (top bit of limb 3)
+      2. conditionally two's-complement negate operands so both are
+         non-negative; remember the sign-pair
+      3. JAL to an `evm_div_callable` shim (LP64) for unsigned division
+      4. conditionally negate the quotient based on `sign(a) XOR sign(b)`
+      5. apply the SDIV(-2^255, -1) = -2^255 fast-path overflow rule
+
+  This file currently has no `evm_sdiv` definition; later slices will
+  add it without breaking the umbrella import graph.
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_sdiv : Program` lands in slice 4 (evm-asm-01uh).
+-- See `docs/sdiv-smod-design.md` for the algorithm and reuse points.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SDiv/Spec.lean
+++ b/EvmAsm/Evm64/SDiv/Spec.lean
@@ -1,0 +1,26 @@
+/-
+  EvmAsm.Evm64.SDiv.Spec
+
+  Top-level (semantic / stack-level) cpsTriple spec for `evm_sdiv`,
+  bridging the limb-level composition to a single `evmWordIs` pre/post
+  pair.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). The
+  actual `evm_sdiv_stack_spec_within` theorem lands in slice
+  evm-asm-01uh and is composed from the verified shared bridge with
+  the boundary blocks.
+-/
+
+import EvmAsm.Evm64.SDiv.Compose.Base
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.SDiv.Compose
+
+-- Placeholder: `evm_sdiv_stack_spec_within` lands in slice 4
+-- (evm-asm-01uh). The signed-division correctness lemma
+-- `EvmWord.sdiv_correct` is added in slice 3 (evm-asm-kvs4).
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod.lean
+++ b/EvmAsm/Evm64/SMod.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.SMod
+
+  Umbrella for the SMOD opcode subtree (GH #90). Re-exports the
+  top-level spec; downstream consumers should `import EvmAsm.Evm64.SMod`
+  and not reach into sub-modules directly.
+
+  AddrNormAttr is imported first (per `AGENTS.md` `register_simp_attr`
+  ordering rule) so the `smod_addr` attribute exists when later modules
+  attach lemmas to it.
+-/
+
+import EvmAsm.Evm64.SMod.AddrNormAttr
+import EvmAsm.Evm64.SMod.Program
+import EvmAsm.Evm64.SMod.LimbSpec
+import EvmAsm.Evm64.SMod.AddrNorm
+import EvmAsm.Evm64.SMod.Compose.Base
+import EvmAsm.Evm64.SMod.Spec

--- a/EvmAsm/Evm64/SMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/SMod/AddrNorm.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.SMod.AddrNorm
+
+  Address-normalization simp set for SMOD composition proofs.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). The
+  `@[smod_addr, grind =]`-tagged atomic facts will be added once the
+  Compose layer (`SMod/Compose/...`) starts emitting concrete address
+  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
+  base and the attribute declaration so downstream files can already
+  open the namespace.
+-/
+
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Evm64.SMod.AddrNormAttr
+
+namespace EvmAsm.Evm64.SMod.AddrNorm
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.SMod.AddrNorm

--- a/EvmAsm/Evm64/SMod/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/SMod/AddrNormAttr.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.SMod.AddrNormAttr
+
+  Declares the `smod_addr` simp attribute used by `SMod/AddrNorm.lean`.
+
+  Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code
+  should import `SMod/AddrNorm.lean` (which imports this file) — not this
+  file directly.
+
+  Skeleton placeholder for GH #90 (SDIV/SMOD opcodes, beads slice
+  evm-asm-kyp6). No tagged lemmas yet; opcode-specific atomic
+  `signExtend12` / `<<<` / `BitVec.toNat` evaluations will be attached as
+  `@[smod_addr, grind =]` once the SMOD Compose layer starts emitting
+  concrete address arithmetic.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for SMOD address arithmetic. Will collect atomic evaluations of
+    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+    in SMOD composition proofs. -/
+register_simp_attr smod_addr

--- a/EvmAsm/Evm64/SMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/SMod/Compose/Base.lean
@@ -1,0 +1,25 @@
+/-
+  EvmAsm.Evm64.SMod.Compose.Base
+
+  Shared composition infrastructure for SMOD: `smodCode` (the union of
+  all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
+  back to `smodCode`, and shared length lemmas.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). Concrete
+  definitions will be added once `evm_smod` is laid out (slice
+  evm-asm-bjnb) and the per-block specs from `LimbSpec.lean` start
+  composing.
+-/
+
+import EvmAsm.Evm64.SMod.LimbSpec
+import EvmAsm.Evm64.SMod.AddrNorm
+
+namespace EvmAsm.Evm64.SMod.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+-- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
+-- land alongside the Compose/<Phase>.lean files in later slices.
+
+end EvmAsm.Evm64.SMod.Compose

--- a/EvmAsm/Evm64/SMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/SMod/LimbSpec.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.SMod.LimbSpec
+
+  Per-block / per-limb cpsTriple specs for SMOD sub-blocks (sign
+  extraction, abs negation, callable-modulo JAL, sign-correction).
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). Per
+  `OPCODE_TEMPLATE.md`, each sub-block will get exactly one cpsTriple
+  lemma once the Compose layer pins the layout.
+-/
+
+import EvmAsm.Evm64.SMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Per-block specs land in slice evm-asm-bjnb and below.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/Program.lean
+++ b/EvmAsm/Evm64/SMod/Program.lean
@@ -1,0 +1,32 @@
+/-
+  EvmAsm.Evm64.SMod.Program
+
+  Signed remainder opcode SMOD (`SMOD(a, b)` = signed-remainder under EVM
+  rules) as a 64-bit RISC-V program.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6).
+
+  The actual `evm_smod : Program` will be defined in slice
+  evm-asm-bjnb. Per `docs/sdiv-smod-design.md` the algorithm is
+
+      1. extract sign of each operand (top bit of limb 3)
+      2. conditionally two's-complement negate operands so both are
+         non-negative; remember `sign(a)`
+      3. JAL to an `evm_mod_callable` shim (LP64) for unsigned modulo
+      4. conditionally negate the remainder based on `sign(a)`
+         (EVM SMOD takes the sign of the dividend)
+
+  This file currently has no `evm_smod` definition; later slices will
+  add it without breaking the umbrella import graph.
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_smod : Program` lands in slice 5 (evm-asm-bjnb).
+-- See `docs/sdiv-smod-design.md` for the algorithm and reuse points.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/SMod/Spec.lean
+++ b/EvmAsm/Evm64/SMod/Spec.lean
@@ -1,0 +1,26 @@
+/-
+  EvmAsm.Evm64.SMod.Spec
+
+  Top-level (semantic / stack-level) cpsTriple spec for `evm_smod`,
+  bridging the limb-level composition to a single `evmWordIs` pre/post
+  pair.
+
+  Skeleton placeholder for GH #90 (beads slice evm-asm-kyp6). The
+  actual `evm_smod_stack_spec_within` theorem lands in slice
+  evm-asm-bjnb and is composed from the verified shared bridge with
+  the boundary blocks. The signed-modulo correctness lemma
+  `EvmWord.smod_correct` is also added in that slice.
+-/
+
+import EvmAsm.Evm64.SMod.Compose.Base
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.SMod.Compose
+
+-- Placeholder: `evm_smod_stack_spec_within` lands in slice 5
+-- (evm-asm-bjnb).
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Slice 2 of evm-asm-34sg (#90 SDIV/SMOD).

Adds the directory skeletons for the SDIV (0x05) and SMOD (0x07) opcode
subtrees per `EvmAsm/Evm64/OPCODE_TEMPLATE.md`, matching the layout used
by the EXP subtree (#92):

- `EvmAsm/Evm64/SDiv/{AddrNormAttr,AddrNorm,Program,LimbSpec,Spec}.lean`
  + `Compose/Base.lean`, plus the `EvmAsm/Evm64/SDiv.lean` umbrella.
- Symmetric set under `EvmAsm/Evm64/SMod/`.

`AddrNormAttr.lean` is split from `AddrNorm.lean` so a freshly-declared
`register_simp_attr` is not used in the same file (per AGENTS.md). The
umbrella imports the attribute file first.

Each placeholder file carries:
- the right namespace and imports for the substrate it represents,
- pointer comments to the slice that fills it in:
  - SDIV: evm-asm-kvs4 (`EvmWord.sdiv_correct`),
    evm-asm-01uh (`evm_sdiv` Program + stack spec).
  - SMOD: evm-asm-bjnb (`evm_smod` Program + stack spec +
    `EvmWord.smod_correct`).

Both subtrees are wired into `EvmAsm/Evm64.lean`. CI checks pass
locally:
- `lake build` clean (1549 jobs, no new sorries).
- `scripts/check-unimported.sh`: 487/487 reachable, 0 orphans.
- `scripts/check-file-size.sh`: all files within cap.

No proofs, programs, or production logic in this slice — purely the
substrate that subsequent slices will land on top of. This avoids
the retrofit tax documented in OPCODE_TEMPLATE.md (issues #262, #263,
#264, #265, #266, #283, #301, #312, #313).

Refs GH #90, beads evm-asm-kyp6 (slice of evm-asm-34sg).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).