### PR TITLE
feat(evmwordarith): EvmWord.smod + smod_correct (#90 slice 5a)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith.lean
+++ b/EvmAsm/Evm64/EvmWordArith.lean
@@ -16,6 +16,7 @@ import EvmAsm.Evm64.EvmWordArith.Comparison
 import EvmAsm.Evm64.EvmWordArith.ByteOps
 import EvmAsm.Evm64.EvmWordArith.SignExtend
 import EvmAsm.Evm64.EvmWordArith.SDiv
+import EvmAsm.Evm64.EvmWordArith.SMod
 
 -- MulCorrect covers Arithmetic → MultiLimb → Common.
 import EvmAsm.Evm64.EvmWordArith.MulCorrect

--- a/EvmAsm/Evm64/EvmWordArith/SMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/SMod.lean
@@ -1,0 +1,78 @@
+/-
+  EvmAsm.Evm64.EvmWordArith.SMod
+
+  EVM SMOD semantics: signed two's-complement modulo of 256-bit words,
+  with the result taking the sign of the dividend.
+
+  EVM short-circuit: `divisor = 0` ⇒ result `0`.
+  Otherwise SMOD is the truncating-toward-zero remainder:
+  `r = sign(x) * (|x| % |y|)`, matching `Int.tmod` of the signed
+  interpretations.
+
+  Mirrors `EvmAsm.Evm64.EvmWordArith.SDiv` (slice 3 / `evm-asm-kvs4`).
+  Slice 5a of evm-asm-34sg (#90 SDIV / SMOD opcodes), beads
+  `evm-asm-pc8g6`. The full evm_smod RISC-V program + stack spec lives
+  in sibling slice 5 (`evm-asm-bjnb`).
+
+  Reference: `execution-specs/src/ethereum/forks/amsterdam/vm/instructions/arithmetic.py`,
+  function `smod`. Underlying lemma: `BitVec.toInt_srem`. Note that
+  `BitVec.srem x 0#w = x` (not `0`), so we wrap `BitVec.srem` with the
+  EVM zero-divisor short-circuit.
+-/
+
+import EvmAsm.Evm64.Basic
+
+namespace EvmAsm.Evm64
+
+open EvmAsm.Rv64
+
+namespace EvmWord
+
+-- ============================================================================
+-- EVM SMOD semantics
+-- ============================================================================
+
+/-- EVM SMOD: signed two's-complement integer remainder on 256-bit words,
+    sign of the dividend.
+
+    Wraps `BitVec.srem` with the EVM zero-divisor short-circuit
+    (`y = 0 ⇒ 0`). `BitVec.srem` itself returns `x` on `y = 0`, which is
+    the SMT-LIB convention but not the EVM one. -/
+def smod (a b : EvmWord) : EvmWord :=
+  if b = 0 then 0 else BitVec.srem a b
+
+-- ============================================================================
+-- Edge-case lemmas
+-- ============================================================================
+
+@[simp]
+theorem smod_zero_right {a : EvmWord} : smod a 0 = 0 := by
+  simp [smod]
+
+@[simp]
+theorem zero_smod_left {b : EvmWord} : smod 0 b = 0 := by
+  unfold smod
+  split
+  · rfl
+  · simp [BitVec.zero_srem]
+
+-- ============================================================================
+-- Correctness vs `Int.tmod` (the spec formula)
+-- ============================================================================
+
+/-- For nonzero divisors, `EvmWord.smod` agrees with the executable-spec
+    formula: the truncating-toward-zero integer remainder of the signed
+    interpretations of the operands.
+
+    `BitVec.toInt_srem` is the underlying lemma; this just relabels it
+    through the `EvmWord.smod` wrapper. The zero-divisor short-circuit
+    is handled by `smod_zero_right`. -/
+theorem smod_correct (a b : EvmWord) (h : b ≠ 0) :
+    (smod a b).toInt = a.toInt.tmod b.toInt := by
+  unfold smod
+  rw [if_neg h]
+  exact BitVec.toInt_srem (w := 256) a b
+
+end EvmWord
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Mirrors EvmWord.sdiv / sdiv_correct (slice 3 / PR #2275) for the SMOD opcode.

Wraps BitVec.srem with the EVM zero-divisor short-circuit (BitVec.srem returns x on y=0; EVM returns 0). Provides smod_correct bridging EvmWord.smod to Int.tmod via BitVec.toInt_srem for nonzero divisors.

Two files:
- EvmAsm/Evm64/EvmWordArith/SMod.lean (new): EvmWord.smod definition + edge-case simp lemmas (smod_zero_right, zero_smod_left) + smod_correct.
- EvmAsm/Evm64/EvmWordArith.lean: import the new module so it lands in the umbrella.

Local `lake build` clean (1577 jobs, no new sorry).

Slice 5a of GH #90 (SDIV/SMOD opcodes); beads `evm-asm-pc8g6`. The full evm_smod RISC-V program + stack spec is sibling slice 5 (`evm-asm-bjnb`), which depends on this one.

Note: this is a re-push of a prior commit (10dde2b9) on a stale branch (`feat/91-slice-5a-smod-correct`) whose previous worker iteration was OOM-killed before opening the PR. Cherry-picked clean onto current main.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).