### PR TITLE
feat(addmod,mulmod): Evm64/AddMod and Evm64/MulMod directory skeletons (#91)

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -60,6 +60,10 @@ import EvmAsm.Evm64.DivMod
 import EvmAsm.Evm64.SDiv
 import EvmAsm.Evm64.SMod
 
+-- ADDMOD / MULMOD skeletons (GH #91)
+import EvmAsm.Evm64.AddMod
+import EvmAsm.Evm64.MulMod
+
 -- Calling convention (LP64)
 import EvmAsm.Evm64.CallingConvention
 

--- a/EvmAsm/Evm64/AddMod.lean
+++ b/EvmAsm/Evm64/AddMod.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.AddMod
+
+  Umbrella for the ADDMOD opcode subtree (GH #91). Re-exports the
+  top-level spec; downstream consumers should `import EvmAsm.Evm64.AddMod`
+  and not reach into sub-modules directly.
+
+  AddrNormAttr is imported first (per `AGENTS.md` `register_simp_attr`
+  ordering rule) so the `addmod_addr` attribute exists when later modules
+  attach lemmas to it.
+-/
+
+import EvmAsm.Evm64.AddMod.AddrNormAttr
+import EvmAsm.Evm64.AddMod.Program
+import EvmAsm.Evm64.AddMod.LimbSpec
+import EvmAsm.Evm64.AddMod.AddrNorm
+import EvmAsm.Evm64.AddMod.Compose.Base
+import EvmAsm.Evm64.AddMod.Spec

--- a/EvmAsm/Evm64/AddMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/AddMod/AddrNorm.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.AddMod.AddrNorm
+
+  Address-normalization simp set for ADDMOD composition proofs.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). The
+  `@[addmod_addr, grind =]`-tagged atomic facts will be added once the
+  Compose layer (`AddMod/Compose/...`) starts emitting concrete address
+  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
+  base and the attribute declaration so downstream files can already
+  open the namespace.
+-/
+
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Evm64.AddMod.AddrNormAttr
+
+namespace EvmAsm.Evm64.AddMod.AddrNorm
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.AddMod.AddrNorm

--- a/EvmAsm/Evm64/AddMod/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/AddMod/AddrNormAttr.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.AddMod.AddrNormAttr
+
+  Declares the `addmod_addr` simp attribute used by `AddMod/AddrNorm.lean`.
+
+  Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code
+  should import `AddMod/AddrNorm.lean` (which imports this file) — not this
+  file directly.
+
+  Skeleton placeholder for GH #91 (ADDMOD/MULMOD opcodes, beads slice
+  evm-asm-w1s0). No tagged lemmas yet; opcode-specific atomic
+  `signExtend12` / `<<<` / `BitVec.toNat` evaluations will be attached as
+  `@[addmod_addr, grind =]` once the ADDMOD Compose layer starts emitting
+  concrete address arithmetic.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for ADDMOD address arithmetic. Will collect atomic evaluations of
+    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+    in ADDMOD composition proofs. -/
+register_simp_attr addmod_addr

--- a/EvmAsm/Evm64/AddMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/AddMod/Compose/Base.lean
@@ -1,0 +1,25 @@
+/-
+  EvmAsm.Evm64.AddMod.Compose.Base
+
+  Shared composition infrastructure for ADDMOD: `addmodCode` (the union
+  of all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
+  back to `addmodCode`, and shared length lemmas.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). Concrete
+  definitions will be added once `evm_addmod` is laid out (slice
+  evm-asm-sord) and the per-block specs from `LimbSpec.lean` start
+  composing.
+-/
+
+import EvmAsm.Evm64.AddMod.LimbSpec
+import EvmAsm.Evm64.AddMod.AddrNorm
+
+namespace EvmAsm.Evm64.AddMod.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+-- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
+-- land alongside the Compose/<Phase>.lean files in later slices.
+
+end EvmAsm.Evm64.AddMod.Compose

--- a/EvmAsm/Evm64/AddMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/AddMod/LimbSpec.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.AddMod.LimbSpec
+
+  Per-block / per-limb cpsTriple specs for ADDMOD sub-blocks (operand
+  widening, callable-divide JAL, result narrowing).
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). Per
+  `OPCODE_TEMPLATE.md`, each sub-block will get exactly one cpsTriple
+  lemma once the Compose layer pins the layout.
+-/
+
+import EvmAsm.Evm64.AddMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Per-block specs land in slice evm-asm-sord and below.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/AddMod/Program.lean
+++ b/EvmAsm/Evm64/AddMod/Program.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.AddMod.Program
+
+  ADDMOD opcode (`ADDMOD(a, b, N)` = (a + b) mod N under EVM
+  rules, with `N = 0` returning `0`) as a 64-bit RISC-V program.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0).
+
+  The actual `evm_addmod : Program` will be defined in slice
+  evm-asm-sord. Per `docs/91-addmod-mulmod-survey.md` the algorithm reuses
+  the existing `evm_div_callable` / `evm_mod_callable` shims after a
+  pre-divide widening pass.
+
+  This file currently has no `evm_addmod` definition; later slices will
+  add it without breaking the umbrella import graph.
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_addmod : Program` lands in slice 3 (evm-asm-sord).
+-- See `docs/91-addmod-mulmod-survey.md` for the algorithm and reuse points.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/AddMod/Spec.lean
+++ b/EvmAsm/Evm64/AddMod/Spec.lean
@@ -1,0 +1,26 @@
+/-
+  EvmAsm.Evm64.AddMod.Spec
+
+  Top-level (semantic / stack-level) cpsTriple spec for `evm_addmod`,
+  bridging the limb-level composition to a single `evmWordIs` pre/post
+  pair.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). The
+  actual `evm_addmod_stack_spec_within` theorem lands in slice
+  evm-asm-sord and is composed from the verified shared bridge with
+  the boundary blocks. The addmod-correctness lemma
+  `EvmWord.addmod_correct` is added in an earlier slice (see
+  parent task evm-asm-z7qm).
+-/
+
+import EvmAsm.Evm64.AddMod.Compose.Base
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.AddMod.Compose
+
+-- Placeholder: `evm_addmod_stack_spec_within` lands in slice evm-asm-sord.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod.lean
+++ b/EvmAsm/Evm64/MulMod.lean
@@ -1,0 +1,18 @@
+/-
+  EvmAsm.Evm64.MulMod
+
+  Umbrella for the MULMOD opcode subtree (GH #91). Re-exports the
+  top-level spec; downstream consumers should `import EvmAsm.Evm64.MulMod`
+  and not reach into sub-modules directly.
+
+  AddrNormAttr is imported first (per `AGENTS.md` `register_simp_attr`
+  ordering rule) so the `mulmod_addr` attribute exists when later modules
+  attach lemmas to it.
+-/
+
+import EvmAsm.Evm64.MulMod.AddrNormAttr
+import EvmAsm.Evm64.MulMod.Program
+import EvmAsm.Evm64.MulMod.LimbSpec
+import EvmAsm.Evm64.MulMod.AddrNorm
+import EvmAsm.Evm64.MulMod.Compose.Base
+import EvmAsm.Evm64.MulMod.Spec

--- a/EvmAsm/Evm64/MulMod/AddrNorm.lean
+++ b/EvmAsm/Evm64/MulMod/AddrNorm.lean
@@ -1,0 +1,21 @@
+/-
+  EvmAsm.Evm64.MulMod.AddrNorm
+
+  Address-normalization simp set for MULMOD composition proofs.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). The
+  `@[mulmod_addr, grind =]`-tagged atomic facts will be added once the
+  Compose layer (`MulMod/Compose/...`) starts emitting concrete address
+  arithmetic. For now this file just imports the shared `Rv64.AddrNorm`
+  base and the attribute declaration so downstream files can already
+  open the namespace.
+-/
+
+import EvmAsm.Rv64.AddrNorm
+import EvmAsm.Evm64.MulMod.AddrNormAttr
+
+namespace EvmAsm.Evm64.MulMod.AddrNorm
+
+open EvmAsm.Rv64
+
+end EvmAsm.Evm64.MulMod.AddrNorm

--- a/EvmAsm/Evm64/MulMod/AddrNormAttr.lean
+++ b/EvmAsm/Evm64/MulMod/AddrNormAttr.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.MulMod.AddrNormAttr
+
+  Declares the `mulmod_addr` simp attribute used by `MulMod/AddrNorm.lean`.
+
+  Split out from `AddrNorm.lean` because Lean 4 does not allow an attribute
+  to be used in the same file in which it is declared. Downstream code
+  should import `MulMod/AddrNorm.lean` (which imports this file) — not this
+  file directly.
+
+  Skeleton placeholder for GH #91 (MULMOD/MULMOD opcodes, beads slice
+  evm-asm-w1s0). No tagged lemmas yet; opcode-specific atomic
+  `signExtend12` / `<<<` / `BitVec.toNat` evaluations will be attached as
+  `@[mulmod_addr, grind =]` once the MULMOD Compose layer starts emitting
+  concrete address arithmetic.
+-/
+
+import Lean.Meta.Tactic.Simp.RegisterCommand
+
+/-- Simp set for MULMOD address arithmetic. Will collect atomic evaluations of
+    `signExtend12`, `<<<`, and `BitVec.toNat` on concrete literals that arise
+    in MULMOD composition proofs. -/
+register_simp_attr mulmod_addr

--- a/EvmAsm/Evm64/MulMod/Compose/Base.lean
+++ b/EvmAsm/Evm64/MulMod/Compose/Base.lean
@@ -1,0 +1,25 @@
+/-
+  EvmAsm.Evm64.MulMod.Compose.Base
+
+  Shared composition infrastructure for MULMOD: `mulmodCode` (the union
+  of all sub-block `CodeReq`s), subsumption helpers tying sub-block codes
+  back to `mulmodCode`, and shared length lemmas.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). Concrete
+  definitions will be added once `evm_mulmod` is laid out (slice
+  evm-asm-m4wu) and the per-block specs from `LimbSpec.lean` start
+  composing.
+-/
+
+import EvmAsm.Evm64.MulMod.LimbSpec
+import EvmAsm.Evm64.MulMod.AddrNorm
+
+namespace EvmAsm.Evm64.MulMod.Compose
+
+open EvmAsm.Rv64.Tactics
+open EvmAsm.Rv64
+
+-- Composition helpers (skipBlock subsumptions, length lemmas, etc.)
+-- land alongside the Compose/<Phase>.lean files in later slices.
+
+end EvmAsm.Evm64.MulMod.Compose

--- a/EvmAsm/Evm64/MulMod/LimbSpec.lean
+++ b/EvmAsm/Evm64/MulMod/LimbSpec.lean
@@ -1,0 +1,23 @@
+/-
+  EvmAsm.Evm64.MulMod.LimbSpec
+
+  Per-block / per-limb cpsTriple specs for MULMOD sub-blocks (operand
+  widening, callable-divide JAL, result narrowing).
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). Per
+  `OPCODE_TEMPLATE.md`, each sub-block will get exactly one cpsTriple
+  lemma once the Compose layer pins the layout.
+-/
+
+import EvmAsm.Evm64.MulMod.Program
+import EvmAsm.Rv64.SyscallSpecs
+import EvmAsm.Rv64.Tactics.XSimp
+import EvmAsm.Rv64.Tactics.RunBlock
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Per-block specs land in slice evm-asm-m4wu and below.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/Program.lean
+++ b/EvmAsm/Evm64/MulMod/Program.lean
@@ -1,0 +1,27 @@
+/-
+  EvmAsm.Evm64.MulMod.Program
+
+  MULMOD opcode (`MULMOD(a, b, N)` = (a * b) mod N under EVM
+  rules, with `N = 0` returning `0`) as a 64-bit RISC-V program.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0).
+
+  The actual `evm_mulmod : Program` will be defined in slice
+  evm-asm-m4wu. Per `docs/91-addmod-mulmod-survey.md` the algorithm reuses
+  the existing `evm_div_callable` / `evm_mod_callable` shims after a
+  pre-divide widening pass.
+
+  This file currently has no `evm_mulmod` definition; later slices will
+  add it without breaking the umbrella import graph.
+-/
+
+import EvmAsm.Evm64.Stack
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+-- Placeholder: `evm_mulmod : Program` lands in slice 3 (evm-asm-m4wu).
+-- See `docs/91-addmod-mulmod-survey.md` for the algorithm and reuse points.
+
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/MulMod/Spec.lean
+++ b/EvmAsm/Evm64/MulMod/Spec.lean
@@ -1,0 +1,26 @@
+/-
+  EvmAsm.Evm64.MulMod.Spec
+
+  Top-level (semantic / stack-level) cpsTriple spec for `evm_mulmod`,
+  bridging the limb-level composition to a single `evmWordIs` pre/post
+  pair.
+
+  Skeleton placeholder for GH #91 (beads slice evm-asm-w1s0). The
+  actual `evm_mulmod_stack_spec_within` theorem lands in slice
+  evm-asm-m4wu and is composed from the verified shared bridge with
+  the boundary blocks. The mulmod-correctness lemma
+  `EvmWord.mulmod_correct` is added in an earlier slice (see
+  parent task evm-asm-z7qm).
+-/
+
+import EvmAsm.Evm64.MulMod.Compose.Base
+import EvmAsm.Rv64.Tactics.XSimp
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+open EvmAsm.Evm64.MulMod.Compose
+
+-- Placeholder: `evm_mulmod_stack_spec_within` lands in slice evm-asm-m4wu.
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Skeleton placeholder files for GH #91 (ADDMOD/MULMOD opcodes), per OPCODE_TEMPLATE.md conventions:

- `AddrNormAttr.lean` — declares opcode-specific `register_simp_attr` (`addmod_addr` / `mulmod_addr`)
- `AddrNorm.lean` — namespace + base imports for the address-norm simp set
- `Program.lean` — placeholder for `evm_addmod` / `evm_mulmod : Program` (lands in slices evm-asm-sord and evm-asm-m4wu)
- `LimbSpec.lean` — placeholder for per-block cpsTriple specs
- `Compose/Base.lean` — placeholder for `addmodCode` / `mulmodCode` and subsumption helpers
- `Spec.lean` — placeholder for `evm_addmod_stack_spec_within` / `evm_mulmod_stack_spec_within`

No theorems, no `Program` definitions yet — only namespace scaffolding so later slices can wire in concrete content without import-graph churn. Mirrors the SDiv/SMod skeleton landed earlier under #90.

Wires both umbrellas into `EvmAsm/Evm64.lean` so `scripts/check-unimported.sh` sees them.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).

Refs GH #91, beads evm-asm-w1s0.