### PR TITLE
feat(storage): bridge ecall results to stack

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -25,6 +25,7 @@ import EvmAsm.EL.Storage
 import EvmAsm.EL.StorageAccessBridge
 import EvmAsm.EL.StorageStackBridge
 import EvmAsm.EL.StorageEcallBridge
+import EvmAsm.EL.StorageEcallStackBridge
 import EvmAsm.EL.Transaction
 import EvmAsm.EL.MessageCall
 import EvmAsm.EL.MessageCallExecution

--- a/EvmAsm/EL/StorageEcallStackBridge.lean
+++ b/EvmAsm/EL/StorageEcallStackBridge.lean
@@ -1,0 +1,72 @@
+/-
+  EvmAsm.EL.StorageEcallStackBridge
+
+  Bridge from storage ECALL results to stack-facing SLOAD/SSTORE effects
+  (GH #110).
+-/
+
+import EvmAsm.EL.StorageEcallBridge
+import EvmAsm.EL.StorageStackBridge
+
+namespace EvmAsm.EL
+namespace StorageEcallStackBridge
+
+abbrev SloadRequest := StorageEcallBridge.SloadRequest
+abbrev SstoreRequest := StorageEcallBridge.SstoreRequest
+
+/-- Convert an executed SLOAD ECALL result to the stack-facing execution record.
+    Distinctive token: StorageEcallStackBridge.sloadEcallStackWord #110. -/
+def sloadExecutionFromEcall (request : SloadRequest) :
+    StorageStackBridge.SloadExecution :=
+  let result := StorageEcallBridge.executeSloadEcall request
+  { value := result.value
+    outcome := result.outcome }
+
+/-- Convert an executed SSTORE ECALL result to the stack-facing execution record. -/
+def sstoreExecutionFromEcall (request : SstoreRequest) :
+    StorageStackBridge.SstoreExecution :=
+  let result := StorageEcallBridge.executeSstoreEcall request
+  { state := result.state
+    outcome := result.outcome }
+
+/-- Stack word pushed by an SLOAD ECALL. -/
+def sloadEcallStackWord (request : SloadRequest) : Word256 :=
+  StorageStackBridge.sloadStackWord (sloadExecutionFromEcall request)
+
+/-- Stack words pushed by an SSTORE ECALL. This is always empty. -/
+def sstoreEcallStackWords (request : SstoreRequest) : List Word256 :=
+  StorageStackBridge.sstoreStackWords (sstoreExecutionFromEcall request)
+
+theorem sloadExecutionFromEcall_value (request : SloadRequest) :
+    (sloadExecutionFromEcall request).value =
+      (StorageEcallBridge.executeSloadEcall request).value := rfl
+
+theorem sloadExecutionFromEcall_outcome (request : SloadRequest) :
+    (sloadExecutionFromEcall request).outcome =
+      (StorageEcallBridge.executeSloadEcall request).outcome := rfl
+
+theorem sloadEcallStackWord_value (request : SloadRequest) :
+    sloadEcallStackWord request =
+      (StorageEcallBridge.executeSloadEcall request).value := rfl
+
+theorem sloadEcallStackWord_storage (request : SloadRequest) :
+    sloadEcallStackWord request =
+      Storage.sload request.state request.address request.slot := rfl
+
+theorem sstoreExecutionFromEcall_state (request : SstoreRequest) :
+    (sstoreExecutionFromEcall request).state =
+      (StorageEcallBridge.executeSstoreEcall request).state := rfl
+
+theorem sstoreExecutionFromEcall_outcome (request : SstoreRequest) :
+    (sstoreExecutionFromEcall request).outcome =
+      (StorageEcallBridge.executeSstoreEcall request).outcome := rfl
+
+@[simp] theorem sstoreEcallStackWords_nil (request : SstoreRequest) :
+    sstoreEcallStackWords request = [] := rfl
+
+theorem sstoreEcallStackWords_length (request : SstoreRequest) :
+    (sstoreEcallStackWords request).length =
+      StorageStackBridge.sstoreResultCount := rfl
+
+end StorageEcallStackBridge
+end EvmAsm.EL


### PR DESCRIPTION
Stacked on #2485.

## Summary
- add StorageEcallStackBridge connecting storage ECALL execution results to stack-facing storage execution records
- expose SLOAD pushed word as the ECALL value / EL Storage.sload result
- prove SSTORE ECALL pushes an empty stack-result list

## Verification
- lake build EvmAsm.EL.StorageEcallStackBridge
- scripts/check-unimported.sh
- scripts/check-file-size.sh --report
- git diff --check
- lake build

Refs evm-asm-r76dw.
Refs GH #110.
Authored by @pirapira; implemented by Codex.