### PR TITLE
feat(env): add value_* rfl lemmas for remaining 9 SimpleEnvFields

### DIFF
--- a/EvmAsm/Evm64/Env/Field.lean
+++ b/EvmAsm/Evm64/Env/Field.lean
@@ -148,6 +148,33 @@ theorem value_callValue (env : EvmEnv) :
 theorem value_selfBalance (env : EvmEnv) :
     value selfBalance env = env.selfBalance := rfl
 
+theorem value_origin (env : EvmEnv) :
+    value origin env = EvmEnv.addrAsWord env.txOrigin := rfl
+
+theorem value_gasPrice (env : EvmEnv) :
+    value gasPrice env = env.gasPrice := rfl
+
+theorem value_coinbase (env : EvmEnv) :
+    value coinbase env = EvmEnv.addrAsWord env.blockCoinbase := rfl
+
+theorem value_timestamp (env : EvmEnv) :
+    value timestamp env = env.blockTimestamp := rfl
+
+theorem value_number (env : EvmEnv) :
+    value number env = env.blockNumber := rfl
+
+theorem value_prevrandao (env : EvmEnv) :
+    value prevrandao env = env.blockPrevrandao := rfl
+
+theorem value_gasLimit (env : EvmEnv) :
+    value gasLimit env = env.blockGasLimit := rfl
+
+theorem value_chainId (env : EvmEnv) :
+    value chainId env = env.chainId := rfl
+
+theorem value_baseFee (env : EvmEnv) :
+    value baseFee env = env.blockBaseFee := rfl
+
 end SimpleEnvField
 
 end Env


### PR DESCRIPTION
Slice of evm-asm-30td (#103). Mechanical prep for slice 5 (evm-asm-3fvb / `evm_env_load_stack_spec`).

`EvmAsm/Evm64/Env/Field.lean` already exposed `value_address`, `value_caller`, `value_callValue`, and `value_selfBalance` as `rfl` bridges. This PR adds the 9 missing siblings — `value_origin`, `value_gasPrice`, `value_coinbase`, `value_timestamp`, `value_number`, `value_prevrandao`, `value_gasLimit`, `value_chainId`, `value_baseFee` — same shape: `value <field> env = <projection> := rfl`.

The upcoming `evm_env_load_stack_spec` proof can then discharge each per-field branch with one `simp [SimpleEnvField.value_<name>]` instead of unfolding the `value` match.

Refs evm-asm-2bhs, evm-asm-30td (#103).

`lake build` green locally.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).