### PR TITLE
chore(divmod): delete 3 unused _eq_*_of_toNat_eq wrappers

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2QuotientWord.lean
@@ -64,18 +64,6 @@ theorem fullDivN2_hdivs_of_word_eq
     delta fullDivN2QuotientWord
     exact EvmWord.getLimbN_fromLimbs_3
 
-/-- BitVec extensionality bridge: a `toNat` equality lifts to an `EvmWord`
-    equality. -/
-theorem fullDivN2QuotientWord_eq_div_of_toNat_eq
-    (bltu_2 bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hdiv_toNat :
-      (fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat) :
-    fullDivN2QuotientWord bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b :=
-  BitVec.eq_of_toNat_eq hdiv_toNat
-
 /-- The `toNat` of the packed quotient word equals the four-limb
     `EvmWord.val256` of the per-limb results (with top limb zero). -/
 theorem fullDivN2QuotientWord_toNat

--- a/EvmAsm/Evm64/DivMod/Spec/N2RemainderWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N2RemainderWord.lean
@@ -98,18 +98,6 @@ theorem fullModN2_hmods_of_word_eq
     delta fullModN2RemainderWord
     exact EvmWord.getLimbN_fromLimbs_3
 
-/-- BitVec extensionality bridge: a `toNat` equality lifts to an `EvmWord`
-    equality. -/
-theorem fullModN2RemainderWord_eq_mod_of_toNat_eq
-    (bltu_2 bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hmod_toNat :
-      (fullModN2RemainderWord bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.mod a b).toNat) :
-    fullModN2RemainderWord bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b :=
-  BitVec.eq_of_toNat_eq hmod_toNat
-
 /-- The `toNat` of the packed remainder word equals the four-limb
     `EvmWord.val256` of the denormalized remainder limbs. -/
 theorem fullModN2RemainderWord_toNat

--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
@@ -63,18 +63,6 @@ theorem fullDivN3_hdivs_of_word_eq
     delta fullDivN3QuotientWord
     exact EvmWord.getLimbN_fromLimbs_3
 
-/-- BitVec extensionality bridge: a `toNat` equality lifts to an `EvmWord`
-    equality. -/
-theorem fullDivN3QuotientWord_eq_div_of_toNat_eq
-    (bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hdiv_toNat :
-      (fullDivN3QuotientWord bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat) :
-    fullDivN3QuotientWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b :=
-  BitVec.eq_of_toNat_eq hdiv_toNat
-
 /-- The `toNat` of the packed quotient word equals the four-limb
     `EvmWord.val256` of the per-limb results (with top two limbs zero). -/
 theorem fullDivN3QuotientWord_toNat


### PR DESCRIPTION
Three BitVec extensionality bridges have no callers anywhere in `EvmAsm/`:

- `fullDivN2QuotientWord_eq_div_of_toNat_eq` (N2QuotientWord.lean)
- `fullModN2RemainderWord_eq_mod_of_toNat_eq` (N2RemainderWord.lean)
- `fullDivN3QuotientWord_eq_div_of_toNat_eq` (N3QuotientWord.lean)

Each is a one-line wrapper around `BitVec.eq_of_toNat_eq`, so deleting them removes dead code without losing any reusable lemma — call sites can apply `BitVec.eq_of_toNat_eq` directly.

`lake build` green, 0 sorry.

Beads: evm-asm-iv6g (parent evm-asm-sboz, DivMod cleanup after #61 closure).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).