### PR TITLE
chore(shake): flag DivMod/LimbSpec 7-file false positives in noshake.json

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -67,6 +67,27 @@
   "EvmAsm.Evm64.Slt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Sgt.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Multiply.Spec":["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.EvmWordArith.MulCorrect"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.CopyAU":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.LoopSetup":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.PhaseA":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.PhaseBInit":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.PhaseBTail":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.PhaseC2":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.DivMod.LimbSpec.ZeroPath":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
+   "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2":
   ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1"],
   "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2":


### PR DESCRIPTION
Slice of #1045 / beads evm-asm-mwnm.

Seven files under `EvmAsm/Evm64/DivMod/LimbSpec/` (CopyAU, LoopSetup, PhaseA, PhaseBInit, PhaseBTail, PhaseC2, ZeroPath) are flagged by `lake exe shake EvmAsm` for importing `SyscallSpecs` / `ControlFlow` / `Tactics.XSimp` / `Tactics.RunBlock` without using anything from them, but each file uses `runBlock` plus several `*_spec_gen_within` lemmas — same attribute/tactic-registry false-positive class as the existing entries for `RLP/Phase1`, `RLP/Phase3SingleByte`, etc.

Verified with `lake exe shake EvmAsm`: the 7 entries no longer appear in shake output after this change. Pure `scripts/noshake.json` edit; no Lean files touched, so build is unaffected.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).