### PR TITLE
chore(divmod): delete 3 dead _unfold rfl wrappers in FullPathN2Bundle/N3LoopUnified

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean
@@ -144,19 +144,4 @@ theorem fullDivN2R0_unfold (bltu_2 bltu_1 bltu_0 : Bool)
   delta fullDivN2R0
   rfl
 
-theorem fullDivN2C3_unfold (bltu_2 bltu_1 bltu_0 : Bool)
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    fullDivN2C3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3 =
-    let v := fullDivN2NormV b0 b1 b2 b3
-    let u := fullDivN2NormU a0 a1 a2 a3 b1
-    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-    if bltu_0 then
-      (mulsubN4 (div128Quot r1.2.2.1 r1.2.1 v.2.1)
-        v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2
-    else
-      (mulsubN4 (signExtend12 4095 : Word)
-        v.1 v.2.1 v.2.2.1 v.2.2.2 u.1 r1.2.1 r1.2.2.1 r1.2.2.2.1).2.2.2.2 := by
-  delta fullDivN2C3
-  rfl
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean
@@ -123,19 +123,6 @@ theorem fullDivN2DenormPre_unfold (bltu_2 bltu_1 bltu_0 : Bool)
   delta fullDivN2DenormPre
   rfl
 
-theorem fullDivN2DenormPost_unfold (bltu_2 bltu_1 bltu_0 : Bool)
-    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    fullDivN2DenormPost bltu_2 bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
-    let shift := fullDivN2Shift b1
-    let r2 := fullDivN2R2 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
-    let r1 := fullDivN2R1 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-    let r0 := fullDivN2R0 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
-    denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
-      r0.1 r1.1 r2.1 (0 : Word) **
-    ((sp + signExtend12 3992) ↦ₘ shift) := by
-  delta fullDivN2DenormPost
-  rfl
-
 theorem fullDivN2Frame_unfold (bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 retMem dMem dloMem scratch_un0 : Word) :
     fullDivN2Frame bltu_2 bltu_1 bltu_0 sp base a0 a1 a2 a3 b0 b1 b2 b3

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean
@@ -484,18 +484,6 @@ theorem fullDivN3Frame_unfold (bltu_1 bltu_0 : Bool)
   delta fullDivN3Frame
   rfl
 
-theorem fullDivN3DenormPost_unfold (bltu_1 bltu_0 : Bool)
-    (sp a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    fullDivN3DenormPost bltu_1 bltu_0 sp a0 a1 a2 a3 b0 b1 b2 b3 =
-    let shift := fullDivN3Shift b2
-    let r1 := fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-    let r0 := fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
-    denormDivPost sp shift r0.2.1 r0.2.2.1 r0.2.2.2.1 r0.2.2.2.2.1
-      r0.1 r1.1 (0 : Word) (0 : Word) **
-    ((sp + signExtend12 3992) ↦ₘ shift) := by
-  delta fullDivN3DenormPost
-  rfl
-
 theorem fullDivN3C3_false (bltu_1 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
     fullDivN3C3 bltu_1 false a0 a1 a2 a3 b0 b1 b2 b3 =
     let v := fullDivN3NormV b0 b1 b2 b3


### PR DESCRIPTION
Slice of beads evm-asm-u30v (parent evm-asm-sboz, DivMod cleanup after #61 closure).

Three rfl-equation `_unfold` wrappers have zero references outside their own definition lines:

- `fullDivN2C3_unfold` in `EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/Base.lean`
- `fullDivN2DenormPost_unfold` in `EvmAsm/Evm64/DivMod/Compose/FullPathN2Bundle/State.lean`
- `fullDivN3DenormPost_unfold` in `EvmAsm/Evm64/DivMod/Compose/FullPathN3LoopUnified.lean`

Consumers unfold the underlying `def`s directly. Verified via grep across all .lean files: only the definition site references each name.

`lake build` clean (1576 jobs); 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).