### PR TITLE
chore(shake): drop unused Exp.AddrNorm import in Exp/Compose/Base

### DIFF
--- a/EvmAsm/Evm64/Exp/Compose/Base.lean
+++ b/EvmAsm/Evm64/Exp/Compose/Base.lean
@@ -11,7 +11,6 @@
 
 import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Exp.LimbSpec
-import EvmAsm.Evm64.Exp.AddrNorm
 
 namespace EvmAsm.Evm64.Exp.Compose
 


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags `EvmAsm/Evm64/Exp/Compose/Base.lean` as importing `EvmAsm.Evm64.Exp.AddrNorm` unused. That module is currently a skeleton placeholder (21 lines, no declarations, no `@[exp_addr]`-tagged atoms yet — see GH #92 / beads evm-asm-cf2c), so the import has no elaboration effect. Drop the line; `lake build` still completes (1575 jobs).

## Plan

- [x] Drop the import in `EvmAsm/Evm64/Exp/Compose/Base.lean`
- [x] `lake build` passes locally

## Refs

- Issue: #1045 (import hygiene sweep)
- Beads: evm-asm-cz8r (parent evm-asm-6qj)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).