### PR TITLE
chore(divmod): delete 5 dead theorems in Spec/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -81,25 +81,6 @@ def n4MaxSkipSemanticHolds (a b : EvmWord) : Prop :=
       (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
       (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)).2.2.2.2 = 0
 
-/-- **EvmWord-form bridge to `isCallTrialN4_of_shift_nz`.**
-
-    Under shift ≠ 0 + b ≠ 0 (top limb), the runtime BLTU check ALWAYS picks
-    the call path. This is the EvmWord-form of
-    `EvmAsm.Evm64.isCallTrialN4_of_shift_nz` (in `MaxTrialVacuity.lean`).
-
-    Useful as the hbltu discharger when assembling
-    `evm_{div,mod}_n4_shift_nz_stack_spec` per
-    `memory/project_n4_shift_nz_dispatcher_plan.md` — the dispatcher
-    doesn't need to handle the max branch under shift ≠ 0 since
-    call-trial holds algebraically. -/
-theorem isCallTrialN4Evm_of_shift_nz (a b : EvmWord)
-    (hb3nz : b.getLimbN 3 ≠ 0)
-    (hshift_nz : (clzResult (b.getLimbN 3)).1 ≠ 0) :
-    isCallTrialN4Evm a b := by
-  rw [isCallTrialN4Evm_def]
-  exact isCallTrialN4_of_shift_nz (a.getLimbN 3) (b.getLimbN 2) (b.getLimbN 3)
-    hb3nz hshift_nz
-
 /-- Semantic-correctness precondition for the n=4 max+addback sub-path: on
     **un-normalized** `a`, `b` limbs with the maximum trial quotient, the
     mulsub carry is `1` *and* the addback carry is `1`. Together these two
@@ -212,38 +193,6 @@ theorem divN4StackPre_unfold {sp : Word} {a b : EvmWord}
        shiftMem nMem jMem) := by
   delta divN4StackPre; rfl
 
-/-- Full-depth unfold of `divN4StackPre`: expands the bundle, both `evmWordIs`
-    atoms, and `divScratchValues` into primitive `regIs` / `memIs` atoms.
-    Parallel to `divN4MaxSkipStackPost_unfold_atoms` — useful when proving
-    the stack spec by unfolding the target and matching position-by-position
-    against a concrete unfolded hypothesis. -/
-theorem divN4StackPre_unfold_atoms {sp : Word} {a b : EvmWord}
-    {v5 v6 v7 v10 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem : Word} :
-    divN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     (.x11 ↦ᵣ v11) **
-     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-     (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
-      ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
-     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
-      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-      ((sp + signExtend12 3984) ↦ₘ nMem) **
-      ((sp + signExtend12 3976) ↦ₘ jMem))) := by
-  rw [divN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
-      divScratchValues_unfold]
-
 /-- Call-trial counterpart to `divN4StackPre`. Identical to `divN4StackPre`
     except for the scratch bundle: uses `divScratchValuesCall` (19 cells —
     15 from `divScratchValues` plus 4 extra for the `div128`-subroutine
@@ -353,36 +302,6 @@ theorem modN4StackPre_unfold {sp : Word} {a b : EvmWord}
        shiftMem nMem jMem) := by
   delta modN4StackPre; rfl
 
-/-- Full-depth unfold of `modN4StackPre`: expands the bundle, both
-    `evmWordIs` atoms, and `divScratchValues` into primitive `regIs` /
-    `memIs` atoms. Mirror of `divN4StackPre_unfold_atoms`. -/
-theorem modN4StackPre_unfold_atoms {sp : Word} {a b : EvmWord}
-    {v5 v6 v7 v10 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem : Word} :
-    modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     (.x11 ↦ᵣ v11) **
-     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-     (((sp + 32) ↦ₘ b.getLimbN 0) ** ((sp + 40) ↦ₘ b.getLimbN 1) **
-      ((sp + 48) ↦ₘ b.getLimbN 2) ** ((sp + 56) ↦ₘ b.getLimbN 3)) **
-     (((sp + signExtend12 4088) ↦ₘ q0) ** ((sp + signExtend12 4080) ↦ₘ q1) **
-      ((sp + signExtend12 4072) ↦ₘ q2) ** ((sp + signExtend12 4064) ↦ₘ q3) **
-      ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-      ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-      ((sp + signExtend12 4024) ↦ₘ u4) ** ((sp + signExtend12 4016) ↦ₘ u5) **
-      ((sp + signExtend12 4008) ↦ₘ u6) ** ((sp + signExtend12 4000) ↦ₘ u7) **
-      ((sp + signExtend12 3992) ↦ₘ shiftMem) **
-      ((sp + signExtend12 3984) ↦ₘ nMem) **
-      ((sp + signExtend12 3976) ↦ₘ jMem))) := by
-  rw [modN4StackPre_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
-      divScratchValues_unfold]
-
 /-- Named unfold for `divN4MaxSkipStackPost`. Restores access to the
     underlying definition once the `@[irreducible]` attribute has made
     `delta` the only way in at call sites. -/
@@ -394,34 +313,6 @@ theorem divN4MaxSkipStackPost_unfold {sp : Word} {a b : EvmWord} :
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.div a b) **
      divScratchOwn sp) := by
   delta divN4MaxSkipStackPost; rfl
-
-/-- Full-depth unfold of `divN4MaxSkipStackPost`: expands the bundle, its
-    inner `evmWordIs` atoms, and `divScratchOwn` all at once. The final RHS
-    has only primitive assertion atoms (`regIs`, `regOwn`, `memIs`, `memOwn`),
-    which is the shape a position-by-position weakening proof wants to match
-    against. Companion to the partial `_unfold` variant; both coexist because
-    some call sites want the `evmWordIs` / `divScratchOwn` bundles kept. -/
-theorem divN4MaxSkipStackPost_unfold_atoms {sp : Word} {a b : EvmWord} :
-    divN4MaxSkipStackPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
-     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
-     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-     (((sp + 32) ↦ₘ (EvmWord.div a b).getLimbN 0) **
-      ((sp + 40) ↦ₘ (EvmWord.div a b).getLimbN 1) **
-      ((sp + 48) ↦ₘ (EvmWord.div a b).getLimbN 2) **
-      ((sp + 56) ↦ₘ (EvmWord.div a b).getLimbN 3)) **
-     (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
-      memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
-      memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
-      memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
-      memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
-      memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
-      memOwn (sp + signExtend12 3992) ** memOwn (sp + signExtend12 3984) **
-      memOwn (sp + signExtend12 3976))) := by
-  rw [divN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
-      divScratchOwn_unfold]
 
 theorem pcFree_divN4MaxSkipStackPost {sp : Word} {a b : EvmWord} :
     (divN4MaxSkipStackPost sp a b).pcFree := by
@@ -484,31 +375,6 @@ theorem modN4MaxSkipStackPost_unfold {sp : Word} {a b : EvmWord} :
      evmWordIs sp a ** evmWordIs (sp + 32) (EvmWord.mod a b) **
      divScratchOwn sp) := by
   delta modN4MaxSkipStackPost; rfl
-
-/-- Full-depth unfold of `modN4MaxSkipStackPost`: expands the bundle, its
-    inner `evmWordIs` atoms, and `divScratchOwn` all at once. Mirror of
-    `divN4MaxSkipStackPost_unfold_atoms`. -/
-theorem modN4MaxSkipStackPost_unfold_atoms {sp : Word} {a b : EvmWord} :
-    modN4MaxSkipStackPost sp a b =
-    ((.x12 ↦ᵣ (sp + 32)) ** regOwn .x1 ** regOwn .x2 **
-     regOwn .x5 ** regOwn .x6 ** regOwn .x7 **
-     regOwn .x10 ** regOwn .x11 ** (.x0 ↦ᵣ (0 : Word)) **
-     ((sp ↦ₘ a.getLimbN 0) ** ((sp + 8) ↦ₘ a.getLimbN 1) **
-      ((sp + 16) ↦ₘ a.getLimbN 2) ** ((sp + 24) ↦ₘ a.getLimbN 3)) **
-     (((sp + 32) ↦ₘ (EvmWord.mod a b).getLimbN 0) **
-      ((sp + 40) ↦ₘ (EvmWord.mod a b).getLimbN 1) **
-      ((sp + 48) ↦ₘ (EvmWord.mod a b).getLimbN 2) **
-      ((sp + 56) ↦ₘ (EvmWord.mod a b).getLimbN 3)) **
-     (memOwn (sp + signExtend12 4088) ** memOwn (sp + signExtend12 4080) **
-      memOwn (sp + signExtend12 4072) ** memOwn (sp + signExtend12 4064) **
-      memOwn (sp + signExtend12 4056) ** memOwn (sp + signExtend12 4048) **
-      memOwn (sp + signExtend12 4040) ** memOwn (sp + signExtend12 4032) **
-      memOwn (sp + signExtend12 4024) ** memOwn (sp + signExtend12 4016) **
-      memOwn (sp + signExtend12 4008) ** memOwn (sp + signExtend12 4000) **
-      memOwn (sp + signExtend12 3992) ** memOwn (sp + signExtend12 3984) **
-      memOwn (sp + signExtend12 3976))) := by
-  rw [modN4MaxSkipStackPost_unfold, evmWordIs_sp_unfold, evmWordIs_sp32_unfold,
-      divScratchOwn_unfold]
 
 theorem pcFree_modN4MaxSkipStackPost {sp : Word} {a b : EvmWord} :
     (modN4MaxSkipStackPost sp a b).pcFree := by


### PR DESCRIPTION
Removes five theorems under `EvmAsm/Evm64/DivMod/Spec/Base.lean` that have no transitive uses anywhere in EvmAsm/ or scripts/:

- `isCallTrialN4Evm_of_shift_nz` — EvmWord-form bridge to `isCallTrialN4_of_shift_nz`. The dispatcher plan it was assembled for (`memory/project_n4_shift_nz_dispatcher_plan.md`) was superseded by the #61 closure path.
- `divN4StackPre_unfold_atoms` / `modN4StackPre_unfold_atoms` — full-depth unfolds. The partial `_unfold` variants and the bundled `_within` specs are what live consumers use; these atom-level expansions had no callers.
- `divN4MaxSkipStackPost_unfold_atoms` / `modN4MaxSkipStackPost_unfold_atoms` — companion full-depth unfolds for the post bundles, similarly unreferenced.

All five had been kept around as sibling helpers for an earlier dispatcher-assembly approach. Verified unused via `grep -rnE` across EvmAsm/ + scripts/: only the declarations themselves and a couple of doc-comment cross-references mentioned each name. Doc cross-refs were also dropped.

`lake build` green, no new sorry, no `maxHeartbeats`/`maxRecDepth` bumps.

Refs evm-asm-sa0ks (parent evm-asm-sboz / GH #61 closure cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).