### PR TITLE
feat(handlers): add terminating entries

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -92,6 +92,7 @@ import EvmAsm.Evm64.StorageAccessOutcome
 -- Opcode dispatch surface (#106)
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.HandlerTable
+import EvmAsm.Evm64.TerminatingHandlers
 
 -- Precompile dispatch surface (#116)
 import EvmAsm.Evm64.Precompile

--- a/EvmAsm/Evm64/TerminatingHandlers.lean
+++ b/EvmAsm/Evm64/TerminatingHandlers.lean
@@ -1,0 +1,91 @@
+/-
+  EvmAsm.Evm64.TerminatingHandlers
+
+  Pure handler-table entries for terminating opcodes (GH #107).
+-/
+
+import EvmAsm.Evm64.HandlerTable
+
+namespace EvmAsm.Evm64
+namespace TerminatingHandlers
+
+/-- STOP handler: terminate successfully without returndata. -/
+def stopHandler : OpcodeHandler :=
+  fun state => state.stop
+
+/-- INVALID handler: terminate with an error status. -/
+def invalidHandler : OpcodeHandler :=
+  fun state => state.invalid
+
+/-- Lookup surface for terminating opcodes that already need no additional
+    stack or memory arguments. RETURN/REVERT/SELFDESTRUCT need separate
+    argument bridges, so this first table only installs STOP and INVALID. -/
+def terminatingHandler? : EvmOpcode → Option OpcodeHandler
+  | .STOP => some stopHandler
+  | .INVALID => some invalidHandler
+  | _ => none
+
+/-- Handler table containing the currently argument-free terminating handlers. -/
+def terminatingHandlerTable : HandlerTable :=
+  HandlerTable.setHandler
+    (HandlerTable.setHandler HandlerTable.empty .STOP stopHandler)
+    .INVALID invalidHandler
+
+@[simp] theorem terminatingHandler?_STOP :
+    terminatingHandler? .STOP = some stopHandler := rfl
+
+@[simp] theorem terminatingHandler?_INVALID :
+    terminatingHandler? .INVALID = some invalidHandler := rfl
+
+@[simp] theorem stopHandler_status (state : EvmState) :
+    (stopHandler state).status = .stopped := rfl
+
+@[simp] theorem invalidHandler_status (state : EvmState) :
+    (invalidHandler state).status = .error := rfl
+
+@[simp] theorem terminatingHandlerTable_STOP :
+    terminatingHandlerTable .STOP = some stopHandler := by
+  simp [terminatingHandlerTable, HandlerTable.setHandler]
+
+@[simp] theorem terminatingHandlerTable_INVALID :
+    terminatingHandlerTable .INVALID = some invalidHandler := by
+  simp [terminatingHandlerTable, HandlerTable.setHandler]
+
+@[simp] theorem dispatchOpcode?_terminatingHandlerTable_STOP
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? terminatingHandlerTable .STOP state =
+      some (state.stop) := by
+  simp [HandlerTable.dispatchOpcode?, stopHandler]
+
+@[simp] theorem dispatchOpcode_terminatingHandlerTable_STOP
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode terminatingHandlerTable .STOP state =
+      state.stop := by
+  simp [HandlerTable.dispatchOpcode]
+
+@[simp] theorem dispatchOpcode?_terminatingHandlerTable_INVALID
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode? terminatingHandlerTable .INVALID state =
+      some (state.invalid) := by
+  simp [HandlerTable.dispatchOpcode?, invalidHandler]
+
+@[simp] theorem dispatchOpcode_terminatingHandlerTable_INVALID
+    (state : EvmState) :
+    HandlerTable.dispatchOpcode terminatingHandlerTable .INVALID state =
+      state.invalid := by
+  simp [HandlerTable.dispatchOpcode]
+
+@[simp] theorem dispatchOpcode_terminatingHandlerTable_STOP_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode terminatingHandlerTable .STOP state).status =
+      .stopped := by
+  simp
+
+@[simp] theorem dispatchOpcode_terminatingHandlerTable_INVALID_status
+    (state : EvmState) :
+    (HandlerTable.dispatchOpcode terminatingHandlerTable .INVALID state).status =
+      .error := by
+  simp
+
+end TerminatingHandlers
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2472.

Adds STOP and INVALID entries for the pure handler-table surface in GH #107.

Summary:
- add stopHandler and invalidHandler
- add terminatingHandler? lookup for argument-free terminating opcodes
- add terminatingHandlerTable using HandlerTable.setHandler
- add lookup, dispatch, and status lemmas for STOP/INVALID

Verification:
- lake build EvmAsm.Evm64.TerminatingHandlers
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in edited files

Slice: evm-asm-kfuk8
Authored by @pirapira; implemented by Codex.