### PR TITLE
chore(divmod): delete 3 dead v2 bounds in CallAddbackV2Bounds.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean
@@ -5,13 +5,11 @@
   Extracted from Spec/CallAddback.lean per #1078 / beads evm-asm-q62k to
   trim the over-cap CallAddback.lean.
 
-  Contents (15 theorems, ~1135 lines, all leaf-level relative to the
-  Phase-1 div-invariant cluster that still lives in CallAddback.lean):
+  Contents (12 theorems, leaf-level relative to the Phase-1 div-invariant
+  cluster that still lives in CallAddback.lean):
 
   - `div128Quot_v2_q1_prime_prime_le_q1_prime`
   - `div128Quot_v2_q1_prime_prime_dLo_no_wrap`
-  - `div128Quot_v2_rhat_prime_lt_2dHi_under_guard`
-  - `div128Quot_v2_rhat_prime_prime_lt_pow33`
   - `div128Quot_v2_toNat_eq_strict`
   - `div128Quot_v2_un21_toNat`
   - `div128Quot_v2_un21_toNat_case`
@@ -21,7 +19,6 @@
   - `div128Quot_v2_qHat_vTop_le_full_untruncated`
   - `div128Quot_v2_le_val256_div_plus_two`
   - `div128Quot_v2_le_val256_div_plus_two_untruncated`
-  - `div128Quot_v2_le_5limb_shifted_div_plus_two_untruncated`
   - `div128Quot_v2_phase1c_in_knuth_range_under_runtime`
 
   No proof changes: this is a pure structural move. The downstream
@@ -120,90 +117,6 @@ theorem div128Quot_v2_q1_prime_prime_dLo_no_wrap
     have h2 : (2^32 + 1) * (2^32 - 1) = 2^64 - 1 := by decide
     omega
   rw [BitVec.toNat_mul, Nat.mod_eq_of_lt h_mul_lt]
-
-/-- **Helper: under v2's 2nd D3 guard fall-through, `rhat' < 2 * dHi`.**
-
-    When the 2nd D3 correction is reachable (guard `rhat' >> 32 = 0`
-    fires, meaning `rhat' < 2^32`), combined with the call-trial
-    precondition `dHi ≥ 2^31`, we get `rhat' < 2 * dHi` automatically.
-
-    Proof: rhat' < 2^32 (from h_guard) and dHi ≥ 2^31 ⟹ 2 * dHi ≥ 2^32
-    > rhat'.
-
-    This is the concrete form of the `h_rhat'_lt` precondition used by
-    `div128Quot_v2_phase1b_2nd_post` — automatically dischargeable when
-    the 2nd D3 actually fires.
-
-    Issue #1337 algorithm fix migration. -/
-theorem div128Quot_v2_rhat_prime_lt_2dHi_under_guard
-    (dHi rhat' : Word)
-    (hdHi_ge : dHi.toNat ≥ 2^31)
-    (h_guard : rhat' >>> (32 : BitVec 6).toNat = 0) :
-    rhat'.toNat < 2 * dHi.toNat := by
-  -- h_guard says (rhat' >> 32).toNat = 0, which means rhat'.toNat < 2^32.
-  have h_rhat'_lt_pow32 : rhat'.toNat < 2^32 := by
-    have h := congrArg BitVec.toNat h_guard
-    simp [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow] at h
-    -- h : rhat'.toNat / 2^32 = 0.
-    have h_word : rhat'.toNat < 2^64 := rhat'.isLt
-    omega
-  -- 2 * dHi ≥ 2 * 2^31 = 2^32 > rhat'.
-  omega
-
-/-- **Phase 1b 2nd D3 weak tightness** — bound `rhat'' < 2^33`.
-
-    Weaker than `rhat'' < 2 * dHi` (which is provably FALSE in Case 2
-    when dHi is small): when 2nd D3 fires with rhat' < 2^32 ≤ 2 * dHi,
-    we have rhat'' = rhat' + dHi < 2^32 + 2^32 = 2^33.
-
-    The weaker bound `< 2^33` is enough for Phase 1's `rhat'' * 2^32 <
-    2^65`, which combined with `div_un1 < 2^32` and `q1'' * dLo` close
-    to `rhat'' * 2^32 + div_un1` (Knuth-D correctness) gives the
-    no_wrap_untruncated upper-bound conjunct.
-
-    Issue #1337 algorithm fix migration. Path 3 sub-lemma. -/
-theorem div128Quot_v2_rhat_prime_prime_lt_pow33
-    (uHi dHi q1' rhat' dLo div_un1 : Word)
-    (hdHi_ge : dHi.toNat ≥ 2^31)
-    (hdHi_lt : dHi.toNat < 2^32)
-    (_h_post_1st : q1'.toNat * dHi.toNat + rhat'.toNat = uHi.toNat)
-    (h_rhat'_lt : rhat'.toNat < 2 * dHi.toNat) :
-    let rhat'' :=
-      if rhat' >>> (32 : BitVec 6).toNat = 0 then
-        let qDlo2 := q1' * dLo
-        let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-        if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
-      else rhat'
-    rhat''.toNat < 2^33 := by
-  intro rhat''
-  by_cases h_guard : rhat' >>> (32 : BitVec 6).toNat = 0
-  · -- Guard taken: rhat' < 2^32 from the guard.
-    have h_rhat'_lt_pow32 : rhat'.toNat < 2^32 := by
-      have h := congrArg BitVec.toNat h_guard
-      simp [BitVec.toNat_ushiftRight, Nat.shiftRight_eq_div_pow] at h
-      have h_word : rhat'.toNat < 2^64 := rhat'.isLt
-      omega
-    by_cases h_check : BitVec.ult ((rhat' <<< (32 : BitVec 6).toNat) ||| div_un1)
-                                    (q1' * dLo)
-    · -- Check fires: rhat'' = rhat' + dHi.
-      have h_rhat'' : rhat'' = rhat' + dHi := by
-        show (if rhat' >>> (32 : BitVec 6).toNat = 0 then _ else rhat') = _
-        rw [if_pos h_guard, if_pos h_check]
-      rw [h_rhat'']
-      -- (rhat' + dHi).toNat ≤ rhat'.toNat + dHi.toNat < 2^32 + 2^32 = 2^33.
-      have h_sum : (rhat' + dHi).toNat ≤ rhat'.toNat + dHi.toNat := by
-        rw [BitVec.toNat_add]; exact Nat.mod_le _ _
-      omega
-    · -- Check doesn't fire: rhat'' = rhat'. So rhat'' < 2^32 < 2^33.
-      have h_rhat'' : rhat'' = rhat' := by
-        show (if rhat' >>> (32 : BitVec 6).toNat = 0 then _ else rhat') = _
-        rw [if_pos h_guard, if_neg h_check]
-      rw [h_rhat'']; omega
-  · -- Guard not taken: rhat'' = rhat'. From h_rhat'_lt: rhat' < 2 * dHi < 2^33.
-    have h_rhat'' : rhat'' = rhat' := by
-      show (if rhat' >>> (32 : BitVec 6).toNat = 0 then _ else rhat') = _
-      rw [if_neg h_guard]
-    rw [h_rhat'']; omega
 
 /-- **Output formula for `div128Quot_v2` via halfword combine** — v2 analog
     of v1's `div128Quot_toNat_eq_strict` from `Div128FinalAssembly.lean:778`.
@@ -976,113 +889,6 @@ theorem div128Quot_v2_le_val256_div_plus_two_untruncated
   calc (div128Quot_v2 u4 un3 b3').toNat
       ≤ (u4.toNat * 2^64 + un3.toNat) / b3'.toNat := h_div_le
     _ ≤ val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := h_step2
-
-/-- **5-limb shifted-domain Knuth-B for v2 — proven path-3 lift.**
-
-    Mirror of `div128Quot_v2_le_val256_div_plus_two_untruncated` but with
-    the conclusion in 5-limb shifted-domain form
-    `qHat ≤ (u4 * 2^256 + val256 un) / val256 b' + 2`.
-
-    Composes:
-    - `div128Quot_v2_qHat_vTop_le_full_untruncated` (existing, proven from
-      the four untruncated invariants).
-    - `knuth_theorem_b_5limb_shifted_val256` (new in `KnuthTheoremB.lean`).
-
-    Compared to the original-domain version:
-    - Sidesteps `val256(a)` algebra entirely (no `u_val256_eq_scaled_with_overflow`).
-    - The 5-limb shifted-domain quotient equals `val256(a) / val256(b)` by
-      scale invariance, so this is logically the same bound — but stated
-      directly in terms of the algorithm's normalized limbs, which is
-      what the v2 carry-partition decomposition wants to consume.
-
-    Note: the 4-limb-only analogue (using `val256(un)` in the divisor's
-    numerator instead of `u4 * 2^256 + val256(un)`) is generally FALSE
-    when `u4 > 0` — see the docstring on `knuth_theorem_b_5limb_shifted_val256`.
-
-    Issue #1337 algorithm fix migration. Alternative path 3, shifted form. -/
-theorem div128Quot_v2_le_5limb_shifted_div_plus_two_untruncated
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (_hshift_nz : (clzResult b3).1 ≠ 0)
-    (hcall : isCallTrialN4 a3 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let un2 := (a2 <<< shift) ||| (a1 >>> antiShift)
-    let un1 := (a1 <<< shift) ||| (a0 >>> antiShift)
-    let un0 := a0 <<< shift
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    let b2' := (b2 <<< shift) ||| (b1 >>> antiShift)
-    let b1' := (b1 <<< shift) ||| (b0 >>> antiShift)
-    let b0' := b0 <<< shift
-    let dHi := b3' >>> (32 : BitVec 6).toNat
-    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    let div_un0 := (un3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u4 dHi
-    let rhat := u4 - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let q1'' := div128Quot_phase2b_q0' q1' rhat' dLo div_un1
-    let rhat'' :=
-      if rhat' >>> (32 : BitVec 6).toNat = 0 then
-        let qDlo2 := q1' * dLo
-        let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-        if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
-      else rhat'
-    let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1'' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if rhat2c >>> (32 : BitVec 6).toNat = 0 then
-                    (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
-                                    (q0c * dLo) then rhat2c + dHi else rhat2c)
-                  else rhat2c
-    -- Untruncated phase-1 invariant (2 conjuncts) + phase-2 + q0' bound:
-    q1''.toNat * dLo.toNat ≤ rhat''.toNat * 2^32 + div_un1.toNat →
-    rhat''.toNat * 2^32 + div_un1.toNat - q1''.toNat * dLo.toNat < 2^64 →
-    q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →
-    q0'.toNat < 2^32 →
-    (div128Quot_v2 u4 un3 b3').toNat ≤
-      (u4.toNat * 2^256 + val256 un0 un1 un2 un3) /
-        val256 b0' b1' b2' b3' + 2 := by
-  intro shift antiShift u4 un3 un2 un1 un0 b3' b2' b1' b0' dHi dLo div_un1 div_un0
-        q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat' q1'' rhat'' cu_rhat_un1
-        cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' rhat2'
-        h_ph1_no_wrap_lo h_ph1_un21_lt h_ph2_no_wrap hq0_lt
-  -- Step 1: same untruncated lift used by the original-domain variant.
-  have hb3prime_ge_pow63 : b3'.toNat ≥ 2^63 := b3_prime_ge_pow63 b3 b2 hb3nz _
-  have hdHi_ge : dHi.toNat ≥ 2^31 := div128Quot_dHi_ge_pow31 b3' hb3prime_ge_pow63
-  have hdLo_lt : dLo.toNat < 2^32 := Word_ushiftRight_32_lt_pow32
-  have hu4_lt_b3prime : u4.toNat < b3'.toNat := isCallTrialN4_toNat_lt a3 b2 b3 hcall
-  have h_vtop : b3'.toNat = dHi.toNat * 2^32 + dLo.toNat :=
-    div128Quot_vTop_decomp b3'
-  have hu4_lt_vTop : u4.toNat < dHi.toNat * 2^32 + dLo.toNat := by
-    rw [← h_vtop]; exact hu4_lt_b3prime
-  have h_step1 := div128Quot_v2_qHat_vTop_le_full_untruncated u4 un3 b3' hdHi_ge
-    hdLo_lt hu4_lt_vTop h_ph1_no_wrap_lo h_ph1_un21_lt h_ph2_no_wrap hq0_lt
-  have hb3prime_pos : 0 < b3'.toNat := by omega
-  have h_div_le : (div128Quot_v2 u4 un3 b3').toNat ≤
-      (u4.toNat * 2^64 + un3.toNat) / b3'.toNat :=
-    (Nat.le_div_iff_mul_le hb3prime_pos).mpr h_step1
-  -- Step 2: 5-limb shifted Knuth-B (NEW), no original-domain bridging needed.
-  have h_step2 := knuth_theorem_b_5limb_shifted_val256
-    un0 un1 un2 un3 b0' b1' b2' b3' u4 hb3prime_ge_pow63 hu4_lt_b3prime
-  calc (div128Quot_v2 u4 un3 b3').toNat
-      ≤ (u4.toNat * 2^64 + un3.toNat) / b3'.toNat := h_div_le
-    _ ≤ (u4.toNat * 2^256 + val256 un0 un1 un2 un3) /
-        val256 b0' b1' b2' b3' + 2 := h_step2
 
 /-- **Knuth's classical baseline at q1c**: the initial trial `q1c` (after
     Phase-1a's hi1-clamp) lies in `[q*, q* + 2]` where `q* = floor(x/vTop)`.


### PR DESCRIPTION
Drop three theorems in `EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean` that are never referenced anywhere outside their own definition:

- `div128Quot_v2_rhat_prime_lt_2dHi_under_guard`
- `div128Quot_v2_rhat_prime_prime_lt_pow33`
- `div128Quot_v2_le_5limb_shifted_div_plus_two_untruncated`

The third is the 5-limb-shifted analogue of `div128Quot_v2_le_val256_div_plus_two_untruncated` — the val256 form is the one actually used downstream (composed via the dispatcher closure surface), and the shifted form was an alternative path that was never wired up. The first two are local helpers that were intermediate stages of an earlier proof structure; both were superseded.

Verified zero external references via grep across `EvmAsm/`. Header docstring updated to describe 12 theorems instead of 15.

Build green (`lake build` 1557 jobs). 198-line reduction, 1 file touched.

Closes beads `evm-asm-sf7y` (slice of `evm-asm-sboz` / DivMod cleanup parent / no GH issue — see https://github.com/Verified-zkEVM/evm-asm/issues for nothing because this is a beads-only cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).