### PR TITLE
feat(conformance): add rlp decode vectors

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -13,6 +13,7 @@ import EvmAsm.EL.LogArgsBridge
 import EvmAsm.EL.LogCallEffects
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.Conformance.Calldata
+import EvmAsm.EL.Conformance.RLP
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.WorldStateAccount
 import EvmAsm.EL.Storage

--- a/EvmAsm/EL/Conformance/RLP.lean
+++ b/EvmAsm/EL/Conformance/RLP.lean
@@ -1,0 +1,82 @@
+/-
+  EvmAsm.EL.Conformance.RLP
+
+  Compact Lean-side conformance vectors for the executable RLP decoder
+  (GH #125 / GH #120).
+-/
+
+import EvmAsm.EL.Conformance
+import EvmAsm.EL.RLP.Decode
+
+namespace EvmAsm.EL
+namespace Conformance
+namespace RLP
+
+abbrev Byte := EvmAsm.EL.RLP.Byte
+abbrev RLPItem := EvmAsm.EL.RLP.RLPItem
+
+/-- Input shape for an RLP decode executable-helper conformance vector. -/
+structure DecodeInput where
+  bytes : List Byte
+  deriving Repr
+
+/-- Decode exactly one RLP item and reject leftover bytes. -/
+def runDecodeFully (input : DecodeInput) : Option RLPItem :=
+  match EvmAsm.EL.RLP.decode input.bytes with
+  | some (item, []) => some item
+  | _ => none
+
+/-- Nested list decode vector, covering recursive item decoding.
+    Distinctive token: rlpNestedListDecodeVector. -/
+def rlpNestedListDecodeVector : TestVector DecodeInput RLPItem :=
+  { id := "rlp-nested-list-decode"
+    input := { bytes := [(0xc3 : Byte), 0x01, 0x02, 0x03] }
+    expected := .value (.list [.bytes [0x01], .bytes [0x02], .bytes [0x03]]) }
+
+/-- Non-canonical singleton byte string must be rejected; `0x01` should be
+    encoded directly as the single byte `0x01`, not as `0x81 0x01`. -/
+def rlpNoncanonicalSingletonVector : TestVector DecodeInput RLPItem :=
+  { id := "rlp-noncanonical-singleton"
+    input := { bytes := [(0x81 : Byte), 0x01] }
+    expected := .error "noncanonical-singleton" }
+
+theorem runDecodeFully_nestedList :
+    runDecodeFully { bytes := [(0xc3 : Byte), 0x01, 0x02, 0x03] } =
+      some (.list [.bytes [0x01], .bytes [0x02], .bytes [0x03]]) := rfl
+
+theorem runDecodeFully_reject_noncanonical_singleton :
+    runDecodeFully { bytes := [(0x81 : Byte), 0x01] } = none := rfl
+
+theorem rlpNestedListDecodeVector_passed :
+    checkVector? runDecodeFully rlpNestedListDecodeVector = .passed :=
+  checkVector?_some_passed runDecodeFully
+    "rlp-nested-list-decode"
+    { bytes := [(0xc3 : Byte), 0x01, 0x02, 0x03] }
+    (.list [.bytes [0x01], .bytes [0x02], .bytes [0x03]])
+    runDecodeFully_nestedList
+
+theorem rlpNoncanonicalSingletonVector_errored :
+    checkVector? runDecodeFully rlpNoncanonicalSingletonVector =
+      .errored "rlp-noncanonical-singleton" "noncanonical-singleton" :=
+  checkVector?_none_error runDecodeFully
+    "rlp-noncanonical-singleton"
+    "noncanonical-singleton"
+    { bytes := [(0x81 : Byte), 0x01] }
+    runDecodeFully_reject_noncanonical_singleton
+
+/-- Compact checked-vector batch for RLP executable decoding.
+    Distinctive token: RLP.rlpConformanceVectors #125 #120. -/
+def rlpConformanceVectors : List CheckResult :=
+  [ checkVector? runDecodeFully rlpNestedListDecodeVector
+  , checkVector? runDecodeFully rlpNoncanonicalSingletonVector
+  ]
+
+theorem rlpConformanceVectors_passed :
+    rlpConformanceVectors =
+      [.passed, .errored "rlp-noncanonical-singleton" "noncanonical-singleton"] := by
+  simp [rlpConformanceVectors, rlpNestedListDecodeVector_passed,
+    rlpNoncanonicalSingletonVector_errored]
+
+end RLP
+end Conformance
+end EvmAsm.EL


### PR DESCRIPTION
Adds compact Lean-side RLP conformance coverage for GH #125 using the EL RLP decoder surface from GH #120.\n\nSummary:\n- adds runDecodeFully for full-input RLP decode vectors\n- checks one nested-list success vector\n- checks one canonicality-rejection vector for noncanonical singleton encoding\n\nVerification:\n- lake build EvmAsm.EL.Conformance.RLP\n- lake build\n- scripts/check-file-size.sh --report\n- scripts/check-unimported.sh\n- git diff --check\n\nRefs evm-asm-sxou.2, GH #125, and GH #120.\nAuthored by @pirapira; implemented by Codex.