### PR TITLE
feat(log): add call side-effect bridge

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -8,6 +8,7 @@ import EvmAsm.EL.Create
 import EvmAsm.EL.CreateAddress
 import EvmAsm.EL.Logs
 import EvmAsm.EL.LogArgsBridge
+import EvmAsm.EL.LogCallEffects
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.WorldStateAccount

--- a/EvmAsm/EL/LogCallEffects.lean
+++ b/EvmAsm/EL/LogCallEffects.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.EL.LogCallEffects
+
+  Bridge from LOG entries to message-call side effects (GH #112 / #121).
+-/
+
+import EvmAsm.EL.LogArgsBridge
+import EvmAsm.EL.MessageCallExecution
+
+namespace EvmAsm.EL
+
+namespace LogCallEffects
+
+abbrev CallSideEffects := MessageCallExecution.CallSideEffects
+abbrev LogArgs := LogArgsBridge.LogArgs
+abbrev LogKind := LogArgsBridge.LogKind
+
+/-- Append a LOG entry into the message-call side-effect bundle, preserving
+    every non-log side-effect field. Distinctive token: appendLogSideEffect. -/
+def appendLogSideEffect
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    CallSideEffects :=
+  { refundCounter := effects.refundCounter
+    logs := LogArgsBridge.appendLogFromArgs effects.logs emitter data args
+    accountsToDelete := effects.accountsToDelete
+    touchedAccounts := effects.touchedAccounts }
+
+@[simp] theorem appendLogSideEffect_refundCounter
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).refundCounter =
+      effects.refundCounter := rfl
+
+@[simp] theorem appendLogSideEffect_accountsToDelete
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).accountsToDelete =
+      effects.accountsToDelete := rfl
+
+@[simp] theorem appendLogSideEffect_touchedAccounts
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).touchedAccounts =
+      effects.touchedAccounts := rfl
+
+@[simp] theorem appendLogSideEffect_logs
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).logs =
+      LogArgsBridge.appendLogFromArgs effects.logs emitter data args := rfl
+
+theorem appendLogSideEffect_log_entries
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).logs.entries =
+      effects.logs.entries ++ [LogArgsBridge.mkLogEntry emitter data args] := rfl
+
+theorem appendLogSideEffect_log_length
+    (effects : CallSideEffects) (emitter : Address) (data : List Byte) (args : LogArgs) :
+    (appendLogSideEffect effects emitter data args).logs.entries.length =
+      effects.logs.entries.length + 1 := by
+  simp [appendLogSideEffect, LogArgsBridge.appendLogFromArgs]
+
+theorem appendLogSideEffect_last_topicCountOk
+    (effects : CallSideEffects) (kind : LogKind) (emitter : Address) (data : List Byte)
+    (args : LogArgs) (h_topics : EvmAsm.Evm64.LogArgs.topicCountOk kind args) :
+    ((appendLogSideEffect effects emitter data args).logs.entries.getLast
+        (by simp [appendLogSideEffect, LogArgsBridge.appendLogFromArgs,
+          LogState.appendLog])).topicCountOk := by
+  simpa [appendLogSideEffect] using
+    LogArgsBridge.topicCountOk_appended effects.logs kind emitter data args h_topics
+
+end LogCallEffects
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds a LOG/message-call side-effect bridge for GH #112 / GH #121 / evm-asm-1hl4o.\n\nSummary:\n- add EvmAsm.EL.LogCallEffects\n- define appendLogSideEffect to append LOG entries into MessageCallExecution.CallSideEffects.logs\n- prove refund counter, accounts-to-delete, and touched accounts are preserved while log entries grow by one\n\nLocal verification:\n- lake build EvmAsm.EL.LogCallEffects\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden-pattern scan on edited files\n\nAuthored by @pirapira; implemented by Codex.