### PR TITLE
feat(termination): add caller-visible bridge

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -23,6 +23,7 @@ import EvmAsm.EL.CallArgsBridge
 import EvmAsm.EL.CallOutputBridge
 import EvmAsm.EL.TerminatingArgsBridge
 import EvmAsm.EL.TerminatingCallOutput
+import EvmAsm.EL.TerminatingCallerVisible
 import EvmAsm.EL.TransactionCall
 import EvmAsm.EL.TransactionExecution
 import EvmAsm.EL.Block

--- a/EvmAsm/EL/TerminatingCallerVisible.lean
+++ b/EvmAsm/EL/TerminatingCallerVisible.lean
@@ -1,0 +1,114 @@
+/-
+  EvmAsm.EL.TerminatingCallerVisible
+
+  Bridge from terminating opcode results to the executable-spec caller-visible
+  message-call result surface (GH #113 / #121).
+-/
+
+import EvmAsm.EL.MessageCallExecution
+import EvmAsm.EL.TerminatingArgsBridge
+
+namespace EvmAsm.EL
+
+namespace TerminatingCallerVisible
+
+abbrev TerminatingKind := TerminatingArgsBridge.TerminatingKind
+abbrev TerminatingArgs := TerminatingArgsBridge.TerminatingArgs
+abbrev CallExecutionInput := MessageCallExecution.CallExecutionInput
+abbrev CallerVisibleResult := MessageCallExecution.CallerVisibleResult
+
+/-- Caller-visible state selected by a terminating opcode result. Successful
+    terminations commit `state`; reverts and failures restore `input.state`.
+    Distinctive token: committedTerminatingState. -/
+def committedTerminatingState
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState) :
+    WorldState :=
+  match kind with
+  | .stop => state
+  | .return_ => state
+  | .revert => input.state
+  | .invalid => input.state
+  | .selfdestruct => state
+
+/-- Caller-visible output selected by a terminating opcode result. RETURN and
+    REVERT propagate their memory slice; STOP, INVALID, and SELFDESTRUCT expose
+    empty output. -/
+def propagatedTerminatingOutput (kind : TerminatingKind) (data : List Byte) :
+    List Byte :=
+  match kind with
+  | .stop => []
+  | .return_ => data
+  | .revert => data
+  | .invalid => []
+  | .selfdestruct => []
+
+/-- Package a terminating-opcode result through `toCallerVisible`, the
+    executable-spec caller-visible result surface. Distinctive token:
+    terminatingCallerVisibleResult. -/
+def terminatingCallerVisibleResult
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState)
+    (data : List Byte) (gasRemaining : Nat) (args : TerminatingArgs) :
+    CallerVisibleResult :=
+  MessageCallExecution.toCallerVisible input
+    (TerminatingArgsBridge.mkResultFromArgs kind state data gasRemaining args)
+
+theorem terminatingCallerVisibleResult_status
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState)
+    (data : List Byte) (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input kind state data gasRemaining args).status =
+      match kind with
+      | .stop => CallStatus.success
+      | .return_ => CallStatus.success
+      | .revert => CallStatus.revert
+      | .invalid => CallStatus.failure
+      | .selfdestruct => CallStatus.success := by
+  cases kind <;> rfl
+
+theorem terminatingCallerVisibleResult_state
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState)
+    (data : List Byte) (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input kind state data gasRemaining args).state =
+      committedTerminatingState input kind state := by
+  cases kind <;> rfl
+
+theorem terminatingCallerVisibleResult_output
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState)
+    (data : List Byte) (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input kind state data gasRemaining args).output =
+      propagatedTerminatingOutput kind data := by
+  cases kind <;> rfl
+
+theorem terminatingCallerVisibleResult_gasRemaining
+    (input : CallExecutionInput) (kind : TerminatingKind) (state : WorldState)
+    (data : List Byte) (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input kind state data gasRemaining args).gasRemaining =
+      gasRemaining := by
+  cases kind <;> rfl
+
+theorem terminatingCallerVisibleResult_return_state
+    (input : CallExecutionInput) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input .return_ state data gasRemaining args).state =
+      state := rfl
+
+theorem terminatingCallerVisibleResult_revert_state
+    (input : CallExecutionInput) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input .revert state data gasRemaining args).state =
+      input.state := rfl
+
+theorem terminatingCallerVisibleResult_return_output
+    (input : CallExecutionInput) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input .return_ state data gasRemaining args).output =
+      data := rfl
+
+theorem terminatingCallerVisibleResult_revert_output
+    (input : CallExecutionInput) (state : WorldState) (data : List Byte)
+    (gasRemaining : Nat) (args : TerminatingArgs) :
+    (terminatingCallerVisibleResult input .revert state data gasRemaining args).output =
+      data := rfl
+
+end TerminatingCallerVisible
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds GH #113 executable-spec bridge from TerminatingArgsBridge.mkResultFromArgs through MessageCallExecution.toCallerVisible.

Summary:
- adds EvmAsm/EL/TerminatingCallerVisible.lean
- defines committedTerminatingState and propagatedTerminatingOutput
- proves Kind-uniform caller-visible status, state, output, and gasRemaining lemmas for STOP/RETURN/REVERT/INVALID/SELFDESTRUCT

Verification:
- lake build EvmAsm.EL.TerminatingCallerVisible
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-token scan over edited files

Slice: evm-asm-ueian
GH issue: #113

Authored by @pirapira; implemented by Codex.