### PR TITLE
refactor(rlp): bundle Phase2LongLoopSeven via rlpAlignedByteWindow7Ok

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
+++ b/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
@@ -78,4 +78,60 @@ theorem rlpAlignedByteWindowOk.mk
   ⟨halign1, halign2, halign3, halign4, halign5, halign6, halign7, halign8,
    hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6, hvalid7, hvalid8⟩
 
+/--
+Side conditions for one seven-byte aligned RLP byte window: every byte at
+offsets `0..6` from `ptr` lives in the same doubleword `dwordAddr` and is a
+valid byte access.
+
+Used by `rlp_phase2_long_loop_seven_byte_spec_within` (Phase 2 long-form
+loop, lenLen = 7). Sibling of `rlpAlignedByteWindowOk` (eight-byte form).
+-/
+def rlpAlignedByteWindow7Ok (ptr dwordAddr : Word) : Prop :=
+  alignToDword ptr = dwordAddr ∧
+  alignToDword (ptr + 1) = dwordAddr ∧
+  alignToDword (ptr + 2) = dwordAddr ∧
+  alignToDword (ptr + 3) = dwordAddr ∧
+  alignToDword (ptr + 4) = dwordAddr ∧
+  alignToDword (ptr + 5) = dwordAddr ∧
+  alignToDword (ptr + 6) = dwordAddr ∧
+  isValidByteAccess ptr = true ∧
+  isValidByteAccess (ptr + 1) = true ∧
+  isValidByteAccess (ptr + 2) = true ∧
+  isValidByteAccess (ptr + 3) = true ∧
+  isValidByteAccess (ptr + 4) = true ∧
+  isValidByteAccess (ptr + 5) = true ∧
+  isValidByteAccess (ptr + 6) = true
+
+/-- Constructor wrapper for `rlpAlignedByteWindow7Ok` from the legacy
+    14-argument form. -/
+theorem rlpAlignedByteWindow7Ok.mk
+    {ptr dwordAddr : Word}
+    (halign1 : alignToDword ptr = dwordAddr)
+    (halign2 : alignToDword (ptr + 1) = dwordAddr)
+    (halign3 : alignToDword (ptr + 2) = dwordAddr)
+    (halign4 : alignToDword (ptr + 3) = dwordAddr)
+    (halign5 : alignToDword (ptr + 4) = dwordAddr)
+    (halign6 : alignToDword (ptr + 5) = dwordAddr)
+    (halign7 : alignToDword (ptr + 6) = dwordAddr)
+    (hvalid1 : isValidByteAccess ptr = true)
+    (hvalid2 : isValidByteAccess (ptr + 1) = true)
+    (hvalid3 : isValidByteAccess (ptr + 2) = true)
+    (hvalid4 : isValidByteAccess (ptr + 3) = true)
+    (hvalid5 : isValidByteAccess (ptr + 4) = true)
+    (hvalid6 : isValidByteAccess (ptr + 5) = true)
+    (hvalid7 : isValidByteAccess (ptr + 6) = true) :
+    rlpAlignedByteWindow7Ok ptr dwordAddr :=
+  ⟨halign1, halign2, halign3, halign4, halign5, halign6, halign7,
+   hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6, hvalid7⟩
+
+/-- The eight-byte bundle implies the seven-byte bundle by dropping the
+    last conjuncts. Useful when a caller already has the eight-byte form
+    on hand. -/
+theorem rlpAlignedByteWindow7Ok.of_eight
+    {ptr dwordAddr : Word}
+    (h : rlpAlignedByteWindowOk ptr dwordAddr) :
+    rlpAlignedByteWindow7Ok ptr dwordAddr := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, h7, _, h9, h10, h11, h12, h13, h14, h15, _⟩ := h
+  exact ⟨h1, h2, h3, h4, h5, h6, h7, h9, h10, h11, h12, h13, h14, h15⟩
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean
@@ -13,6 +13,7 @@
   whenever `byteOffset ptr ≤ 1`.
 -/
 
+import EvmAsm.Rv64.RLP.Phase2ByteWindow
 import EvmAsm.Rv64.RLP.Phase2LongLoopSix
 
 namespace EvmAsm.Rv64.RLP
@@ -141,5 +142,38 @@ theorem rlp_phase2_long_loop_seven_byte_spec_within
     (fun _ hp => hp)
     (fun h hp => by xperm_hyp hp)
     composed
+
+/-- Bundled-hypothesis form of `rlp_phase2_long_loop_seven_byte_spec_within`.
+
+    Takes a single `rlpAlignedByteWindow7Ok ptr dwordAddr` instead of 14
+    separate `halign{1..7}` / `hvalid{1..7}` hypotheses. Mirror of
+    `rlp_phase2_long_loop_eight_byte_spec_within_bundled`. See parent
+    `evm-asm-yrz5` (sibling slice `evm-asm-wdyg` / PR #2276). -/
+theorem rlp_phase2_long_loop_seven_byte_spec_within_bundled
+    (len ptr v12Old wordVal dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (hwindow : rlpAlignedByteWindow7Ok ptr dwordAddr)
+    (hback : (base + 20) + signExtend13 back = base) :
+    cpsTripleWithin 42 base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (7 : Word)) **
+       (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_loop_seven_byte_post len ptr
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 3))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 4))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 5))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 6))).zeroExtend 64)
+        wordVal dwordAddr) := by
+  obtain ⟨halign1, halign2, halign3, halign4, halign5, halign6, halign7,
+          hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6, hvalid7⟩
+    := hwindow
+  exact rlp_phase2_long_loop_seven_byte_spec_within
+    len ptr v12Old wordVal dwordAddr base back
+    halign1 halign2 halign3 halign4 halign5 halign6 halign7
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hvalid7 hback
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Mirror of PR #2276 (eight-byte form) for the seven-iteration closure of the RLP Phase 2 long-form loop.

## Changes

`EvmAsm/Rv64/RLP/Phase2ByteWindow.lean`:
- `rlpAlignedByteWindow7Ok ptr dwordAddr` — 14-conjunct bundle of the per-byte side conditions (`alignToDword` + `isValidByteAccess` for offsets 0..6).
- `rlpAlignedByteWindow7Ok.mk` — constructor from the legacy 14-argument form so existing callers can adopt the bundle without rebuilding derivations.
- `rlpAlignedByteWindow7Ok.of_eight` — projection from `rlpAlignedByteWindowOk`, letting callers that already have the eight-byte bundle reuse it.

`EvmAsm/Rv64/RLP/Phase2LongLoopSeven.lean`:
- `rlp_phase2_long_loop_seven_byte_spec_within_bundled` — same statement as the existing `rlp_phase2_long_loop_seven_byte_spec_within` but takes one `rlpAlignedByteWindow7Ok` hypothesis instead of 14 separate `halign{1..7}` / `hvalid{1..7}` arguments. Implementation just destructures the bundle and forwards.

Pure addition: the legacy form is unchanged and existing call sites keep compiling. No new sorry; `lake build` green locally.

Refs evm-asm-yrz5 (parent, MSTORE/MLOAD/RLP per-byte hypothesis bundling) / evm-asm-itxp (this slice) / PR #2276 (sibling slice for the eight-byte form).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).