### PR TITLE
chore(divmod): delete 3 dead _eq_*_of_toNat_eq wrappers in Spec/Dispatcher.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean
@@ -399,16 +399,6 @@ theorem fullDivN1_hdivs_of_word_eq
     delta fullDivN1QuotientWord
     exact EvmWord.getLimbN_fromLimbs_3
 
-theorem fullDivN1QuotientWord_eq_div_of_toNat_eq
-    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hdiv_toNat :
-      (fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.div a b).toNat) :
-    fullDivN1QuotientWord bltu_3 bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.div a b :=
-  BitVec.eq_of_toNat_eq hdiv_toNat
-
 theorem fullDivN1QuotientWord_toNat
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
@@ -605,16 +595,6 @@ theorem fullModN1_hmods_of_word_eq
   · rw [← hmod]
     delta fullModN1RemainderWord
     exact EvmWord.getLimbN_fromLimbs_3
-
-theorem fullModN1RemainderWord_eq_mod_of_toNat_eq
-    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hmod_toNat :
-      (fullModN1RemainderWord bltu_3 bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.mod a b).toNat) :
-    fullModN1RemainderWord bltu_3 bltu_2 bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b :=
-  BitVec.eq_of_toNat_eq hmod_toNat
 
 theorem fullModN1RemainderWord_toNat
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
@@ -1030,16 +1010,6 @@ theorem fullModN3_hmods_of_word_eq
   · rw [← hmod]
     delta fullModN3RemainderWord
     exact EvmWord.getLimbN_fromLimbs_3
-
-theorem fullModN3RemainderWord_eq_mod_of_toNat_eq
-    (bltu_1 bltu_0 : Bool)
-    (a b : EvmWord) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (hmod_toNat :
-      (fullModN3RemainderWord bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3).toNat = (EvmWord.mod a b).toNat) :
-    fullModN3RemainderWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3 = EvmWord.mod a b :=
-  BitVec.eq_of_toNat_eq hmod_toNat
 
 theorem fullModN3RemainderWord_toNat
     (bltu_1 bltu_0 : Bool)


### PR DESCRIPTION
Drops three dead BitVec.eq_of_toNat_eq wrappers in EvmAsm/Evm64/DivMod/Spec/Dispatcher.lean:

- fullDivN1QuotientWord_eq_div_of_toNat_eq
- fullModN1RemainderWord_eq_mod_of_toNat_eq
- fullModN3RemainderWord_eq_mod_of_toNat_eq

A repo-wide grep finds zero references outside their own definition site. They are leftovers from earlier closure attempts that were superseded by the *Word forms.

lake build green; no sorries introduced.

Refs evm-asm-3vbh (parent evm-asm-sboz / DivMod cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).