### PR TITLE
chore(divmod): delete 18 dead spec_within abbrev shims in Compose/Dispatcher

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
@@ -30,29 +30,6 @@ abbrev divDispatcherCode (base : Word) : CodeReq :=
 abbrev modDispatcherCode (base : Word) : CodeReq :=
   modCode base
 
-abbrev evm_div_spec_within_bzero := evm_div_bzero_spec_within
-abbrev evm_div_spec_within_n1Full := evm_div_n1_full_unified_spec
-abbrev evm_div_spec_within_n2Full := evm_div_n2_full_bundled_spec
-abbrev evm_div_spec_within_n3Full := evm_div_n3_full_unified_spec
-abbrev evm_div_spec_within_n4MaxSkip := evm_div_n4_full_max_skip_spec
-abbrev evm_div_spec_within_n4CallSkip := evm_div_n4_full_call_skip_spec
-abbrev evm_div_spec_within_n4MaxAddbackBeq := evm_div_n4_full_max_addback_beq_spec
-abbrev evm_div_spec_within_n4CallAddbackBeq := evm_div_n4_full_call_addback_beq_spec
-abbrev evm_div_spec_within_n4Shift0CallSkip := evm_div_n4_full_shift0_call_skip_spec
-abbrev evm_div_spec_within_n4Shift0CallAddbackBeq :=
-  evm_div_n4_full_shift0_call_addback_beq_spec
-
-abbrev evm_mod_spec_within_bzero := evm_mod_bzero_spec_within
-abbrev evm_mod_spec_within_n1Full := evm_mod_n1_full_unified_spec
-abbrev evm_mod_spec_within_n2Full := evm_mod_n2_full_unified_spec
-abbrev evm_mod_spec_within_n3Full := evm_mod_n3_full_unified_spec
-abbrev evm_mod_spec_within_n4MaxSkip := evm_mod_n4_full_max_skip_spec_within
-abbrev evm_mod_spec_within_n4CallSkip := evm_mod_n4_full_call_skip_spec_within
-abbrev evm_mod_spec_within_n4CallAddbackBeq := evm_mod_n4_full_call_addback_beq_spec_within
-abbrev evm_mod_spec_within_n4Shift0CallSkip := evm_mod_n4_full_shift0_call_skip_spec
-abbrev evm_mod_spec_within_n4Shift0CallAddbackBeq :=
-  evm_mod_n4_full_shift0_call_addback_beq_spec
-
 inductive DivDispatchBranch where
   | bzero
   | n1Full


### PR DESCRIPTION
Slice of evm-asm-gxcb (parent evm-asm-sboz / DivMod cleanup post #61).

The 18 abbrevs `evm_{div,mod}_spec_within_{bzero,n1Full,n2Full,n3Full,n4MaxSkip,n4CallSkip,…}` on lines 33-54 of `EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean` are not referenced anywhere in EvmAsm. Each was a one-line rename of a real path-spec theorem (e.g. `evm_div_spec_within_n1Full := evm_div_n1_full_unified_spec`). The dispatcher registry tables `evm_div_spec_within` / `evm_mod_spec_within` (still kept) document the real underlying theorem names directly in their trailing line comments, so the rename layer was carrying no information; downstream proofs reference the underlying names directly.

Verified by ripgrep across `EvmAsm/` — no consumers.

`lake build` green; 0 sorry; no `maxHeartbeats`/`maxRecDepth` bumps.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes). Refs evm-asm-gxcb.