### PR TITLE
chore(shake): tighten Program.lean imports for 5 opcode subtrees

### DIFF
--- a/EvmAsm/Evm64/Byte/Program.lean
+++ b/EvmAsm/Evm64/Byte/Program.lean
@@ -36,7 +36,7 @@
     Exit point: offset 180
 -/
 
-import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -18,7 +18,7 @@
   it without breaking the umbrella import graph.
 -/
 
-import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Program
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -39,7 +39,7 @@
     Exit point: offset 252
 -/
 
-import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/Shift/Program.lean
+++ b/EvmAsm/Evm64/Shift/Program.lean
@@ -32,7 +32,7 @@
     Exit point: offset 360
 -/
 
-import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/SignExtend/Program.lean
+++ b/EvmAsm/Evm64/SignExtend/Program.lean
@@ -34,7 +34,7 @@
     Exit point: offset 192
 -/
 
-import EvmAsm.Rv64.SepLogic
+import EvmAsm.Rv64.Execution
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Shake (#1045) flagged five `EvmAsm/Evm64/*/Program.lean` files importing `Rv64.SepLogic` when a different import was the correct fit:

- `Shift/Program.lean`, `Byte/Program.lean`, `SignExtend/Program.lean`, `Multiply/Program.lean` → `Rv64.Execution` (their concrete-test sections use `loadProgram` / `stepN`).
- `Exp/Program.lean` → `Rv64.Program` (no concrete tests, lighter import is enough).

`lake build` green; `lake exe shake EvmAsm | scripts/shake-filter.py` confirms all five file blocks are gone from the output.

Refs #1045, beads evm-asm-kego (parent evm-asm-9tq).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).