### PR TITLE
docs(#334): note scratchpad-layout convention in AGENTS.md / TACTICS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1007,6 +1007,41 @@ far from the definition).
 The project roadmap is maintained in `PLAN.md`. See `CLAUDE.md` for the
 maintenance protocol (when and how to update it).
 
+## Scratchpad Layout (#334)
+
+Routines that need `sp`-relative internal scratch cells (DivMod today, EXP /
+Multiply with internal scratch later) must take their scratchpad layout as a
+**parameter**, not bake offsets into the spec. Hardcoding offsets like
+`sp + signExtend12 4056` makes the routine impossible to compose from a
+non-trivial caller frame and forces every call site to use the same fixed
+placement.
+
+Convention (per `docs/scratchpad-layout-design.md`):
+
+- One `XxxScratchpadLayout` structure per routine, with named fields for
+  each scratch cell (e.g. `dividendNorm`, `divisorNorm`, `quotientHi`).
+- A companion `XxxScratchpadLayout.Valid (L : XxxScratchpadLayout) : Prop`
+  bundling per-cell validity (`isValidDwordAccess`) plus disjointness from
+  the caller frame and from each other.
+- A `canonicalXxxScratchpadLayout : XxxScratchpadLayout` matching today's
+  hardcoded offsets, and a `canonicalXxxScratchpadLayout_valid` instance.
+- Specs take `(L : XxxScratchpadLayout) (hL : L.Valid)` as parameters and
+  reference `L.fieldName` instead of `sp + signExtend12 N` literals.
+- The routine's existing fixed-offset spec stays as a thin shim that
+  instantiates the canonical layout, so existing call sites keep compiling.
+
+The naming convention is fixed: `EvmAsm/Evm64/<Routine>/Layout.lean`,
+`<Routine>ScratchpadLayout`, `.Valid`, `canonical<Routine>ScratchpadLayout`,
+`canonical<Routine>ScratchpadLayout_valid`. Slice 3 (`EvmAsm/Evm64/Multiply/Layout.lean`)
+is the canonical empty-layout pilot — copy its file shape when adding scratch
+to a new routine.
+
+When introducing a new opcode subtree that will carry internal scratch
+(EXP-class routines, future precompiles), define the layout struct from day
+one — even if it starts empty — to avoid the retrofit tax. See `docs/scratchpad-layout-design.md`
+for the full design and `docs/scratchpad-layout-survey.md` for the
+hardcoded-offset inventory that motivated the change.
+
 ## New opcode conventions (OPCODE_TEMPLATE.md)
 
 Before starting a new opcode subtree (SDIV, SMOD, ADDMOD, MULMOD, EXP, …),

--- a/TACTICS.md
+++ b/TACTICS.md
@@ -251,3 +251,23 @@ xperm (AC permutation proofs)
 
 Each layer builds on the one below. All tactics work at the `MetaM` level,
 constructing proof terms directly rather than using tactic combinators.
+
+
+## Scratchpad layout (parameterizing internal scratch cells)
+
+Routines with `sp`-relative internal scratch cells must take their layout as
+a parameter rather than baking `sp + signExtend12 N` literals into the spec.
+The convention lives in `AGENTS.md` (section "Scratchpad Layout (#334)") and
+the design rationale + migration plan in
+`docs/scratchpad-layout-design.md`.
+
+Canonical instances:
+
+- `EvmAsm/Evm64/Multiply/Layout.lean` — empty-layout pilot (Multiply has no
+  internal scratch; struct defined to fix the naming convention).
+- DivMod / Byte / Shift layouts will follow the same shape under #334
+  slice 4 (beads `evm-asm-vst1`).
+
+When writing a new spec that touches scratchpad cells, prefer
+`L.fieldName` over `sp + signExtend12 N` and add `(L : XxxScratchpadLayout)
+(hL : L.Valid)` parameters from day one.


### PR DESCRIPTION
Slice 5 of #334 (beads evm-asm-stjl, parent evm-asm-4mka).

Adds a 'Scratchpad Layout (#334)' section to AGENTS.md spelling out the
layout-as-parameter convention already shipped in PR #1579 (design note,
beads evm-asm-86d1) and PR #1645 (Multiply pilot, beads evm-asm-1d1o):

- One `XxxScratchpadLayout` struct per routine, with `.Valid` predicate,
  canonical instance, and canonical-validity lemma.
- Specs take `(L : XxxScratchpadLayout) (hL : L.Valid)` and reference
  `L.fieldName` instead of `sp + signExtend12 N` literals.
- Existing fixed-offset specs stay as thin shims over the canonical
  layout so call sites are unaffected.

Adds a brief pointer in TACTICS.md to the canonical empty-layout pilot
(`EvmAsm/Evm64/Multiply/Layout.lean`) and the design doc
(`docs/scratchpad-layout-design.md`).

Docs only — no code change. `lake build` green locally.

Refs #334. Closes beads evm-asm-stjl.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).