### PR TITLE
chore(noshake): mark Add/Sub/Eq/IsZero LimbSpec SyscallSpecs/RunBlock false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -64,7 +64,15 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Swap.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
-  "EvmAsm.Evm64.And.LimbSpec":
+  "EvmAsm.Evm64.Add.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Sub.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.Eq.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.IsZero.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
+ "EvmAsm.Evm64.And.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Or.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],


### PR DESCRIPTION
## What

Mark `EvmAsm/Evm64/{Add,Sub,Eq,IsZero}/LimbSpec.lean` as `noshake` for the imports `EvmAsm.Rv64.SyscallSpecs` and `EvmAsm.Rv64.Tactics.RunBlock`.

## Why

`lake exe shake EvmAsm` flags these files for "unused" SyscallSpecs / RunBlock imports. False positive: each file uses `runBlock` and `*_spec_gen_within` attribute lemmas (`ld_spec_gen_within`, `sd_spec_gen_within`, `add_spec_gen_*_within`, `sub_spec_gen_*_within`, etc.) sourced from the SyscallSpecs/InstructionSpecs attribute database, but `shake` doesn't track attribute-driven simp lemmas. Same false-positive class as the existing entries for And/Or/Xor/Not LimbSpec (PR #2346), Pop.Spec, MSize.Spec, RLP.Phase1.

## Verification

- `lake build` clean (1575 jobs).
- `lake exe shake EvmAsm` no longer flags SyscallSpecs / RunBlock for those 4 files.

## Refs

- GH #1045 (Import hygiene sweep via `lake exe shake`)
- Beads: evm-asm-6tcm (parent: evm-asm-6qj)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).