### PR TITLE
refactor(mstore): bundle 24-hyp mstore_one_limb_spec_within via mstoreLimbWindowOk

### DIFF
--- a/EvmAsm/Evm64/MStore/LimbSpec.lean
+++ b/EvmAsm/Evm64/MStore/LimbSpec.lean
@@ -462,6 +462,44 @@ theorem mstore_byte_unpack_step_pair_last_spec_within
       xperm_hyp hp)
     step
 
+/-- Side conditions for one eight-byte MSTORE limb window. The destination
+    byte offsets may cross from `loAddr` into `hiAddr` depending on `start`. -/
+def mstoreLimbWindowOk
+    (addrPtr loAddr hiAddr : Word) (start : Nat)
+    (off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) : Prop :=
+  alignToDword (addrPtr + signExtend12 off0) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 0 ∧
+  isValidByteAccess (addrPtr + signExtend12 off0) = true ∧
+  byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off1) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 1 ∧
+  isValidByteAccess (addrPtr + signExtend12 off1) = true ∧
+  byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off2) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 2 ∧
+  isValidByteAccess (addrPtr + signExtend12 off2) = true ∧
+  byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off3) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 3 ∧
+  isValidByteAccess (addrPtr + signExtend12 off3) = true ∧
+  byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off4) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 4 ∧
+  isValidByteAccess (addrPtr + signExtend12 off4) = true ∧
+  byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off5) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 5 ∧
+  isValidByteAccess (addrPtr + signExtend12 off5) = true ∧
+  byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off6) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 6 ∧
+  isValidByteAccess (addrPtr + signExtend12 off6) = true ∧
+  byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8 ∧
+  alignToDword (addrPtr + signExtend12 off7) =
+      MStore.mstoreDwordPairAddr loAddr hiAddr start 7 ∧
+  isValidByteAccess (addrPtr + signExtend12 off7) = true ∧
+  byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8
+
 /-- One MSTORE source limb: load the limb from the EVM stack, then store its
     eight big-endian bytes into an unaligned low/high destination dword pair. -/
 theorem mstore_one_limb_spec_within
@@ -471,46 +509,8 @@ theorem mstore_one_limb_spec_within
     (srcOff off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) (base : Word)
     (h_byte_ne_x0 : byteReg ≠ .x0)
     (h_acc_ne_x0 : accReg ≠ .x0)
-    (h_align0 :
-      alignToDword (addrPtr + signExtend12 off0) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
-    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
-    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
-    (h_align1 :
-      alignToDword (addrPtr + signExtend12 off1) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
-    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
-    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
-    (h_align2 :
-      alignToDword (addrPtr + signExtend12 off2) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
-    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
-    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
-    (h_align3 :
-      alignToDword (addrPtr + signExtend12 off3) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
-    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
-    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
-    (h_align4 :
-      alignToDword (addrPtr + signExtend12 off4) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
-    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
-    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
-    (h_align5 :
-      alignToDword (addrPtr + signExtend12 off5) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
-    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
-    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
-    (h_align6 :
-      alignToDword (addrPtr + signExtend12 off6) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
-    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
-    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
-    (h_align7 :
-      alignToDword (addrPtr + signExtend12 off7) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
-    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true)
-    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8) :
+    (hWindow : mstoreLimbWindowOk addrPtr loAddr hiAddr start
+      off0 off1 off2 off3 off4 off5 off6 off7) :
     cpsTripleWithin 17 base (base + 68)
       (mstoreOneLimbCode addrReg byteReg accReg
         srcOff off0 off1 off2 off3 off4 off5 off6 off7 base)
@@ -518,6 +518,10 @@ theorem mstore_one_limb_spec_within
         addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal srcOff)
       (mstoreOneLimbPost addrReg byteReg accReg
         addrPtr loVal hiVal loAddr hiAddr sp limbVal start srcOff) := by
+  obtain ⟨h_align0, h_valid0, h_byte0, h_align1, h_valid1, h_byte1,
+    h_align2, h_valid2, h_byte2, h_align3, h_valid3, h_byte3,
+    h_align4, h_valid4, h_byte4, h_align5, h_valid5, h_byte5,
+    h_align6, h_valid6, h_byte6, h_align7, h_valid7, h_byte7⟩ := hWindow
   rw [mstoreOneLimbPre_unfold, mstoreOneLimbPost_unfold]
   dsimp only []
   let p0 := MStore.mstoreDwordPairReplaceByte loVal hiVal start 0 (extractByte limbVal 7)
@@ -590,46 +594,8 @@ theorem mstore_one_limb_ofProg_spec_within
     (srcOff off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) (base : Word)
     (h_byte_ne_x0 : byteReg ≠ .x0)
     (h_acc_ne_x0 : accReg ≠ .x0)
-    (h_align0 :
-      alignToDword (addrPtr + signExtend12 off0) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 0)
-    (h_valid0 : isValidByteAccess (addrPtr + signExtend12 off0) = true)
-    (h_byte0 : byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8)
-    (h_align1 :
-      alignToDword (addrPtr + signExtend12 off1) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 1)
-    (h_valid1 : isValidByteAccess (addrPtr + signExtend12 off1) = true)
-    (h_byte1 : byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8)
-    (h_align2 :
-      alignToDword (addrPtr + signExtend12 off2) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 2)
-    (h_valid2 : isValidByteAccess (addrPtr + signExtend12 off2) = true)
-    (h_byte2 : byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8)
-    (h_align3 :
-      alignToDword (addrPtr + signExtend12 off3) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 3)
-    (h_valid3 : isValidByteAccess (addrPtr + signExtend12 off3) = true)
-    (h_byte3 : byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8)
-    (h_align4 :
-      alignToDword (addrPtr + signExtend12 off4) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 4)
-    (h_valid4 : isValidByteAccess (addrPtr + signExtend12 off4) = true)
-    (h_byte4 : byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8)
-    (h_align5 :
-      alignToDword (addrPtr + signExtend12 off5) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 5)
-    (h_valid5 : isValidByteAccess (addrPtr + signExtend12 off5) = true)
-    (h_byte5 : byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8)
-    (h_align6 :
-      alignToDword (addrPtr + signExtend12 off6) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 6)
-    (h_valid6 : isValidByteAccess (addrPtr + signExtend12 off6) = true)
-    (h_byte6 : byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8)
-    (h_align7 :
-      alignToDword (addrPtr + signExtend12 off7) =
-        MStore.mstoreDwordPairAddr loAddr hiAddr start 7)
-    (h_valid7 : isValidByteAccess (addrPtr + signExtend12 off7) = true)
-    (h_byte7 : byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8) :
+    (hWindow : mstoreLimbWindowOk addrPtr loAddr hiAddr start
+      off0 off1 off2 off3 off4 off5 off6 off7) :
     cpsTripleWithin 17 base (base + 68)
       (CodeReq.ofProg base
         (mstoreOneLimbProg addrReg byteReg accReg
@@ -644,14 +610,6 @@ theorem mstore_one_limb_ofProg_spec_within
     addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
     start
     srcOff off0 off1 off2 off3 off4 off5 off6 off7 base
-    h_byte_ne_x0 h_acc_ne_x0
-    h_align0 h_valid0 h_byte0
-    h_align1 h_valid1 h_byte1
-    h_align2 h_valid2 h_byte2
-    h_align3 h_valid3 h_byte3
-    h_align4 h_valid4 h_byte4
-    h_align5 h_valid5 h_byte5
-    h_align6 h_valid6 h_byte6
-    h_align7 h_valid7 h_byte7
+    h_byte_ne_x0 h_acc_ne_x0 hWindow
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MStore/Spec.lean
+++ b/EvmAsm/Evm64/MStore/Spec.lean
@@ -867,43 +867,10 @@ theorem mstore_four_limb_body_sequence_spec_within
   exact mstore_four_limb_sequence_spec_within addrReg byteReg accReg base
     h0Body h1Body h2Body h3Body
 
-/-- Side conditions for one eight-byte MSTORE limb window. The destination
-    byte offsets may cross from `loAddr` into `hiAddr` depending on `start`. -/
-def mstoreLimbWindowOk
-    (addrPtr loAddr hiAddr : Word) (start : Nat)
-    (off0 off1 off2 off3 off4 off5 off6 off7 : BitVec 12) : Prop :=
-  alignToDword (addrPtr + signExtend12 off0) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 0 ∧
-  isValidByteAccess (addrPtr + signExtend12 off0) = true ∧
-  byteOffset (addrPtr + signExtend12 off0) = (start + 0) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off1) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 1 ∧
-  isValidByteAccess (addrPtr + signExtend12 off1) = true ∧
-  byteOffset (addrPtr + signExtend12 off1) = (start + 1) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off2) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 2 ∧
-  isValidByteAccess (addrPtr + signExtend12 off2) = true ∧
-  byteOffset (addrPtr + signExtend12 off2) = (start + 2) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off3) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 3 ∧
-  isValidByteAccess (addrPtr + signExtend12 off3) = true ∧
-  byteOffset (addrPtr + signExtend12 off3) = (start + 3) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off4) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 4 ∧
-  isValidByteAccess (addrPtr + signExtend12 off4) = true ∧
-  byteOffset (addrPtr + signExtend12 off4) = (start + 4) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off5) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 5 ∧
-  isValidByteAccess (addrPtr + signExtend12 off5) = true ∧
-  byteOffset (addrPtr + signExtend12 off5) = (start + 5) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off6) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 6 ∧
-  isValidByteAccess (addrPtr + signExtend12 off6) = true ∧
-  byteOffset (addrPtr + signExtend12 off6) = (start + 6) % 8 ∧
-  alignToDword (addrPtr + signExtend12 off7) =
-      MStore.mstoreDwordPairAddr loAddr hiAddr start 7 ∧
-  isValidByteAccess (addrPtr + signExtend12 off7) = true ∧
-  byteOffset (addrPtr + signExtend12 off7) = (start + 7) % 8
+/-! `mstoreLimbWindowOk` (the bundled per-byte side-condition predicate for
+    one MSTORE limb window) is defined in
+    `EvmAsm.Evm64.MStore.LimbSpec` so that the base building block
+    `mstore_one_limb_spec_within` can take it as a single hypothesis. -/
 
 theorem mstore_limb0_four_code_spec_within
     (addrReg byteReg accReg : Reg)
@@ -919,20 +886,13 @@ theorem mstore_limb0_four_code_spec_within
         addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (32 : BitVec 12))
       (mstoreOneLimbPost addrReg byteReg accReg
         addrPtr loVal hiVal loAddr hiAddr sp limbVal start (32 : BitVec 12)) := by
-  obtain ⟨h_align0, h_valid0, h_byte0, h_align1, h_valid1, h_byte1,
-    h_align2, h_valid2, h_byte2, h_align3, h_valid3, h_byte3,
-    h_align4, h_valid4, h_byte4, h_align5, h_valid5, h_byte5,
-    h_align6, h_valid6, h_byte6, h_align7, h_valid7, h_byte7⟩ := hWindow
   have h := cpsTripleWithin_extend_code
     (hmono := mstoreFourLimbsCode_limb0_sub addrReg byteReg accReg base)
     (h := mstore_one_limb_spec_within
       addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
       start (32 : BitVec 12) (24 : BitVec 12) (25 : BitVec 12) (26 : BitVec 12)
       (27 : BitVec 12) (28 : BitVec 12) (29 : BitVec 12) (30 : BitVec 12)
-      (31 : BitVec 12) (base + 8) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
-      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
-      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
-      h_align7 h_valid7 h_byte7)
+      (31 : BitVec 12) (base + 8) h_byte_ne_x0 h_acc_ne_x0 hWindow)
   rw [show (base + 8 : Word) + 68 = base + 76 from by bv_addr] at h
   exact h
 
@@ -950,20 +910,13 @@ theorem mstore_limb1_four_code_spec_within
         addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (40 : BitVec 12))
       (mstoreOneLimbPost addrReg byteReg accReg
         addrPtr loVal hiVal loAddr hiAddr sp limbVal start (40 : BitVec 12)) := by
-  obtain ⟨h_align0, h_valid0, h_byte0, h_align1, h_valid1, h_byte1,
-    h_align2, h_valid2, h_byte2, h_align3, h_valid3, h_byte3,
-    h_align4, h_valid4, h_byte4, h_align5, h_valid5, h_byte5,
-    h_align6, h_valid6, h_byte6, h_align7, h_valid7, h_byte7⟩ := hWindow
   have h := cpsTripleWithin_extend_code
     (hmono := mstoreFourLimbsCode_limb1_sub addrReg byteReg accReg base)
     (h := mstore_one_limb_spec_within
       addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
       start (40 : BitVec 12) (16 : BitVec 12) (17 : BitVec 12) (18 : BitVec 12)
       (19 : BitVec 12) (20 : BitVec 12) (21 : BitVec 12) (22 : BitVec 12)
-      (23 : BitVec 12) (base + 76) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
-      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
-      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
-      h_align7 h_valid7 h_byte7)
+      (23 : BitVec 12) (base + 76) h_byte_ne_x0 h_acc_ne_x0 hWindow)
   rw [show (base + 76 : Word) + 68 = base + 144 from by bv_addr] at h
   exact h
 
@@ -981,20 +934,13 @@ theorem mstore_limb2_four_code_spec_within
         addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (48 : BitVec 12))
       (mstoreOneLimbPost addrReg byteReg accReg
         addrPtr loVal hiVal loAddr hiAddr sp limbVal start (48 : BitVec 12)) := by
-  obtain ⟨h_align0, h_valid0, h_byte0, h_align1, h_valid1, h_byte1,
-    h_align2, h_valid2, h_byte2, h_align3, h_valid3, h_byte3,
-    h_align4, h_valid4, h_byte4, h_align5, h_valid5, h_byte5,
-    h_align6, h_valid6, h_byte6, h_align7, h_valid7, h_byte7⟩ := hWindow
   have h := cpsTripleWithin_extend_code
     (hmono := mstoreFourLimbsCode_limb2_sub addrReg byteReg accReg base)
     (h := mstore_one_limb_spec_within
       addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
       start (48 : BitVec 12) (8 : BitVec 12) (9 : BitVec 12) (10 : BitVec 12)
       (11 : BitVec 12) (12 : BitVec 12) (13 : BitVec 12) (14 : BitVec 12)
-      (15 : BitVec 12) (base + 144) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
-      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
-      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
-      h_align7 h_valid7 h_byte7)
+      (15 : BitVec 12) (base + 144) h_byte_ne_x0 h_acc_ne_x0 hWindow)
   rw [show (base + 144 : Word) + 68 = base + 212 from by bv_addr] at h
   exact h
 
@@ -1012,20 +958,13 @@ theorem mstore_limb3_four_code_spec_within
         addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal (56 : BitVec 12))
       (mstoreOneLimbPost addrReg byteReg accReg
         addrPtr loVal hiVal loAddr hiAddr sp limbVal start (56 : BitVec 12)) := by
-  obtain ⟨h_align0, h_valid0, h_byte0, h_align1, h_valid1, h_byte1,
-    h_align2, h_valid2, h_byte2, h_align3, h_valid3, h_byte3,
-    h_align4, h_valid4, h_byte4, h_align5, h_valid5, h_byte5,
-    h_align6, h_valid6, h_byte6, h_align7, h_valid7, h_byte7⟩ := hWindow
   have h := cpsTripleWithin_extend_code
     (hmono := mstoreFourLimbsCode_limb3_sub addrReg byteReg accReg base)
     (h := mstore_one_limb_spec_within
       addrReg byteReg accReg addrPtr byteOld accOld loVal hiVal loAddr hiAddr sp limbVal
       start (56 : BitVec 12) (0 : BitVec 12) (1 : BitVec 12) (2 : BitVec 12)
       (3 : BitVec 12) (4 : BitVec 12) (5 : BitVec 12) (6 : BitVec 12)
-      (7 : BitVec 12) (base + 212) h_byte_ne_x0 h_acc_ne_x0 h_align0 h_valid0 h_byte0
-      h_align1 h_valid1 h_byte1 h_align2 h_valid2 h_byte2 h_align3 h_valid3 h_byte3
-      h_align4 h_valid4 h_byte4 h_align5 h_valid5 h_byte5 h_align6 h_valid6 h_byte6
-      h_align7 h_valid7 h_byte7)
+      (7 : BitVec 12) (base + 212) h_byte_ne_x0 h_acc_ne_x0 hWindow)
   rw [show (base + 212 : Word) + 68 = base + 280 from by bv_addr] at h
   exact h
 


### PR DESCRIPTION
Slice of #yrz5 / parent beads evm-asm-yrz5.

Both `mstore_one_limb_spec_within` and its program-form sibling `mstore_one_limb_ofProg_spec_within` in `EvmAsm/Evm64/MStore/LimbSpec.lean` took 24 separate hypotheses (`h_align_i`, `h_valid_i`, `h_byte_i` for i=0..7). Replace them with a single `hWindow : mstoreLimbWindowOk` bundle, matching the shape of their callers in `MStore/Spec.lean`.

`mstoreLimbWindowOk` moves from `MStore/Spec.lean` to `MStore/LimbSpec.lean` so the base building block can reference it; a stub comment in Spec.lean points readers to the new location. The four call sites (`mstore_limb{0,1,2,3}_four_code_spec_within`) no longer need to destructure `hWindow` themselves — they just forward it.

No semantic change; `lake build` green.

Beads: evm-asm-cm6q (slice of evm-asm-yrz5).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).