### PR TITLE
chore(shake): flag SailEquiv ALUProofs imports as false positives in noshake.json

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -195,6 +195,11 @@
  "EvmAsm.Evm64.Push.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"],
+  "EvmAsm.Rv64.SailEquiv.ShiftProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
+  "EvmAsm.Rv64.SailEquiv.ImmProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
+  "EvmAsm.Rv64.SailEquiv.BranchProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
+  "EvmAsm.Rv64.SailEquiv.MemProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
+  "EvmAsm.Rv64.SailEquiv.MExtProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
 "EvmAsm.Evm64.EvmWordArith.Common": ["Mathlib.Tactic.Linarith"],
 "EvmAsm.Evm64.EvmWordArith.ByteOps":
  ["Mathlib.Tactic.Linarith", "Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],


### PR DESCRIPTION
`lake exe shake EvmAsm` flags 5 files under `EvmAsm/Rv64/SailEquiv/` as importing `EvmAsm.Rv64.SailEquiv.ALUProofs` without using anything from it:

- `ShiftProofs.lean`
- `ImmProofs.lean`
- `BranchProofs.lean`
- `MemProofs.lean`
- `MExtProofs.lean`

In reality, each file uses `reg_agree_after_insert` (a theorem defined in `ALUProofs.lean`); `ImmProofs` additionally uses `reg_ne_*` lemmas. shake does not see these direct-by-name theorem references and proposes a redirect that drops `ALUProofs` and adds `Execution` / `MonadLemmas` / `StateRel` instead — verified locally: dropping `ALUProofs` breaks the build with `Unknown identifier reg_agree_after_insert`.

Mark all 5 files in `scripts/noshake.json` so future shake runs no longer flag this transitive-via-theorem case.

Refs #1045 (evm-asm-6qj / evm-asm-qg0o).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).