### PR TITLE
feat(handlers): add pc gas and jumpdest entries

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -93,6 +93,7 @@ import EvmAsm.Evm64.StorageAccessOutcome
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.HandlerTable
 import EvmAsm.Evm64.StackHandlers
+import EvmAsm.Evm64.ControlHandlers
 import EvmAsm.Evm64.InterpreterLoop
 
 -- Precompile dispatch surface (#116)

--- a/EvmAsm/Evm64/ControlHandlers.lean
+++ b/EvmAsm/Evm64/ControlHandlers.lean
@@ -1,0 +1,111 @@
+/-
+  EvmAsm.Evm64.ControlHandlers
+
+  Pure PC/GAS/JUMPDEST handler entries for the interpreter handler table
+  (GH #107).
+-/
+
+import EvmAsm.Evm64.HandlerTable
+
+namespace EvmAsm.Evm64
+
+namespace ControlHandlers
+
+/-- EVM word pushed by the PC opcode for the current abstract state. -/
+def pcWord (state : EvmState) : EvmWord :=
+  BitVec.ofNat 256 state.pc
+
+/-- EVM word pushed by the GAS opcode for the current abstract state. -/
+def gasWord (state : EvmState) : EvmWord :=
+  BitVec.ofNat 256 state.gas
+
+/-- PC pushes the current EVM program counter. -/
+def pcHandler : OpcodeHandler :=
+  fun state => state.withStack (pcWord state :: state.stack)
+
+/-- GAS pushes the current remaining-gas counter. -/
+def gasHandler : OpcodeHandler :=
+  fun state => state.withStack (gasWord state :: state.stack)
+
+/-- JUMPDEST is a marker opcode and leaves the abstract state unchanged. -/
+def jumpdestHandler : OpcodeHandler :=
+  fun state => state
+
+/-- Lookup just the control/metadata handlers introduced in this slice. -/
+def controlHandler? : EvmOpcode → Option OpcodeHandler
+  | .PC => some pcHandler
+  | .GAS => some gasHandler
+  | .JUMPDEST => some jumpdestHandler
+  | _ => none
+
+/-- Handler table fragment containing PC, GAS, and JUMPDEST entries.
+    Distinctive token: ControlHandlers.controlHandlerTable #107. -/
+def controlHandlerTable : HandlerTable :=
+  controlHandler?
+
+@[simp] theorem controlHandler?_PC :
+    controlHandler? .PC = some pcHandler := rfl
+
+@[simp] theorem controlHandler?_GAS :
+    controlHandler? .GAS = some gasHandler := rfl
+
+@[simp] theorem controlHandler?_JUMPDEST :
+    controlHandler? .JUMPDEST = some jumpdestHandler := rfl
+
+@[simp] theorem pcHandler_stack (state : EvmState) :
+    (pcHandler state).stack = pcWord state :: state.stack := rfl
+
+@[simp] theorem gasHandler_stack (state : EvmState) :
+    (gasHandler state).stack = gasWord state :: state.stack := rfl
+
+@[simp] theorem jumpdestHandler_eq (state : EvmState) :
+    jumpdestHandler state = state := rfl
+
+@[simp] theorem pcHandler_status (state : EvmState) :
+    (pcHandler state).status = state.status := rfl
+
+@[simp] theorem gasHandler_status (state : EvmState) :
+    (gasHandler state).status = state.status := rfl
+
+@[simp] theorem controlHandlerTable_PC :
+    controlHandlerTable .PC = some pcHandler := rfl
+
+@[simp] theorem controlHandlerTable_GAS :
+    controlHandlerTable .GAS = some gasHandler := rfl
+
+@[simp] theorem controlHandlerTable_JUMPDEST :
+    controlHandlerTable .JUMPDEST = some jumpdestHandler := rfl
+
+@[simp] theorem dispatchOpcode?_controlHandlerTable_PC (state : EvmState) :
+    HandlerTable.dispatchOpcode? controlHandlerTable .PC state =
+      some (pcHandler state) := by
+  simp [HandlerTable.dispatchOpcode?]
+
+@[simp] theorem dispatchOpcode_controlHandlerTable_PC (state : EvmState) :
+    HandlerTable.dispatchOpcode controlHandlerTable .PC state =
+      pcHandler state := by
+  simp [HandlerTable.dispatchOpcode]
+
+@[simp] theorem dispatchOpcode?_controlHandlerTable_GAS (state : EvmState) :
+    HandlerTable.dispatchOpcode? controlHandlerTable .GAS state =
+      some (gasHandler state) := by
+  simp [HandlerTable.dispatchOpcode?]
+
+@[simp] theorem dispatchOpcode_controlHandlerTable_GAS (state : EvmState) :
+    HandlerTable.dispatchOpcode controlHandlerTable .GAS state =
+      gasHandler state := by
+  simp [HandlerTable.dispatchOpcode]
+
+@[simp] theorem dispatchOpcode?_controlHandlerTable_JUMPDEST (state : EvmState) :
+    HandlerTable.dispatchOpcode? controlHandlerTable .JUMPDEST state =
+      some (jumpdestHandler state) := by
+  simp [HandlerTable.dispatchOpcode?]
+
+@[simp] theorem dispatchOpcode_controlHandlerTable_JUMPDEST (state : EvmState) :
+    HandlerTable.dispatchOpcode controlHandlerTable .JUMPDEST state =
+      jumpdestHandler state := by
+  simp [HandlerTable.dispatchOpcode]
+
+end ControlHandlers
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2480.\n\nAdds GH #107 slice evm-asm-h8tti: pure PC, GAS, and JUMPDEST interpreter handler entries in EvmAsm/Evm64/ControlHandlers.lean. The slice defines ControlHandlers.pcWord, gasWord, pcHandler, gasHandler, jumpdestHandler, controlHandler?, controlHandlerTable, and dispatch projection lemmas through HandlerTable.dispatchOpcode/dispatchOpcode?.\n\nLocal verification:\n- lake build EvmAsm.Evm64.ControlHandlers\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden proof-escape scan clean