### PR TITLE
chore(shake): flag 5 noshake false-positive imports

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -36,6 +36,16 @@
   "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Bridge":
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse",
    "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue"],
+  "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeFalse":
+  ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches"],
+  "EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.BridgeTrue":
+  ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches"],
+  "EvmAsm.Evm64.DivMod.Shift0Dispatcher":
+  ["EvmAsm.Evm64.DivMod.Shift0AddbackMod", "EvmAsm.Evm64.DivMod.SpecCallShift0"],
+  "EvmAsm.Evm64.DivMod.N4StackSpec":
+  ["EvmAsm.Evm64.DivMod.Spec.CallAddbackMod"],
+  "EvmAsm.Evm64.EvmWordArith.DivBridge":
+  ["EvmAsm.Evm64.EvmWordArith.Normalization"],
   "EvmAsm.Rv64.AddrNorm": ["EvmAsm.Rv64.AddrNormAttr"],
   "EvmAsm.Rv64.AddrNormAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],
   "EvmAsm.Rv64.RegOpsAttr": ["Lean.Meta.Tactic.Simp.RegisterCommand"],


### PR DESCRIPTION
Suppress shake suggestions on 5 files where the flagged imports are genuinely needed (verified by attempting removal and observing build failures with `Unknown identifier` errors):

- `FullPathN2Bundle/BridgeFalse.lean`: needs `Branches` (uses `fullDivN2{R0,R1,R2,C3}_{false,true}` in `simp only`).
- `FullPathN2Bundle/BridgeTrue.lean`: same.
- `DivMod/Shift0Dispatcher.lean`: needs `Shift0AddbackMod` (`n4_shift0_addback_carry_nz`, `evm_{div,mod}_n4_shift0_call_addback_beq_stack_spec`) and `SpecCallShift0` (`evm_{div,mod}_n4_shift0_call_skip_stack_spec`).
- `DivMod/N4StackSpec.lean`: needs `Spec/CallAddbackMod` (`evm_div_n4_call_stack_spec`, `evm_mod_n4_call_stack_spec_within`).
- `EvmWordArith/DivBridge.lean`: `Normalization` is needed transitively for downstream `DivMulSubLimb` (`mulsub_chain_nat`, `mulsub_chain_no_underflow`).

Slice of #1045. Refs beads `evm-asm-hiv14`, parent `evm-asm-6qj`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).