### PR TITLE
feat(log): append-LogState helper from LogArgs

### DIFF
--- a/EvmAsm/EL/LogArgsBridge.lean
+++ b/EvmAsm/EL/LogArgsBridge.lean
@@ -67,6 +67,53 @@ theorem topicCountOk_log4
   exact topicCountOk_of_logArgs .log4 emitter data
     { data := range, topics := [topic0, topic1, topic2, topic3] } rfl
 
+/--
+Append a log entry built from `LogArgs` to a `LogState`, bundling
+`mkLogEntry` with `LogState.appendLog`. Mirrors how
+`TerminatingArgsBridge.mkReturnResult` / `mkRevertResult` package the
+bridge output for downstream consumers.
+-/
+def appendLogFromArgs
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) : LogState :=
+  logs.appendLog (mkLogEntry emitter data args)
+
+@[simp] theorem appendLogFromArgs_entries
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogFromArgs logs emitter data args).entries =
+      logs.entries ++ [mkLogEntry emitter data args] := rfl
+
+theorem appendLogFromArgs_length
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogFromArgs logs emitter data args).entries.length =
+      logs.entries.length + 1 := by
+  simp [appendLogFromArgs]
+
+theorem appendLogFromArgs_emitter
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    ((appendLogFromArgs logs emitter data args).entries.getLast
+        (by simp [appendLogFromArgs, LogState.appendLog])).emitter = emitter := by
+  simp [appendLogFromArgs, LogState.appendLog, mkLogEntry, LogEntry.mkChecked]
+
+theorem appendLogFromArgs_data
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    ((appendLogFromArgs logs emitter data args).entries.getLast
+        (by simp [appendLogFromArgs, LogState.appendLog])).data = data := by
+  simp [appendLogFromArgs, LogState.appendLog, mkLogEntry, LogEntry.mkChecked]
+
+theorem appendLogFromArgs_topics
+    (logs : LogState) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    ((appendLogFromArgs logs emitter data args).entries.getLast
+        (by simp [appendLogFromArgs, LogState.appendLog])).topics = topics args := by
+  simp [appendLogFromArgs, LogState.appendLog, mkLogEntry, LogEntry.mkChecked]
+
+theorem topicCountOk_appended
+    (logs : LogState) (kind : LogKind) (emitter : Address) (data : List Byte)
+    (args : LogArgs) (h_topics : EvmAsm.Evm64.LogArgs.topicCountOk kind args) :
+    ((appendLogFromArgs logs emitter data args).entries.getLast
+        (by simp [appendLogFromArgs, LogState.appendLog])).topicCountOk := by
+  simpa [appendLogFromArgs, LogState.appendLog] using
+    topicCountOk_of_logArgs kind emitter data args h_topics
+
 end LogArgsBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
Child slice for GH #112 (parent beads evm-asm-molh, this slice evm-asm-mofc).

Adds `appendLogFromArgs : LogState → Address → List Byte → LogArgs → LogState` to `EvmAsm/EL/LogArgsBridge.lean`, bundling `mkLogEntry` with `LogState.appendLog` so downstream consumers (interpreter loop, conformance harness) get a single packaged operation — mirroring how `TerminatingArgsBridge.mkReturnResult` / `mkRevertResult` package their bridge outputs.

Companion lemmas (5 + 1):

- `appendLogFromArgs_entries` (`@[simp]`): the new entries list is `old ++ [mkLogEntry...]`
- `appendLogFromArgs_length`: length grows by 1
- `appendLogFromArgs_{emitter,data,topics}`: last-entry projections
- `topicCountOk_appended`: topic-count validity propagates from `EvmAsm.Evm64.LogArgs.topicCountOk`

Local verification:

- `lake build EvmAsm.EL.LogArgsBridge`: clean
- `lake build`: 1576/1576 jobs
- `scripts/check-file-size.sh`: clean
- `scripts/check-unimported.sh`: 514/514 reachable
- No new sorry / proof option / file-size escape

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).