### PR TITLE
chore(divmod): delete obsolete SpecCallV4 compat shim

### DIFF
--- a/EvmAsm/Evm64/DivMod.lean
+++ b/EvmAsm/Evm64/DivMod.lean
@@ -14,7 +14,7 @@ import EvmAsm.Evm64.DivMod.Spec
 -- cover the MOD n=1/n=2/n=3 wrappers. FullPathN2Bundle carries shared N2
 -- irreducible intermediates for later full-wrapper refactors. FullPathN2Full
 -- covers FullPathN2LoopUnified + FullPathN2Cases + FullPath.
--- SpecCallV4 transitively covers SpecCallAddbackBeq (+ AlgDefs, AlgEuclideans)
+-- Spec.V4 transitively covers SpecCallAddbackBeq (+ AlgDefs, AlgEuclideans)
 -- and LoopDefs.IterV4InvariantsPhase2 (→ IterV4Invariants). The leaf
 -- NumericalTests / NumericalTestsV4 files are imported explicitly so the
 -- unimported-file check (#1209/#1440) sees them reachable from the umbrella.
@@ -35,6 +35,6 @@ import EvmAsm.Evm64.DivMod.Compose.Dispatcher
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Full
 import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
-import EvmAsm.Evm64.DivMod.SpecCallV4
+import EvmAsm.Evm64.DivMod.Spec.V4
 import EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTests
 import EvmAsm.Evm64.DivMod.SpecCallAddbackBeq.NumericalTestsV4

--- a/EvmAsm/Evm64/DivMod/SpecCallV4.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallV4.lean
@@ -1,5 +1,0 @@
-/-
-  Compatibility re-export for the former SpecCallV4 module path.
--/
-
-import EvmAsm.Evm64.DivMod.Spec.V4


### PR DESCRIPTION
EvmAsm/Evm64/DivMod/SpecCallV4.lean is a 6-line compatibility re-export of `EvmAsm.Evm64.DivMod.Spec.V4` left behind by the spec-surface split (commit a941a19d, *refactor(divmod): split stack spec surface*).

The sole consumer is the umbrella `EvmAsm/Evm64/DivMod.lean` (line 38). This PR replaces that import with the direct `EvmAsm.Evm64.DivMod.Spec.V4` path, updates the adjacent comment, and deletes the shim file.

Verification:
- `lake build` green (1557 jobs)
- `scripts/check-unimported.sh` green (495 modules / 495 reachable)
- 0 sorry, no warnings introduced

Refs evm-asm-1yd5 (slice of evm-asm-sboz, the DivMod cleanup umbrella tracking #61 closure).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).