### PR TITLE
feat(rlp): add full decode bridge

### DIFF
--- a/EvmAsm/EL/RLP.lean
+++ b/EvmAsm/EL/RLP.lean
@@ -8,4 +8,5 @@ import EvmAsm.EL.RLP.Prefix
 import EvmAsm.EL.RLP.PrefixDecode
 import EvmAsm.EL.RLP.Program
 import EvmAsm.EL.RLP.ProgramSpec
+import EvmAsm.EL.RLP.FullDecode
 import EvmAsm.EL.RLP.Properties

--- a/EvmAsm/EL/RLP/FullDecode.lean
+++ b/EvmAsm/EL/RLP/FullDecode.lean
@@ -1,0 +1,60 @@
+/-
+  EvmAsm.EL.RLP.FullDecode
+
+  Top-level wrapper for consumers that require an RLP decode to consume the
+  whole input.
+-/
+
+import EvmAsm.EL.RLP.Decode
+
+namespace EvmAsm.EL.RLP
+
+/-- Decode one complete RLP item, rejecting successful prefix decodes that
+leave trailing input. -/
+def decodeFully (bs : List Byte) : Option RLPItem :=
+  match decode bs with
+  | some (item, []) => some item
+  | _ => none
+
+/-- Distinctive token: FullDecode.decodeFully_eq_some_iff #120. -/
+theorem decodeFully_eq_some_iff (bs : List Byte) (item : RLPItem) :
+    decodeFully bs = some item ↔ decode bs = some (item, []) := by
+  unfold decodeFully
+  cases h_decode : decode bs with
+  | none =>
+      simp
+  | some decoded =>
+      cases decoded with
+      | mk item' leftover =>
+          cases leftover with
+          | nil => simp
+          | cons b rest => simp
+
+theorem decodeFully_eq_none_of_decode_none
+    {bs : List Byte} (h_decode : decode bs = none) :
+    decodeFully bs = none := by
+  simp [decodeFully, h_decode]
+
+theorem decodeFully_eq_none_of_decode_leftover
+    {bs leftover : List Byte} {item : RLPItem}
+    (h_decode : decode bs = some (item, leftover))
+    (h_leftover : leftover ≠ []) :
+    decodeFully bs = none := by
+  unfold decodeFully
+  cases leftover with
+  | nil => contradiction
+  | cons b rest => simp [h_decode]
+
+theorem decodeFully_eq_some_of_decode
+    {bs : List Byte} {item : RLPItem}
+    (h_decode : decode bs = some (item, [])) :
+    decodeFully bs = some item := by
+  exact (decodeFully_eq_some_iff bs item).2 h_decode
+
+theorem decodeFully_encode_of_decode_encode
+    {item : RLPItem}
+    (h_roundtrip : decode (encode item) = some (item, [])) :
+    decodeFully (encode item) = some item := by
+  exact decodeFully_eq_some_of_decode h_roundtrip
+
+end EvmAsm.EL.RLP


### PR DESCRIPTION
Adds EvmAsm.EL.RLP.FullDecode for GH #120: a reusable decodeFully wrapper that accepts only top-level decodes consuming all input, plus iff/projection lemmas and an encode-roundtrip adapter. This gives conformance and future RISC-V pipeline specs a shared semantic target instead of per-consumer runners or more examples.\n\nVerification:\n- lake build EvmAsm.EL.RLP.FullDecode\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- lake build\n\nRefs evm-asm-k8box and GH #120.\n\nAuthored by @pirapira; implemented by Codex.