### PR TITLE
chore(shake): drop unused Dispatcher import in N3QuotientWord

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
@@ -16,7 +16,7 @@
   See beads `evm-asm-pwvj`, parent `evm-asm-pb40` (#61).
 -/
 
-import EvmAsm.Evm64.DivMod.Spec.Dispatcher
+import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Slice of #1045 (import hygiene sweep, beads parent `evm-asm-9tq`, child `evm-asm-ir1o`).

Replace `EvmAsm.Evm64.DivMod.Spec.Dispatcher` with the direct `EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified` import in `EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean`. `Spec/Dispatcher` just transitively re-exports `FullPathN3LoopUnified`; this file only uses the `fullDivN3R0`/`fullDivN3R1` family from the latter, so the indirect import is unnecessary.

**Verified true positive** (not a typical attribute-driven false positive — see `evm-asm-o6y` for the false-positive class): `lake build` green; `lake exe shake EvmAsm` no longer flags this file.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).