### PR TITLE
chore(shake): flag MStore/ByteAlg BVDecide+IntervalCases as false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -37,9 +37,11 @@
   "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],
-  "EvmAsm.Evm64.Basic":
+ "EvmAsm.Evm64.Basic":
   ["Std.Tactic.BVDecide"],
-  "EvmAsm.Evm64.SpAddr":
+ "EvmAsm.Evm64.MStore.ByteAlg":
+  ["Std.Tactic.BVDecide", "Mathlib.Tactic.IntervalCases"],
+ "EvmAsm.Evm64.SpAddr":
   ["EvmAsm.Rv64.Tactics.SeqFrame"],
   "EvmAsm.Evm64.MSize.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],


### PR DESCRIPTION
Slice of #1045 import hygiene (beads evm-asm-tl2w, parent evm-asm-6qj).

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/MStore/ByteAlg.lean` as importing `Std.Tactic.BVDecide` and `Mathlib.Tactic.IntervalCases` without using anything from them. Both are tactic-registry imports — the file uses `interval_cases i <;> (...; bv_decide)` on line 64, which shake's import-graph analysis cannot see (same false-positive class as the existing `EvmAsm.Rv64.ByteOps` noshake entry).

Suppressed via `scripts/noshake.json` rather than dropping the imports.

Verified locally: `lake build` green; `lake exe shake EvmAsm` no longer flags `MStore/ByteAlg`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).