### PR TITLE
chore(divmod): delete 10 dead j0 step-bounded alias shims in FullPathN4Loop

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean
@@ -104,34 +104,6 @@ theorem divK_loop_body_n4_max_skip_j0_divCode_within
     (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow))
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_max_skip_j0_divCode
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult uTop v3) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-      (qAddr ↦ₘ qOld))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  exact cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-    (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hborrow))
-
 /-- Bundled precondition for the `divK_loop_body_n4_max_skip_j0_modCode_within` /
     `_divCode` code-extended loop-body specs. Wraps the 21-atom sepConj
     chain that the `let uBase / qAddr` bindings make awkward in the
@@ -203,24 +175,6 @@ theorem divK_loop_body_n4_max_skip_j0_modCode_within
   rw [loopBodyN4SkipJ0Pre_unfold] at hp
   exact hp
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_max_skip_j0_modCode
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult uTop v3)
-    (hborrow : (if BitVec.ult uTop
-                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
-                then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode base)
-      (loopBodyN4SkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld)
-      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_skip_j0_modCode_within sp jOld v5Old v6Old
-    v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base
-    hbltu hborrow)
-
 /-- Max_skip j=0 loop body against modCode with sp-relative addresses in the
     precondition. Mirror of the DIV `divK_loop_body_n4_max_skip_j0_norm`
     with `divCode → modCode`. `qHat = signExtend12 4095` is inlined so no
@@ -256,103 +210,12 @@ theorem divK_loop_body_n4_max_skip_j0_norm_modCode_within (sp base : Word)
              u_base_off4072_j0, u_base_off4064_j0, q_addr_j0]
   exact hp
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_max_skip_j0_norm_modCode (sp base : Word)
-    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (hbltu : ¬BitVec.ult uTop v3)
-    (hborrow : (if BitVec.ult uTop
-                  (mulsubN4_c3 (signExtend12 4095) v0 v1 v2 v3 u0 u1 u2 u3)
-                then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 76 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
-       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
-       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ uTop) **
-       ((sp + signExtend12 4088) ↦ₘ qOld))
-      (loopBodyN4SkipPost sp (0 : Word) (signExtend12 4095)
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_skip_j0_norm_modCode_within sp base jOld
-    v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    qOld hbltu hborrow)
-
 -- ============================================================================
 -- Call path: Loop body j=0 extended to divCode (from sharedDivModCode)
 -- ============================================================================
 
 /-- Extend call_skip j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_call_skip_j0_divCode_within
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    -- div128 intermediates
-    let dHi := v3 >>> (32 : BitVec 6).toNat
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := u3 >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu uTop dHi
-    let rhat := uTop - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro uBase
-        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
-        qAddr hborrow
-  exact cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-    (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_skip_j0_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign hbltu hborrow))
-
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_skip_j0_divCode
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -449,103 +312,8 @@ theorem divK_loop_body_n4_max_addback_j0_beq_divCode_within
     (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
       v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hcarry2_nz hborrow))
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_max_addback_j0_beq_divCode
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (base : Word)
-    (hbltu : ¬BitVec.ult uTop v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Max v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    let qHat : Word := signExtend12 4095
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 152 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  intro uBase qHat qAddr hborrow
-  exact cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-    (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_max_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld base hbltu hcarry2_nz hborrow))
-
 /-- Extend call_addback (BEQ double-addback) j=0 loop body from sharedDivModCode to divCode. -/
 theorem divK_loop_body_n4_call_addback_j0_beq_divCode_within
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let uBase := sp + signExtend12 4056 - (0 : Word) <<< (3 : BitVec 6).toNat
-    -- div128 intermediates
-    let dHi := v3 >>> (32 : BitVec 6).toNat
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un1 := u3 >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let q1 := rv64_divu uTop dHi
-    let rhat := uTop - q1 * dHi
-    let hi1 := q1 >>> (32 : BitVec 6).toNat
-    let q1c := if hi1 = 0 then q1 else q1 + signExtend12 4095
-    let rhatc := if hi1 = 0 then rhat else rhat + dHi
-    let qDlo := q1c * dLo
-    let rhatUn1 := (rhatc <<< (32 : BitVec 6).toNat) ||| div_un1
-    let q1' := if BitVec.ult rhatUn1 qDlo then q1c + signExtend12 4095 else q1c
-    let rhat' := if BitVec.ult rhatUn1 qDlo then rhatc + dHi else rhatc
-    let cu_rhat_un1 := (rhat' <<< (32 : BitVec 6).toNat) ||| div_un1
-    let cu_q1_dlo := q1' * dLo
-    let un21 := cu_rhat_un1 - cu_q1_dlo
-    let q0 := rv64_divu un21 dHi
-    let rhat2 := un21 - q0 * dHi
-    let hi2 := q0 >>> (32 : BitVec 6).toNat
-    let q0c := if hi2 = 0 then q0 else q0 + signExtend12 4095
-    let rhat2c := if hi2 = 0 then rhat2 else rhat2 + dHi
-    let q0' := div128Quot_phase2b_q0' q0c rhat2c dLo div_un0
-    let qHat := (q1' <<< (32 : BitVec 6).toNat) ||| q0'
-    let qAddr := sp + signExtend12 4088 - (0 : Word) <<< (3 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (divCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + signExtend12 32) ↦ₘ v0) ** ((uBase + signExtend12 0) ↦ₘ u0) **
-       ((sp + signExtend12 40) ↦ₘ v1) ** ((uBase + signExtend12 4088) ↦ₘ u1) **
-       ((sp + signExtend12 48) ↦ₘ v2) ** ((uBase + signExtend12 4080) ↦ₘ u2) **
-       ((sp + signExtend12 56) ↦ₘ v3) ** ((uBase + signExtend12 4072) ↦ₘ u3) **
-       ((uBase + signExtend12 4064) ↦ₘ uTop) **
-       (qAddr ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro uBase
-        dHi dLo div_un1 div_un0 q1 rhat hi1 q1c rhatc qDlo rhatUn1 q1' rhat'
-        cu_rhat_un1 cu_q1_dlo un21 q0 rhat2 hi2 q0c rhat2c q0' qHat
-        qAddr hborrow
-  exact cpsTripleWithin_extend_code (hmono := sharedDivModCode_sub_divCode)
-    (cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_addback_j0_beq_spec_within sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0 base
-      halign hbltu hcarry2_nz hborrow))
-
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_divCode
     (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
      v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
     (retMem dMem dloMem scratch_un0 : Word)
@@ -736,25 +504,6 @@ theorem divK_loop_body_n4_call_skip_j0_modCode_within
     rw [loopBodyN4CallSkipJ0Post_unfold]
     exact hq
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_skip_j0_modCode
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hborrow : (if BitVec.ult uTop
-                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
-                then (1 : Word) else 0) = (0 : Word)) :
-    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
-      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
-      (loopBodyN4CallSkipJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_skip_j0_modCode_within sp jOld v5Old v6Old
-    v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem
-    dMem dloMem scratch_un0 base halign hbltu hborrow)
-
 /-- Call_skip j=0 loop body against modCode with sp-relative addresses
     in the precondition. Mirror of `divK_loop_body_n4_call_skip_j0_norm`
     (the divCode variant in FullPathN4.lean) with `divCode → modCode`. -/
@@ -804,44 +553,6 @@ theorem divK_loop_body_n4_call_skip_j0_norm_modCode_within (sp base : Word)
   · intro _ hq
     rw [loopBodyN4CallSkipJ0Post_unfold] at hq
     exact hq
-
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_skip_j0_norm_modCode (sp base : Word)
-    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3) :
-    let qHat := div128Quot uTop u3 v3
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
-     then (1 : Word) else 0) = (0 : Word) →
-    cpsTripleWithin 126 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
-       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
-       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ uTop) **
-       ((sp + signExtend12 4088) ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4SkipPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro qHat dLo div_un0 hborrow
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_skip_j0_norm_modCode_within sp base jOld
-    v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    qOld retMem dMem dloMem scratch_un0 halign hbltu hborrow)
 
 -- ============================================================================
 -- Call-addback path (BEQ double-addback): Loop body j=0 extended to modCode
@@ -914,26 +625,6 @@ theorem divK_loop_body_n4_call_addback_j0_beq_modCode_within
     rw [loopBodyN4CallAddbackBeqJ0Post_unfold]
     exact hq
 
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_modCode
-    (sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (base : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop)
-    (hborrow : (if BitVec.ult uTop
-                  (mulsubN4_c3 (div128Quot uTop u3 v3) v0 v1 v2 v3 u0 u1 u2 u3)
-                then (1 : Word) else 0) ≠ (0 : Word)) :
-    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
-      (loopBodyN4CallSkipJ0Pre sp jOld v5Old v6Old v7Old v10Old v11Old v2Old
-        v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld retMem dMem dloMem scratch_un0)
-      (loopBodyN4CallAddbackBeqJ0Post sp base v0 v1 v2 v3 u0 u1 u2 u3 uTop) := by
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_addback_j0_beq_modCode_within sp jOld v5Old
-    v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-    retMem dMem dloMem scratch_un0 base halign hbltu hcarry2_nz hborrow)
-
 /-- Call_addback (BEQ) j=0 loop body against modCode with sp-relative
     addresses in the precondition. -/
 theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Word)
@@ -983,45 +674,5 @@ theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within (sp base : Wor
   · intro _ hq
     rw [loopBodyN4CallAddbackBeqJ0Post_unfold] at hq
     exact hq
-
-/-- Bounded alias for the step-bounded specification. -/
-theorem divK_loop_body_n4_call_addback_j0_beq_norm_modCode (sp base : Word)
-    (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)
-    (v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld : Word)
-    (retMem dMem dloMem scratch_un0 : Word)
-    (halign : ((base + div128CallRetOff) + signExtend12 (0 : BitVec 12)) &&& ~~~(1 : Word) = base + div128CallRetOff)
-    (hbltu : BitVec.ult uTop v3)
-    (hcarry2_nz : isAddbackCarry2NzN4Call v0 v1 v2 v3 u0 u1 u2 u3 uTop) :
-    let qHat := div128Quot uTop u3 v3
-    let dLo := (v3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    let div_un0 := (u3 <<< (32 : BitVec 6).toNat) >>> (32 : BitVec 6).toNat
-    (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3)
-     then (1 : Word) else 0) ≠ (0 : Word) →
-    cpsTripleWithin 202 (base + loopBodyOff) (base + denormOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x1 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5Old) ** (.x6 ↦ᵣ v6Old) **
-       (.x7 ↦ᵣ v7Old) ** (.x10 ↦ᵣ v10Old) ** (.x11 ↦ᵣ v11Old) **
-       (.x2 ↦ᵣ v2Old) ** (.x0 ↦ᵣ (0 : Word)) **
-       (sp + signExtend12 3976 ↦ₘ jOld) ** (sp + signExtend12 3984 ↦ₘ (4 : Word)) **
-       ((sp + 32) ↦ₘ v0) ** ((sp + signExtend12 4056) ↦ₘ u0) **
-       ((sp + 40) ↦ₘ v1) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + 48) ↦ₘ v2) ** ((sp + signExtend12 4040) ↦ₘ u2) **
-       ((sp + 56) ↦ₘ v3) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ uTop) **
-       ((sp + signExtend12 4088) ↦ₘ qOld) **
-       (sp + signExtend12 3968 ↦ₘ retMem) **
-       (sp + signExtend12 3960 ↦ₘ dMem) **
-       (sp + signExtend12 3952 ↦ₘ dloMem) **
-       (sp + signExtend12 3944 ↦ₘ scratch_un0))
-      (loopBodyN4AddbackBeqPost sp (0 : Word) qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop **
-       (sp + signExtend12 3968 ↦ₘ (base + div128CallRetOff)) **
-       (sp + signExtend12 3960 ↦ₘ v3) **
-       (sp + signExtend12 3952 ↦ₘ dLo) **
-       (sp + signExtend12 3944 ↦ₘ div_un0)) := by
-  intro qHat dLo div_un0 hborrow
-  exact cpsTripleWithin_mono_nSteps (by decide) (divK_loop_body_n4_call_addback_j0_beq_norm_modCode_within sp base
-    jOld v5Old v6Old v7Old v10Old v11Old v2Old v0 v1 v2 v3 u0 u1 u2 u3
-    uTop qOld retMem dMem dloMem scratch_un0 halign hbltu hcarry2_nz
-    hborrow)
 
 end EvmAsm.Evm64


### PR DESCRIPTION
All ten step-bounded alias theorems in `EvmAsm/Evm64/DivMod/Compose/FullPathN4Loop.lean` are unreferenced wrappers around the corresponding `_within` sibling (each is just `cpsTripleWithin_extend_code` + `cpsTripleWithin_mono_nSteps`). Verified via `rg -w <name> EvmAsm` that each name has count 1 (its own definition site only). The `_within` siblings are kept (they have callers).

Removed:
- `divK_loop_body_n4_max_skip_j0_divCode`
- `divK_loop_body_n4_max_skip_j0_modCode`
- `divK_loop_body_n4_max_skip_j0_norm_modCode`
- `divK_loop_body_n4_call_skip_j0_divCode`
- `divK_loop_body_n4_call_skip_j0_modCode`
- `divK_loop_body_n4_call_skip_j0_norm_modCode`
- `divK_loop_body_n4_max_addback_j0_beq_divCode`
- `divK_loop_body_n4_call_addback_j0_beq_divCode`
- `divK_loop_body_n4_call_addback_j0_beq_modCode`
- `divK_loop_body_n4_call_addback_j0_beq_norm_modCode`

`lake build` green locally; no `maxHeartbeats`/`maxRecDepth` bumps; no new sorry. Net: -349 lines.

beads: `evm-asm-2fjp` (slice of `evm-asm-sboz`, parent of #61 follow-up cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).