### PR TITLE
feat(conformance): bridge rlp runner to full decode

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -19,6 +19,7 @@ import EvmAsm.EL.KeccakResultBridge
 import EvmAsm.EL.Conformance
 import EvmAsm.EL.Conformance.Calldata
 import EvmAsm.EL.Conformance.RLP
+import EvmAsm.EL.Conformance.RLPFullDecodeBridge
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.WorldStateAccount
 import EvmAsm.EL.Storage

--- a/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
+++ b/EvmAsm/EL/Conformance/RLPFullDecodeBridge.lean
@@ -1,0 +1,56 @@
+/-
+  EvmAsm.EL.Conformance.RLPFullDecodeBridge
+
+  Bridge the RLP conformance runner to the reusable top-level RLP full-decode
+  wrapper (GH #125 / GH #120).
+-/
+
+import EvmAsm.EL.Conformance.RLP
+import EvmAsm.EL.RLP.FullDecode
+
+namespace EvmAsm.EL
+namespace Conformance
+namespace RLPConformanceFullDecodeBridge
+
+/--
+The RLP conformance runner is exactly the reusable full-input decode wrapper
+applied to the input bytes.
+
+Distinctive token: RLPConformanceFullDecodeBridge.runDecodeFully_eq_decodeFully #125 #120.
+-/
+theorem runDecodeFully_eq_decodeFully (input : RLP.DecodeInput) :
+    RLP.runDecodeFully input = EvmAsm.EL.RLP.decodeFully input.bytes := by
+  unfold RLP.runDecodeFully EvmAsm.EL.RLP.decodeFully
+  rfl
+
+theorem runDecodeFully_eq_some_iff
+    (input : RLP.DecodeInput) (item : RLP.RLPItem) :
+    RLP.runDecodeFully input = some item ↔
+      EvmAsm.EL.RLP.decode input.bytes = some (item, []) := by
+  rw [runDecodeFully_eq_decodeFully]
+  exact EvmAsm.EL.RLP.decodeFully_eq_some_iff input.bytes item
+
+theorem checkVector?_runDecodeFully_eq_decodeFully
+    (vector : TestVector RLP.DecodeInput RLP.RLPItem) :
+    checkVector? RLP.runDecodeFully vector =
+      checkVector? (fun input => EvmAsm.EL.RLP.decodeFully input.bytes) vector := by
+  cases vector with
+  | mk id input expected =>
+      cases expected <;> simp [checkVector?, runDecodeFully_eq_decodeFully]
+
+theorem rlpNestedListDecodeVector_passed_via_decodeFully :
+    checkVector? (fun input => EvmAsm.EL.RLP.decodeFully input.bytes)
+        RLP.rlpNestedListDecodeVector = .passed := by
+  rw [← checkVector?_runDecodeFully_eq_decodeFully]
+  exact RLP.rlpNestedListDecodeVector_passed
+
+theorem rlpNoncanonicalSingletonVector_errored_via_decodeFully :
+    checkVector? (fun input => EvmAsm.EL.RLP.decodeFully input.bytes)
+        RLP.rlpNoncanonicalSingletonVector =
+      .errored "rlp-noncanonical-singleton" "noncanonical-singleton" := by
+  rw [← checkVector?_runDecodeFully_eq_decodeFully]
+  exact RLP.rlpNoncanonicalSingletonVector_errored
+
+end RLPConformanceFullDecodeBridge
+end Conformance
+end EvmAsm.EL


### PR DESCRIPTION
Stacked on #2511.\n\nAdds EvmAsm.EL.Conformance.RLPFullDecodeBridge for GH #125 / GH #120, proving the existing RLP conformance runDecodeFully runner agrees with the reusable EvmAsm.EL.RLP.decodeFully semantic target. This avoids adding more concrete vectors or another local runner.\n\nVerification:\n- lake build EvmAsm.EL.Conformance.RLPFullDecodeBridge\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- lake build\n\nRefs evm-asm-xplcx, GH #125, and GH #120.\n\nAuthored by @pirapira; implemented by Codex.