### PR TITLE
chore(noshake): flag Env/MStore8/MLoad/Calldata Spec false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -162,4 +162,12 @@
  "EvmAsm.Rv64.RLP.Phase2LongLoopSeven": ["EvmAsm.Rv64.RLP.Phase2LongLoopSix"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopEight": ["EvmAsm.Rv64.RLP.Phase2LongLoopSeven"],
  "EvmAsm.Evm64.EvmWordArith.IsZero": ["EvmAsm.Evm64.EvmWordArith.Common"],
- "EvmAsm.Evm64.EvmWordArith.Eq": ["EvmAsm.Evm64.EvmWordArith.Common"]}}
+ "EvmAsm.Evm64.EvmWordArith.Eq": ["EvmAsm.Evm64.EvmWordArith.Common"],
+ "EvmAsm.Evm64.Env.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.MStore8.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.MLoad.Expansion":
+  ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.Calldata.SizeSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"]}}


### PR DESCRIPTION
shake suggests removing `EvmAsm.Rv64.SyscallSpecs` / `Tactics.RunBlock` / `Tactics.XSimp` from `Env/Spec.lean`, `MStore8/Spec.lean`, `MLoad/Expansion.lean`, `Calldata/SizeSpec.lean` (and `AddrNorm` + `Tactics.ExtractPure` for `MLoad/Expansion`). Same tactic-driven false-positive class as the existing entries for `RLP/Phase1`, `RLP/Phase3SingleByte`, `MSize/Spec`, `Pop/Push0/Dup/Swap`, and the DivMod/LimbSpec batch (PR #2336): each file uses `runBlock` plus attribute-driven `*_spec_gen_within` lemmas that shake's import analysis can't see.

Adds four entries to `scripts/noshake.json` mirroring the existing pattern.

Verification:
- `lake build` green.
- `lake exe shake EvmAsm` no longer flags those four files for these imports.

Refs beads evm-asm-1xix, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).