### PR TITLE
feat(create): add stack argument records

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -78,6 +78,7 @@ import EvmAsm.Evm64.Env.Spec
 import EvmAsm.Evm64.Env.StackSpec
 import EvmAsm.Evm64.Env.Wrappers
 import EvmAsm.Evm64.CallArgs
+import EvmAsm.Evm64.CreateArgs
 import EvmAsm.Evm64.LogArgs
 import EvmAsm.Evm64.TerminatingArgs
 

--- a/EvmAsm/Evm64/CreateArgs.lean
+++ b/EvmAsm/Evm64/CreateArgs.lean
@@ -1,0 +1,100 @@
+/-
+  EvmAsm.Evm64.CreateArgs
+
+  Pure stack-argument records for CREATE-family opcodes (GH #115).
+-/
+
+import EvmAsm.Evm64.Basic
+
+namespace EvmAsm.Evm64
+
+namespace CreateArgs
+
+/-- Memory slice containing initcode, described by an EVM offset and byte size. -/
+structure InitcodeRange where
+  offset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+/-- CREATE stack arguments: value plus initcode memory range. -/
+structure Create where
+  value : EvmWord
+  initcode : InitcodeRange
+  deriving Repr
+
+/-- CREATE2 stack arguments: value, initcode memory range, and salt. -/
+structure Create2 where
+  value : EvmWord
+  initcode : InitcodeRange
+  salt : EvmWord
+  deriving Repr
+
+/-- Opcode family classifier for CREATE-family stack argument decoding. -/
+inductive Kind where
+  | create
+  | create2
+  deriving DecidableEq, Repr
+
+def argumentCount : Kind → Nat
+  | .create => 3
+  | .create2 => 4
+
+def resultCount (_kind : Kind) : Nat := 1
+
+def initcodeRangeCount (_kind : Kind) : Nat := 1
+
+def usesSalt : Kind → Bool
+  | .create => false
+  | .create2 => true
+
+def hasInitcodeRange (_kind : Kind) : Bool := true
+
+theorem createArgumentCount :
+    argumentCount .create = 3 := rfl
+
+theorem create2ArgumentCount :
+    argumentCount .create2 = 4 := rfl
+
+theorem resultCount_eq_one (kind : Kind) :
+    resultCount kind = 1 := rfl
+
+theorem initcodeRangeCount_eq_one (kind : Kind) :
+    initcodeRangeCount kind = 1 := rfl
+
+theorem hasInitcodeRange_eq_true (kind : Kind) :
+    hasInitcodeRange kind = true := rfl
+
+theorem argumentCount_eq_three_plus_salt (kind : Kind) :
+    argumentCount kind = 3 + if usesSalt kind then 1 else 0 := by
+  cases kind <;> rfl
+
+theorem createUsesNoSalt :
+    usesSalt .create = false := rfl
+
+theorem create2UsesSalt :
+    usesSalt .create2 = true := rfl
+
+theorem usesSalt_iff_create2 (kind : Kind) :
+    usesSalt kind = true ↔ kind = .create2 := by
+  cases kind <;> decide
+
+theorem not_usesSalt_iff_create (kind : Kind) :
+    usesSalt kind = false ↔ kind = .create := by
+  cases kind <;> decide
+
+theorem create2_argumentCount_eq_succ_create :
+    argumentCount .create2 = argumentCount .create + 1 := rfl
+
+theorem create_initcode (args : Create) :
+    args.initcode = { offset := args.initcode.offset, size := args.initcode.size } := by
+  cases args.initcode
+  rfl
+
+theorem create2_initcode (args : Create2) :
+    args.initcode = { offset := args.initcode.offset, size := args.initcode.size } := by
+  cases args.initcode
+  rfl
+
+end CreateArgs
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds Evm64 CREATE-family stack argument records for GH #115.\n\nSummary:\n- add EvmAsm.Evm64.CreateArgs\n- define CREATE and CREATE2 stack operand records\n- add Kind, argumentCount/resultCount/initcodeRangeCount helpers\n- add compact salt classifier and arity lemmas\n\nVerification:\n- lake build EvmAsm.Evm64.CreateArgs\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden proof-option/sorry scan on edited files\n\nRefs evm-asm-n7d8r, GH #115.\n\nAuthored by @pirapira; implemented by Codex.