### PR TITLE
chore(shake): drop unused EvmWordArith.Common import in Exp.lean

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/Exp.lean
+++ b/EvmAsm/Evm64/EvmWordArith/Exp.lean
@@ -5,7 +5,7 @@
   the executable EXP opcode proof: exponentiation in Nat, reduced modulo 2^256.
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Common
+import EvmAsm.Evm64.Basic
 
 namespace EvmAsm.Evm64
 
@@ -42,11 +42,9 @@ theorem exp_zero_left_of_ne_zero (exponent : EvmWord) (h : exponent ≠ 0) :
   apply BitVec.eq_of_toNat_eq
   rw [exp_correct]
   have hpos : 0 < exponent.toNat := by
-    by_contra hnot
-    have hz : exponent.toNat = 0 := by omega
-    apply h
-    apply BitVec.eq_of_toNat_eq
-    simp [hz]
+    rcases Nat.eq_zero_or_pos exponent.toNat with hz | hp
+    · exact absurd (BitVec.eq_of_toNat_eq (by simp [hz])) h
+    · exact hp
   simp [Nat.zero_pow hpos]
 
 /-- Any base raised to the EVM word one is itself. -/


### PR DESCRIPTION
Slice of #1045 import-hygiene sweep (evm-asm-6qj parent, evm-asm-jmih slice).

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/EvmWordArith/Exp.lean` as importing `EvmAsm.Evm64.EvmWordArith.Common` without using anything from it. Exp.lean only uses `BitVec.ofNat`, `.toNat`, `Nat.zero_pow`, `omega`, and `EvmWord.toNat` from `Basic`. None of Common's lemmas (`bv_or_eq_zero`, `ult_one_eq_zero`, `xor_eq_zero_imp`, `borrow_*`) are referenced.

This PR replaces the `Common` import with `EvmAsm.Evm64.Basic` and rewrites the small `by_contra` in `exp_zero_left_of_ne_zero` to use `Nat.eq_zero_or_pos` so the proof no longer depends on tactics transitively brought in by `Common` (`Mathlib.Tactic.Linarith`).

`lake build` is green.

Closes evm-asm-jmih (slice of evm-asm-6qj / #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).