### PR TITLE
refactor(rlp): bundle Phase2LongLoopSix via rlpAlignedByteWindow6Ok

### DIFF
--- a/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
+++ b/EvmAsm/Rv64/RLP/Phase2ByteWindow.lean
@@ -134,4 +134,64 @@ theorem rlpAlignedByteWindow7Ok.of_eight
   obtain ⟨h1, h2, h3, h4, h5, h6, h7, _, h9, h10, h11, h12, h13, h14, h15, _⟩ := h
   exact ⟨h1, h2, h3, h4, h5, h6, h7, h9, h10, h11, h12, h13, h14, h15⟩
 
+/--
+Side conditions for one six-byte aligned RLP byte window: every byte at
+offsets `0..5` from `ptr` lives in the same doubleword `dwordAddr` and is a
+valid byte access.
+
+Used by `rlp_phase2_long_loop_six_byte_spec_within` (Phase 2 long-form
+loop, lenLen = 6). Sibling of `rlpAlignedByteWindowOk` (eight-byte form)
+and `rlpAlignedByteWindow7Ok` (seven-byte form).
+-/
+def rlpAlignedByteWindow6Ok (ptr dwordAddr : Word) : Prop :=
+  alignToDword ptr = dwordAddr ∧
+  alignToDword (ptr + 1) = dwordAddr ∧
+  alignToDword (ptr + 2) = dwordAddr ∧
+  alignToDword (ptr + 3) = dwordAddr ∧
+  alignToDword (ptr + 4) = dwordAddr ∧
+  alignToDword (ptr + 5) = dwordAddr ∧
+  isValidByteAccess ptr = true ∧
+  isValidByteAccess (ptr + 1) = true ∧
+  isValidByteAccess (ptr + 2) = true ∧
+  isValidByteAccess (ptr + 3) = true ∧
+  isValidByteAccess (ptr + 4) = true ∧
+  isValidByteAccess (ptr + 5) = true
+
+/-- Constructor wrapper for `rlpAlignedByteWindow6Ok` from the legacy
+    12-argument form. -/
+theorem rlpAlignedByteWindow6Ok.mk
+    {ptr dwordAddr : Word}
+    (halign1 : alignToDword ptr = dwordAddr)
+    (halign2 : alignToDword (ptr + 1) = dwordAddr)
+    (halign3 : alignToDword (ptr + 2) = dwordAddr)
+    (halign4 : alignToDword (ptr + 3) = dwordAddr)
+    (halign5 : alignToDword (ptr + 4) = dwordAddr)
+    (halign6 : alignToDword (ptr + 5) = dwordAddr)
+    (hvalid1 : isValidByteAccess ptr = true)
+    (hvalid2 : isValidByteAccess (ptr + 1) = true)
+    (hvalid3 : isValidByteAccess (ptr + 2) = true)
+    (hvalid4 : isValidByteAccess (ptr + 3) = true)
+    (hvalid5 : isValidByteAccess (ptr + 4) = true)
+    (hvalid6 : isValidByteAccess (ptr + 5) = true) :
+    rlpAlignedByteWindow6Ok ptr dwordAddr :=
+  ⟨halign1, halign2, halign3, halign4, halign5, halign6,
+   hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6⟩
+
+/-- The seven-byte bundle implies the six-byte bundle by dropping the
+    last conjuncts. -/
+theorem rlpAlignedByteWindow6Ok.of_seven
+    {ptr dwordAddr : Word}
+    (h : rlpAlignedByteWindow7Ok ptr dwordAddr) :
+    rlpAlignedByteWindow6Ok ptr dwordAddr := by
+  obtain ⟨h1, h2, h3, h4, h5, h6, _, h8, h9, h10, h11, h12, h13, _⟩ := h
+  exact ⟨h1, h2, h3, h4, h5, h6, h8, h9, h10, h11, h12, h13⟩
+
+/-- The eight-byte bundle implies the six-byte bundle by dropping the
+    last conjuncts. -/
+theorem rlpAlignedByteWindow6Ok.of_eight
+    {ptr dwordAddr : Word}
+    (h : rlpAlignedByteWindowOk ptr dwordAddr) :
+    rlpAlignedByteWindow6Ok ptr dwordAddr :=
+  rlpAlignedByteWindow6Ok.of_seven (rlpAlignedByteWindow7Ok.of_eight h)
+
 end EvmAsm.Rv64.RLP

--- a/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
+++ b/EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean
@@ -13,6 +13,7 @@
   whenever `byteOffset ptr ≤ 2`.
 -/
 
+import EvmAsm.Rv64.RLP.Phase2ByteWindow
 import EvmAsm.Rv64.RLP.Phase2LongLoopFive
 
 namespace EvmAsm.Rv64.RLP
@@ -133,5 +134,37 @@ theorem rlp_phase2_long_loop_six_byte_spec_within
     (fun _ hp => hp)
     (fun h hp => by xperm_hyp hp)
     composed
+
+/-- Bundled-hypothesis form of `rlp_phase2_long_loop_six_byte_spec_within`.
+
+    Takes a single `rlpAlignedByteWindow6Ok ptr dwordAddr` instead of 12
+    separate `halign{1..6}` / `hvalid{1..6}` hypotheses. Mirror of
+    `rlp_phase2_long_loop_seven_byte_spec_within_bundled` (PR #2281) and
+    `rlp_phase2_long_loop_eight_byte_spec_within_bundled` (PR #2276). -/
+theorem rlp_phase2_long_loop_six_byte_spec_within_bundled
+    (len ptr v12Old wordVal dwordAddr : Word)
+    (base : Word) (back : BitVec 13)
+    (hwindow : rlpAlignedByteWindow6Ok ptr dwordAddr)
+    (hback : (base + 20) + signExtend13 back = base) :
+    cpsTripleWithin 36 base (base + 24)
+      (CodeReq.ofProg base (rlp_phase2_long_loop_body_prog back))
+      ((.x11 ↦ᵣ len) ** (.x13 ↦ᵣ ptr) ** (.x14 ↦ᵣ (6 : Word)) **
+       (.x12 ↦ᵣ v12Old) ** (.x0 ↦ᵣ (0 : Word)) **
+       (dwordAddr ↦ₘ wordVal))
+      (rlp_phase2_long_loop_six_byte_post len ptr
+        ((extractByte wordVal (byteOffset ptr)).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 1))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 2))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 3))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 4))).zeroExtend 64)
+        ((extractByte wordVal (byteOffset (ptr + 5))).zeroExtend 64)
+        wordVal dwordAddr) := by
+  obtain ⟨halign1, halign2, halign3, halign4, halign5, halign6,
+          hvalid1, hvalid2, hvalid3, hvalid4, hvalid5, hvalid6⟩
+    := hwindow
+  exact rlp_phase2_long_loop_six_byte_spec_within
+    len ptr v12Old wordVal dwordAddr base back
+    halign1 halign2 halign3 halign4 halign5 halign6
+    hvalid1 hvalid2 hvalid3 hvalid4 hvalid5 hvalid6 hback
 
 end EvmAsm.Rv64.RLP


### PR DESCRIPTION
Mirror of PR #2276 (eight-byte form) and PR #2281 (seven-byte form) for the six-iteration closure.

Adds in `EvmAsm/Rv64/RLP/Phase2ByteWindow.lean`:
- `rlpAlignedByteWindow6Ok` : 12-conjunct bundle for the six-byte loop closure.
- `rlpAlignedByteWindow6Ok.mk` : constructor wrapper from the legacy 12-argument form.
- `rlpAlignedByteWindow6Ok.of_seven` / `rlpAlignedByteWindow6Ok.of_eight` : projections.

Adds in `EvmAsm/Rv64/RLP/Phase2LongLoopSix.lean`:
- `rlp_phase2_long_loop_six_byte_spec_within_bundled` : bundled-hypothesis form that destructures and forwards.

Pure addition; the legacy 12-arg form remains. `lake build` green, no new sorries.

Refs evm-asm-yrz5 (parent) / evm-asm-g3ou (this slice) / PRs #2276 #2281 (siblings).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).