### PR TITLE
feat(evmwordarith): EvmWord.addmod_correct + 257-bit add helper

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -33,6 +33,7 @@ import EvmAsm.Evm64.EvmWordArith.Exp
 -- Div → Common.
 import EvmAsm.Evm64.EvmWordArith.Div128Shift0
 import EvmAsm.Evm64.EvmWordArith.DivCorrect
+import EvmAsm.Evm64.EvmWordArith.AddMod
 
 -- ModBridgeAssemble covers ModBridgeUtop → Val256ModBridge.
 import EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble

--- a/EvmAsm/Evm64/EvmWordArith/AddMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/AddMod.lean
@@ -1,0 +1,95 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.AddMod
+
+  EVM ADDMOD semantics: word-level definition and correctness theorem.
+
+  Provides:
+  * `EvmWord.addmod a b N` — the EVM `ADDMOD` operation: `(a + b) mod N`
+    with `N = 0 ⇒ 0`, where the intermediate sum `a + b` is taken at
+    full 257-bit precision (carry out of bit 255).
+  * `EvmWord.addCarry a b` — the 257-bit add helper: returns the
+    Boolean carry-out alongside the truncated 256-bit sum, with a
+    proof that the pair faithfully represents the natural-number sum
+    `a.toNat + b.toNat`.
+  * `EvmWord.addmod_correct` — algebraic correctness:
+    `(addmod a b N).toNat = if N = 0 then 0 else (a.toNat + b.toNat) % N.toNat`.
+
+  This is the slice-2 deliverable for GH issue #91 (ADDMOD/MULMOD)
+  and matches the algebraic shape required by the future
+  `evm_addmod_stack_spec` (slice 3, beads `evm-asm-sord`).
+
+  See `docs/91-addmod-mulmod-survey.md` §1.3, §3, §4 for context.
+-/
+
+import EvmAsm.Evm64.Basic
+
+namespace EvmAsm.Evm64
+
+namespace EvmWord
+
+-- ============================================================================
+-- 257-bit add helper
+-- ============================================================================
+
+/-- Pair of (carry-out, truncated 256-bit sum) for the addition of two
+    `EvmWord`s. The carry bit is `true` exactly when `a.toNat + b.toNat`
+    overflows 256 bits, i.e. equals `2^256` or more. -/
+def addCarry (a b : EvmWord) : Bool × EvmWord :=
+  (decide (a.toNat + b.toNat ≥ 2 ^ 256), a + b)
+
+/-- The 257-bit identity for `addCarry`: the natural-number sum of the
+    inputs is exactly `(carry · 2^256) + truncated`. This is the
+    algebraic shape downstream proofs use to bridge the limb-level
+    RISC-V add-with-carry to the EVM word-level model. -/
+theorem addCarry_spec (a b : EvmWord) :
+    a.toNat + b.toNat =
+      (if (addCarry a b).fst then 2 ^ 256 else 0) + (addCarry a b).snd.toNat := by
+  unfold addCarry
+  simp only [BitVec.toNat_add]
+  have ha : a.toNat < 2 ^ 256 := a.isLt
+  have hb : b.toNat < 2 ^ 256 := b.isLt
+  by_cases h : a.toNat + b.toNat ≥ 2 ^ 256
+  · simp only [decide_eq_true_eq, h, ↓reduceIte]
+    have hmod : (a.toNat + b.toNat) % 2 ^ 256 = a.toNat + b.toNat - 2 ^ 256 := by
+      rw [Nat.mod_eq_sub_mod h, Nat.mod_eq_of_lt (by omega)]
+    rw [hmod]; omega
+  · simp only [decide_eq_true_eq, h, ↓reduceIte]
+    have hlt : a.toNat + b.toNat < 2 ^ 256 := by omega
+    rw [Nat.mod_eq_of_lt hlt]
+    omega
+
+-- ============================================================================
+-- ADDMOD
+-- ============================================================================
+
+/-- EVM `ADDMOD` semantics: `(a + b) mod N` evaluated at full 257-bit
+    precision when `N ≠ 0`; returns `0` when `N = 0`. -/
+def addmod (a b N : EvmWord) : EvmWord :=
+  if N = 0 then 0 else BitVec.ofNat 256 ((a.toNat + b.toNat) % N.toNat)
+
+/-- Algebraic correctness of `EvmWord.addmod`. -/
+theorem addmod_correct (a b N : EvmWord) :
+    (EvmWord.addmod a b N).toNat =
+      if N = 0 then 0 else (a.toNat + b.toNat) % N.toNat := by
+  unfold addmod
+  by_cases h : N = 0
+  · simp [h]
+  · simp only [if_neg h]
+    rw [BitVec.toNat_ofNat]
+    -- The mod result is < N.toNat ≤ 2^256 - 1 < 2^256, so no further
+    -- reduction modulo 2^256 is needed.
+    have hNpos : 0 < N.toNat := by
+      have hne : N.toNat ≠ 0 := by
+        intro hz
+        apply h
+        exact BitVec.eq_of_toNat_eq (by simpa using hz)
+      omega
+    have hlt : (a.toNat + b.toNat) % N.toNat < 2 ^ 256 := by
+      have hN : N.toNat < 2 ^ 256 := N.isLt
+      have : (a.toNat + b.toNat) % N.toNat < N.toNat := Nat.mod_lt _ hNpos
+      omega
+    exact Nat.mod_eq_of_lt hlt
+
+end EvmWord
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `EvmAsm/Evm64/EvmWordArith/AddMod.lean` with the slice-2 deliverables for GH issue #91 (ADDMOD/MULMOD opcodes):

- `EvmWord.addCarry (a b : EvmWord) : Bool × EvmWord` — Boolean carry-out alongside the truncated 256-bit sum.
- `addCarry_spec` — the 257-bit identity `a.toNat + b.toNat = (carry · 2^256) + truncated.toNat`.
- `EvmWord.addmod (a b N : EvmWord) : EvmWord` — EVM ADDMOD semantics (`(a+b) mod N`, with `N = 0 ⇒ 0`).
- `EvmWord.addmod_correct` — algebraic correctness against `Nat.add_mod`.

Wired into `EvmAsm/Evm64/EvmWordArith.lean` umbrella so downstream files can import. `lake build` green; 0 sorry.

Slice 2 of beads `evm-asm-z7qm` (#91 — ADDMOD/MULMOD). Implements the algebraic surface specified in `docs/91-addmod-mulmod-survey.md` §1.3, §3, §4 (PR #2259). Unblocks slice 3 (beads `evm-asm-sord`, the `evm_addmod` Program/stack-spec slice).

Beads: `evm-asm-f453`. Refs GH #91.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).