### PR TITLE
chore(divmod): drop stale file-size-exception marker in Spec/CallAddback.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddback.lean
@@ -1,4 +1,3 @@
--- file-size-exception: tracked by #66 / #61 (call-addback BEQ Word-level wrappers + closure are still being filled in; further sub-split deferred until the chain stabilizes).
 /-
   EvmAsm.Evm64.DivMod.Spec.CallAddback
 


### PR DESCRIPTION
Drops the now-stale `-- file-size-exception:` marker on line 1 of
`EvmAsm/Evm64/DivMod/Spec/CallAddback.lean`.

After successive extractions tracked under #1078 (CallAddbackMod,
PureNat, V2Bounds, SubStubs, Phase-1 stubs, numerical-counterexample
tests, Pure-Nat algebra block, v2 counterexamples, single-addback
wrappers), the file is **1394 lines** — under the 1500-line default
cap. The marker referencing #66 / #61 is therefore a no-op:

```
$ scripts/check-file-size.sh --report
checked 357 files, 0 exempted, 0 over cap
```

Same output before and after this change. Comment-only, no Lean content
modified.

Refs #1078, beads `evm-asm-5f2m`. Sibling of merged #2249 (which dropped
markers in three other Spec headers).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).