### PR TITLE
chore(noshake): flag And/Or/Xor/Not LimbSpec SyscallSpecs/RunBlock false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -54,6 +54,14 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Swap.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.And.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Or.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Xor.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.Not.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.And.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Or.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Xor.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
lake exe shake EvmAsm flags EvmAsm/Evm64/{And,Or,Xor,Not}/LimbSpec.lean as importing `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock` without using anything from them — but each file calls `runBlock` once and uses the `*_spec_gen_within` attribute lemmas (`ld_spec_gen_within`, `sd_spec_gen_within`, `and_spec_gen_rd_eq_rs1_within`, etc.) via the `SyscallSpecs` / `InstructionSpecs` attribute database, which shake doesn't track.

Same false-positive class as `Pop.Spec`, `MSize.Spec`, `RLP.Phase1`, etc. already flagged in `scripts/noshake.json`.

Verification: `lake exe shake EvmAsm` no longer flags those four files for the SyscallSpecs/RunBlock imports.

Refs #1045, beads evm-asm-5qo3.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).