### PR TITLE
chore(noshake): flag Mathlib.Tactic.* false-positives in EvmWordArith + CallAddbackPureNat

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -190,4 +190,13 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Push.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
- "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"]}}
+ "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"],
+"EvmAsm.Evm64.EvmWordArith.Common": ["Mathlib.Tactic.Linarith"],
+"EvmAsm.Evm64.EvmWordArith.ByteOps":
+ ["Mathlib.Tactic.Linarith", "Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
+"EvmAsm.Evm64.EvmWordArith.MultiLimb":
+ ["Mathlib.Tactic.Linarith", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
+"EvmAsm.Evm64.EvmWordArith.Arithmetic":
+ ["Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
+"EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
+ ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"]}}


### PR DESCRIPTION
shake suggested removing Mathlib.Tactic.{Linarith,Ring,NormNum,Positivity} imports from 5 files where the tactics are actually used in proof bodies. Verified false positives:

- `EvmAsm/Evm64/EvmWordArith/Common.lean` — uses `nlinarith` (lines 69, 81)
- `EvmAsm/Evm64/EvmWordArith/ByteOps.lean` — uses `positivity`, `ring`, `norm_num` (lines 38, 45, 46, 52)
- `EvmAsm/Evm64/EvmWordArith/MultiLimb.lean` — uses `positivity`, `ring`, `linarith`, `nlinarith` (lines 44, 45, 90, 103)
- `EvmAsm/Evm64/EvmWordArith/Arithmetic.lean` — uses `norm_num`, `positivity` (lines 115, 117, 119, 125, 126)
- `EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean` — uses `ring`, `linarith` (lines 54, 85, 144, 225, 247, 370)

Added entries to `scripts/noshake.json` so shake stops flagging these. `lake build` green; `lake exe shake EvmAsm` no longer reports these files for the listed Mathlib.Tactic.* imports.

Refs GH #1045, beads evm-asm-rbal.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).