### PR TITLE
chore(noshake): mark Stack.lean SpAddr import as used (false positive)

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -50,6 +50,8 @@
   ["EvmAsm.Rv64.Basic", "Std.Tactic.BVDecide"],
  "EvmAsm.Evm64.SpAddr":
   ["EvmAsm.Rv64.Tactics.SeqFrame"],
+  "EvmAsm.Evm64.Stack":
+  ["EvmAsm.Evm64.SpAddr"],
   "EvmAsm.Evm64.MSize.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Pop.Spec":


### PR DESCRIPTION
EvmAsm/Evm64/Stack.lean uses `spAddr32_8`/`spAddr32_16`/`spAddr32_24` (line 242) and `spAddr64_8`/`spAddr64_16`/`spAddr64_24` (line 262) theorems from `EvmAsm.Evm64.SpAddr` via `rw [...]`. shake's static analysis does not follow these tactic-mode lemma references, so it flags `EvmAsm.Evm64.SpAddr` as an unused import.

This PR adds a `noshake.json` entry to suppress the false positive (same class as the `HalfwordOps` / `WordOps` / `SpAddr` itself entries already in the file).

- `lake build`: green
- `lake exe shake EvmAsm`: no longer flags `EvmAsm/Evm64/Stack.lean`

Refs evm-asm-o453, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).