### PR TITLE
chore(shake): mark Env.Wrappers StackSpec import as noshake false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -180,6 +180,8 @@
  "EvmAsm.Evm64.EvmWordArith.Comparison": ["EvmAsm.Evm64.EvmWordArith.Common"],
  "EvmAsm.Evm64.Env.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.Env.Wrappers":
+  ["EvmAsm.Evm64.Env.StackSpec"],
  "EvmAsm.Evm64.MStore8.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.MLoad.Expansion":


### PR DESCRIPTION
EvmAsm/Evm64/Env/Wrappers.lean uses `evm_env_load_stack_spec_within` (defined in `EvmAsm.Evm64.Env.StackSpec`, see line 102 etc.) — shake's suggestion to drop `StackSpec` in favour of `Env.Program` is a false positive because `Program` does not provide that theorem. Add the entry to `scripts/noshake.json` so `lake exe shake EvmAsm` no longer flags this file.

Verified locally:
- json valid
- lake build clean (1561 jobs)
- shake no longer flags Env/Wrappers

Refs GH #1045 (beads evm-asm-7ogi).
Authored by @pirapira; implemented by Hermes-bot (evm-hermes).