### PR TITLE
feat(termination): add structural-preservation simp lemmas

### DIFF
--- a/EvmAsm/Evm64/Termination.lean
+++ b/EvmAsm/Evm64/Termination.lean
@@ -71,7 +71,98 @@ theorem invalid_status_tag (state : EvmState) :
     (state.revertWith data).stack = state.stack := rfl
 
 @[simp] theorem invalid_stack (state : EvmState) :
-    state.invalid.stack = state.stack := rfl
+    (state.invalid).stack = state.stack := rfl
+
+/-! ### Structural preservation lemmas
+
+The terminating helpers only update the `status` field; gas, memory, code, and
+environment fields are preserved untouched. Frame-side reasoning for the
+upcoming RETURN/REVERT/STOP/INVALID handler specs and the interpreter-loop
+termination proofs needs each preservation fact as a `simp` lemma. -/
+
+@[simp] theorem stop_gas (state : EvmState) :
+    state.stop.gas = state.gas := rfl
+
+@[simp] theorem stop_memoryCells (state : EvmState) :
+    state.stop.memoryCells = state.memoryCells := rfl
+
+@[simp] theorem stop_memory (state : EvmState) :
+    state.stop.memory = state.memory := rfl
+
+@[simp] theorem stop_memSize (state : EvmState) :
+    state.stop.memSize = state.memSize := rfl
+
+@[simp] theorem stop_code (state : EvmState) :
+    state.stop.code = state.code := rfl
+
+@[simp] theorem stop_codeLen (state : EvmState) :
+    state.stop.codeLen = state.codeLen := rfl
+
+@[simp] theorem stop_env (state : EvmState) :
+    state.stop.env = state.env := rfl
+
+@[simp] theorem returnWith_gas (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).gas = state.gas := rfl
+
+@[simp] theorem returnWith_memoryCells (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).memoryCells = state.memoryCells := rfl
+
+@[simp] theorem returnWith_memory (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).memory = state.memory := rfl
+
+@[simp] theorem returnWith_memSize (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).memSize = state.memSize := rfl
+
+@[simp] theorem returnWith_code (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).code = state.code := rfl
+
+@[simp] theorem returnWith_codeLen (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).codeLen = state.codeLen := rfl
+
+@[simp] theorem returnWith_env (state : EvmState) (data : List (BitVec 8)) :
+    (state.returnWith data).env = state.env := rfl
+
+@[simp] theorem revertWith_gas (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).gas = state.gas := rfl
+
+@[simp] theorem revertWith_memoryCells (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).memoryCells = state.memoryCells := rfl
+
+@[simp] theorem revertWith_memory (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).memory = state.memory := rfl
+
+@[simp] theorem revertWith_memSize (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).memSize = state.memSize := rfl
+
+@[simp] theorem revertWith_code (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).code = state.code := rfl
+
+@[simp] theorem revertWith_codeLen (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).codeLen = state.codeLen := rfl
+
+@[simp] theorem revertWith_env (state : EvmState) (data : List (BitVec 8)) :
+    (state.revertWith data).env = state.env := rfl
+
+@[simp] theorem invalid_gas (state : EvmState) :
+    state.invalid.gas = state.gas := rfl
+
+@[simp] theorem invalid_memoryCells (state : EvmState) :
+    state.invalid.memoryCells = state.memoryCells := rfl
+
+@[simp] theorem invalid_memory (state : EvmState) :
+    state.invalid.memory = state.memory := rfl
+
+@[simp] theorem invalid_memSize (state : EvmState) :
+    state.invalid.memSize = state.memSize := rfl
+
+@[simp] theorem invalid_code (state : EvmState) :
+    state.invalid.code = state.code := rfl
+
+@[simp] theorem invalid_codeLen (state : EvmState) :
+    state.invalid.codeLen = state.codeLen := rfl
+
+@[simp] theorem invalid_env (state : EvmState) :
+    state.invalid.env = state.env := rfl
 
 end EvmState
 end EvmAsm.Evm64


### PR DESCRIPTION
## Summary

Extends `EvmAsm/Evm64/Termination.lean` with structural-preservation `@[simp]` lemmas for each of the four terminating-status helpers (`stop`, `returnWith`, `revertWith`, `invalid`). For every helper, we now have the seven preservation facts: `gas`, `memoryCells`, `memory`, `memSize`, `code`, `codeLen`, `env` (28 new lemmas total).

These give frame-side simp-fuel for the upcoming RETURN / REVERT / STOP / INVALID handler specs and for interpreter-loop termination reasoning: applying any terminating helper on the EvmState only changes `status`, so any goal mentioning the other fields can `simp` them through.

All 28 lemmas are `rfl` since the helpers are defined via `withStatus`, which is a single-field record update.

## Verification

- `lake build EvmAsm.Evm64.Termination` ✓
- `lake build` ✓
- `scripts/check-file-size.sh` ✓
- `scripts/check-unimported.sh` ✓
- `git diff --check` clean
- No new `sorry` / `set_option maxHeartbeats` / `set_option maxRecDepth`

## Refs

- GH #113 (RETURN, REVERT, STOP, INVALID, SELFDESTRUCT opcodes)
- beads `evm-asm-hx4d` (parent `evm-asm-lb52`)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
