### PR TITLE
feat(conformance): add calldata vectors

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -12,6 +12,7 @@ import EvmAsm.EL.Logs
 import EvmAsm.EL.LogArgsBridge
 import EvmAsm.EL.LogCallEffects
 import EvmAsm.EL.Conformance
+import EvmAsm.EL.Conformance.Calldata
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.WorldStateAccount
 import EvmAsm.EL.Storage

--- a/EvmAsm/EL/Conformance/Calldata.lean
+++ b/EvmAsm/EL/Conformance/Calldata.lean
@@ -1,0 +1,86 @@
+/-
+  EvmAsm.EL.Conformance.Calldata
+
+  Initial Lean-side conformance vectors for executable calldata helpers
+  (GH #125).
+-/
+
+import EvmAsm.EL.Conformance
+import EvmAsm.Evm64.Calldata.Basic
+import EvmAsm.Evm64.Calldata.Size
+
+namespace EvmAsm.EL
+namespace Conformance
+namespace Calldata
+
+abbrev EvmWord := EvmAsm.Evm64.EvmWord
+
+/-- Input shape for a CALLDATALOAD executable-helper conformance vector. -/
+structure CallDataLoadInput where
+  data : List (BitVec 8)
+  offset : Nat
+  deriving Repr
+
+/-- Input shape for a CALLDATASIZE executable-helper conformance vector. -/
+structure CallDataSizeInput where
+  data : List (BitVec 8)
+  deriving Repr
+
+def runCallDataLoad (input : CallDataLoadInput) : EvmWord :=
+  EvmAsm.Evm64.Calldata.callDataLoadWord input.data input.offset
+
+def runCallDataSize (input : CallDataSizeInput) : EvmWord :=
+  EvmAsm.Evm64.Calldata.callDataSizeOf input.data
+
+/-- CALLDATALOAD reads zero when the requested 32-byte window starts at the
+    end of calldata. Distinctive token: callDataLoadOutOfBoundsVector. -/
+def callDataLoadOutOfBoundsVector : TestVector CallDataLoadInput EvmWord :=
+  { id := "calldataload-oob-zero"
+    input := { data := [(0x12 : BitVec 8)], offset := 1 }
+    expected := .value 0 }
+
+/-- CALLDATASIZE pushes the byte length of calldata as an EVM word. -/
+def callDataSizeTwoBytesVector : TestVector CallDataSizeInput EvmWord :=
+  { id := "calldatasize-two-bytes"
+    input := { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)] }
+    expected := .value 2 }
+
+theorem runCallDataLoad_outOfBounds :
+    runCallDataLoad { data := [(0x12 : BitVec 8)], offset := 1 } = 0 := by
+  exact EvmAsm.Evm64.Calldata.callDataLoadWord_of_ge_length (by decide)
+
+theorem runCallDataSize_twoBytes :
+    runCallDataSize { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)] } =
+      (2 : EvmWord) := rfl
+
+theorem callDataLoadOutOfBoundsVector_passed :
+    checkVector runCallDataLoad callDataLoadOutOfBoundsVector = .passed :=
+  checkVector_value_passed runCallDataLoad
+    "calldataload-oob-zero"
+    { data := [(0x12 : BitVec 8)], offset := 1 }
+    (0 : EvmWord)
+    runCallDataLoad_outOfBounds
+
+theorem callDataSizeTwoBytesVector_passed :
+    checkVector runCallDataSize callDataSizeTwoBytesVector = .passed :=
+  checkVector_value_passed runCallDataSize
+    "calldatasize-two-bytes"
+    { data := [(0xaa : BitVec 8), (0xbb : BitVec 8)] }
+    (2 : EvmWord)
+    runCallDataSize_twoBytes
+
+/-- Compact initial checked-vector batch for calldata executable helpers.
+    Distinctive token: calldataConformanceVectors. -/
+def calldataConformanceVectors : List CheckResult :=
+  [ checkVector runCallDataLoad callDataLoadOutOfBoundsVector
+  , checkVector runCallDataSize callDataSizeTwoBytesVector
+  ]
+
+theorem calldataConformanceVectors_passed :
+    calldataConformanceVectors = [.passed, .passed] := by
+  simp [calldataConformanceVectors, callDataLoadOutOfBoundsVector_passed,
+    callDataSizeTwoBytesVector_passed]
+
+end Calldata
+end Conformance
+end EvmAsm.EL


### PR DESCRIPTION
Adds initial GH #125 checked vectors against executable calldata helpers.

Summary:
- adds EvmAsm/EL/Conformance/Calldata.lean
- defines compact CALLDATALOAD and CALLDATASIZE vector input surfaces
- checks CALLDATALOAD out-of-bounds zero-padding
- checks CALLDATASIZE byte-length output
- exposes calldataConformanceVectors_passed for the compact batch

Verification:
- lake build EvmAsm.EL.Conformance.Calldata
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- forbidden-token scan over edited files

Slice: evm-asm-8c2xd
GH issue: #125

Authored by @pirapira; implemented by Codex.