### PR TITLE
chore(shake): drop unused EvmAsm.Evm64.Calldata.Size import in SizeSpec

### DIFF
--- a/EvmAsm/Evm64/Calldata/SizeSpec.lean
+++ b/EvmAsm/Evm64/Calldata/SizeSpec.lean
@@ -10,7 +10,6 @@
 -/
 
 import EvmAsm.Evm64.Calldata.SizeProgram
-import EvmAsm.Evm64.Calldata.Size
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs


### PR DESCRIPTION
lake exe shake EvmAsm flags EvmAsm.Evm64.Calldata.Size as unused in EvmAsm/Evm64/Calldata/SizeSpec.lean. The file only references it on the import line; no callDataSizeWord / callDataSizeOf declaration from EvmAsm.Evm64.Calldata.Size is used. Drop the import.

lake build green.

Refs #1045, beads evm-asm-zb11.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
