### PR TITLE
chore(shake): move {And,Or,Xor}.Program import from LimbSpec to Spec

### DIFF
--- a/EvmAsm/Evm64/And/LimbSpec.lean
+++ b/EvmAsm/Evm64/And/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb AND spec.
 -/
 
-import EvmAsm.Evm64.And.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/And/Spec.lean
+++ b/EvmAsm/Evm64/And/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `And.LimbSpec → And.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.And.LimbSpec
+import EvmAsm.Evm64.And.Program
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Evm64/Or/LimbSpec.lean
+++ b/EvmAsm/Evm64/Or/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb OR spec.
 -/
 
-import EvmAsm.Evm64.Or.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Or/Spec.lean
+++ b/EvmAsm/Evm64/Or/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Or.LimbSpec → Or.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Or.LimbSpec
+import EvmAsm.Evm64.Or.Program
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/EvmAsm/Evm64/Xor/LimbSpec.lean
+++ b/EvmAsm/Evm64/Xor/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb XOR spec.
 -/
 
-import EvmAsm.Evm64.Xor.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Xor/Spec.lean
+++ b/EvmAsm/Evm64/Xor/Spec.lean
@@ -6,6 +6,7 @@
 
 -- `Xor.LimbSpec → Xor.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Xor.LimbSpec
+import EvmAsm.Evm64.Xor.Program
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -90,9 +90,9 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Not.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
-  "EvmAsm.Evm64.And.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
-  "EvmAsm.Evm64.Or.Spec":      ["EvmAsm.Rv64.Tactics.XSimp"],
-  "EvmAsm.Evm64.Xor.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.And.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.And.LimbSpec"],
+ "EvmAsm.Evm64.Or.Spec":      ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Or.LimbSpec"],
+ "EvmAsm.Evm64.Xor.Spec":     ["EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Evm64.Xor.LimbSpec"],
   "EvmAsm.Evm64.Not.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Add.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],
   "EvmAsm.Evm64.Sub.Spec":     ["EvmAsm.Rv64.Tactics.XSimp"],


### PR DESCRIPTION
shake flagged `Evm64/{And,Or,Xor}/LimbSpec.lean` as importing `.Program` without using anything from it. The Program defs (`evm_and` / `evm_or` / `evm_xor`) are in fact only referenced from the corresponding `Spec.lean` (via `CodeReq.ofProg`). This PR drops the unused import from LimbSpec and adds it to Spec — the real shake fix, not a noshake annotation.

Also extends the noshake entries for And/Or/Xor.Spec to cover `.LimbSpec` — it is a real false-positive (those Spec files use `{and,or,xor}_limb_spec_within`), matching the existing pattern for LimbSpec files importing SyscallSpecs/RunBlock.

After this:
```
$ lake exe shake EvmAsm 2>&1 | grep -E 'And/(Lim|Sp)|Or/(Lim|Sp)|Xor/(Lim|Sp)'
(no output)
```

Refs evm-asm-ty674, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).