### PR TITLE
chore(noshake): flag AddMod/MulMod AddrNormAttr RegisterCommand imports

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -36,6 +36,8 @@
   "EvmAsm.Evm64.SDiv.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.SMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Evm64.Exp.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.AddMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
+  "EvmAsm.Evm64.MulMod.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],
  "EvmAsm.Evm64.Basic":


### PR DESCRIPTION
Adds two `scripts/noshake.json` entries for shake false positives:

- `EvmAsm.Evm64.AddMod.AddrNormAttr`
- `EvmAsm.Evm64.MulMod.AddrNormAttr`

Both files use `register_simp_attr` (provided by `Lean.Meta.Tactic.Simp.RegisterCommand`, not by `.Attr` alone). Mirrors the existing entries for `DivMod`/`SDiv`/`SMod`/`Exp` AddrNormAttr files (lines 35–38).

Verified locally:
- `lake build` green.
- `lake exe shake EvmAsm` no longer flags either file.

Refs #1045. Beads evm-asm-vwdr.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).