### PR TITLE
chore(divmod): delete 4 dead evmWordIs (div|mod) zero-right lemmas in Spec/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -62,36 +62,6 @@ namespace EvmAsm.Evm64
 open EvmAsm.Rv64
 open EvmAsm.Rv64.AddrNorm (word_add_zero word_toNat_0)
 
-/-- `evmWordIs addr (EvmWord.div a 0) = evmWordIs addr 0`. Specialized
-    rewrite for the zero-divisor path, bundling `evmWordIs_congr` +
-    `EvmWord.div_zero_right` into a single named lemma. Saves the inline
-    `rw [evmWordIs_congr addr (EvmWord.div_zero_right a)]` idiom at each
-    bzero spec's postcondition site. -/
-theorem evmWordIs_div_zero_right {addr : Word} {a : EvmWord} :
-    evmWordIs addr (EvmWord.div a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr EvmWord.div_zero_right
-
-/-- MOD counterpart of `evmWordIs_div_zero_right`. -/
-theorem evmWordIs_mod_zero_right {addr : Word} {a : EvmWord} :
-    evmWordIs addr (EvmWord.mod a 0) = evmWordIs addr (0 : EvmWord) :=
-  evmWordIs_congr EvmWord.mod_zero_right
-
-/-- Full unfold of `evmWordIs addr (EvmWord.div a 0)` straight to four zero
-    memIs atoms, bundling `evmWordIs_div_zero_right` + `evmWordIs_zero`
-    into a single rewrite. -/
-theorem evmWordIs_div_zero_right_atoms {addr : Word} {a : EvmWord} :
-    evmWordIs addr (EvmWord.div a 0) =
-    ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
-     ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
-  rw [evmWordIs_div_zero_right, evmWordIs_zero]
-
-/-- MOD counterpart of `evmWordIs_div_zero_right_atoms`. -/
-theorem evmWordIs_mod_zero_right_atoms {addr : Word} {a : EvmWord} :
-    evmWordIs addr (EvmWord.mod a 0) =
-    ((addr ↦ₘ (0 : Word)) ** ((addr + 8) ↦ₘ (0 : Word)) **
-     ((addr + 16) ↦ₘ (0 : Word)) ** ((addr + 24) ↦ₘ (0 : Word))) := by
-  rw [evmWordIs_mod_zero_right, evmWordIs_zero]
-
 -- ============================================================================
 -- Stack-level post state for n=4 max-skip DIV
 -- ============================================================================


### PR DESCRIPTION
Bzero-path rewrite shortcut helpers in `EvmAsm/Evm64/DivMod/Spec/Base.lean` are mutually self-referential dead code:

- `evmWordIs_div_zero_right`
- `evmWordIs_mod_zero_right`
- `evmWordIs_div_zero_right_atoms`
- `evmWordIs_mod_zero_right_atoms`

The bare `_zero_right` lemmas are referenced only by the corresponding `_atoms` variant via `rw`; neither `_atoms` variant is referenced anywhere in `EvmAsm/`, `scripts/` or `docs/`. Originally intended as bzero-path postcondition shortcuts but never adopted at any call site.

Net change: 30 lines removed; `lake build` green; 0 new `sorry`; no `maxHeartbeats`/`maxRecDepth` bumps.

Refs: `evm-asm-sboz`, `evm-asm-yhow`, GH #61.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).