### PR TITLE
chore(shake): suppress IsZero/Eq EvmWordArith.Common false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -136,4 +136,6 @@
  "EvmAsm.Rv64.RLP.Phase2LongLoopFive":  ["EvmAsm.Rv64.RLP.Phase2LongLoopFour"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopSix":   ["EvmAsm.Rv64.RLP.Phase2LongLoopFive"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopSeven": ["EvmAsm.Rv64.RLP.Phase2LongLoopSix"],
- "EvmAsm.Rv64.RLP.Phase2LongLoopEight": ["EvmAsm.Rv64.RLP.Phase2LongLoopSeven"]}}
+ "EvmAsm.Rv64.RLP.Phase2LongLoopEight": ["EvmAsm.Rv64.RLP.Phase2LongLoopSeven"],
+ "EvmAsm.Evm64.EvmWordArith.IsZero": ["EvmAsm.Evm64.EvmWordArith.Common"],
+ "EvmAsm.Evm64.EvmWordArith.Eq": ["EvmAsm.Evm64.EvmWordArith.Common"]}}


### PR DESCRIPTION
Slice of #1045 import hygiene sweep (parent beads evm-asm-6qj, slice evm-asm-i8o4).

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/EvmWordArith/IsZero.lean` and `EvmAsm/Evm64/EvmWordArith/Eq.lean` as importing `EvmAsm.Evm64.EvmWordArith.Common` without using anything from it. **Both reports are false positives** — IsZero.lean uses `ult_one_eq_zero` and `bv_or_eq_zero`; Eq.lean uses all three of `ult_one_eq_zero`, `bv_or_eq_zero`, and `xor_eq_zero_imp`. Removing the import causes `lake build` to fail with `Unknown identifier` errors at the use sites.

Shake misses these because the lemmas are referenced by direct application, not via `simp` / `grind` attribute lookups, and shake's olean-metadata analysis here does not see them as users of the import. Adding a `noshake.json` entry is the documented escape hatch (see `AGENTS.md` § Import Hygiene: "When in doubt, prefer adding a `noshake.json` entry over removing the import.").

Verified locally:
- `lake exe shake EvmAsm` no longer reports either file after this change.
- `lake build` succeeds (1558 jobs green).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).