### PR TITLE
feat(calldata): add calldatacopy args

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -117,3 +117,4 @@ import EvmAsm.Evm64.Calldata.SizeProgram
 import EvmAsm.Evm64.Calldata.SizeSpec
 import EvmAsm.Evm64.Calldata.LoadProgram
 import EvmAsm.Evm64.Calldata.CopyArgs
+import EvmAsm.Evm64.Calldata.CopyExec

--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -116,3 +116,4 @@ import EvmAsm.Evm64.Calldata.Size
 import EvmAsm.Evm64.Calldata.SizeProgram
 import EvmAsm.Evm64.Calldata.SizeSpec
 import EvmAsm.Evm64.Calldata.LoadProgram
+import EvmAsm.Evm64.Calldata.CopyArgs

--- a/EvmAsm/Evm64/Calldata/CopyArgs.lean
+++ b/EvmAsm/Evm64/Calldata/CopyArgs.lean
@@ -1,0 +1,119 @@
+/-
+  EvmAsm.Evm64.Calldata.CopyArgs
+
+  Pure stack-argument record for CALLDATACOPY (GH #104).
+-/
+
+import EvmAsm.Evm64.Basic
+import EvmAsm.Evm64.MemoryGas
+
+namespace EvmAsm.Evm64
+namespace CallDataCopyArgs
+
+/-- Memory slice described by an EVM offset and byte size. -/
+structure MemoryRange where
+  offset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+/-- CALLDATACOPY stack arguments: destination memory offset, calldata source
+    offset, and byte size. -/
+structure Args where
+  destOffset : EvmWord
+  dataOffset : EvmWord
+  size : EvmWord
+  deriving Repr
+
+/-- CALLDATACOPY pops three stack words. -/
+def stackArgumentCount : Nat := 3
+
+/-- CALLDATACOPY pushes no result words. -/
+def resultCount : Nat := 0
+
+/-- CALLDATACOPY has one destination memory range. -/
+def memoryRangeCount : Nat := 1
+
+/-- Convenience builder for CALLDATACOPY stack arguments. -/
+def copyArgs (destOffset dataOffset size : EvmWord) : Args :=
+  { destOffset := destOffset, dataOffset := dataOffset, size := size }
+
+/-- Destination memory range written by CALLDATACOPY. -/
+def destinationRange (args : Args) : MemoryRange :=
+  { offset := args.destOffset, size := args.size }
+
+/-- Destination memory offset as a host `Nat` for executable memory helpers. -/
+def destinationOffsetNat (args : Args) : Nat :=
+  args.destOffset.toNat
+
+/-- Calldata source offset as a host `Nat` for executable calldata helpers. -/
+def sourceOffsetNat (args : Args) : Nat :=
+  args.dataOffset.toNat
+
+/-- Byte count as a host `Nat` for executable memory/calldata helpers. -/
+def sizeNat (args : Args) : Nat :=
+  args.size.toNat
+
+/-- Memory expansion caused by the CALLDATACOPY destination range.
+    Distinctive token: CallDataCopyArgs.copyMemoryExpansionCostFromArgs. -/
+def copyMemoryExpansionCostFromArgs (sizeBytes : Nat) (args : Args) : Nat :=
+  MemoryGas.memoryAccessExpansionCost
+    sizeBytes (destinationOffsetNat args) (sizeNat args)
+
+theorem stackArgumentCount_eq_three : stackArgumentCount = 3 := rfl
+
+theorem resultCount_eq_zero : resultCount = 0 := rfl
+
+theorem memoryRangeCount_eq_one : memoryRangeCount = 1 := rfl
+
+theorem copyArgs_destOffset (destOffset dataOffset size : EvmWord) :
+    (copyArgs destOffset dataOffset size).destOffset = destOffset := rfl
+
+theorem copyArgs_dataOffset (destOffset dataOffset size : EvmWord) :
+    (copyArgs destOffset dataOffset size).dataOffset = dataOffset := rfl
+
+theorem copyArgs_size (destOffset dataOffset size : EvmWord) :
+    (copyArgs destOffset dataOffset size).size = size := rfl
+
+theorem destinationRange_offset (args : Args) :
+    (destinationRange args).offset = args.destOffset := rfl
+
+theorem destinationRange_size (args : Args) :
+    (destinationRange args).size = args.size := rfl
+
+theorem destinationOffsetNat_eq (args : Args) :
+    destinationOffsetNat args = args.destOffset.toNat := rfl
+
+theorem sourceOffsetNat_eq (args : Args) :
+    sourceOffsetNat args = args.dataOffset.toNat := rfl
+
+theorem sizeNat_eq (args : Args) :
+    sizeNat args = args.size.toNat := rfl
+
+theorem copyMemoryExpansionCostFromArgs_eq
+    (sizeBytes : Nat) (args : Args) :
+    copyMemoryExpansionCostFromArgs sizeBytes args =
+      MemoryGas.memoryAccessExpansionCost
+        sizeBytes args.destOffset.toNat args.size.toNat := rfl
+
+@[simp] theorem copyMemoryExpansionCostFromArgs_zero_size
+    (sizeBytes : Nat) (destOffset dataOffset : EvmWord) :
+    copyMemoryExpansionCostFromArgs sizeBytes
+      (copyArgs destOffset dataOffset 0) = 0 := by
+  simp [copyMemoryExpansionCostFromArgs, copyArgs, destinationOffsetNat, sizeNat]
+
+theorem copyMemoryExpansionCostFromArgs_eq_zero_of_no_growth
+    {sizeBytes : Nat} {args : Args}
+    (h_no_growth :
+      evmMemExpand sizeBytes args.destOffset.toNat args.size.toNat = sizeBytes) :
+    copyMemoryExpansionCostFromArgs sizeBytes args = 0 := by
+  exact MemoryGas.memoryAccessExpansionCost_eq_zero_of_no_growth h_no_growth
+
+theorem copyMemoryExpansionCostFromArgs_eq_zero_of_access_le
+    {sizeBytes : Nat} {args : Args}
+    (h_access :
+      roundUpTo32 (args.destOffset.toNat + args.size.toNat) ≤ sizeBytes) :
+    copyMemoryExpansionCostFromArgs sizeBytes args = 0 := by
+  exact MemoryGas.memoryAccessExpansionCost_eq_zero_of_access_le h_access
+
+end CallDataCopyArgs
+end EvmAsm.Evm64

--- a/EvmAsm/Evm64/Calldata/CopyExec.lean
+++ b/EvmAsm/Evm64/Calldata/CopyExec.lean
@@ -1,0 +1,70 @@
+/-
+  EvmAsm.Evm64.Calldata.CopyExec
+
+  Bridge from CALLDATACOPY stack arguments to executable calldata bytes
+  (GH #104).
+-/
+
+import EvmAsm.Evm64.Calldata.Basic
+import EvmAsm.Evm64.Calldata.CopyArgs
+
+namespace EvmAsm.Evm64
+namespace CallDataCopyExec
+
+/-- Bytes written by CALLDATACOPY for a decoded stack-argument record.
+    Distinctive token: CallDataCopyExec.copiedBytesFromArgs. -/
+def copiedBytesFromArgs
+    (data : List (BitVec 8)) (args : CallDataCopyArgs.Args) : List (BitVec 8) :=
+  Calldata.callDataCopyBytes
+    data (CallDataCopyArgs.sourceOffsetNat args) (CallDataCopyArgs.sizeNat args)
+
+theorem copiedBytesFromArgs_eq
+    (data : List (BitVec 8)) (args : CallDataCopyArgs.Args) :
+    copiedBytesFromArgs data args =
+      Calldata.callDataCopyBytes data args.dataOffset.toNat args.size.toNat := rfl
+
+@[simp] theorem copiedBytesFromArgs_length
+    (data : List (BitVec 8)) (args : CallDataCopyArgs.Args) :
+    (copiedBytesFromArgs data args).length = args.size.toNat := by
+  simp [copiedBytesFromArgs, CallDataCopyArgs.sizeNat]
+
+@[simp] theorem copiedBytesFromArgs_zero_size
+    (data : List (BitVec 8)) (destOffset dataOffset : EvmWord) :
+    copiedBytesFromArgs data (CallDataCopyArgs.copyArgs destOffset dataOffset 0) = [] := by
+  simp [copiedBytesFromArgs, CallDataCopyArgs.copyArgs,
+    CallDataCopyArgs.sourceOffsetNat, CallDataCopyArgs.sizeNat]
+
+theorem copiedBytesFromArgs_get
+    {data : List (BitVec 8)} {args : CallDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = Calldata.callDataByte data (args.dataOffset.toNat + i) := by
+  unfold copiedBytesFromArgs CallDataCopyArgs.sourceOffsetNat CallDataCopyArgs.sizeNat
+  exact Calldata.callDataCopyBytes_get h
+
+theorem copiedBytesFromArgs_get_of_in_bounds
+    {data : List (BitVec 8)} {args : CallDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : args.dataOffset.toNat + i < data.length) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = data[args.dataOffset.toNat + i] := by
+  rw [copiedBytesFromArgs_get h, Calldata.callDataByte_of_lt hsrc]
+
+theorem copiedBytesFromArgs_get_of_out_of_bounds
+    {data : List (BitVec 8)} {args : CallDataCopyArgs.Args} {i : Nat}
+    (h : i < args.size.toNat)
+    (hsrc : data.length ≤ args.dataOffset.toNat + i) :
+    (copiedBytesFromArgs data args)[i]'(by
+      simpa [copiedBytesFromArgs_length] using h)
+      = 0 := by
+  rw [copiedBytesFromArgs_get h, Calldata.callDataByte_of_ge hsrc]
+
+@[simp] theorem copiedBytesFromArgs_nil
+    (args : CallDataCopyArgs.Args) :
+    copiedBytesFromArgs [] args = List.replicate args.size.toNat 0 := by
+  simp [copiedBytesFromArgs_eq]
+
+end CallDataCopyExec
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure CALLDATACOPY stack-argument record for GH #104.

Summary:
- add CallDataCopyArgs.Args with destination offset, calldata source offset, and size
- add destination memory range and Nat conversion accessors
- add stack/result/memory-range count facts
- add copyMemoryExpansionCostFromArgs bridge to MemoryGas.memoryAccessExpansionCost

Verification:
- lake build EvmAsm.Evm64.Calldata.CopyArgs
- lake build
- scripts/check-file-size.sh --report
- scripts/check-unimported.sh
- git diff --check
- rg forbidden proof escapes in edited files

Slice: evm-asm-1n7o4
Authored by @pirapira; implemented by Codex.