### PR TITLE
chore(shake): drop Compose.Base import in SharedLoopPost.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/SharedLoopPost.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/SharedLoopPost.lean
@@ -31,9 +31,7 @@
   `denormDoneSharedPre`.
 -/
 
-import EvmAsm.Evm64.DivMod.Compose.Base
-
-open EvmAsm.Rv64.Tactics
+import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Slice of #1045 import-hygiene sweep (beads evm-asm-ceigl).

`EvmAsm/Evm64/DivMod/Compose/SharedLoopPost.lean` only references `Assertion`, `regIs`/`memIs`/`sepConj`, `pcFree` and the `signExtend12` helper — all available from `EvmAsm.Rv64.SepLogic`. The current `EvmAsm.Evm64.DivMod.Compose.Base` import is unused (no `divCode`, `modCode`, `epilogueOff`, etc. mentioned in the file). The accompanying `open EvmAsm.Rv64.Tactics` was likewise unused — dropped.

### Verification
- `lake build` — green (1576 targets).
- `lake exe shake EvmAsm | grep SharedLoopPost` — no longer flagged.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes). Refs #1045.