### PR TITLE
feat(evmstate): add evmStateIs_x12_split helper

### DIFF
--- a/EvmAsm/Evm64/EvmState.lean
+++ b/EvmAsm/Evm64/EvmState.lean
@@ -225,6 +225,22 @@ def evmStateGasRest (layout : EvmLayout) (state : EvmState) : Assertion :=
   evmCodeIs layout.codeBase state.code **
   EvmEnv.envIs layout.envBase state.env
 
+/-- Everything in `evmStateIs` except the EVM stack pointer register `x12`. -/
+def evmStateX12Rest (layout : EvmLayout) (state : EvmState) : Assertion :=
+  (layout.pcReg ↦ᵣ BitVec.ofNat 64 state.pc) **
+  (layout.gasReg ↦ᵣ BitVec.ofNat 64 state.gas) **
+  (layout.memBaseReg ↦ᵣ layout.memBase) **
+  (layout.memSizeReg ↦ᵣ layout.memSizeLoc) **
+  (layout.codeBaseReg ↦ᵣ layout.codeBase) **
+  (layout.codeLenReg ↦ᵣ BitVec.ofNat 64 state.codeLen) **
+  (layout.envBaseReg ↦ᵣ layout.envBase) **
+  (layout.statusReg ↦ᵣ state.status.tag) **
+  evmStackIs layout.stackPtr state.stack **
+  evmMemIs layout.memBase state.memoryCells state.memory **
+  evmMemSizeIs layout.memSizeLoc state.memSize **
+  evmCodeIs layout.codeBase state.code **
+  EvmEnv.envIs layout.envBase state.env
+
 /-- Everything in `evmStateIs` except the scalar status register. -/
 def evmStateStatusRest (layout : EvmLayout) (state : EvmState) : Assertion :=
   (layout.pcReg ↦ᵣ BitVec.ofNat 64 state.pc) **
@@ -263,6 +279,15 @@ theorem evmStateIs_status_split (layout : EvmLayout) (state : EvmState) :
   unfold evmStateIs evmStateStatusRest
   ac_rfl
 
+/-- Split out the EVM stack pointer register `x12` from the composite state
+    assertion. -/
+theorem evmStateIs_x12_split (layout : EvmLayout) (state : EvmState) :
+    evmStateIs layout state =
+      ((.x12 ↦ᵣ layout.stackPtr) **
+       evmStateX12Rest layout state) := by
+  unfold evmStateIs evmStateX12Rest
+  ac_rfl
+
 theorem pcFree_evmStatePcRest {layout : EvmLayout} {state : EvmState} :
     (evmStatePcRest layout state).pcFree := by
   unfold evmStatePcRest
@@ -276,6 +301,11 @@ theorem pcFree_evmStateGasRest {layout : EvmLayout} {state : EvmState} :
 theorem pcFree_evmStateStatusRest {layout : EvmLayout} {state : EvmState} :
     (evmStateStatusRest layout state).pcFree := by
   unfold evmStateStatusRest
+  pcFree
+
+theorem pcFree_evmStateX12Rest {layout : EvmLayout} {state : EvmState} :
+    (evmStateX12Rest layout state).pcFree := by
+  unfold evmStateX12Rest
   pcFree
 
 theorem pcFree_evmStateIs {layout : EvmLayout} {state : EvmState} :
@@ -294,6 +324,10 @@ instance (layout : EvmLayout) (state : EvmState) :
 instance (layout : EvmLayout) (state : EvmState) :
     Assertion.PCFree (evmStateStatusRest layout state) :=
   ⟨pcFree_evmStateStatusRest⟩
+
+instance (layout : EvmLayout) (state : EvmState) :
+    Assertion.PCFree (evmStateX12Rest layout state) :=
+  ⟨pcFree_evmStateX12Rest⟩
 
 instance (layout : EvmLayout) (state : EvmState) :
     Assertion.PCFree (evmStateIs layout state) :=


### PR DESCRIPTION
Adds the analog of `evmStateIs_pc_split` / `evmStateIs_gas_split` / `evmStateIs_status_split` for the EVM stack pointer register `.x12` (LP64/EVM convention).

Slice 4 of #105 ([`evm-asm-88z7`](https://github.com/Verified-zkEVM/evm-asm)), beads task `evm-asm-9b9p`.

What's added in `EvmAsm/Evm64/EvmState.lean`:
- `evmStateX12Rest` — everything in `evmStateIs` except the `.x12 ↦ᵣ stackPtr` atom.
- `evmStateIs_x12_split` — `evmStateIs = (.x12 ↦ᵣ stackPtr) ** evmStateX12Rest`, by `ac_rfl`.
- `pcFree_evmStateX12Rest` and the corresponding `Assertion.PCFree` instance.

Useful for handler specs of any stack-arity-changing opcode that needs to update only the EVM stack pointer without unfolding the full `evmStateIs` assertion.

`lake build` green, 0 sorries.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).