### PR TITLE
chore(noshake): flag Evm64/Memory.lean ByteOps false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -40,6 +40,8 @@
   ["EvmAsm.Rv64.SepLogic"],
  "EvmAsm.Evm64.Basic":
   ["Std.Tactic.BVDecide"],
+ "EvmAsm.Evm64.Memory":
+  ["EvmAsm.Rv64.ByteOps"],
  "EvmAsm.Evm64.MStore.ByteAlg":
   ["Std.Tactic.BVDecide", "Mathlib.Tactic.IntervalCases"],
  "EvmAsm.Evm64.SpAddr":


### PR DESCRIPTION
lake exe shake EvmAsm reports EvmAsm.Evm64.Memory should drop the EvmAsm.Rv64.ByteOps import and add Mathlib.Data.Nat.Basic / Mathlib.Algebra.Group.Nat.Defs.

Verified false positive: Memory.lean uses byteOffset_lt_8 (line 129) and extractByte_replaceByte_same (line 159) from ByteOps.lean — the replacement Mathlib imports are insufficient. Same pattern as the EvmWordArith.Common entries.

lake build green, lake exe shake EvmAsm no longer flags Evm64/Memory.lean.

Refs #1045. Beads: evm-asm-c8q8.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).