### PR TITLE
feat(interpreter): add decoded opcode trace

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -93,6 +93,7 @@ import EvmAsm.Evm64.StorageAccessOutcome
 import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.InterpreterLoop
 import EvmAsm.Evm64.InterpreterSimulation
+import EvmAsm.Evm64.InterpreterTrace
 import EvmAsm.Evm64.InterpreterLoopCompose
 
 -- Precompile dispatch surface (#116)

--- a/EvmAsm/Evm64/InterpreterTrace.lean
+++ b/EvmAsm/Evm64/InterpreterTrace.lean
@@ -1,0 +1,91 @@
+/-
+  EvmAsm.Evm64.InterpreterTrace
+
+  Decoded-opcode trace bridge for the pure interpreter loop (GH #108).
+-/
+
+import EvmAsm.Evm64.InterpreterLoop
+
+namespace EvmAsm.Evm64
+
+namespace InterpreterTrace
+
+abbrev Handler := InterpreterLoop.Handler
+
+/--
+Trace the supported opcodes decoded by `InterpreterLoop.loopFuel`. EOF or an
+unsupported byte contributes no opcode and transitions through the loop's
+`invalid` branch.
+
+Distinctive token: InterpreterTrace.loopTrace #108.
+-/
+def loopTrace (handler : Handler) : Nat → EvmState → List EvmOpcode
+  | 0, _ => []
+  | fuel + 1, state =>
+      match state.status with
+      | .running =>
+          match InterpreterLoop.decodeCurrentOpcode? state with
+          | some opcode =>
+              opcode :: loopTrace handler fuel (InterpreterLoop.stepWithHandler handler state)
+          | none => []
+      | _ => []
+
+@[simp] theorem loopTrace_zero (handler : Handler) (state : EvmState) :
+    loopTrace handler 0 state = [] := rfl
+
+theorem loopTrace_succ_decode
+    (handler : Handler) (fuel : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    loopTrace handler (fuel + 1) state =
+      opcode :: loopTrace handler fuel (InterpreterLoop.stepWithHandler handler state) := by
+  simp [loopTrace, h_status, h_decode]
+
+theorem loopTrace_succ_unsupported
+    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    loopTrace handler (fuel + 1) state = [] := by
+  simp [loopTrace, h_status, h_decode]
+
+theorem loopTrace_succ_stopped
+    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (h_status : state.status = .stopped) :
+    loopTrace handler (fuel + 1) state = [] := by
+  simp [loopTrace, h_status]
+
+theorem loopTrace_succ_returned
+    (handler : Handler) (fuel : Nat) {state : EvmState} {data : List (BitVec 8)}
+    (h_status : state.status = .returned data) :
+    loopTrace handler (fuel + 1) state = [] := by
+  simp [loopTrace, h_status]
+
+theorem loopTrace_succ_reverted
+    (handler : Handler) (fuel : Nat) {state : EvmState} {data : List (BitVec 8)}
+    (h_status : state.status = .reverted data) :
+    loopTrace handler (fuel + 1) state = [] := by
+  simp [loopTrace, h_status]
+
+theorem loopTrace_succ_error
+    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (h_status : state.status = .error) :
+    loopTrace handler (fuel + 1) state = [] := by
+  simp [loopTrace, h_status]
+
+theorem loopTrace_length_le_fuel (handler : Handler) :
+    ∀ (fuel : Nat) (state : EvmState), (loopTrace handler fuel state).length ≤ fuel
+  | 0, _ => Nat.zero_le 0
+  | fuel + 1, state => by
+      cases h_status : state.status <;>
+        simp [loopTrace, h_status]
+      cases h_decode : InterpreterLoop.decodeCurrentOpcode? state with
+      | none =>
+          simp
+      | some opcode =>
+          simp [
+            Nat.succ_le_succ (loopTrace_length_le_fuel handler fuel
+              (InterpreterLoop.stepWithHandler handler state))]
+
+end InterpreterTrace
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure decoded-opcode trace bridge for the executable interpreter fuel loop (GH #108).\n\nSummary:\n- adds EvmAsm.Evm64.InterpreterTrace.loopTrace over InterpreterLoop.loopFuel's decode/dispatch structure\n- proves decode, unsupported, terminal-status, and fuel-length lemmas\n- wires the new module into EvmAsm.Evm64\n\nVerification:\n- lake build EvmAsm.Evm64.InterpreterTrace\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- lake build\n\nRefs evm-asm-rgu0x.\nAuthored by @pirapira; implemented by Codex.