### PR TITLE
chore(noshake): flag SignExtend/Compose EvmWordArith.Common as false positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -27,6 +27,7 @@
   ["EvmAsm.Rv64.Tactics.PerfTrace", "EvmAsm.Rv64.InstructionSpecs"],
   "EvmAsm.Rv64.Tactics.LiftSpec":
   ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Stack"],
+  "EvmAsm.Evm64.SignExtend.Compose": ["EvmAsm.Evm64.EvmWordArith.Common"],
   "EvmAsm.Rv64.AddrNorm": ["EvmAsm.Rv64.AddrNormAttr"],
   "EvmAsm.Rv64.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.RegOpsAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],


### PR DESCRIPTION
Slice of #1045 import hygiene sweep (beads parent evm-asm-6qj, child evm-asm-ljbo).

`lake exe shake EvmAsm` reports `EvmAsm/Evm64/SignExtend/Compose.lean` as
importing `EvmAsm.Evm64.EvmWordArith.Common` without using it. The file
actually uses `EvmWord.toNat_eq_limb_sum` at line 794, which is defined in
`Common.lean` — so shake is wrong here. Removing the import breaks the
build ("Unknown constant EvmAsm.Evm64.EvmWord.toNat_eq_limb_sum").

Fix: add an entry under `EvmAsm.Evm64.SignExtend.Compose` in
`scripts/noshake.json` so shake stops flagging this import. This matches
the established pattern in `scripts/shake-filter.md` for confirmed
false-positive imports.

Verification:

- `lake build` succeeds (1558 jobs, no new warnings).
- `lake exe shake EvmAsm` no longer flags this import.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).