### PR TITLE
feat(termination): TerminatingArgsBridge reverted/failed Kind-pointwise iff

### DIFF
--- a/EvmAsm/EL/TerminatingArgsBridge.lean
+++ b/EvmAsm/EL/TerminatingArgsBridge.lean
@@ -244,6 +244,30 @@ theorem mkResultFromArgs_selfdestruct_succeeded
     (mkResultFromArgs .selfdestruct state data gasRemaining args).succeeded :=
   mkStopResult_succeeded state data gasRemaining args
 
+/-- Kind-pointwise iff: the dispatcher's result is `reverted` exactly when the
+    Kind is `.revert`. Note: this is sharper than `Kind.reverts`, which is
+    also `true` for `.invalid`. The dispatcher maps `.invalid` to a
+    `.failure`-status result (not `.revert`), so the constructor-precise
+    iff identifies `.revert` uniquely. -/
+theorem mkResultFromArgs_reverted_iff_revert
+    (kind : TerminatingKind) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (mkResultFromArgs kind state data gasRemaining args).reverted ↔ kind = .revert := by
+  cases kind <;>
+    simp [mkResultFromArgs, mkStopResult, mkReturnResult, mkRevertResult,
+      mkFailureResult, CallResult.reverted]
+
+/-- Kind-pointwise iff: the dispatcher's result is `failed` exactly when the
+    Kind is `.invalid`. Only `.invalid` produces a `.failure`-status result;
+    `.revert` is distinct (`.revert` status, not `.failure`). -/
+theorem mkResultFromArgs_failed_iff_invalid
+    (kind : TerminatingKind) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (mkResultFromArgs kind state data gasRemaining args).failed ↔ kind = .invalid := by
+  cases kind <;>
+    simp [mkResultFromArgs, mkStopResult, mkReturnResult, mkRevertResult,
+      mkFailureResult, CallResult.failed]
+
 end TerminatingArgsBridge
 
 end EvmAsm.EL


### PR DESCRIPTION
Adds two Kind-pointwise iff lemmas to `mkResultFromArgs` in `EvmAsm/EL/TerminatingArgsBridge.lean`, complementing PR #2413 (`succeeded ↔ isSuccess` Kind-uniform):

- `mkResultFromArgs_reverted_iff_revert` — `(mkResultFromArgs kind ...).reverted ↔ kind = .revert`
- `mkResultFromArgs_failed_iff_invalid` — `(mkResultFromArgs kind ...).failed ↔ kind = .invalid`

These are **constructor-precise** (sharper than `Kind.reverts`, which is `true` for both `.revert` and `.invalid`): only `.revert` produces a `.revert`-status result, and only `.invalid` produces a `.failure`-status result. So at the dispatcher's `CallStatus` level, each predicate identifies its Kind exactly.

Each proof is `cases kind <;> simp` over the 5 terminating Kinds.

Local: `lake build` clean (1576 jobs).

Refs GH #113. Beads: evm-asm-wyi7x.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).