### PR TITLE
chore(shake): flag SailEquiv.StateRel LeanRV64D false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -183,4 +183,5 @@
  "EvmAsm.Evm64.Calldata.SizeSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Push.Spec":
-  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"]}}
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"]}}


### PR DESCRIPTION
Slice of #1045 import hygiene sweep.

`lake exe shake EvmAsm` flags `EvmAsm/Rv64/SailEquiv/StateRel.lean`:

```
remove #[LeanRV64D]
add #[LeanRV64D.Defs]
```

Verified false positive: the file uses `open LeanRV64D.Functions` (line 11). `LeanRV64D.Defs` alone does not expose that namespace — applying shake's suggestion breaks the build with:

```
error: EvmAsm/Rv64/SailEquiv/StateRel.lean:11:5: unknown namespace `LeanRV64D.Functions`
```

The umbrella `LeanRV64D` module is required. Add a `noshake.json` entry covering `EvmAsm.Rv64.SailEquiv.StateRel: [LeanRV64D]`. Local `lake build` green; `lake exe shake EvmAsm` no longer flags this file.

Refs #1045. Beads evm-asm-1uqs.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).