### PR TITLE
chore(noshake): flag Push/Spec.lean SyscallSpecs/RunBlock/XSimp false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -170,4 +170,6 @@
  "EvmAsm.Evm64.MLoad.Expansion":
   ["EvmAsm.Rv64.AddrNorm", "EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.ExtractPure", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.SizeSpec":
-  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"]}}
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Push.Spec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"]}}


### PR DESCRIPTION
Push/Spec.lean uses runBlock/xsimp tactics and `@[spec_gen_*]` attributes that shake does not track, so it incorrectly flags SyscallSpecs / Tactics.RunBlock / Tactics.XSimp as unused. These are real dependencies — add a noshake.json entry to silence the false positive.

Verified with `lake exe shake EvmAsm` after the change: Push/Spec.lean no longer appears in the output. `lake build` is green locally.

Refs #1045, beads evm-asm-kmxc.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).