### PR TITLE
feat(log): bridge args to event data bytes

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -10,6 +10,7 @@ import EvmAsm.EL.CreateArgsBridge
 import EvmAsm.EL.CreateEffects
 import EvmAsm.EL.Logs
 import EvmAsm.EL.LogArgsBridge
+import EvmAsm.EL.LogDataBridge
 import EvmAsm.EL.LogCallEffects
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.Conformance.Calldata

--- a/EvmAsm/EL/LogDataBridge.lean
+++ b/EvmAsm/EL/LogDataBridge.lean
@@ -1,0 +1,88 @@
+/-
+  EvmAsm.EL.LogDataBridge
+
+  Bridge from LOG stack arguments to event data bytes (GH #112).
+-/
+
+import EvmAsm.EL.LogArgsBridge
+
+namespace EvmAsm.EL
+
+namespace LogDataBridge
+
+abbrev LogArgs := EvmAsm.Evm64.LogArgs.Args
+abbrev MemoryReader := Nat → Byte
+
+/-- First memory byte consumed as LOG event data. -/
+def dataStart (args : LogArgs) : Nat :=
+  args.data.offset.toNat
+
+/-- Number of memory bytes consumed as LOG event data. -/
+def dataSize (args : LogArgs) : Nat :=
+  args.data.size.toNat
+
+/-- LOG event data bytes loaded from a pure memory-reader function. -/
+def logDataFromMemory (readByte : MemoryReader) (args : LogArgs) : List Byte :=
+  (List.range (dataSize args)).map (fun i => readByte (dataStart args + i))
+
+/-- Build a LOG entry directly from stack args and a pure memory reader.
+    Distinctive token: LogDataBridge.mkLogEntryFromMemory #112. -/
+def mkLogEntryFromMemory (emitter : Address) (readByte : MemoryReader) (args : LogArgs) :
+    LogEntry :=
+  LogArgsBridge.mkLogEntry emitter (logDataFromMemory readByte args) args
+
+theorem dataStart_eq (args : LogArgs) :
+    dataStart args = args.data.offset.toNat := rfl
+
+theorem dataSize_eq (args : LogArgs) :
+    dataSize args = args.data.size.toNat := rfl
+
+@[simp] theorem logDataFromMemory_length (readByte : MemoryReader) (args : LogArgs) :
+    (logDataFromMemory readByte args).length = dataSize args := by
+  simp [logDataFromMemory]
+
+theorem logDataFromMemory_get
+    {readByte : MemoryReader} {args : LogArgs} {i : Nat}
+    (h : i < dataSize args) :
+    (logDataFromMemory readByte args)[i]'(by
+      simpa [logDataFromMemory_length] using h) =
+      readByte (dataStart args + i) := by
+  simp [logDataFromMemory, List.getElem_map, List.getElem_range]
+
+@[simp] theorem logDataFromMemory_zero_size
+    (readByte : MemoryReader) (rangeOffset : EvmAsm.Evm64.EvmWord)
+    (topics : List EvmAsm.Evm64.EvmWord) :
+    logDataFromMemory readByte
+        { data := { offset := rangeOffset, size := 0 }, topics := topics } =
+      [] := rfl
+
+theorem mkLogEntryFromMemory_eq
+    (emitter : Address) (readByte : MemoryReader) (args : LogArgs) :
+    mkLogEntryFromMemory emitter readByte args =
+      LogArgsBridge.mkLogEntry emitter (logDataFromMemory readByte args) args := rfl
+
+theorem mkLogEntryFromMemoryEmitter
+    (emitter : Address) (readByte : MemoryReader) (args : LogArgs) :
+    (mkLogEntryFromMemory emitter readByte args).emitter = emitter := rfl
+
+theorem mkLogEntryFromMemoryData
+    (emitter : Address) (readByte : MemoryReader) (args : LogArgs) :
+    (mkLogEntryFromMemory emitter readByte args).data =
+      logDataFromMemory readByte args := rfl
+
+theorem mkLogEntryFromMemoryTopics
+    (emitter : Address) (readByte : MemoryReader) (args : LogArgs) :
+    (mkLogEntryFromMemory emitter readByte args).topics =
+      LogArgsBridge.topics args := rfl
+
+theorem mkLogEntryFromMemoryTopicCountOk
+    (kind : LogArgsBridge.LogKind) (emitter : Address) (readByte : MemoryReader)
+    (args : LogArgs)
+    (h_topics : EvmAsm.Evm64.LogArgs.topicCountOk kind args) :
+    (mkLogEntryFromMemory emitter readByte args).topicCountOk := by
+  exact LogArgsBridge.topicCountOk_of_logArgs
+    kind emitter (logDataFromMemory readByte args) args h_topics
+
+end LogDataBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds GH #112 slice evm-asm-y70dj: a pure LOG data bridge in EvmAsm/EL/LogDataBridge.lean. The bridge defines dataStart, dataSize, logDataFromMemory, and LogDataBridge.mkLogEntryFromMemory, with projection lemmas tying a memory-reader-backed byte slice to LogArgsBridge.mkLogEntry.\n\nLocal verification:\n- lake build EvmAsm.EL.LogDataBridge\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n- forbidden proof-escape scan clean