### PR TITLE
feat(create): add address executable bridge

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -6,6 +6,7 @@
 import EvmAsm.EL.RLP
 import EvmAsm.EL.Create
 import EvmAsm.EL.CreateAddress
+import EvmAsm.EL.CreateAddressExecutableBridge
 import EvmAsm.EL.CreateArgsBridge
 import EvmAsm.EL.CreateInitcodeBridge
 import EvmAsm.EL.CreateEffects

--- a/EvmAsm/EL/CreateAddressExecutableBridge.lean
+++ b/EvmAsm/EL/CreateAddressExecutableBridge.lean
@@ -1,0 +1,102 @@
+/-
+  EvmAsm.EL.CreateAddressExecutableBridge
+
+  Request-level executable bridge for CREATE/CREATE2 address derivation
+  (GH #115).
+-/
+
+import EvmAsm.EL.CreateAddress
+
+namespace EvmAsm.EL
+
+namespace CreateAddressExecutableBridge
+
+/-- Apply an executable address derivation backend to a well-formed CREATE or
+    CREATE2 request. Malformed request/salt combinations return `none`. -/
+def deriveRequestAddress?
+    (deriver : CreateAddress.AddressDeriver) (request : CreateRequest)
+    (creatorNonce : Nat) (initcodeHash : Hash256) : Option Address :=
+  (CreateAddress.fromRequest? request creatorNonce initcodeHash).map
+    (CreateAddress.derivedAddress deriver)
+
+theorem deriveRequestAddress?_forCreate
+    (deriver : CreateAddress.AddressDeriver)
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas creatorNonce : Nat)
+    (initcodeHash : Hash256) :
+    deriveRequestAddress? deriver
+        (CreateRequest.forCreate creator value initcode gas) creatorNonce initcodeHash =
+      some
+        (deriver
+          { creator := creator
+            nonce := creatorNonce
+            salt? := none
+            initcodeHash := initcodeHash }) := rfl
+
+theorem deriveRequestAddress?_forCreate2
+    (deriver : CreateAddress.AddressDeriver)
+    (creator : Address) (value : Word256) (initcode : List Byte) (gas creatorNonce : Nat)
+    (salt initcodeHash : Hash256) :
+    deriveRequestAddress? deriver
+        (CreateRequest.forCreate2 creator value initcode gas salt) creatorNonce initcodeHash =
+      some
+        (deriver
+          { creator := creator
+            nonce := creatorNonce
+            salt? := some salt
+            initcodeHash := initcodeHash }) := rfl
+
+theorem deriveRequestAddress?_create_with_salt
+    (deriver : CreateAddress.AddressDeriver)
+    (creator : Address) (value salt : Word256) (initcode : List Byte)
+    (gas creatorNonce : Nat) (initcodeHash : Hash256) :
+    deriveRequestAddress? deriver
+        { kind := .create
+          creator := creator
+          value := value
+          initcode := initcode
+          gas := gas
+          salt? := some salt } creatorNonce initcodeHash =
+      none := rfl
+
+theorem deriveRequestAddress?_create2_without_salt
+    (deriver : CreateAddress.AddressDeriver)
+    (creator : Address) (value : Word256) (initcode : List Byte)
+    (gas creatorNonce : Nat) (initcodeHash : Hash256) :
+    deriveRequestAddress? deriver
+        { kind := .create2
+          creator := creator
+          value := value
+          initcode := initcode
+          gas := gas
+          salt? := none } creatorNonce initcodeHash =
+      none := rfl
+
+theorem deriveRequestAddress?_eq_some_iff
+    (deriver : CreateAddress.AddressDeriver) (request : CreateRequest)
+    (creatorNonce : Nat) (initcodeHash : Hash256) (address : Address) :
+    deriveRequestAddress? deriver request creatorNonce initcodeHash = some address ↔
+      ∃ input,
+        CreateAddress.fromRequest? request creatorNonce initcodeHash = some input ∧
+          deriver input = address := by
+  unfold deriveRequestAddress?
+  cases h_input : CreateAddress.fromRequest? request creatorNonce initcodeHash with
+  | none =>
+      simp
+  | some input =>
+      simp [CreateAddress.derivedAddress]
+
+theorem result_address?_eq_deriveRequestAddress?_of_matches
+    {deriver : CreateAddress.AddressDeriver} {request : CreateRequest}
+    {creatorNonce : Nat} {initcodeHash : Hash256} {result : CreateResult}
+    {address : Address}
+    (h_derive :
+      deriveRequestAddress? deriver request creatorNonce initcodeHash = some address)
+    (h_match : CreateAddress.resultAddressMatches result address) :
+    result.address? =
+      deriveRequestAddress? deriver request creatorNonce initcodeHash := by
+  rw [h_derive]
+  exact h_match.2
+
+end CreateAddressExecutableBridge
+
+end EvmAsm.EL


### PR DESCRIPTION
## Summary
- add request-level CREATE/CREATE2 address derivation bridge over AddressDeriver
- return none for malformed CREATE-with-salt and CREATE2-without-salt request shapes
- connect derived request addresses to CreateResult address matching

## Verification
- lake build EvmAsm.EL.CreateAddressExecutableBridge
- scripts/check-unimported.sh
- scripts/check-file-size.sh --report
- git diff --check
- lake build

Refs evm-asm-wdamc.
Refs GH #115.
Authored by @pirapira; implemented by Codex.