### PR TITLE
chore(shake): noshake EvmWordArith.Common in EvmWordArith/Div

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -226,5 +226,6 @@
 "EvmAsm.Evm64.EvmWordArith.Arithmetic":
  ["EvmAsm.Evm64.EvmWordArith.Common",
   "Mathlib.Tactic.NormNum", "Mathlib.Tactic.Ring", "Mathlib.Tactic.Positivity"],
+"EvmAsm.Evm64.EvmWordArith.Div": ["EvmAsm.Evm64.EvmWordArith.Common"],
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
  ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"]}}


### PR DESCRIPTION
Add `EvmAsm.Evm64.EvmWordArith.Common` to `scripts/noshake.json` for `EvmAsm.Evm64.EvmWordArith.Div`. shake flags this import as unused, but Div.lean uses `bv_or_eq_zero` (defined in Common) at lines 80-82. The reference is invisible to shake's static analysis because the lemma is consumed via `have ⟨h012, h3⟩ := bv_or_eq_zero h` destructuring patterns.

Verified locally:
- `lake build` passes (1576 jobs).
- `lake exe shake EvmAsm | scripts/shake-filter.py` no longer flags `EvmWordArith/Div.lean` (or `EvmWordArith/Arithmetic.lean`, paired in #2438).

Refs GH #1045 (parent evm-asm-6qj), beads evm-asm-9ng5g.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).