### PR TITLE
feat(calldata): bridge calldataload window to mload

### DIFF
--- a/EvmAsm/Evm64/Calldata/LoadProgram.lean
+++ b/EvmAsm/Evm64/Calldata/LoadProgram.lean
@@ -14,6 +14,7 @@
   Authored by @pirapira; implemented by Codex.
 -/
 
+import EvmAsm.Evm64.MLoad.Program
 import EvmAsm.Rv64.SepLogic
 
 namespace EvmAsm.Evm64
@@ -21,43 +22,20 @@ namespace Calldata
 
 open EvmAsm.Rv64
 
-/-- Pack `k + 1` calldata bytes, starting at `addrReg + limbStart`, into
-    `accReg` in big-endian order.  The first byte seeds the accumulator;
-    each later byte shifts the accumulator left by 8 and ORs in the next
-    zero-extended LBU result. -/
-private def calldataload_byte_pack
-    (addrReg byteReg accReg : Reg) (limbStart : Nat) : Nat → Program
-  | 0 =>
-      LBU accReg addrReg (BitVec.ofNat 12 limbStart)
-  | k + 1 =>
-      calldataload_byte_pack addrReg byteReg accReg limbStart k ;;
-      LBU byteReg addrReg (BitVec.ofNat 12 (limbStart + (k + 1))) ;;
-      SLLI accReg accReg (BitVec.ofNat 6 8) ;;
-      OR' accReg accReg byteReg
-
-/-- Pack one output limb of the 32-byte CALLDATALOAD window and store it
-    at the canonical EVM-stack limb offset.  Limb `0` is the low 64 bits,
-    so it consumes calldata bytes 24..31; limb `3` consumes bytes 0..7. -/
-private def calldataload_one_limb
-    (addrReg byteReg accReg : Reg) (j : Nat) : Program :=
-  calldataload_byte_pack addrReg byteReg accReg (8 * (3 - j)) 7 ;;
-  SD .x12 accReg (BitVec.ofNat 12 (8 * j))
-
 /-- Straight-line in-bounds CALLDATALOAD byte-window core.
 
     `envPtrReg` is expected to hold `env.callDataPtr`.  The program pops
     the low 64-bit offset limb from the EVM stack at `x12`, computes the
     source byte pointer, packs the 32-byte calldata window, and stores
     the result back to the same stack slot.  The stack pointer is
-    unchanged because CALLDATALOAD pops one word and pushes one word. -/
+    unchanged because CALLDATALOAD pops one word and pushes one word.
+
+    The instruction sequence is intentionally the same as `evm_mload`;
+    CALLDATALOAD supplies `env.callDataPtr` as the base register where
+    MLOAD supplies the EVM memory base register. -/
 def evm_calldataload_window
     (offReg byteReg accReg addrReg envPtrReg : Reg) : Program :=
-  LD offReg .x12 0 ;;
-  ADD addrReg envPtrReg offReg ;;
-  calldataload_one_limb addrReg byteReg accReg 0 ;;
-  calldataload_one_limb addrReg byteReg accReg 1 ;;
-  calldataload_one_limb addrReg byteReg accReg 2 ;;
-  calldataload_one_limb addrReg byteReg accReg 3
+  evm_mload offReg byteReg accReg addrReg envPtrReg
 
 /-- Code requirement for `evm_calldataload_window` placed at `base`. -/
 abbrev evm_calldataload_window_code
@@ -65,33 +43,13 @@ abbrev evm_calldataload_window_code
   CodeReq.ofProg base
     (evm_calldataload_window offReg byteReg accReg addrReg envPtrReg)
 
-/-- Instruction length of the byte-pack block: one seed `LBU`, then
-    `k` repetitions of `LBU; SLLI; OR`. -/
-theorem calldataload_byte_pack_length
-    (addrReg byteReg accReg : Reg) (limbStart k : Nat) :
-    (calldataload_byte_pack addrReg byteReg accReg limbStart k).length =
-      1 + 3 * k := by
-  induction k with
-  | zero => rfl
-  | succ k ih =>
-      simp [calldataload_byte_pack, LBU, SLLI, OR', single, seq,
-        Program.length_append, ih, Nat.mul_succ]
-      omega
-
-/-- One packed output limb is 23 instructions. -/
-theorem calldataload_one_limb_length
-    (addrReg byteReg accReg : Reg) (j : Nat) :
-    (calldataload_one_limb addrReg byteReg accReg j).length = 23 := by
-  simp [calldataload_one_limb, SD, single, seq, Program.length_append,
-    calldataload_byte_pack_length]
-
 /-- `evm_calldataload_window` is 94 RISC-V instructions. -/
 theorem evm_calldataload_window_program_length
     (offReg byteReg accReg addrReg envPtrReg : Reg) :
     (evm_calldataload_window offReg byteReg accReg addrReg envPtrReg).length =
       94 := by
-  simp [evm_calldataload_window, LD, ADD, single, seq, Program.length_append,
-    calldataload_one_limb_length]
+  simpa [evm_calldataload_window] using
+    evm_mload_length offReg byteReg accReg addrReg envPtrReg
 
 /-- `evm_calldataload_window` occupies 376 bytes in RV64 code memory. -/
 theorem evm_calldataload_window_byte_length
@@ -102,44 +60,69 @@ theorem evm_calldataload_window_byte_length
 
 /-- Byte offset of the offset-load instruction. -/
 theorem evm_calldataload_window_offset_load_byte_off : 4 * 0 = 0 := by
-  rfl
+  exact evm_mload_offset_load_byte_off
 
 /-- Byte offset of the source-address ADD instruction. -/
 theorem evm_calldataload_window_addr_add_byte_off : 4 * 1 = 4 := by
-  rfl
+  exact evm_mload_addr_add_byte_off
 
 /-- Byte offset of the seed LBU inside a byte-pack block. -/
 theorem calldataload_byte_pack_seed_byte_off : 4 * 0 = 0 := by
-  rfl
+  exact mload_byte_pack_seed_byte_off
 
 /-- Byte offset of repeated LBU instruction `i` inside a byte-pack block. -/
 theorem calldataload_byte_pack_lbu_byte_off (i : Nat) :
     4 * (1 + 3 * i) = 4 + 12 * i := by
-  omega
+  exact mload_byte_pack_lbu_byte_off i
 
 /-- Byte offset of repeated SLLI instruction `i` inside a byte-pack block. -/
 theorem calldataload_byte_pack_slli_byte_off (i : Nat) :
     4 * (1 + 3 * i + 1) = 8 + 12 * i := by
-  omega
+  exact mload_byte_pack_slli_byte_off i
 
 /-- Byte offset of repeated OR instruction `i` inside a byte-pack block. -/
 theorem calldataload_byte_pack_or_byte_off (i : Nat) :
     4 * (1 + 3 * i + 2) = 12 + 12 * i := by
-  omega
+  exact mload_byte_pack_or_byte_off i
 
 /-- Byte offset of the final stack-store inside one output-limb block. -/
 theorem calldataload_one_limb_store_byte_off : 4 * 22 = 88 := by
-  rfl
+  exact mload_one_limb_store_byte_off
 
 /-- Byte offset of CALLDATALOAD output-limb block `j` within the window core. -/
 theorem evm_calldataload_window_limb_block_byte_off (j : Nat) :
     4 * (2 + 23 * j) = 8 + 92 * j := by
-  omega
+  exact evm_mload_limb_block_byte_off j
 
 /-- Byte offset of the final stack-store in output-limb block `j`. -/
 theorem evm_calldataload_window_limb_store_byte_off (j : Nat) :
     4 * (2 + 23 * j + 22) = 96 + 92 * j := by
-  omega
+  exact evm_mload_limb_store_byte_off j
+
+/-! ## MLOAD program bridge
+
+The in-bounds CALLDATALOAD byte-window core has the same instruction
+shape as MLOAD: both load an offset from `x12`, add a base pointer, pack
+the 32-byte big-endian window, and store the result back to the same EVM
+stack slot.  CALLDATALOAD supplies `env.callDataPtr` as that base
+pointer; MLOAD supplies the EVM memory base pointer.
+-/
+
+/-- The CALLDATALOAD byte-window core is program-identical to MLOAD with
+    the base register interpreted as the calldata pointer register. -/
+theorem evm_calldataload_window_eq_evm_mload
+    (offReg byteReg accReg addrReg envPtrReg : Reg) :
+    evm_calldataload_window offReg byteReg accReg addrReg envPtrReg =
+      evm_mload offReg byteReg accReg addrReg envPtrReg := by
+  rfl
+
+/-- CodeReq bridge induced by `evm_calldataload_window_eq_evm_mload`. -/
+theorem evm_calldataload_window_code_eq_evm_mload_code
+    (offReg byteReg accReg addrReg envPtrReg : Reg) (base : Word) :
+    evm_calldataload_window_code offReg byteReg accReg addrReg envPtrReg base =
+      evm_mload_code offReg byteReg accReg addrReg envPtrReg base := by
+  unfold evm_calldataload_window_code evm_mload_code
+  rw [evm_calldataload_window_eq_evm_mload]
 
 end Calldata
 end EvmAsm.Evm64


### PR DESCRIPTION
Adds the bridge that makes the CALLDATALOAD in-bounds byte-window core reuse the existing MLOAD program surface for GH #104. The calldata-specific name remains evm_calldataload_window, but its instruction sequence is definitionally evm_mload with env.callDataPtr as the base register. This avoids maintaining a second 94-instruction byte-packer and gives the later evm_calldataload_stack_spec_within proof direct program/code equality lemmas to compose against MLOAD proof components.

Verification:
- lake build EvmAsm.Evm64.Calldata.LoadProgram
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check origin/main..HEAD
- rg forbidden-token scan over edited file (clean)

Refs evm-asm-2k3fz and evm-asm-ugei. Refs GH #104.

Authored by @pirapira; implemented by Codex.