### PR TITLE
chore(shake): move {Eq,IsZero}.Program import from LimbSpec to Spec

### DIFF
--- a/EvmAsm/Evm64/Eq/LimbSpec.lean
+++ b/EvmAsm/Evm64/Eq/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb EQ specs (XOR + OR accumulation).
 -/
 
-import EvmAsm.Evm64.Eq.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Eq/Spec.lean
+++ b/EvmAsm/Evm64/Eq/Spec.lean
@@ -7,6 +7,7 @@
 
 -- `Eq.LimbSpec → Eq.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Eq.LimbSpec
+import EvmAsm.Evm64.Eq.Program
 import EvmAsm.Evm64.EvmWordArith.Eq
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/IsZero/LimbSpec.lean
+++ b/EvmAsm/Evm64/IsZero/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb ISZERO spec (OR reduction).
 -/
 
-import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/IsZero/Spec.lean
+++ b/EvmAsm/Evm64/IsZero/Spec.lean
@@ -6,6 +6,7 @@
 -/
 
 import EvmAsm.Evm64.IsZero.LimbSpec
+import EvmAsm.Evm64.IsZero.Program
 import EvmAsm.Evm64.EvmWordArith.IsZero
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp


### PR DESCRIPTION
Slice of #1045 (import hygiene sweep via lake exe shake).

Mirror of #2426 (And/Or/Xor analog). lake exe shake EvmAsm flags
EvmAsm/Evm64/Eq/LimbSpec.lean and EvmAsm/Evm64/IsZero/LimbSpec.lean as
importing the corresponding Program module without using anything from
it; the program (evm_eq / evm_iszero) is in fact only referenced from
the corresponding Spec.lean (via CodeReq.ofProg).

Cleanup: drop Eq.Program / IsZero.Program from the LimbSpec.lean files
and add them to the Spec.lean files. lake build green; shake no longer
flags those 2 files for Program; 0 sorry.

Beads: evm-asm-o29yf (parent evm-asm-6qj).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).