### PR TITLE
feat(termination): TerminatingArgsBridge Kind-keyed status predicates

### DIFF
--- a/EvmAsm/EL/TerminatingArgsBridge.lean
+++ b/EvmAsm/EL/TerminatingArgsBridge.lean
@@ -207,6 +207,43 @@ theorem mkResultFromArgs_selfdestruct
     mkResultFromArgs .selfdestruct state data gasRemaining args
       = mkStopResult state data gasRemaining args := rfl
 
+/-- For STOP, the dispatcher's result is `succeeded`. -/
+theorem mkResultFromArgs_stop_succeeded
+    (state : WorldState) (data : List Byte) (gasRemaining : Nat)
+    (args : TerminatingArgs) :
+    (mkResultFromArgs .stop state data gasRemaining args).succeeded :=
+  mkStopResult_succeeded state data gasRemaining args
+
+/-- For RETURN, the dispatcher's result is `succeeded`. -/
+theorem mkResultFromArgs_return_succeeded
+    (state : WorldState) (data : List Byte) (gasRemaining : Nat)
+    (args : TerminatingArgs) :
+    (mkResultFromArgs .return_ state data gasRemaining args).succeeded :=
+  mkReturnResult_succeeded state data gasRemaining args
+
+/-- For REVERT, the dispatcher's result is `reverted`. -/
+theorem mkResultFromArgs_revert_reverted
+    (state : WorldState) (data : List Byte) (gasRemaining : Nat)
+    (args : TerminatingArgs) :
+    (mkResultFromArgs .revert state data gasRemaining args).reverted :=
+  mkRevertResult_reverted state data gasRemaining args
+
+/-- For INVALID, the dispatcher's result is not `succeeded`. -/
+theorem mkResultFromArgs_invalid_not_succeeded
+    (state : WorldState) (data : List Byte) (gasRemaining : Nat)
+    (args : TerminatingArgs) :
+    ¬ (mkResultFromArgs .invalid state data gasRemaining args).succeeded :=
+  mkFailureResult_not_succeeded state data gasRemaining args
+
+/-- For SELFDESTRUCT, the dispatcher's result is `succeeded` (post-Cancun:
+    SELFDESTRUCT no longer self-destructs the account; it succeeds with empty
+    output). -/
+theorem mkResultFromArgs_selfdestruct_succeeded
+    (state : WorldState) (data : List Byte) (gasRemaining : Nat)
+    (args : TerminatingArgs) :
+    (mkResultFromArgs .selfdestruct state data gasRemaining args).succeeded :=
+  mkStopResult_succeeded state data gasRemaining args
+
 end TerminatingArgsBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
Adds five Kind-keyed status-predicate lemmas to `mkResultFromArgs` in `EvmAsm/EL/TerminatingArgsBridge.lean`, complementing the existing Kind-uniform projections (`mkResultFromArgs_status` etc. from PRs #2402 / #2409):

- `mkResultFromArgs_stop_succeeded`
- `mkResultFromArgs_return_succeeded`
- `mkResultFromArgs_revert_reverted`
- `mkResultFromArgs_invalid_not_succeeded`
- `mkResultFromArgs_selfdestruct_succeeded`

Each composes the existing per-builder predicate (`mkStopResult_succeeded`, `mkReturnResult_succeeded`, `mkRevertResult_reverted`, `mkFailureResult_not_succeeded`) with the matching `mkResultFromArgs` Kind-equation. Useful for handler specs that work directly off the dispatcher entry point.

Local: `lake build` clean (1576 jobs); `check-file-size` + `check-unimported` clean.

Tracks beads `evm-asm-r96f` (slice of #113).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).