### PR TITLE
chore(shake): drop unused ByteOps import in Phase2ByteWindow

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
+++ b/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
@@ -16,7 +16,6 @@
 -/
 
 import EvmAsm.Rv64.Basic
-import EvmAsm.Rv64.ByteOps
 
 namespace EvmAsm.Rv64.RLP
 


### PR DESCRIPTION
Slice of #1045 (import hygiene sweep). Tracked as beads evm-asm-z75y under parent evm-asm-6qj.

`scripts/shake-filter.py` flagged `EvmAsm/Rv64/RLP/Phase2ByteWindow.lean` as importing `EvmAsm.Rv64.ByteOps` without using anything from it. The file's bundled-byte-window predicates (`rlpAlignedByteWindowOk` / `rlpAlignedByteWindow7Ok` and their constructor wrappers) only reference `alignToDword`, `isValidByteAccess`, and `Word`, all of which come from `EvmAsm.Rv64.Basic` (verified via `grep -nE '^(def|notation|abbrev) (isValidByteAccess|alignToDword|Word)'`).

The file uses no spec_gen / runBlock / xperm / xsimp / seqFrame tactics, so this is a genuine unused import, not one of the shake false-positive classes documented in evm-asm-o6y.

`lake build` is green locally (1558 jobs).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).