### PR TITLE
chore(shake): flag MSize/Spec SyscallSpecs/XSimp/RunBlock as noshake false-positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -41,7 +41,9 @@
   ["Std.Tactic.BVDecide"],
   "EvmAsm.Evm64.SpAddr":
   ["EvmAsm.Rv64.Tactics.SeqFrame"],
-  "EvmAsm.Evm64.Pop.Spec":
+  "EvmAsm.Evm64.MSize.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Pop.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Push0.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],


### PR DESCRIPTION
lake exe shake EvmAsm flagged `EvmAsm.Rv64.SyscallSpecs`, `EvmAsm.Rv64.Tactics.XSimp`, and `EvmAsm.Rv64.Tactics.RunBlock` as unused in `EvmAsm/Evm64/MSize/Spec.lean`. They are in fact required:

- `SyscallSpecs` provides `ld_spec_gen_within` / `sd_spec_gen_within` used by `run_block` via the `@[spec_gen_rv64]` registry (not tracked by shake).
- `Tactics.RunBlock` and `Tactics.XSimp` register `run_block` / `xsimp_chain` tactics — also not tracked by shake.

Verified empirically: dropping the imports yields `unknown tactic` and `Unknown identifier `ld_spec_gen_within`` errors during `lake build`. Restoring them and adding a `noshake.json` entry is the established pattern (mirrors `Pop.Spec`, `Push0.Spec`, `Dup.Spec`, `Swap.Spec`).

Refs evm-asm-2pvj (slice of evm-asm-6qj, GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).