### PR TITLE
chore(divmod): delete dead div128Quot_v2_le_val256_div_plus_two_untruncated

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean
@@ -5,7 +5,7 @@
   Extracted from Spec/CallAddback.lean per #1078 / beads evm-asm-q62k to
   trim the over-cap CallAddback.lean.
 
-  Contents (12 theorems, leaf-level relative to the Phase-1 div-invariant
+  Contents (11 theorems, leaf-level relative to the Phase-1 div-invariant
   cluster that still lives in CallAddback.lean):
 
   - `div128Quot_v2_q1_prime_prime_le_q1_prime`
@@ -18,7 +18,6 @@
   - `div128Quot_v2_qHat_vTop_le_full`
   - `div128Quot_v2_qHat_vTop_le_full_untruncated`
   - `div128Quot_v2_le_val256_div_plus_two`
-  - `div128Quot_v2_le_val256_div_plus_two_untruncated`
   - `div128Quot_v2_phase1c_in_knuth_range_under_runtime`
 
   No proof changes: this is a pure structural move. The downstream
@@ -797,95 +796,6 @@ theorem div128Quot_v2_le_val256_div_plus_two
   have h_step2 := knuth_theorem_b_from_clz a0 a1 a2 a3 b0 b1 b2 b3
     hb3nz hshift_nz hcall
   -- Transitivity.
-  calc (div128Quot_v2 u4 un3 b3').toNat
-      ≤ (u4.toNat * 2^64 + un3.toNat) / b3'.toNat := h_div_le
-    _ ≤ val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := h_step2
-
-/-- **Untruncated val256 form** — alternative path 3 lift to the val256 level.
-
-    Same conclusion as `div128Quot_v2_le_val256_div_plus_two` but takes the
-    UNTRUNCATED phase-1 invariants (with the upper-bound conjunct) instead
-    of the truncated form (provably FALSE under runtime preconditions).
-
-    Composes:
-    - `div128Quot_v2_qHat_vTop_le_full_untruncated` (new, proven).
-    - `Nat.le_div_iff_mul_le` for the division bound.
-    - `knuth_theorem_b_from_clz` for the abstract Knuth-B bound (existing).
-
-    Issue #1337 algorithm fix migration. Alternative path 3. -/
-theorem div128Quot_v2_le_val256_div_plus_two_untruncated
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hb3nz : b3 ≠ 0)
-    (hshift_nz : (clzResult b3).1 ≠ 0)
-    (hcall : isCallTrialN4 a3 b2 b3) :
-    let shift := (clzResult b3).1.toNat % 64
-    let antiShift := (signExtend12 (0 : BitVec 12) - (clzResult b3).1).toNat % 64
-    let u4 := a3 >>> antiShift
-    let un3 := (a3 <<< shift) ||| (a2 >>> antiShift)
-    let b3' := (b3 <<< shift) ||| (b2 >>> antiShift)
-    let dHi := b3' >>> (32 : BitVec 6).toNat
-    let dLo := (b3' <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := un3 >>> (32 : BitVec 6).toNat
-    let div_un0 := (un3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu u4 dHi
-    let rhat := u4 - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let q1'' := div128Quot_phase2b_q0' q1' rhat' dLo div_un1
-    let rhat'' :=
-      if rhat' >>> (32 : BitVec 6).toNat = 0 then
-        let qDlo2 := q1' * dLo
-        let rhatUn1' := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-        if BitVec.ult rhatUn1' qDlo2 then rhat' + dHi else rhat'
-      else rhat'
-    let cu_rhat_un1 := (rhat'' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1'' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let rhat2' := if rhat2c >>> (32 : BitVec 6).toNat = 0 then
-                    (if BitVec.ult ((rhat2c <<< (32 : BitVec 6).toNat) ||| div_un0)
-                                    (q0c * dLo) then rhat2c + dHi else rhat2c)
-                  else rhat2c
-    -- Untruncated phase-1 invariant (2 conjuncts) + phase-2 + q0' bound:
-    q1''.toNat * dLo.toNat ≤ rhat''.toNat * 2^32 + div_un1.toNat →
-    rhat''.toNat * 2^32 + div_un1.toNat - q1''.toNat * dLo.toNat < 2^64 →
-    q0'.toNat * dLo.toNat ≤ rhat2'.toNat * 2^32 + div_un0.toNat →
-    q0'.toNat < 2^32 →
-    (div128Quot_v2 u4 un3 b3').toNat ≤
-      val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := by
-  intro shift antiShift u4 un3 b3' dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc
-        qDlo rhatUn1 q1' rhat' q1'' rhat'' cu_rhat_un1 cu_q1_dlo un21 q0 rhat2
-        hi2 q0c rhat2c q0' rhat2'
-        h_ph1_no_wrap_lo h_ph1_un21_lt h_ph2_no_wrap hq0_lt
-  -- Step 1 preconditions (same as the truncated variant).
-  have hb3prime_ge_pow63 : b3'.toNat ≥ 2^63 := b3_prime_ge_pow63 b3 b2 hb3nz _
-  have hdHi_ge : dHi.toNat ≥ 2^31 := div128Quot_dHi_ge_pow31 b3' hb3prime_ge_pow63
-  have hdLo_lt : dLo.toNat < 2^32 := Word_ushiftRight_32_lt_pow32
-  have hu4_lt_b3prime : u4.toNat < b3'.toNat := isCallTrialN4_toNat_lt a3 b2 b3 hcall
-  have h_vtop : b3'.toNat = dHi.toNat * 2^32 + dLo.toNat :=
-    div128Quot_vTop_decomp b3'
-  have hu4_lt_vTop : u4.toNat < dHi.toNat * 2^32 + dLo.toNat := by
-    rw [← h_vtop]; exact hu4_lt_b3prime
-  -- Step 1 via UNTRUNCATED wrapper.
-  have h_step1 := div128Quot_v2_qHat_vTop_le_full_untruncated u4 un3 b3' hdHi_ge
-    hdLo_lt hu4_lt_vTop h_ph1_no_wrap_lo h_ph1_un21_lt h_ph2_no_wrap hq0_lt
-  have hb3prime_pos : 0 < b3'.toNat := by omega
-  have h_div_le : (div128Quot_v2 u4 un3 b3').toNat ≤
-      (u4.toNat * 2^64 + un3.toNat) / b3'.toNat :=
-    (Nat.le_div_iff_mul_le hb3prime_pos).mpr h_step1
-  -- Step 2 (existing): Knuth-B abstract bound from CLZ.
-  have h_step2 := knuth_theorem_b_from_clz a0 a1 a2 a3 b0 b1 b2 b3
-    hb3nz hshift_nz hcall
   calc (div128Quot_v2 u4 un3 b3').toNat
       ≤ (u4.toNat * 2^64 + un3.toNat) / b3'.toNat := h_div_le
     _ ≤ val256 a0 a1 a2 a3 / val256 b0 b1 b2 b3 + 2 := h_step2


### PR DESCRIPTION
Drop `div128Quot_v2_le_val256_div_plus_two_untruncated` in `EvmAsm/Evm64/DivMod/Spec/CallAddbackV2Bounds.lean`. Verified zero external references via grep across `EvmAsm/`.

This is the v2 algorithm's untruncated val256-form Knuth-B lift (alternative path 3). It mirrors the truncated `div128Quot_v2_le_val256_div_plus_two` (which itself is leaf-only — only ever invoked as a v2 sanity check) but takes the four untruncated phase-1/2 hypotheses. The v2 algorithm has been superseded by `div128Quot_v4` (see `EvmAsm/Evm64/DivMod/LoopDefs/IterV4.lean` for the bug history), so this third v2 path-3 lift is dead.

The 5-limb-shifted untruncated form `div128Quot_v2_le_5limb_shifted_div_plus_two_untruncated` was deleted in #2295. This PR removes the val256 untruncated sibling, keeping the cleanup symmetric.

Header docstring updated to list 11 theorems instead of 12.

Build green (`lake build`, 1557 jobs). 87-line reduction, 1 file touched.

**Stacked on #2295** (`chore/sf7y-dead-v2-bounds`); base is set accordingly. Will rebase onto `main` once #2295 merges, or trivially auto-merge when the dependency lands.

Closes beads `evm-asm-7lq5` (slice of `evm-asm-sboz` / DivMod cleanup parent — no GH issue, beads-only cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).