### PR TITLE
chore: drop unused Base import from FullPathN2Bundle/Scratch.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean
@@ -4,7 +4,7 @@
   One-step irreducible scratch-state transitions for n=2 full-path wrappers.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
+import EvmAsm.Evm64.DivMod.LoopDefs.Iter
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -4,6 +4,7 @@
   Bundled n=2 denorm precondition and preserved frame definitions.
 -/
 
+import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Base
 import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Scratch
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
Slice of evm-asm-6qj (#1045 / shake import-hygiene sweep).

Filtered shake output flagged `EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Scratch.lean` as importing `Base` without using any of its symbols. Audit confirms: Scratch only references `N2ScratchState` (a Word tuple alias defined locally) and the `fullDivN2Scratch[012]` symbols it itself defines. None of `Base.lean`'s `fullDivN2Shift/AntiShift/NormU/NormV/R[12]` are named in Scratch — they are only used in `State.lean`, which currently inherits `Base` transitively via `Scratch`.

Per shake's "instead" suggestion: move the `Base` import down to `State.lean` (its actual consumer), and replace Scratch's transitive `Word` reach with a direct import of `LoopDefs.Iter`.

Verification:
- `lake build` succeeds (1561 jobs).
- `lake exe shake EvmAsm` no longer reports the `FullPathN2Bundle/Scratch` import block.

Refs evm-asm-0iwn / evm-asm-6qj / GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
