### PR TITLE
chore(shake): drop unused EvmWordArith.Common import in SDiv

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/SDiv.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SDiv.lean
@@ -18,7 +18,7 @@
   `evm-asm-kvs4`. SMOD lives in a sibling slice (5 / `evm-asm-bjnb`).
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Common
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Slice of #1045 import hygiene (beads evm-asm-tc1f, parent evm-asm-6qj).

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/EvmWordArith/SDiv.lean` as importing `EvmAsm.Evm64.EvmWordArith.Common` without using anything from it. SDiv.lean uses only BitVec lemmas (`BitVec.sdiv`, `BitVec.intMin_sdiv_neg_one`, `BitVec.toInt_sdiv_of_ne_or_ne`) plus `EvmWord.toInt` from Basic — none of Common's helpers (`bv_or_eq_zero`, `ult_one_eq_zero`, `xor_eq_zero_imp`, `borrow_*`) are referenced.

Replace with `EvmAsm.Evm64.Basic` (which Common itself imports, so this is a strict downgrade).

Verified locally: `lake build` green, 1557 jobs.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).