### PR TITLE
chore(divmod): delete 2 dead _def rfl wrappers in SpecPredicates

### DIFF
--- a/EvmAsm/Evm64/DivMod/SpecPredicates.lean
+++ b/EvmAsm/Evm64/DivMod/SpecPredicates.lean
@@ -101,21 +101,11 @@ def isAddbackBorrowN4CallEvm_v2 (a b : EvmWord) : Prop :=
   isAddbackBorrowN4Call_v2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                            (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
-theorem isAddbackBorrowN4CallEvm_v2_def {a b : EvmWord} :
-    isAddbackBorrowN4CallEvm_v2 a b =
-    isAddbackBorrowN4Call_v2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-                             (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
-
 /-- v2 mirror of `isAddbackCarry2NzN4CallEvm` — uses `div128Quot_v2` via
     `isAddbackCarry2NzN4CallAb_v2`. Issue #1337 algorithm fix migration. -/
 def isAddbackCarry2NzN4CallEvm_v2 (a b : EvmWord) : Prop :=
   isAddbackCarry2NzN4CallAb_v2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                                (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-
-theorem isAddbackCarry2NzN4CallEvm_v2_def {a b : EvmWord} :
-    isAddbackCarry2NzN4CallEvm_v2 a b =
-    isAddbackCarry2NzN4CallAb_v2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-                                 (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
 /-- Addback-needed condition at n=4 max path in EvmWord form: the runtime
     borrow check fires (mulsub underflowed), so the algorithm decrements


### PR DESCRIPTION
Deletes the trivial `:= rfl` wrappers `isAddbackBorrowN4CallEvm_v2_def` and `isAddbackCarry2NzN4CallEvm_v2_def` in `EvmAsm/Evm64/DivMod/SpecPredicates.lean`. Both lemmas have zero call sites in the codebase (`rg -nw <name> --type lean` shows only their own definitions). Their non-v2 siblings (`isAddbackBorrowN4CallEvm_def`, `isAddbackCarry2NzN4CallEvm_def`) are intentionally kept — they have consumers.

The `def`s themselves (`isAddbackBorrowN4CallEvm_v2`, `isAddbackCarry2NzN4CallEvm_v2`) remain — used by `Spec/CallAddback.lean` and `Spec/CallAddbackPhase1Stubs.lean`.

`lake build` green locally.

Refs evm-asm-sboz (DivMod cleanup parent), evm-asm-16ym (this slice).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).