### PR TITLE
chore(divmod): delete dead divK_beq_passthrough_v2_spec_within

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean
@@ -52,24 +52,6 @@ theorem divK_beq_passthrough_spec_within {carry : Word} (base : Word) (hne : car
       (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
     ntaken
 
-/-- v2 mirror of `divK_beq_passthrough_spec_within`. -/
-theorem divK_beq_passthrough_v2_spec_within {carry : Word} (base : Word) (hne : carry ≠ 0) :
-    cpsTripleWithin 1 (base + addbackBeqOff) (base + storeLoopOff) (sharedDivModCode_v2 base)
-      ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word)))
-      ((.x7 ↦ᵣ carry) ** (.x0 ↦ᵣ (0 : Word))) := by
-  have hbeq := beq_spec_gen_within .x7 .x0 (8044 : BitVec 13) carry 0 (base + addbackBeqOff)
-  rw [lb_beq_back_ntaken_local] at hbeq
-  have hbeq_ext := cpsBranchWithin_extend_code (hmono :=
-    lb_sub_v2 108 _ _ (by decide) (by bv_addr) (by decide)) hbeq
-  have ntaken := cpsBranchWithin_ntakenPath hbeq_ext (fun hp hQt => by
-    obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
-    exact hne hpure)
-  exact cpsTripleWithin_weaken
-    (fun h hp => hp)
-    (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
-    ntaken
-
 theorem divK_mulsub_correction_addback_880_spec_within
     (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
     (v1Old v5Old v6Old v7Old v10Old v2Old : Word)


### PR DESCRIPTION
v2 mirror of `divK_beq_passthrough_spec_within` in
`EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionAddback.lean` had no
callers anywhere under `EvmAsm/` (verified via ripgrep). The v1 version
just above it remains in active use. File shrinks 18 lines.

Refs beads `evm-asm-aqte` (parent `evm-asm-sboz` — DivMod cleanup
parent for #61).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).