### PR TITLE
chore(shake): drop EvmWordArith.Common import in ByteOps/MultiLimb (#1045)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
+++ b/EvmAsm/Evm64/EvmWordArith/ByteOps.lean
@@ -4,7 +4,7 @@
   BYTE correctness: limb-level byte extraction = 256-bit byte extraction.
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Common
+import EvmAsm.Evm64.Basic
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.NormNum
 import Mathlib.Tactic.Ring

--- a/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MultiLimb.lean
@@ -6,7 +6,7 @@
   rv64_mulhu, and multi-limb value representation.
 -/
 
-import EvmAsm.Evm64.EvmWordArith.Common
+import EvmAsm.Evm64.Basic
 import EvmAsm.Rv64.Instructions
 import Mathlib.Tactic.Linarith
 import Mathlib.Tactic.Ring


### PR DESCRIPTION
Both EvmAsm/Evm64/EvmWordArith/ByteOps.lean and EvmAsm/Evm64/EvmWordArith/MultiLimb.lean import EvmAsm.Evm64.EvmWordArith.Common but never reference any of its helpers (bv_or_eq_zero / ult_one_eq_zero / xor_eq_zero_imp / ult_iff / borrow_* / toNat_eq_limb_sum / eq_zero_iff_limbs). They use only BitVec/Nat lemmas (from Basic) and explicit Mathlib tactics.

Common itself imports only Basic + Linarith, so swapping Common for Basic is a strict downgrade — both files already keep Linarith explicit, so transitive availability is unchanged.

Verified locally with `lake build` (1557 jobs green) and `lake exe shake EvmAsm`.

Refs #1045. beads: evm-asm-n319.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).