### PR TITLE
refactor(rlp): bundle per-byte window hypotheses via rlpAlignedByteWindowOk

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
+++ b/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
@@ -1,0 +1,81 @@
+/-
+  EvmAsm.Rv64.RLP.Phase2ByteWindow
+
+  Bundled per-byte side conditions for an eight-byte aligned window inside a
+  single doubleword, used by the RLP Phase 2 long-form loop closures.
+
+  Sibling of `mloadAlignedLimbWindowOk` (Evm64/MLoad/LimbSpec.lean) and
+  `mstoreLimbWindowOk` (Evm64/MStore/Spec.lean). See parent task evm-asm-yrz5
+  / sibling slice evm-asm-jb8a.
+
+  The closures `rlp_phase2_long_loop_{seven,eight}_byte_spec_within` previously
+  took `2*N` separate `alignToDword`/`isValidByteAccess` hypotheses per call
+  site (N = 7 or 8). Bundling them under a single predicate cuts the lemma
+  signature down to one hypothesis per dword window and removes the
+  `halign1..halignN` / `hvalid1..hvalidN` boilerplate.
+-/
+
+import EvmAsm.Rv64.Basic
+import EvmAsm.Rv64.ByteOps
+
+namespace EvmAsm.Rv64.RLP
+
+open EvmAsm.Rv64
+
+/--
+Side conditions for one eight-byte aligned RLP byte window: every byte at
+offsets `0..7` from `ptr` lives in the same doubleword `dwordAddr` and is a
+valid byte access.
+
+Used by the RLP Phase 2 long-form loop closures (`rlp_phase2_long_loop_*_byte_spec_within`)
+that iteratively load consecutive bytes from a single doubleword.
+
+The eight conjuncts are listed in the order the consumer specs introduce
+them (`halign1..halign8` then `hvalid1..hvalid8`) so destructuring matches the
+historical naming.
+-/
+def rlpAlignedByteWindowOk (ptr dwordAddr : Word) : Prop :=
+  alignToDword ptr = dwordAddr ∧
+  alignToDword (ptr + 1) = dwordAddr ∧
+  alignToDword (ptr + 2) = dwordAddr ∧
+  alignToDword (ptr + 3) = dwordAddr ∧
+  alignToDword (ptr + 4) = dwordAddr ∧
+  alignToDword (ptr + 5) = dwordAddr ∧
+  alignToDword (ptr + 6) = dwordAddr ∧
+  alignToDword (ptr + 7) = dwordAddr ∧
+  isValidByteAccess ptr = true ∧
+  isValidByteAccess (ptr + 1) = true ∧
+  isValidByteAccess (ptr + 2) = true ∧
+  isValidByteAccess (ptr + 3) = true ∧
+  isValidByteAccess (ptr + 4) = true ∧
+  isValidByteAccess (ptr + 5) = true ∧
+  isValidByteAccess (ptr + 6) = true ∧
+  isValidByteAccess (ptr + 7) = true
+
+/-- Constructor wrapper — assemble the bundle from the legacy 16-argument form
+    so existing call sites (and downstream consumers that still produce raw
+    per-byte hypotheses) can adopt the bundle without rebuilding their own
+    derivation chains. -/
+theorem rlpAlignedByteWindowOk.mk
+    {ptr dwordAddr : Word}
+    (halign1 : alignToDword ptr = dwordAddr)
+    (halign2 : alignToDword (ptr + 1) = dwordAddr)
+    (halign3 : alignToDword (ptr + 2) = dwordAddr)
+    (halign4 : alignToDword (ptr + 3) = dwordAddr)
+    (halign5 : alignToDword (ptr + 4) = dwordAddr)
+    (halign6 : alignToDword (ptr + 5) = dwordAddr)
+    (halign7 : alignToDword (ptr + 6) = dwordAddr)
+    (halign8 : alignToDword (ptr + 7) = dwordAddr)
+    (hvalid1 : isValidByteAccess ptr = true)
+    (hvalid2 : isValidByteAccess (ptr + 1) = true)
+    (hvalid3 : isValidByteAccess (ptr + 2) = true)
+    (hvalid4 : isValidByteAccess (ptr + 3) = true)
+    (hvalid5 : isValidByteAccess (ptr + 4) = true)
+    (hvalid6 : isValidByteAccess (ptr + 5) = true)
+    (hvalid7 : isValidByteAccess (ptr + 6) = true)
+    (hvalid8 : isValidByteAccess (ptr + 7) = true) :
+    rlpAlignedByteWindowOk ptr dwordAddr :=
+  ⟨halign1, halign2, halign3, halign4, halign5, halign6, halign7, halign8,
+   hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6, hvalid7, hvalid8⟩
+
+end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean
@@ -16,6 +16,7 @@
   whenever `byteOffset ptr = 0` (i.e., `ptr` is doubleword-aligned).
 -/
 
+import EvmAsm.Rv64.RLP.Phase2ByteWindow
 import EvmAsm.Rv64.RLP.Phase2LongLoopSeven
 
 namespace EvmAsm.Rv64.RLP
@@ -151,5 +152,39 @@ theorem rlp_phase2_long_loop_eight_byte_spec_within
     (fun _ hp => hp)
     (fun h hp => by xperm_hyp hp)
     composed
+
+/-- Bundled-hypothesis form of `rlp_phase2_long_loop_eight_byte_spec_within`.
+
+    Takes a single `rlpAlignedByteWindowOk ptr dwordAddr` instead of 16
+    separate `halign{1..8}` / `hvalid{1..8}` hypotheses. Cuts the call-site
+    boilerplate that bottlenecks `evm-asm-yrz5` (parent: bundle per-byte memory
+    address validity hypotheses). -/
+theorem rlp_phase2_long_loop_eight_byte_spec_within_bundled
+    (len ptr v12Old wordVal dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (hwindow : rlpAlignedByteWindowOk ptr dwordAddr)
+    (hback : (base + 20) + signExtend13 back = base) :
+    cpsTripleWithin 48 base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (8 : Word)) **
+       (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_loop_eight_byte_post len ptr
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 3))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 4))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 5))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 6))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 7))).zeroExtend 64)
+        wordVal dwordAddr) := by
+  obtain ⟨halign1, halign2, halign3, halign4, halign5, halign6, halign7, halign8,
+          hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6, hvalid7, hvalid8⟩
+    := hwindow
+  exact rlp_phase2_long_loop_eight_byte_spec_within
+    len ptr v12Old wordVal dwordAddr base back
+    halign1 halign2 halign3 halign4 halign5 halign6 halign7 halign8
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hvalid8 hback
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Slice of evm-asm-yrz5 (parent: bundle per-byte memory address validity hypotheses), sibling of evm-asm-jb8a / evm-asm-k5pj for the MLOAD/MSTORE windows.

## What

Introduces `rlpAlignedByteWindowOk ptr dwordAddr` in a new `EvmAsm/Rv64/RLP/Phase2ByteWindow.lean` — the RLP analog of `mloadAlignedLimbWindowOk` and `mstoreLimbWindowOk`. Bundles the eight `alignToDword (ptr+i) = dwordAddr` and eight `isValidByteAccess (ptr+i) = true` side conditions for one aligned dword window into a single hypothesis (16 → 1).

Adds `rlp_phase2_long_loop_eight_byte_spec_within_bundled` as a thin wrapper over the existing 16-hypothesis spec. Call sites that already produce per-byte hypotheses keep compiling unchanged; new consumers (RLP Phase 5 long-list decode, future loop closures) can adopt the bundle and skip the `halign1..8 / hvalid1..8` boilerplate.

## Scope

- New file: `EvmAsm/Rv64/RLP/Phase2ByteWindow.lean` (definition + `mk` constructor lemma).
- `EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean`: import the new module, add the bundled-form theorem.
- No changes to existing lemmas or call sites — additive only.

## Acceptance

- [x] `lake build` green (1558 jobs).
- [x] No new `sorry`.
- [x] No `maxHeartbeats` / `maxRecDepth` bumps.
- [x] New file imported by `EvmAsm/Rv64/RLP/Phase2LongLoopEight.lean` (so transitively reachable via `EvmAsm.lean → Rv64 → RLP → Phase2LongLoopEight`).

## Refs

- evm-asm-yrz5 (parent)
- evm-asm-wdyg (this slice)
- PR #2270 (jb8a — MLOAD aligned bundle, in flight)
- PR #2256 (k5pj — MLOAD unaligned bundle, merged)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).