### PR TITLE
docs(sail): document InstrMap coverage and pseudo-instruction exclusion (#93)

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/InstrMap.lean
+++ b/EvmAsm/Rv64/SailEquiv/InstrMap.lean
@@ -1,8 +1,36 @@
 /-
   EvmAsm.Rv64.SailEquiv.InstrMap
 
-  First bridge from the hand-written `Instr` AST to the SAIL-generated
-  RISC-V `instruction` AST.
+  Bridge from the hand-written `Instr` AST (`EvmAsm.Rv64.Basic`) to the
+  SAIL-generated RISC-V `instruction` AST.
+
+  ## Coverage (GH #93)
+
+  `toSailInstr?` covers every `Instr` constructor for the supported RV64IM
+  subset:
+
+  - RTYPE / SLT family: ADD, SUB, SLL, SRL, SRA, AND, OR, XOR, SLT, SLTU
+  - ITYPE: ADDI, ANDI, ORI, XORI, SLTI, SLTIU
+  - SHIFTIOP: SLLI, SRLI, SRAI
+  - UTYPE: LUI, AUIPC
+  - ADDIW
+  - LOAD / STORE: LD, LW, LWU, LB, LBU, LH, LHU, SD, SW, SB, SH
+  - BTYPE: BEQ, BNE, BLT, BGE, BLTU, BGEU
+  - JAL, JALR
+  - System: ECALL, EBREAK, FENCE
+  - M-extension: MUL, MULH, MULHSU, MULHU, DIV, DIVU, REM, REMU
+
+  The pseudo-instruction constructors `.MV`, `.LI`, and `.NOP` are
+  intentionally **not** mapped: they re-encode pre-existing real
+  instructions (`ADDI rd rs 0`, sequences of `LUI`/`ADDI`/`SLLI`, and
+  `ADDI x0 x0 0` respectively) and a SAIL-side mapping would collide with
+  the real ADDI round-trips. Surface code that needs to bridge through
+  SAIL should desugar pseudo-instructions before calling
+  `toSailInstr?`.
+
+  `fromSailInstr?` is the partial inverse on the supported SAIL
+  constructors and the round-trip lemma `fromSailInstr?_toSailInstr?_*`
+  is proved per concrete-instruction family above.
 
   Authored by @pirapira; implemented by Codex.
 -/


### PR DESCRIPTION
Slice 7 of GH #93 (beads evm-asm-7k49, parent evm-asm-t7w4).

Audits `EvmAsm/Rv64/SailEquiv/InstrMap.lean` against `EvmAsm/Rv64/Basic.lean` and documents the full coverage in the file header:

- Every `Instr` constructor in the supported RV64IM subset is mapped through `toSailInstr?` / `fromSailInstr?` with a round-trip lemma.
- The pseudo-instruction constructors `.MV`, `.LI`, `.NOP` are intentionally **not** mapped — they re-encode `ADDI rd rs 0`, `LUI`/`ADDI`/`SLLI` sequences, and `ADDI x0 x0 0` respectively, so a SAIL-side mapping would collide with the real `ADDI` round-trips. Surface code needing the SAIL bridge should desugar pseudo-instructions first.

No code change beyond the file-header doc-comment. Slice 1-6 PRs that landed the actual coverage: #1756, #1759, #1760, #1761, #1762.

This makes the SAIL-bridge subset for #93 self-documenting and ready for a close decision by @pirapira (Hermes-bot does not close issues).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).