### PR TITLE
chore(divmod): delete 5 dead spec shims in NormA/ModNormA/ModNorm

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNorm.lean
@@ -107,15 +107,6 @@ theorem mod_phaseC2_taken_spec_within (sp shift v2 shiftMem : Word) (base : Word
     (fun h hq => by xperm_hyp hq)
     hC2
 
-theorem mod_phaseC2_taken_spec (sp shift v2 shiftMem : Word) (base : Word)
-    (hshift_z : shift = 0) :
-    cpsTripleWithin 4 (base + phaseC2Off) (base + copyAUOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ (signExtend12 (0 : BitVec 12) - shift)) **
-       (.x0 ↦ᵣ (0 : Word)) ** ((sp + signExtend12 3992) ↦ₘ shift)) :=
-  mod_phaseC2_taken_spec_within sp shift v2 shiftMem base hshift_z
-
 -- ============================================================================
 -- MOD NormB composition (normalize divisor, 21 instructions)
 -- base+228: 3 merge blocks (6 instrs each) + 1 last block (3 instrs)

--- a/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/ModNormA.lean
@@ -174,31 +174,6 @@ theorem mod_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : W
     (fun h hq => by xperm_hyp hq)
     h123456
 
-theorem mod_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
-    (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
-    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
-       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
-       ((sp + signExtend12 4056) ↦ₘ u0Old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4056) ↦ₘ u0)) :=
-  mod_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
-    u0Old u1Old u2Old u3Old u4Old base
-
 -- ============================================================================
 -- MOD CopyAU composition (copy a[] to u[], 9 instructions)
 -- base+396: used when shift=0 (no normalization needed)
@@ -232,23 +207,6 @@ theorem mod_copyAU_full_spec_within (sp : Word)
   have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
   rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTripleWithin_extend_code divK_copyAU_code_sub_modCode hcopy
-
-theorem mod_copyAU_full_spec (sp : Word)
-    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
-       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
-       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
-       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) :=
-  mod_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base
 
 -- ============================================================================
 -- MOD LoopSetup composition (4 instructions at base+432)

--- a/EvmAsm/Evm64/DivMod/Compose/NormA.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/NormA.lean
@@ -176,31 +176,6 @@ theorem divK_normA_full_spec_within (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : 
     (fun h hq => by xperm_hyp hq)
     h123456
 
-theorem divK_normA_full_spec (sp a0 a1 a2 a3 v5 v7 v10 shift antiShift : Word)
-    (u0Old u1Old u2Old u3Old u4Old : Word) (base : Word) :
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
-    cpsTripleWithin 21 (base + normAOff) (base + loopSetupOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x10 ↦ᵣ v10) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4Old) ** ((sp + signExtend12 4032) ↦ₘ u3Old) **
-       ((sp + signExtend12 4040) ↦ₘ u2Old) ** ((sp + signExtend12 4048) ↦ₘ u1Old) **
-       ((sp + signExtend12 4056) ↦ₘ u0Old))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ u1) ** (.x7 ↦ᵣ u0) ** (.x10 ↦ᵣ (a0 >>> (antiShift.toNat % 64))) **
-       (.x6 ↦ᵣ shift) ** (.x2 ↦ᵣ antiShift) **
-       ((sp + 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4056) ↦ₘ u0)) :=
-  divK_normA_full_spec_within sp a0 a1 a2 a3 v5 v7 v10 shift antiShift
-    u0Old u1Old u2Old u3Old u4Old base
-
 -- ============================================================================
 -- Section 10j: CopyAU composition (copy a[] to u[], 9 instructions)
 -- base+396: used when shift=0 (no normalization needed)
@@ -233,23 +208,6 @@ theorem divK_copyAU_full_spec_within (sp : Word)
   have hcopy := divK_copyAU_spec_within sp (base + copyAUOff) a0 a1 a2 a3 u0 u1 u2 u3 u4 v5
   rw [show (base + copyAUOff : Word) + 36 = base + loopSetupOff from by bv_addr] at hcopy
   exact cpsTripleWithin_extend_code divK_copyAU_code_sub_divCode hcopy
-
-theorem divK_copyAU_full_spec (sp : Word)
-    (a0 a1 a2 a3 : Word) (u0 u1 u2 u3 u4 v5 : Word) (base : Word) :
-    cpsTripleWithin 9 (base + copyAUOff) (base + loopSetupOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) **
-       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u4))
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ a3) **
-       ((sp + signExtend12 0) ↦ₘ a0) ** ((sp + 8) ↦ₘ a1) **
-       ((sp + 16) ↦ₘ a2) ** ((sp + 24) ↦ₘ a3) **
-       ((sp + signExtend12 4056) ↦ₘ a0) ** ((sp + signExtend12 4048) ↦ₘ a1) **
-       ((sp + signExtend12 4040) ↦ₘ a2) ** ((sp + signExtend12 4032) ↦ₘ a3) **
-       ((sp + signExtend12 4024) ↦ₘ (0 : Word))) :=
-  divK_copyAU_full_spec_within sp a0 a1 a2 a3 u0 u1 u2 u3 u4 v5 base
 
 -- ============================================================================
 -- Section 10k: LoopSetup composition (4 instructions at base+432)


### PR DESCRIPTION
Five theorems are pure re-statements of their `_spec_within` siblings with bodies that just re-apply the within form, and have zero callers anywhere in `EvmAsm/`, `scripts/`, or `docs/`:

- `divK_normA_full_spec`     (`Compose/NormA.lean`)
- `divK_copyAU_full_spec`    (`Compose/NormA.lean`)
- `mod_normA_full_spec`      (`Compose/ModNormA.lean`)
- `mod_copyAU_full_spec`     (`Compose/ModNormA.lean`)
- `mod_phaseC2_taken_spec`   (`Compose/ModNorm.lean`)

Verified each name occurs only at its own definition site:
```
rg -nw 'divK_normA_full_spec|divK_copyAU_full_spec|mod_normA_full_spec|mod_copyAU_full_spec|mod_phaseC2_taken_spec' EvmAsm/ scripts/ docs/
```
returns exactly 5 hits — the 5 `theorem` lines being deleted.

Same dead-shim pattern as the in-flight PR for `Compose/Epilogue.lean` (`divK_denorm_body_spec` / `divK_div_epilogue_spec` / `evm_mod_phaseA_ntaken_spec`, beads evm-asm-0q6w).

`lake build` green; 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs beads evm-asm-tpdv (slice of evm-asm-sboz / DivMod cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).