### PR TITLE
feat(evmstate): add evmStateIs_code_split / evmStateCodeRest helper

### DIFF
--- a/EvmAsm/Evm64/EvmState.lean
+++ b/EvmAsm/Evm64/EvmState.lean
@@ -260,6 +260,25 @@ def evmStateX12Rest (layout : EvmLayout) (state : EvmState) : Assertion :=
   evmCodeIs layout.codeBase state.code **
   EvmEnv.envIs layout.envBase state.env
 
+/-- Everything in `evmStateIs` except the EVM code region assertion
+    `evmCodeIs layout.codeBase state.code`. Mirrors the gas/status/x12/stack
+    rests — opcode handlers that only read the EVM code region (PUSH, JUMP,
+    JUMPDEST) can frame against this rest. -/
+def evmStateCodeRest (layout : EvmLayout) (state : EvmState) : Assertion :=
+  (layout.pcReg ↦ᵣ BitVec.ofNat 64 state.pc) **
+  (layout.gasReg ↦ᵣ BitVec.ofNat 64 state.gas) **
+  (layout.memBaseReg ↦ᵣ layout.memBase) **
+  (layout.memSizeReg ↦ᵣ layout.memSizeLoc) **
+  (layout.codeBaseReg ↦ᵣ layout.codeBase) **
+  (layout.codeLenReg ↦ᵣ BitVec.ofNat 64 state.codeLen) **
+  (layout.envBaseReg ↦ᵣ layout.envBase) **
+  (layout.statusReg ↦ᵣ state.status.tag) **
+  (.x12 ↦ᵣ layout.stackPtr) **
+  evmStackIs layout.stackPtr state.stack **
+  evmMemIs layout.memBase state.memoryCells state.memory **
+  evmMemSizeIs layout.memSizeLoc state.memSize **
+  EvmEnv.envIs layout.envBase state.env
+
 /-- Everything in `evmStateIs` except the scalar status register. -/
 def evmStateStatusRest (layout : EvmLayout) (state : EvmState) : Assertion :=
   (layout.pcReg ↦ᵣ BitVec.ofNat 64 state.pc) **
@@ -315,6 +334,15 @@ theorem evmStateIs_x12_split (layout : EvmLayout) (state : EvmState) :
   unfold evmStateIs evmStateX12Rest
   ac_rfl
 
+/-- Split out the EVM code region assertion from the composite state
+    assertion. -/
+theorem evmStateIs_code_split (layout : EvmLayout) (state : EvmState) :
+    evmStateIs layout state =
+      (evmCodeIs layout.codeBase state.code **
+       evmStateCodeRest layout state) := by
+  unfold evmStateIs evmStateCodeRest
+  ac_rfl
+
 theorem pcFree_evmStatePcRest {layout : EvmLayout} {state : EvmState} :
     (evmStatePcRest layout state).pcFree := by
   unfold evmStatePcRest
@@ -338,6 +366,11 @@ theorem pcFree_evmStateStatusRest {layout : EvmLayout} {state : EvmState} :
 theorem pcFree_evmStateX12Rest {layout : EvmLayout} {state : EvmState} :
     (evmStateX12Rest layout state).pcFree := by
   unfold evmStateX12Rest
+  pcFree
+
+theorem pcFree_evmStateCodeRest {layout : EvmLayout} {state : EvmState} :
+    (evmStateCodeRest layout state).pcFree := by
+  unfold evmStateCodeRest
   pcFree
 
 theorem pcFree_evmStateIs {layout : EvmLayout} {state : EvmState} :
@@ -364,6 +397,10 @@ instance (layout : EvmLayout) (state : EvmState) :
 instance (layout : EvmLayout) (state : EvmState) :
     Assertion.PCFree (evmStateX12Rest layout state) :=
   ⟨pcFree_evmStateX12Rest⟩
+
+instance (layout : EvmLayout) (state : EvmState) :
+    Assertion.PCFree (evmStateCodeRest layout state) :=
+  ⟨pcFree_evmStateCodeRest⟩
 
 instance (layout : EvmLayout) (state : EvmState) :
     Assertion.PCFree (evmStateIs layout state) :=


### PR DESCRIPTION
Mirror of the existing pc/gas/status/x12/stack splits in `EvmAsm/Evm64/EvmState.lean`.

Adds:
- `evmStateCodeRest`: everything in `evmStateIs` except `evmCodeIs layout.codeBase state.code`
- `evmStateIs_code_split`: `evmStateIs = evmCodeIs ** evmStateCodeRest` (ac_rfl after unfold)
- `pcFree_evmStateCodeRest` + `Assertion.PCFree` instance

Useful for opcode handlers that read the EVM code region (PUSH/JUMP/JUMPDEST) and want to frame against everything except the code atom.

Refs beads `evm-asm-h9cl`, GH #105.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).