### PR TITLE
chore(shake): flag EvmWordArith.Common false-positive in Arithmetic.lean

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -224,6 +224,7 @@
 "EvmAsm.Evm64.EvmWordArith.MultiLimb":
  ["Mathlib.Tactic.Linarith", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
 "EvmAsm.Evm64.EvmWordArith.Arithmetic":
- ["Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
+ ["EvmAsm.Evm64.EvmWordArith.Common",
+  "Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
  ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"]}}


### PR DESCRIPTION
`lake exe shake EvmAsm` flags `EvmAsm/Evm64/EvmWordArith/Arithmetic.lean` as not using `EvmAsm.Evm64.EvmWordArith.Common`. **False positive** — Arithmetic.lean uses these declarations from Common.lean throughout the ADD/SUB carry-chain proofs:

- `ult_iff` (lines 29, 31, 273, 274, 285, 286, 304, 305)
- `borrow_or_iff` (lines 280, 298)
- `borrow_step_iff` (lines 288, 311)
- `toNat_eq_limb_sum` (lines 101, 103, 352)
- `add_carry_01`, `add_carry_nat`

Shake's heuristic appears to miss references when the namespace is opened. Add `EvmAsm.Evm64.EvmWordArith.Common` to the existing `Arithmetic` entry in `scripts/noshake.json` so future runs don't re-suggest the (incorrect) removal.

**Verified:** `lake exe shake EvmAsm` no longer flags Arithmetic.lean after this change. `scripts/noshake.json` parses as valid JSON. No source-code changes; build is unaffected.

Refs GH #1045, beads evm-asm-0s2oc.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).