### PR TITLE
shake: drop unused FullPath* imports in DivMod/Compose/Dispatcher.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/Dispatcher.lean
@@ -4,17 +4,7 @@
   Dispatcher-level scaffold for the bounded DIV/MOD limb specs.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.FullPathN1LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Full
-import EvmAsm.Evm64.DivMod.Compose.FullPathN3LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Beq
-import EvmAsm.Evm64.DivMod.Compose.FullPathN4Shift0
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN2LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4
-import EvmAsm.Evm64.DivMod.Compose.ModFullPathN4Shift0
+import EvmAsm.Evm64.DivMod.Compose.Base
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Dispatcher.lean only references `divCode`/`modCode` (from `Compose.Base`) and the local `DivDispatchBranch`/`ModDispatchBranch` inductives plus their bound tables. The 11 `FullPathN*`/`ModFullPathN*` imports it carried were unused — `DivMod.lean` already imports them directly so downstream visibility is unaffected. Replace them with `Compose.Base`.

`lake exe shake EvmAsm` flagged this and `scripts/shake-filter.py` agrees; `lake build` remains green; 0 sorry; no `maxHeartbeats`/`maxRecDepth` bumps.

Refs: GH #1045, beads `evm-asm-oci5` (parent `evm-asm-9tq`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).