### PR TITLE
feat(calldata): add evm_calldatasize program + stack spec

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -102,3 +102,5 @@ import EvmAsm.Evm64.MLoad
 -- Calldata helpers (issue #104)
 import EvmAsm.Evm64.Calldata.Basic
 import EvmAsm.Evm64.Calldata.Size
+import EvmAsm.Evm64.Calldata.SizeProgram
+import EvmAsm.Evm64.Calldata.SizeSpec

--- a/EvmAsm/Evm64/Calldata/SizeProgram.lean
+++ b/EvmAsm/Evm64/Calldata/SizeProgram.lean
@@ -1,0 +1,61 @@
+/-
+  EvmAsm.Evm64.Calldata.SizeProgram
+
+  RISC-V program implementing the EVM `CALLDATASIZE` opcode.
+
+  CALLDATASIZE pushes the calldata byte length (held in the env block at
+  `callDataLenOff = 424`) onto the EVM stack as a 256-bit word.  Because the
+  length always fits in 64 bits in any realistic execution, the value goes
+  in the LOW limb of the pushed word and the upper three limbs are zero —
+  the same shape as `MSIZE`.
+
+  Implementation (6 instructions = 24 bytes):
+
+    LD   tmpReg envBaseReg callDataLenOff   -- load callDataLen into tmpReg
+    ADDI x12    x12        -32              -- decrement EVM stack pointer
+    SD   x12    tmpReg     0                -- write low limb (size value)
+    SD   x12    x0         8                -- zero upper three limbs
+    SD   x12    x0         16
+    SD   x12    x0         24
+
+  Slice 3 of issue #104 (parent `evm-asm-xjk8`, this slice
+  `evm-asm-8mp7`).  Authored by @pirapira; implemented by Hermes-bot
+  (evm-hermes).
+-/
+
+import EvmAsm.Rv64.SepLogic
+import EvmAsm.Evm64.Environment.Layout
+
+namespace EvmAsm.Evm64
+namespace Calldata
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.EvmEnv (callDataLenOff)
+
+/-- Parameterized RISC-V program implementing `CALLDATASIZE`.
+    `envBaseReg` is the caller's environment-base register (the env block
+    starts at `envBaseReg`); `tmpReg` is a caller-saved temporary
+    distinct from `x0`, `x12`, and `envBaseReg`.
+    6 instructions = 24 bytes. -/
+def evm_calldatasize (envBaseReg tmpReg : Reg) : Program :=
+  LD tmpReg envBaseReg (BitVec.ofNat 12 callDataLenOff) ;;
+  ADDI .x12 .x12 (-32) ;;
+  SD .x12 tmpReg 0 ;;
+  SD .x12 .x0 8 ;;
+  SD .x12 .x0 16 ;;
+  SD .x12 .x0 24
+
+abbrev evm_calldatasize_code (envBaseReg tmpReg : Reg) (base : Word) : CodeReq :=
+  CodeReq.ofProg base (evm_calldatasize envBaseReg tmpReg)
+
+/-- `evm_calldatasize` is exactly 6 RISC-V instructions = 24 bytes. -/
+theorem evm_calldatasize_length (envBaseReg tmpReg : Reg) :
+    (evm_calldatasize envBaseReg tmpReg).length = 6 := by
+  simp [evm_calldatasize, LD, ADDI, SD, single, seq, Program.length_append]
+
+theorem evm_calldatasize_byte_length (envBaseReg tmpReg : Reg) :
+    4 * (evm_calldatasize envBaseReg tmpReg).length = 24 := by
+  rw [evm_calldatasize_length]
+
+end Calldata
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Calldata/SizeSpec.lean
+++ b/EvmAsm/Evm64/Calldata/SizeSpec.lean
@@ -1,0 +1,163 @@
+/-
+  EvmAsm.Evm64.Calldata.SizeSpec
+
+  Stack-level cpsTripleWithin specification for the EVM `CALLDATASIZE`
+  opcode (see `EvmAsm/Evm64/Calldata/SizeProgram.lean`).
+
+  Slice 3 of issue #104 (parent `evm-asm-xjk8`, this slice
+  `evm-asm-8mp7`).  Authored by @pirapira; implemented by Hermes-bot
+  (evm-hermes).
+-/
+
+import EvmAsm.Evm64.Calldata.SizeProgram
+import EvmAsm.Evm64.Calldata.Size
+import EvmAsm.Evm64.Environment.Assertion
+import EvmAsm.Evm64.Stack
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+open EvmAsm.Rv64.Tactics
+
+namespace EvmAsm.Evm64
+namespace Calldata
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.EvmEnv (callDataLenOff envIs envIs_callDataLen_split envIsCallDataLenRest)
+
+/-- The on-disk `callDataLenOff` immediate (424) sign-extends to itself
+    as a 64-bit word.  Used to normalise the load address that LD's
+    spec produces (`v_addr + signExtend12 (BitVec.ofNat 12 424)`) so it
+    matches the canonical `v_addr + BitVec.ofNat 64 callDataLenOff`
+    spelling used by `envIs_callDataLen_split`. -/
+private theorem signExtend12_callDataLenOff :
+    signExtend12 (BitVec.ofNat 12 callDataLenOff) =
+      BitVec.ofNat 64 callDataLenOff := by
+  rw [signExtend12_ofNat_small (by decide)]
+
+/-- Raw memory-cell-level CALLDATASIZE spec: load `callDataLen` from the
+    env block at `envAddr + callDataLenOff` into `tmpReg`, decrement EVM
+    SP by 32, write the loaded value at the new top-of-stack low limb
+    and zero the upper three limbs.  6 instructions = 24 bytes. -/
+theorem evm_calldatasize_spec_within
+    (envBaseReg tmpReg : Reg)
+    (htmp_ne_x0 : tmpReg ≠ .x0)
+    (nsp base envAddr tempOld callDataLen : Word)
+    (d0 d1 d2 d3 : Word) :
+    let code := evm_calldatasize_code envBaseReg tmpReg base
+    cpsTripleWithin 6 base (base + 24) code
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ tempOld) **
+       (.x12 ↦ᵣ (nsp + 32)) **
+       (nsp ↦ₘ d0) ** ((nsp + 8) ↦ₘ d1) **
+       ((nsp + 16) ↦ₘ d2) ** ((nsp + 24) ↦ₘ d3) **
+       ((envAddr + BitVec.ofNat 64 callDataLenOff) ↦ₘ callDataLen))
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ callDataLen) **
+       (.x12 ↦ᵣ nsp) **
+       (nsp ↦ₘ callDataLen) ** ((nsp + 8) ↦ₘ 0) **
+       ((nsp + 16) ↦ₘ 0) ** ((nsp + 24) ↦ₘ 0) **
+       ((envAddr + BitVec.ofNat 64 callDataLenOff) ↦ₘ callDataLen)) := by
+  -- LD tmpReg envBaseReg callDataLenOff : load env.callDataLen.
+  have LLD := ld_spec_gen_within tmpReg envBaseReg envAddr tempOld
+                callDataLen (BitVec.ofNat 12 callDataLenOff) base htmp_ne_x0
+  simp only [signExtend12_callDataLenOff] at LLD
+  -- ADDI x12 x12 -32 : decrement SP. Normalize (nsp+32) + (-32) = nsp.
+  have LADDI := addi_spec_gen_same_within .x12 (nsp + 32) (-32) (base + 4) (by nofun)
+  simp only [signExtend12_neg32] at LADDI
+  rw [show (nsp + 32 : Word) + (-32 : Word) = nsp from by bv_omega] at LADDI
+  -- SD x12 tmpReg 0 : write callDataLen at low limb (nsp).
+  have LSD0 := sd_spec_gen_within .x12 tmpReg nsp callDataLen
+                  d0 (0 : BitVec 12) (base + 8)
+  -- SD x12 x0 {8,16,24} : zero the upper three limbs.
+  have LSD1 := sd_x0_spec_gen_within .x12 nsp d1 8 (base + 12)
+  have LSD2 := sd_x0_spec_gen_within .x12 nsp d2 16 (base + 16)
+  have LSD3 := sd_x0_spec_gen_within .x12 nsp d3 24 (base + 20)
+  runBlock LLD LADDI LSD0 LSD1 LSD2 LSD3
+
+/-! ## Stack-form lift
+
+  Lift the raw spec to the EVM stack view.  The pushed word is the
+  256-bit zero-extension of the 64-bit `callDataLen`, expressed as
+  `BitVec.ofNat 256 callDataLen.toNat` so it matches the pure semantics
+  in `EvmAsm/Evm64/Calldata/Size.lean`.
+-/
+
+/-- Concretization of `evmWordIs nsp (BitVec.ofNat 256 callDataLen.toNat)`
+    as four limb cells: low limb is `callDataLen`, upper three are zero.
+    Mirror of `evmWordIs_msize_unfold`. -/
+private theorem evmWordIs_calldatasize_unfold
+    (nsp : Word) (callDataLen : Word) :
+    evmWordIs nsp (BitVec.ofNat 256 callDataLen.toNat) =
+      ((nsp ↦ₘ callDataLen) ** ((nsp + 8) ↦ₘ 0) **
+       ((nsp + 16) ↦ₘ 0) ** ((nsp + 24) ↦ₘ 0)) := by
+  have h_size_lt : callDataLen.toNat < 2 ^ 64 := callDataLen.isLt
+  have hlow :
+      EvmWord.getLimbN (BitVec.ofNat 256 callDataLen.toNat) 0 = callDataLen := by
+    rw [EvmWord.getLimbN_eq_extractLsb']
+    apply BitVec.eq_of_toNat_eq
+    simp only [BitVec.extractLsb'_toNat, BitVec.toNat_ofNat, Nat.shiftRight_zero,
+               Nat.zero_mul]
+    have h1 : callDataLen.toNat % 2 ^ 256 = callDataLen.toNat :=
+      Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le h_size_lt (by norm_num))
+    rw [h1, Nat.mod_eq_of_lt h_size_lt]
+  have hhigh : ∀ k : Nat, k ≠ 0 → k < 4 →
+      EvmWord.getLimbN (BitVec.ofNat 256 callDataLen.toNat) k = 0 := by
+    intro k hk hk4
+    rw [EvmWord.getLimbN_eq_extractLsb']
+    apply BitVec.eq_of_toNat_eq
+    simp only [BitVec.extractLsb'_toNat, BitVec.toNat_ofNat,
+               Nat.shiftRight_eq_div_pow]
+    have h1 : callDataLen.toNat % 2 ^ 256 = callDataLen.toNat :=
+      Nat.mod_eq_of_lt (Nat.lt_of_lt_of_le h_size_lt (by norm_num))
+    rw [h1]
+    have hp : 2 ^ 64 ≤ 2 ^ (k * 64) :=
+      Nat.pow_le_pow_right (by norm_num) (by
+        have : 0 < k := Nat.pos_of_ne_zero hk
+        omega)
+    have hdiv : callDataLen.toNat / 2 ^ (k * 64) = 0 :=
+      Nat.div_eq_of_lt (Nat.lt_of_lt_of_le h_size_lt hp)
+    simp [hdiv]
+  unfold evmWordIs
+  rw [hlow, hhigh 1 (by decide) (by decide),
+      hhigh 2 (by decide) (by decide),
+      hhigh 3 (by decide) (by decide)]
+
+/-- CALLDATASIZE stack spec: pops nothing, pushes the 64-bit
+    `callDataLen` zero-extended to 256 bits onto the EVM stack.
+
+    The callDataLen cell is exposed via `envIs_callDataLen_split`, which
+    rotates that cell to the head of `envIs base env`; the remainder
+    `envIsCallDataLenRest base env` is preserved by the spec. -/
+theorem evm_calldatasize_stack_spec_within
+    (envBaseReg tmpReg : Reg)
+    (htmp_ne_x0 : tmpReg ≠ .x0)
+    (nsp base envAddr tempOld : Word) (env : EvmEnv)
+    (d0 d1 d2 d3 : Word) (rest : List EvmWord) :
+    let code := evm_calldatasize_code envBaseReg tmpReg base
+    cpsTripleWithin 6 base (base + 24) code
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ tempOld) **
+       (.x12 ↦ᵣ (nsp + 32)) **
+       (nsp ↦ₘ d0) ** ((nsp + 8) ↦ₘ d1) **
+       ((nsp + 16) ↦ₘ d2) ** ((nsp + 24) ↦ₘ d3) **
+       envIs envAddr env **
+       evmStackIs (nsp + 32) rest)
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ env.callDataLen) **
+       (.x12 ↦ᵣ nsp) **
+       evmStackIs nsp (BitVec.ofNat 256 env.callDataLen.toNat :: rest) **
+       envIs envAddr env) :=
+  cpsTripleWithin_weaken
+    (fun _ hp => by
+      rw [envIs_callDataLen_split envAddr env] at hp
+      xperm_hyp hp)
+    (fun _ hq => by
+      rw [evmStackIs_cons, evmWordIs_calldatasize_unfold,
+          envIs_callDataLen_split envAddr env]
+      xperm_hyp hq)
+    (cpsTripleWithin_frameR
+      (envIsCallDataLenRest envAddr env ** evmStackIs (nsp + 32) rest)
+      (pcFree_sepConj (by unfold envIsCallDataLenRest; pcFree)
+        pcFree_evmStackIs)
+      (evm_calldatasize_spec_within envBaseReg tmpReg htmp_ne_x0
+        nsp base envAddr tempOld env.callDataLen d0 d1 d2 d3))
+
+end Calldata
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Environment/Assertion.lean
+++ b/EvmAsm/Evm64/Environment/Assertion.lean
@@ -520,5 +520,37 @@ theorem envIs_baseFee_split (base : Word) (env : EvmEnv) :
   unfold envIsBlockBaseFeeRest
   ac_rfl
 
+/-- Remaining 16 env-field cells after the `callDataLen` cell is rotated
+    to the head. Used by `CALLDATASIZE` (slice 3 of `evm-asm-xjk8` /
+    `evm-asm-8mp7`) to frame on the single 64-bit length cell while
+    keeping ownership of every other env field. -/
+def envIsCallDataLenRest (base : Word) (env : EvmEnv) : Assertion :=
+  evmWordIs (base + BitVec.ofNat 64 addressOff)         (addrAsWord env.address) **
+  evmWordIs (base + BitVec.ofNat 64 selfBalanceOff)     env.selfBalance **
+  evmWordIs (base + BitVec.ofNat 64 callerOff)          (addrAsWord env.caller) **
+  evmWordIs (base + BitVec.ofNat 64 callValueOff)       env.callValue **
+  evmWordIs (base + BitVec.ofNat 64 txOriginOff)        (addrAsWord env.txOrigin) **
+  evmWordIs (base + BitVec.ofNat 64 gasPriceOff)        env.gasPrice **
+  evmWordIs (base + BitVec.ofNat 64 blockCoinbaseOff)   (addrAsWord env.blockCoinbase) **
+  evmWordIs (base + BitVec.ofNat 64 blockTimestampOff)  env.blockTimestamp **
+  evmWordIs (base + BitVec.ofNat 64 blockNumberOff)     env.blockNumber **
+  evmWordIs (base + BitVec.ofNat 64 blockPrevrandaoOff) env.blockPrevrandao **
+  evmWordIs (base + BitVec.ofNat 64 blockGasLimitOff)   env.blockGasLimit **
+  evmWordIs (base + BitVec.ofNat 64 blockBaseFeeOff)    env.blockBaseFee **
+  evmWordIs (base + BitVec.ofNat 64 chainIdOff)         env.chainId **
+  ((base + BitVec.ofNat 64 callDataPtrOff)    ↦ₘ env.callDataPtr) **
+  ((base + BitVec.ofNat 64 returnDataPtrOff)  ↦ₘ env.returnDataPtr) **
+  ((base + BitVec.ofNat 64 returnDataSizeOff) ↦ₘ env.returnDataSize)
+
+/-- Rotate the `callDataLen` cell to the head. Mirror of
+    `envIs_caller_split` for the `CALLDATASIZE` opcode. -/
+theorem envIs_callDataLen_split (base : Word) (env : EvmEnv) :
+    envIs base env =
+      (((base + BitVec.ofNat 64 callDataLenOff) ↦ₘ env.callDataLen) **
+        envIsCallDataLenRest base env) := by
+  rw [envIs_unfold]
+  unfold envIsCallDataLenRest
+  ac_rfl
+
 end EvmEnv
 end EvmAsm.Evm64


### PR DESCRIPTION
Slice 3 of issue #104 (parent beads `evm-asm-xjk8`, this slice `evm-asm-8mp7`).

## What

Adds the RV64 program implementing the EVM `CALLDATASIZE` opcode and its stack-level Hoare triple specification.

- **`EvmAsm/Evm64/Calldata/SizeProgram.lean`** — parameterized 6-instruction (24-byte) program: load `env.callDataLen` from the env block at offset `callDataLenOff = 424` into a temporary register, decrement EVM SP by 32, write the loaded value at the new top-of-stack low limb, zero the upper three limbs.
- **`EvmAsm/Evm64/Calldata/SizeSpec.lean`**
  - `evm_calldatasize_spec_within` — raw memory-cell-level `cpsTripleWithin`.
  - `evm_calldatasize_stack_spec_within` — stack-form lift; pre/post are framed in terms of `envIs envAddr env` and `evmStackIs nsp …`. Pushes `BitVec.ofNat 256 env.callDataLen.toNat` onto the EVM stack.
- **`EvmAsm/Evm64/Environment/Assertion.lean`** — adds `envIsCallDataLenRest` + `envIs_callDataLen_split`, mirror of the existing per-field rotate-to-head splits (the only `callDataLen` cell is a raw mapsto, not an `evmWordIs`).
- **`EvmAsm/Evm64.lean`** — imports the two new files.

The shape mirrors `MSize` (which reads a single 64-bit cell and pushes it as a 256-bit word). The semantic constant `callDataSizeWord` already lives in `EvmAsm/Evm64/Calldata/Size.lean` (PR #_, merged); no changes there.

## Verification

```
lake build  # green, 0 new sorry, 0 new maxHeartbeats / maxRecDepth bumps
```

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).