### PR TITLE
chore(divmod): delete 4 dead _unfold_atoms_right theorems in Spec/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -14,12 +14,12 @@
   * Precondition bundle: `divN4StackPre` (`modN4StackPre`) — `@[irreducible]`,
     bundles 9 registers + `evmWordIs sp a` + `evmWordIs (sp+32) b` +
     `divScratchValues` starting state. Unfold helpers: `_unfold`,
-    `_unfold_atoms`, `_unfold_atoms_right`.
+    `_unfold_atoms`.
   * Postcondition bundle: `divN4MaxSkipStackPost` (`modN4MaxSkipStackPost`) —
     `@[irreducible]`, bundles 9 registers (7 weakened to `regOwn`) +
     `evmWordIs sp a` (preserved) + `evmWordIs (sp+32) (EvmWord.div a b)`
     (`EvmWord.mod a b` for MOD) + `divScratchOwn`. Unfold helpers: `_unfold`,
-    `_unfold_atoms`, `_unfold_atoms_right`.
+    `_unfold_atoms`.
   * Runtime condition wrappers (EvmWord form): `isMaxTrialN4Evm`,
     `isSkipBorrowN4MaxEvm`, `isCallTrialN4Evm`, `isSkipBorrowN4CallEvm`,
     `isAddbackBorrowN4CallEvm`. Each is a thin shim over the Word-level
@@ -540,116 +540,6 @@ theorem modN4MaxSkipStackPost_unfold_atoms {sp : Word} {a b : EvmWord} :
       memOwn (sp + signExtend12 3976))) := by
   rw [modN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
       divScratchOwn_unfold]
-
-/-- Mid-tree variant of `modN4MaxSkipStackPost_unfold_atoms`. Mirror of
-    `divN4MaxSkipStackPost_unfold_atoms_right`. -/
-theorem modN4MaxSkipStackPost_unfold_atoms_right {sp : Word} {a b : EvmWord}
-    {Q : Assertion} :
-    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
-      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
-      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-      (((sp + 32) ↦ₘ (EvmWord.mod a b).getLimbN 0) **
-       ((sp + 40) ↦ₘ (EvmWord.mod a b).getLimbN 1) **
-       ((sp + 48) ↦ₘ (EvmWord.mod a b).getLimbN 2) **
-       ((sp + 56) ↦ₘ (EvmWord.mod a b).getLimbN 3)) **
-      (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
-       memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
-       memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
-       memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
-       memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
-       memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
-       memOwn (sp + signExtend12 3992) ** memOwn (sp + signExtend12 3984) **
-       memOwn (sp + signExtend12 3976))) ** Q) =
-    (modN4MaxSkipStackPost sp a b ** Q) := by
-  rw [modN4MaxSkipStackPost_unfold_atoms]
-
-/-- Mid-tree variant of `modN4StackPre_unfold_atoms`: threads a remainder
-    `Q` through the equality so `rw ←` can fold atoms back into the MOD stack
-    pre bundle even when they sit mid-chain. Mirror of
-    `divN4StackPre_unfold_atoms_right`. -/
-theorem modN4StackPre_unfold_atoms_right {sp : Word} {a b : EvmWord}
-    {v5 v6 v7 v10 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word}
-    {Q : Assertion} :
-    (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-      (.x11 ↦ᵣ v11) **
-      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-      (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
-       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
-      (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
-       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-       ((sp + signExtend12 3984) ↦ₘ nMem) **
-       ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
-    (modN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem ** Q) := by
-  rw [modN4StackPre_unfold_atoms]
-
-/-- Mid-tree variant of `divN4StackPre_unfold_atoms`: threads a remainder
-    `Q` through the equality so `rw ←` can fold atoms back into the stack
-    pre bundle even when they sit mid-chain. Parallel to the other `_right`
-    fold variants. -/
-theorem divN4StackPre_unfold_atoms_right {sp : Word} {a b : EvmWord}
-    {v5 v6 v7 v10 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem : Word}
-    {Q : Assertion} :
-    (((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-      (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-      (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-      (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-      (.x11 ↦ᵣ v11) **
-      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-      (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
-       ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
-      (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-       ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
-       ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-       ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-       ((sp + signExtend12 3984) ↦ₘ nMem) **
-       ((sp + signExtend12 3976) ↦ₘ jMem))) ** Q) =
-    (divN4StackPre sp a b v5 v6 v7 v10 v11
-      q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem ** Q) := by
-  rw [divN4StackPre_unfold_atoms]
-
-/-- Mid-tree variant of the `divN4MaxSkipStackPost_unfold_atoms` family:
-    threads a remainder `Q` through the equality so `rw ←` can fold the
-    atoms back into the stack post bundle **even when they sit mid-chain**.
-    Parallel to `evmWordIs_sp_limbs_eq_right` / `divScratchValues_unfold_right`. -/
-theorem divN4MaxSkipStackPost_unfold_atoms_right {sp : Word} {a b : EvmWord}
-    {Q : Assertion} :
-    (((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
-      regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-      regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
-      ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-       ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-      (((sp + 32) ↦ₘ (EvmWord.div a b).getLimbN 0) **
-       ((sp + 40) ↦ₘ (EvmWord.div a b).getLimbN 1) **
-       ((sp + 48) ↦ₘ (EvmWord.div a b).getLimbN 2) **
-       ((sp + 56) ↦ₘ (EvmWord.div a b).getLimbN 3)) **
-      (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
-       memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
-       memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
-       memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
-       memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
-       memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
-       memOwn (sp + signExtend12 3992) ** memOwn (sp + signExtend12 3984) **
-       memOwn (sp + signExtend12 3976))) ** Q) =
-    (divN4MaxSkipStackPost sp a b ** Q) := by
-  rw [divN4MaxSkipStackPost_unfold_atoms]
 
 theorem pcFree_modN4MaxSkipStackPost {sp : Word} {a b : EvmWord} :
     (modN4MaxSkipStackPost sp a b).pcFree := by


### PR DESCRIPTION
Removes four mid-tree `_unfold_atoms_right` helpers in `EvmAsm/Evm64/DivMod/Spec/Base.lean` that have no callers anywhere in the codebase (verified via grep — only their own declaration sites matched):

- `divN4StackPre_unfold_atoms_right`
- `modN4StackPre_unfold_atoms_right`
- `divN4MaxSkipStackPost_unfold_atoms_right`
- `modN4MaxSkipStackPost_unfold_atoms_right`

Also drops the corresponding stale entries from the file-header overview comment.

`lake build` green; 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs DivMod cleanup parent `evm-asm-sboz` / slice `evm-asm-td769`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).