### PR TITLE
chore(divmod): delete 4 dead dispatcher sub_code lemmas

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
@@ -30,24 +30,6 @@ abbrev divDispatcherCode (base : Word) : CodeReq :=
 abbrev modDispatcherCode (base : Word) : CodeReq :=
   modCode base
 
-theorem divDispatcherCode_sub_divCode {base : Word} :
-    ∀ a i, (divDispatcherCode base) a = some i → (divCode base) a = some i := by
-  intro a i h
-  exact h
-
-theorem modDispatcherCode_sub_modCode {base : Word} :
-    ∀ a i, (modDispatcherCode base) a = some i → (modCode base) a = some i := by
-  intro a i h
-  exact h
-
-theorem sharedDivModCode_sub_divDispatcherCode {base : Word} :
-    ∀ a i, (sharedDivModCode base) a = some i → (divDispatcherCode base) a = some i :=
-  sharedDivModCode_sub_divCode
-
-theorem sharedDivModCode_sub_modDispatcherCode {base : Word} :
-    ∀ a i, (sharedDivModCode base) a = some i → (modDispatcherCode base) a = some i :=
-  sharedDivModCode_sub_modCode
-
 abbrev evm_div_spec_within_bzero := evm_div_bzero_spec_within
 abbrev evm_div_spec_within_n1Full := evm_div_n1_full_unified_spec
 abbrev evm_div_spec_within_n2Full := evm_div_n2_full_bundled_spec


### PR DESCRIPTION
Slice of evm-asm-sboz (#61 DivMod cleanup).

Deletes four lemmas in `EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean` that had zero references outside their declaration sites:

- `divDispatcherCode_sub_divCode`
- `modDispatcherCode_sub_modCode`
- `sharedDivModCode_sub_divDispatcherCode`
- `sharedDivModCode_sub_modDispatcherCode`

These were scaffolding for a dispatcher composition layer that never materialized; the dispatcher registries (`evm_div_spec_within` / `evm_mod_spec_within`) cite per-branch specs directly. The companion `divDispatcherCode` / `modDispatcherCode` abbreviations are kept as a stable surface alias for future dispatcher proofs.

Verification: ripgrep across `EvmAsm/+scripts/+docs/` shows no consumers; `lake build` green.

Refs evm-asm-p5n6, evm-asm-sboz, GH #61.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).