### PR TITLE
refactor(mload): bundle mload_one_limb_unaligned_spec_within hyps via mloadLimbWindowOk

### DIFF
--- a/EvmAsm/Evm64/MLoad/UnalignedSpec.lean
+++ b/EvmAsm/Evm64/MLoad/UnalignedSpec.lean
@@ -212,46 +212,8 @@ theorem mload_one_limb_unaligned_spec_within
     (start : Nat) (base : Word)
     (h_byte_ne_x0 : byteReg ≠ .x0)
     (h_acc_ne_x0  : accReg  ≠ .x0)
-    (h_align0 :
-      alignToDword (addrPtr + signExtend12 off0) =
-        mloadDwordPairAddr loAddr hiAddr start 0)
-    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
-    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
-    (h_align1 :
-      alignToDword (addrPtr + signExtend12 off1) =
-        mloadDwordPairAddr loAddr hiAddr start 1)
-    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
-    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
-    (h_align2 :
-      alignToDword (addrPtr + signExtend12 off2) =
-        mloadDwordPairAddr loAddr hiAddr start 2)
-    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
-    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
-    (h_align3 :
-      alignToDword (addrPtr + signExtend12 off3) =
-        mloadDwordPairAddr loAddr hiAddr start 3)
-    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
-    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
-    (h_align4 :
-      alignToDword (addrPtr + signExtend12 off4) =
-        mloadDwordPairAddr loAddr hiAddr start 4)
-    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
-    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
-    (h_align5 :
-      alignToDword (addrPtr + signExtend12 off5) =
-        mloadDwordPairAddr loAddr hiAddr start 5)
-    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
-    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
-    (h_align6 :
-      alignToDword (addrPtr + signExtend12 off6) =
-        mloadDwordPairAddr loAddr hiAddr start 6)
-    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
-    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
-    (h_align7 :
-      alignToDword (addrPtr + signExtend12 off7) =
-        mloadDwordPairAddr loAddr hiAddr start 7)
-    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8)
-    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true) :
+    (h_window : mloadLimbWindowOk addrPtr loAddr hiAddr start
+      off0 off1 off2 off3 off4 off5 off6 off7) :
     cpsTripleWithin 23 base (base + 92)
       (mloadOneLimbCode addrReg byteReg accReg
         off0 off1 off2 off3 off4 off5 off6 off7 dstOff base)
@@ -275,15 +237,7 @@ theorem mload_one_limb_unaligned_spec_within
   have eight := mload_byte_pack_eight_pair_spec_within addrReg byteReg accReg
     addrPtr accOld byteOld loVal hiVal loAddr hiAddr
     off0 off1 off2 off3 off4 off5 off6 off7 start base
-    h_byte_ne_x0 h_acc_ne_x0
-    ⟨h_align0, h_valid0, h_byte0,
-     h_align1, h_valid1, h_byte1,
-     h_align2, h_valid2, h_byte2,
-     h_align3, h_valid3, h_byte3,
-     h_align4, h_valid4, h_byte4,
-     h_align5, h_valid5, h_byte5,
-     h_align6, h_valid6, h_byte6,
-     h_align7, h_valid7, h_byte7⟩
+    h_byte_ne_x0 h_acc_ne_x0 h_window
   have eightPacked : cpsTripleWithin 22 base (base + 88)
       (mloadBytePackEightCode addrReg byteReg accReg
         off0 off1 off2 off3 off4 off5 off6 off7 base)


### PR DESCRIPTION
## Summary

Replaces the 24-hypothesis flat list (`h_align0..7`, `h_byte0..7`, `h_valid0..7`) on `mload_one_limb_unaligned_spec_within` (in `EvmAsm/Evm64/MLoad/UnalignedSpec.lean`) with a single `h_window : mloadLimbWindowOk` bundle, matching the shape of the byte-pack sibling `mload_byte_pack_eight_pair_spec_within` (refactored in #2256).

The internal anonymous-constructor that re-bundled the 24 hypotheses for the call to `mload_byte_pack_eight_pair_spec_within` drops out — the hypothesis is now passed through unchanged. No external call sites existed, so this is a pure signature cleanup.

## Verification

- `lake build EvmAsm.Evm64.MLoad.UnalignedSpec` — green
- `lake build` — green (1557 jobs)
- No new sorries, no `maxHeartbeats` / `maxRecDepth` bumps.

## Refs

- Slice of evm-asm-yrz5 (sibling slice evm-asm-4xm4)
- Builds on #2256 (byte-pack bundle)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
