### PR TITLE
feat(evmwordarith): EvmWord.sdiv + sdiv_correct (#90 slice 3)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -15,6 +15,7 @@ import EvmAsm.Evm64.EvmWordArith.Eq
 import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.EvmWordArith.ByteOps
 import EvmAsm.Evm64.EvmWordArith.SignExtend
+import EvmAsm.Evm64.EvmWordArith.SDiv
 
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect

--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -1,0 +1,83 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.SDiv
+
+  EVM SDIV semantics: signed two's-complement division of 256-bit words,
+  with the EVM spec short-circuits already baked into `BitVec.sdiv`:
+
+    * `divisor = 0` ⇒ result `0`        (`BitVec.sdiv_zero`)
+    * `dividend = −2^255 ∧ divisor = −1` ⇒ result `−2^255`
+                                          (`BitVec.intMin_sdiv_neg_one`)
+
+  Both align with the executable spec
+  (`execution-specs/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py`,
+  function `sdiv`) and the EVM Yellow Paper §3 truncating-toward-zero
+  semantics. This file provides the `EvmWord.sdiv` wrapper plus the
+  correctness bridge connecting it to `Int.tdiv`.
+
+  Slice 3 of evm-asm-34sg (#90 SDIV / SMOD opcodes), beads
+  `evm-asm-kvs4`. SMOD lives in a sibling slice (5 / `evm-asm-bjnb`).
+-/
+
+import EvmAsm.Evm64.EvmWordArith.Common
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+namespace EvmWord
+
+-- ============================================================================
+-- EVM SDIV semantics
+-- ============================================================================
+
+/-- EVM SDIV: signed two's-complement integer division on 256-bit words.
+
+    Identical to `BitVec.sdiv` because the latter already implements the
+    EVM short-circuits:
+
+    * `BitVec.sdiv_zero` makes any-by-zero return `0`.
+    * `BitVec.intMin_sdiv_neg_one` makes `(−2^255).sdiv (−1) = −2^255`,
+      so the signed-overflow case is handled (rather than wrapping to the
+      mathematical result `+2^255` which is unrepresentable). -/
+def sdiv (a b : EvmWord) : EvmWord := BitVec.sdiv a b
+
+-- ============================================================================
+-- Edge-case lemmas
+-- ============================================================================
+
+@[simp]
+theorem sdiv_zero_right {a : EvmWord} : sdiv a 0 = 0 := by
+  simp [sdiv]
+
+@[simp]
+theorem zero_sdiv_left {b : EvmWord} : sdiv 0 b = 0 := by
+  simp [sdiv]
+
+/-- The signed-division overflow case: `(−2^255) / (−1) = −2^255` rather
+    than the unrepresentable `+2^255`. This matches the EVM executable
+    spec's short-circuit on the unique signed overflow point. -/
+theorem sdiv_intMin_neg_one : sdiv (BitVec.intMin 256) (-1) = BitVec.intMin 256 := by
+  show (BitVec.intMin 256).sdiv (-1) = BitVec.intMin 256
+  have h : (-1 : BitVec 256) = -1#256 := by decide
+  rw [h, BitVec.intMin_sdiv_neg_one]
+
+-- ============================================================================
+-- Correctness vs `Int.tdiv` (the spec formula)
+-- ============================================================================
+
+/-- Outside the unique overflow point, `EvmWord.sdiv` agrees with the
+    executable-spec formula: the truncating-toward-zero integer division
+    of the signed interpretations of the operands.
+
+    `BitVec.toInt_sdiv_of_ne_or_ne` is the underlying lemma; this just
+    relabels it through the `EvmWord.sdiv` wrapper. The two short-circuit
+    cases (`b = 0`, the overflow point) are handled by `sdiv_zero_right`
+    and `sdiv_intMin_neg_one`. -/
+theorem sdiv_correct (a b : EvmWord)
+    (h : a ≠ BitVec.intMin 256 ∨ b ≠ -1) :
+    (sdiv a b).toInt = a.toInt.tdiv b.toInt := by
+  simpa [sdiv] using BitVec.toInt_sdiv_of_ne_or_ne (w := 256) a b h
+
+end EvmWord
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Slice 3 of #90 (SDIV/SMOD opcodes), beads `evm-asm-kvs4` under parent `evm-asm-34sg`.

Adds the pure-`BitVec 256` SDIV semantic target plus its correctness
bridge to `Int.tdiv`. New file `EvmAsm/Evm64/EvmWordArith/SDiv.lean`,
wired through the `EvmWordArith` umbrella.

## What it provides

* `EvmWord.sdiv (a b : EvmWord) : EvmWord := BitVec.sdiv a b`
* `@[simp] sdiv_zero_right` — divisor 0 ⇒ 0
* `@[simp] zero_sdiv_left` — dividend 0 ⇒ 0
* `sdiv_intMin_neg_one` — the EVM signed-overflow short-circuit
* `sdiv_correct` — outside the overflow point, agrees with `Int.tdiv` of the
  signed interpretations

## Why this is short

Both EVM short-circuits already follow from Lean core lemmas:
* `BitVec.sdiv_zero` (`Init/Data/BitVec/Lemmas.lean:4517`)
* `BitVec.intMin_sdiv_neg_one` (`Init/Data/BitVec/Bitblast.lean:1650`)

so `sdiv := BitVec.sdiv` inherits the EVM spec for free. The correctness
theorem just relabels `BitVec.toInt_sdiv_of_ne_or_ne` through the new
wrapper.

## Out of scope

* `evm_sdiv` RISC-V program and `evm_sdiv_stack_spec` — slice 4
  (`evm-asm-01uh`).
* `EvmWord.smod` / `evm_smod` — slice 5 (`evm-asm-bjnb`).
* Dispatcher wiring — slice 6 (`evm-asm-ipi7`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).