### PR TITLE
feat(interpreter): add fuel loop composition hook

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -92,6 +92,7 @@ import EvmAsm.Evm64.StorageAccessOutcome
 -- Opcode dispatch surface (#106)
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.InterpreterLoop
+import EvmAsm.Evm64.InterpreterLoopCompose
 
 -- Precompile dispatch surface (#116)
 import EvmAsm.Evm64.Precompile

--- a/EvmAsm/Evm64/InterpreterLoopCompose.lean
+++ b/EvmAsm/Evm64/InterpreterLoopCompose.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.Evm64.InterpreterLoopCompose
+
+  Whole-loop composition hooks for the pure interpreter loop (GH #109).
+-/
+
+import EvmAsm.Evm64.InterpreterLoop
+
+namespace EvmAsm.Evm64
+
+namespace InterpreterLoopCompose
+
+abbrev Handler := InterpreterLoop.Handler
+
+/-- Non-running states are fixed points for every fuel budget. -/
+theorem loopFuel_of_not_running
+    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (h_status : state.status ≠ .running) :
+    InterpreterLoop.loopFuel handler fuel state = state := by
+  cases fuel with
+  | zero => rfl
+  | succ _ =>
+      cases h : state.status <;> simp [InterpreterLoop.loopFuel, h] at h_status ⊢
+
+/-- Distinctive token: InterpreterLoopCompose.loopFuel_add #109. -/
+theorem loopFuel_add
+    (handler : Handler) (fuelA fuelB : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (fuelA + fuelB) state =
+      InterpreterLoop.loopFuel handler fuelB
+        (InterpreterLoop.loopFuel handler fuelA state) := by
+  induction fuelA generalizing state with
+  | zero => simp
+  | succ fuelA ih =>
+      rw [Nat.succ_add]
+      cases h_status : state.status
+      · simp [InterpreterLoop.loopFuel, h_status]
+        exact ih (InterpreterLoop.stepWithHandler handler state)
+      · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
+      · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
+      · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
+      · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
+
+theorem loopFuel_one_add
+    (handler : Handler) (fuel : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (1 + fuel) state =
+      InterpreterLoop.loopFuel handler fuel
+        (InterpreterLoop.loopFuel handler 1 state) := by
+  exact loopFuel_add handler 1 fuel state
+
+theorem loopFuel_add_one
+    (handler : Handler) (fuel : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (fuel + 1) state =
+      InterpreterLoop.loopFuel handler 1
+        (InterpreterLoop.loopFuel handler fuel state) := by
+  exact loopFuel_add handler fuel 1 state
+
+end InterpreterLoopCompose
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds GH #109 whole-loop composition hooks for the pure interpreter loop.\n\nSummary:\n- proves non-running states are fixed points for every fuel budget\n- proves split fuel budgets compose for InterpreterLoop.loopFuel\n- adds one-step split specializations for downstream simulation callers\n\nVerification:\n- lake build EvmAsm.Evm64.InterpreterLoopCompose\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n\nRefs evm-asm-fyia.2 and GH #109.\nAuthored by @pirapira; implemented by Codex.