### PR TITLE
feat(env): add evm_env_load_spec_within low-level 9-instr cell spec (#103)

### DIFF
--- a/EvmAsm/Evm64/Env/Spec.lean
+++ b/EvmAsm/Evm64/Env/Spec.lean
@@ -79,5 +79,152 @@ theorem env_one_limb_spec_within
   rw [h_store_se] at hSD
   runBlock hLD hSD
 
+/-! ## Low-level cell spec for the full 9-instruction `evm_env_load`
+
+  Slice 5a-low (`evm-asm-ibey`). Compose `env_one_limb_spec_within`
+  four times with `addi_spec_gen_same_within` for the SP-bumping
+  prologue, producing a single 9-instruction = 36-byte
+  `cpsTripleWithin` for the parameterized `evm_env_load` program at
+  `base`. The four memory source cells (env block) are framed
+  through unchanged; the four target cells (above the new EVM SP
+  `nsp`) are overwritten with the four 64-bit limbs of
+  `field.value env`.
+
+  Mirror of `evm_calldatasize_spec_within` (`Calldata/SizeSpec.lean`)
+  but with four limbs instead of one + zero-fill.
+-/
+
+/-- Every `SimpleEnvField` has its 32-byte slot inside the 12-bit
+    immediate range, so all four limb load offsets sign-extend to
+    themselves. -/
+private theorem field_offset_plus_24_lt_2048 (field : SimpleEnvField) :
+    field.offset + 24 < 2048 := by
+  cases field <;> decide
+
+/-- Low-level (per-cell) spec for `evm_env_load envBaseReg tmpReg field`.
+
+    Pre: registers `envBaseReg ↦ envAddr`, `tmpReg ↦ tempOld`,
+    `x12 ↦ nsp + 32`; four env source cells at
+    `envAddr + BitVec.ofNat 64 (field.offset + 8 * i)` carrying the
+    four limbs of `field.value env`; four target cells at
+    `nsp + BitVec.ofNat 64 (8 * i)` holding garbage `d_i`.
+
+    Post: same source cells (frame-through); `tmpReg` now holds the
+    high limb (`getLimbN 3`); `x12` decremented to `nsp`; the four
+    target cells now hold the four limbs of `field.value env`. -/
+theorem evm_env_load_spec_within
+    (envBaseReg tmpReg : Reg) (htmp_ne_x0 : tmpReg ≠ .x0)
+    (envAddr nsp tempOld : Word) (env : EvmEnv) (field : SimpleEnvField)
+    (d0 d1 d2 d3 : Word) (base : Word) :
+    cpsTripleWithin 9 base (base + 36)
+      (evm_env_load_code envBaseReg tmpReg field base)
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ tempOld) **
+       (.x12 ↦ᵣ (nsp + 32)) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 0)) ↦ₘ
+          (field.value env).getLimbN 0) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 1)) ↦ₘ
+          (field.value env).getLimbN 1) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 2)) ↦ₘ
+          (field.value env).getLimbN 2) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 3)) ↦ₘ
+          (field.value env).getLimbN 3) **
+       ((nsp + BitVec.ofNat 64 (8 * 0)) ↦ₘ d0) **
+       ((nsp + BitVec.ofNat 64 (8 * 1)) ↦ₘ d1) **
+       ((nsp + BitVec.ofNat 64 (8 * 2)) ↦ₘ d2) **
+       ((nsp + BitVec.ofNat 64 (8 * 3)) ↦ₘ d3))
+      ((envBaseReg ↦ᵣ envAddr) ** (tmpReg ↦ᵣ (field.value env).getLimbN 3) **
+       (.x12 ↦ᵣ nsp) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 0)) ↦ₘ
+          (field.value env).getLimbN 0) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 1)) ↦ₘ
+          (field.value env).getLimbN 1) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 2)) ↦ₘ
+          (field.value env).getLimbN 2) **
+       ((envAddr + BitVec.ofNat 64 (field.offset + 8 * 3)) ↦ₘ
+          (field.value env).getLimbN 3) **
+       ((nsp + BitVec.ofNat 64 (8 * 0)) ↦ₘ (field.value env).getLimbN 0) **
+       ((nsp + BitVec.ofNat 64 (8 * 1)) ↦ₘ (field.value env).getLimbN 1) **
+       ((nsp + BitVec.ofNat 64 (8 * 2)) ↦ₘ (field.value env).getLimbN 2) **
+       ((nsp + BitVec.ofNat 64 (8 * 3)) ↦ₘ (field.value env).getLimbN 3)) := by
+  -- ADDI x12 x12 -32 : decrement EVM SP by 32 (nsp + 32 ↦ nsp).
+  have LADDI := addi_spec_gen_same_within .x12 (nsp + 32) (-32) base (by nofun)
+  simp only [signExtend12_neg32] at LADDI
+  rw [show (nsp + 32 : Word) + (-32 : Word) = nsp from by bv_omega] at LADDI
+  -- Bounds for the four limb-pair offsets.
+  have h_off := field_offset_plus_24_lt_2048 field
+  have h_l0 : field.offset + 8 * 0 < 2048 := by omega
+  have h_l1 : field.offset + 8 * 1 < 2048 := by omega
+  have h_l2 : field.offset + 8 * 2 < 2048 := by omega
+  have h_l3 : field.offset + 8 * 3 < 2048 := by omega
+  have h_s0 : (8 * 0 : Nat) < 2048 := by decide
+  have h_s1 : (8 * 1 : Nat) < 2048 := by decide
+  have h_s2 : (8 * 2 : Nat) < 2048 := by decide
+  have h_s3 : (8 * 3 : Nat) < 2048 := by decide
+  -- Sign-extension normalisations for the 8 limb addresses.
+  have h_se_l0 : signExtend12 (BitVec.ofNat 12 (field.offset + 8 * 0))
+                  = BitVec.ofNat 64 (field.offset + 8 * 0) :=
+    signExtend12_ofNat_small h_l0
+  have h_se_l1 : signExtend12 (BitVec.ofNat 12 (field.offset + 8 * 1))
+                  = BitVec.ofNat 64 (field.offset + 8 * 1) :=
+    signExtend12_ofNat_small h_l1
+  have h_se_l2 : signExtend12 (BitVec.ofNat 12 (field.offset + 8 * 2))
+                  = BitVec.ofNat 64 (field.offset + 8 * 2) :=
+    signExtend12_ofNat_small h_l2
+  have h_se_l3 : signExtend12 (BitVec.ofNat 12 (field.offset + 8 * 3))
+                  = BitVec.ofNat 64 (field.offset + 8 * 3) :=
+    signExtend12_ofNat_small h_l3
+  have h_se_s0 : signExtend12 (BitVec.ofNat 12 (8 * 0))
+                  = BitVec.ofNat 64 (8 * 0) :=
+    signExtend12_ofNat_small h_s0
+  have h_se_s1 : signExtend12 (BitVec.ofNat 12 (8 * 1))
+                  = BitVec.ofNat 64 (8 * 1) :=
+    signExtend12_ofNat_small h_s1
+  have h_se_s2 : signExtend12 (BitVec.ofNat 12 (8 * 2))
+                  = BitVec.ofNat 64 (8 * 2) :=
+    signExtend12_ofNat_small h_s2
+  have h_se_s3 : signExtend12 (BitVec.ofNat 12 (8 * 3))
+                  = BitVec.ofNat 64 (8 * 3) :=
+    signExtend12_ofNat_small h_s3
+  -- Limb 0: LD + SD at base+4 / base+8.
+  have L0LD := ld_spec_gen_within tmpReg envBaseReg envAddr tempOld
+                ((field.value env).getLimbN 0)
+                (BitVec.ofNat 12 (field.offset + 8 * 0)) (base + 4) htmp_ne_x0
+  rw [h_se_l0] at L0LD
+  have L0SD := sd_spec_gen_within .x12 tmpReg nsp
+                ((field.value env).getLimbN 0) d0
+                (BitVec.ofNat 12 (8 * 0)) (base + 8)
+  rw [h_se_s0] at L0SD
+  -- Limb 1.
+  have L1LD := ld_spec_gen_within tmpReg envBaseReg envAddr
+                ((field.value env).getLimbN 0)
+                ((field.value env).getLimbN 1)
+                (BitVec.ofNat 12 (field.offset + 8 * 1)) (base + 12) htmp_ne_x0
+  rw [h_se_l1] at L1LD
+  have L1SD := sd_spec_gen_within .x12 tmpReg nsp
+                ((field.value env).getLimbN 1) d1
+                (BitVec.ofNat 12 (8 * 1)) (base + 16)
+  rw [h_se_s1] at L1SD
+  -- Limb 2.
+  have L2LD := ld_spec_gen_within tmpReg envBaseReg envAddr
+                ((field.value env).getLimbN 1)
+                ((field.value env).getLimbN 2)
+                (BitVec.ofNat 12 (field.offset + 8 * 2)) (base + 20) htmp_ne_x0
+  rw [h_se_l2] at L2LD
+  have L2SD := sd_spec_gen_within .x12 tmpReg nsp
+                ((field.value env).getLimbN 2) d2
+                (BitVec.ofNat 12 (8 * 2)) (base + 24)
+  rw [h_se_s2] at L2SD
+  -- Limb 3.
+  have L3LD := ld_spec_gen_within tmpReg envBaseReg envAddr
+                ((field.value env).getLimbN 2)
+                ((field.value env).getLimbN 3)
+                (BitVec.ofNat 12 (field.offset + 8 * 3)) (base + 28) htmp_ne_x0
+  rw [h_se_l3] at L3LD
+  have L3SD := sd_spec_gen_within .x12 tmpReg nsp
+                ((field.value env).getLimbN 3) d3
+                (BitVec.ofNat 12 (8 * 3)) (base + 32)
+  rw [h_se_s3] at L3SD
+  runBlock LADDI L0LD L0SD L1LD L1SD L2LD L2SD L3LD L3SD
+
 end Env
 end EvmAsm.Evm64


### PR DESCRIPTION
Slice 5a-low of GH #103 (parent beads task evm-asm-3jso, this slice evm-asm-ibey).

Adds the low-level cell-level cpsTripleWithin spec for the parameterized
`evm_env_load envBaseReg tmpReg field` program from slice 4 (#2253):

- Pre: `envBaseReg ↦ envAddr`, `tmpReg ↦ tempOld`, `x12 ↦ nsp + 32`,
  four env source cells at `envAddr + (field.offset + 8*i)` carrying the
  four 64-bit limbs of `field.value env`, four target cells at
  `nsp + 8*i` holding garbage.
- Post: `x12 ↦ nsp`, `tmpReg ↦ getLimbN 3`, env source cells frame through,
  target cells now hold the four limbs of `field.value env`.

Composition: 1× `addi_spec_gen_same_within` (SP bump) + 4× LD/SD pairs
via `runBlock`. Mirror of `evm_calldatasize_spec_within` from
`Calldata/SizeSpec.lean` but four limbs instead of one + zero-fill.
9 instructions = 36 bytes.

No new sorry, no `maxHeartbeats` / `maxRecDepth` overrides. `lake build`
green.

Unblocks slice 5a (`evm-asm-3jso`) and slice 5 (`evm-asm-3fvb`,
`evm_env_load_stack_spec`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).