### PR TITLE
feat(termination): add RETURN/REVERT stack argument record

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -75,6 +75,7 @@ import EvmAsm.Evm64.Env.StackSpec
 import EvmAsm.Evm64.Env.Wrappers
 import EvmAsm.Evm64.CallArgs
 import EvmAsm.Evm64.LogArgs
+import EvmAsm.Evm64.TerminatingArgs
 
 -- Static gas schedule (#117)
 import EvmAsm.Evm64.Gas

--- a/EvmAsm/Evm64/TerminatingArgs.lean
+++ b/EvmAsm/Evm64/TerminatingArgs.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.Evm64.TerminatingArgs
+
+  Pure stack-argument records for RETURN and REVERT (GH #113).
+
+  RETURN and REVERT both pop a memory offset and size from the stack and
+  return/revert the corresponding memory slice.  This module factors that
+  shared shape into a tiny pure record so future handler specs and the
+  interpreter dispatch layer can talk about it without committing to any
+  particular EvmState representation.
+-/
+
+import EvmAsm.Evm64.Basic
+
+namespace EvmAsm.Evm64
+
+namespace TerminatingArgs
+
+/-- Memory slice described by an EVM offset and byte size.  Mirrors
+    `LogArgs.MemoryRange` and `CallArgs.MemoryRange` so call sites can
+    share helpers in the future without coercing between record types. -/
+structure MemoryRange where
+  offset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+/-- Terminating opcode arity classifier — RETURN vs REVERT. -/
+inductive Kind where
+  | return_
+  | revert_
+  deriving DecidableEq, Repr
+
+/-- Stack arguments for RETURN/REVERT: just the data memory range. -/
+structure Args where
+  data : MemoryRange
+  deriving Repr
+
+/-- RETURN and REVERT both pop exactly two stack words (offset, size). -/
+def stackArgumentCount (_kind : Kind) : Nat := 2
+
+/-- The data memory range projected from a terminating-args record. -/
+def dataRange (args : Args) : MemoryRange :=
+  args.data
+
+theorem stackArgumentCount_return : stackArgumentCount .return_ = 2 := rfl
+theorem stackArgumentCount_revert : stackArgumentCount .revert_ = 2 := rfl
+
+theorem dataRange_offset (offset size : EvmWord) :
+    (dataRange { data := { offset := offset, size := size } }).offset = offset := rfl
+
+theorem dataRange_size (offset size : EvmWord) :
+    (dataRange { data := { offset := offset, size := size } }).size = size := rfl
+
+end TerminatingArgs
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds `EvmAsm/Evm64/TerminatingArgs.lean` with pure stack-argument records for RETURN and REVERT (GH #113):

- `TerminatingArgs.MemoryRange` (offset, size : EvmWord) mirroring the `LogArgs`/`CallArgs` pattern.
- `TerminatingArgs.Kind` arity classifier (`return_`, `revert_`).
- `TerminatingArgs.Args` carrying the data memory range.
- `stackArgumentCount _ = 2` plus `dataRange` projection rfl-lemmas.

Wires the new module into `EvmAsm/Evm64.lean` next to `CallArgs` / `LogArgs`.

This gives later RETURN/REVERT handler specs and the interpreter dispatch layer a shared, EvmState-independent target for the (offset, size) memory-slice arguments — same role `CallArgs` plays for the CALL family.

Local verification:
- `lake build EvmAsm.Evm64.TerminatingArgs`
- `lake build` (full)
- `scripts/check-file-size.sh`
- `scripts/check-unimported.sh`
- forbidden-proof-escape grep on the new file (no `sorry`/`admit`/`maxHeartbeats`/`maxRecDepth`).

Beads: evm-asm-lcrg (parent evm-asm-lb52, GH #113).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).