### PR TITLE
chore(noshake): flag Push/Spec.lean SyscallSpecs/RunBlock/XSimp false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -170,4 +170,6 @@
  "EvmAsm.Evm64.MLoad.Expansion":
   ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.SizeSpec":
-  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"]}}
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Push.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"]}}


### PR DESCRIPTION
shake suggests removing `EvmAsm.Rv64.SyscallSpecs` / `Tactics.RunBlock` / `Tactics.XSimp` from `EvmAsm/Evm64/Push/Spec.lean`. Same tactic-driven false-positive class as the existing entries for `RLP/Phase1`, `RLP/Phase3SingleByte`, `MSize/Spec`, `Pop/Push0/Dup/Swap`, `Env/MStore8/MLoad/Calldata` Spec (PR #2339), and the DivMod/LimbSpec batch: the file uses `runBlock` plus attribute-driven `*_spec_gen_within` lemmas (`lbu_spec_gen_within`, `sb_spec_gen_within`, `addi_spec_gen_same_within`) that shake's import analysis can't see.

Adds one entry to `scripts/noshake.json` mirroring the existing pattern.

Verification:
- `lake build` green.
- `lake exe shake EvmAsm` no longer flags `Push/Spec.lean` for these imports.

Refs beads evm-asm-kmxc, parent evm-asm-6qj, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).