### PR TITLE
chore(#1045): mark RegisterCommand imports in 4 *AddrNormAttr files as shake false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -31,6 +31,10 @@
   "EvmAsm.Rv64.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.RegOpsAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.ByteAlgAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.DivMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.SDiv.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.SMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],
   "EvmAsm.Evm64.Basic":


### PR DESCRIPTION
Shake suggests swapping `Lean.Meta.Tactic.Simp.RegisterCommand` for `Lean.Meta.Tactic.Simp.Attr` in the four Evm64-side `*AddrNormAttr.lean` files (DivMod, SDiv, SMod, Exp). The suggestion is incorrect: `register_simp_attr` is a command-elaborator that is declared in `Simp.RegisterCommand`. Swapping the import causes `unexpected identifier; expected '#guard_msgs', ...` (verified locally on `SDiv/AddrNormAttr.lean`).

The matching three Rv64-side `*Attr.lean` files (`AddrNormAttr`, `RegOpsAttr`, `ByteAlgAttr`) already have noshake entries for the same false positive. This PR extends the allowance to the Evm64-side files so `lake exe shake EvmAsm` reports cleanly on them.

Verification: `lake build` green, `lake exe shake EvmAsm` no longer flags any `*AddrNormAttr.lean` file.

Refs #1045. Closes beads slice evm-asm-atbt (parent evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).