### PR TITLE
feat(create): bridge initcode memory bytes

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -7,6 +7,7 @@ import EvmAsm.EL.RLP
 import EvmAsm.EL.Create
 import EvmAsm.EL.CreateAddress
 import EvmAsm.EL.CreateArgsBridge
+import EvmAsm.EL.CreateInitcodeBridge
 import EvmAsm.EL.CreateEffects
 import EvmAsm.EL.Logs
 import EvmAsm.EL.LogArgsBridge

--- a/EvmAsm/EL/CreateInitcodeBridge.lean
+++ b/EvmAsm/EL/CreateInitcodeBridge.lean
@@ -1,0 +1,129 @@
+/-
+  EvmAsm.EL.CreateInitcodeBridge
+
+  Bridge from CREATE/CREATE2 initcode stack ranges to memory bytes (GH #115).
+-/
+
+import EvmAsm.EL.CreateArgsBridge
+
+namespace EvmAsm.EL
+
+namespace CreateInitcodeBridge
+
+abbrev InitcodeRange := EvmAsm.Evm64.CreateArgs.InitcodeRange
+abbrev CreateArgs := EvmAsm.Evm64.CreateArgs.Create
+abbrev Create2Args := EvmAsm.Evm64.CreateArgs.Create2
+abbrev MemoryReader := Nat → Byte
+
+/-- First memory byte consumed as CREATE/CREATE2 initcode. -/
+def initcodeStart (range : InitcodeRange) : Nat :=
+  range.offset.toNat
+
+/-- Number of memory bytes consumed as CREATE/CREATE2 initcode. -/
+def initcodeSize (range : InitcodeRange) : Nat :=
+  range.size.toNat
+
+/-- CREATE/CREATE2 initcode bytes loaded from a pure memory-reader function.
+    Distinctive token: CreateInitcodeBridge.initcodeFromMemory #115. -/
+def initcodeFromMemory (readByte : MemoryReader) (range : InitcodeRange) : List Byte :=
+  (List.range (initcodeSize range)).map (fun i => readByte (initcodeStart range + i))
+
+def createInitcodeFromMemory (readByte : MemoryReader) (args : CreateArgs) : List Byte :=
+  initcodeFromMemory readByte (CreateArgsBridge.createInitcodeRange args)
+
+def create2InitcodeFromMemory (readByte : MemoryReader) (args : Create2Args) : List Byte :=
+  initcodeFromMemory readByte (CreateArgsBridge.create2InitcodeRange args)
+
+/-- Build the EL CREATE request directly from stack args and a pure memory reader. -/
+def createRequestFromMemory
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : CreateArgs) : CreateRequest :=
+  CreateArgsBridge.createRequest creator (createInitcodeFromMemory readByte args) gas args
+
+/-- Build the EL CREATE2 request directly from stack args and a pure memory reader. -/
+def create2RequestFromMemory
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : Create2Args) : CreateRequest :=
+  CreateArgsBridge.create2Request creator (create2InitcodeFromMemory readByte args) gas args
+
+theorem initcodeStart_eq (range : InitcodeRange) :
+    initcodeStart range = range.offset.toNat := rfl
+
+theorem initcodeSize_eq (range : InitcodeRange) :
+    initcodeSize range = range.size.toNat := rfl
+
+@[simp] theorem initcodeFromMemory_length (readByte : MemoryReader) (range : InitcodeRange) :
+    (initcodeFromMemory readByte range).length = initcodeSize range := by
+  simp [initcodeFromMemory]
+
+theorem initcodeFromMemory_get
+    {readByte : MemoryReader} {range : InitcodeRange} {i : Nat}
+    (h : i < initcodeSize range) :
+    (initcodeFromMemory readByte range)[i]'(by
+      simpa [initcodeFromMemory_length] using h) =
+      readByte (initcodeStart range + i) := by
+  simp [initcodeFromMemory, List.getElem_map, List.getElem_range]
+
+@[simp] theorem initcodeFromMemory_zero_size
+    (readByte : MemoryReader) (rangeOffset : EvmAsm.Evm64.EvmWord) :
+    initcodeFromMemory readByte { offset := rangeOffset, size := 0 } = [] := rfl
+
+theorem createInitcodeFromMemory_eq
+    (readByte : MemoryReader) (args : CreateArgs) :
+    createInitcodeFromMemory readByte args =
+      initcodeFromMemory readByte args.initcode := rfl
+
+theorem create2InitcodeFromMemory_eq
+    (readByte : MemoryReader) (args : Create2Args) :
+    create2InitcodeFromMemory readByte args =
+      initcodeFromMemory readByte args.initcode := rfl
+
+theorem createRequestFromMemory_eq
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : CreateArgs) :
+    createRequestFromMemory creator readByte gas args =
+      CreateArgsBridge.createRequest creator (createInitcodeFromMemory readByte args) gas args :=
+  rfl
+
+theorem create2RequestFromMemory_eq
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : Create2Args) :
+    create2RequestFromMemory creator readByte gas args =
+      CreateArgsBridge.create2Request creator (create2InitcodeFromMemory readByte args) gas args :=
+  rfl
+
+theorem createRequestFromMemoryInitcode
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : CreateArgs) :
+    (createRequestFromMemory creator readByte gas args).initcode =
+      createInitcodeFromMemory readByte args := rfl
+
+theorem create2RequestFromMemoryInitcode
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : Create2Args) :
+    (create2RequestFromMemory creator readByte gas args).initcode =
+      create2InitcodeFromMemory readByte args := rfl
+
+theorem createRequestFromMemoryKind
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : CreateArgs) :
+    (createRequestFromMemory creator readByte gas args).kind = .create := rfl
+
+theorem create2RequestFromMemoryKind
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : Create2Args) :
+    (create2RequestFromMemory creator readByte gas args).kind = .create2 := rfl
+
+theorem createRequestFromMemoryValue
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : CreateArgs) :
+    (createRequestFromMemory creator readByte gas args).value = args.value := rfl
+
+theorem create2RequestFromMemorySalt?
+    (creator : Address) (readByte : MemoryReader) (gas : EvmAsm.Evm64.EvmWord)
+    (args : Create2Args) :
+    (create2RequestFromMemory creator readByte gas args).salt? = some args.salt := rfl
+
+end CreateInitcodeBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds GH #115 CREATE/CREATE2 initcode memory bridge.\n\nSummary:\n- adds CreateInitcodeBridge.initcodeFromMemory over a pure memory reader\n- connects CREATE and CREATE2 stack argument ranges to EL creation requests\n- proves length/get/zero-size and request projection lemmas\n\nVerification:\n- lake build EvmAsm.EL.CreateInitcodeBridge\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- lake build\n\nBead: evm-asm-dtys.3\n\nAuthored by @pirapira; implemented by Codex.