### PR TITLE
feat(interpreter): bridge executable bytes to loop step

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -99,6 +99,7 @@ import EvmAsm.Evm64.InterpreterSimulation
 import EvmAsm.Evm64.InterpreterLoopCompose
 import EvmAsm.Evm64.ExecutableSpecOpcodeBridge
 import EvmAsm.Evm64.InterpreterExecutableFetchBridge
+import EvmAsm.Evm64.InterpreterExecutableStepBridge
 
 -- Precompile dispatch surface (#116)
 import EvmAsm.Evm64.Precompile

--- a/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
+++ b/EvmAsm/Evm64/InterpreterExecutableStepBridge.lean
@@ -1,0 +1,68 @@
+/-
+  EvmAsm.Evm64.InterpreterExecutableStepBridge
+
+  Lift executable-spec byte fetch/decode facts through one running interpreter
+  loop step (GH #109).
+-/
+
+import EvmAsm.Evm64.InterpreterExecutableFetchBridge
+
+namespace EvmAsm.Evm64
+
+namespace InterpreterExecutableStepBridge
+
+/--
+An executable-spec opcode byte at the current PC drives one running loop step
+to the same handler result as direct opcode dispatch.
+
+Distinctive token: InterpreterExecutableStepBridge.loopFuel_one_of_execSpecByte #109.
+-/
+theorem loopFuel_one_of_execSpecByte
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState} {byte : BitVec 8} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code : state.code[state.pc] = byte)
+    (h_decode : EvmOpcode.decodeByte? byte.toNat = some opcode) :
+    InterpreterLoop.loopFuel handler 1 state = handler opcode state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterExecutableFetchBridge.stepWithHandler_of_execSpecByte
+    handler h_pc h_code h_decode
+
+theorem loopFuel_one_of_roundtrip
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState} {byte : BitVec 8} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code : state.code[state.pc] = byte)
+    (h_roundtrip :
+      EvmOpcode.byte? opcode = some byte.toNat ∧
+        EvmOpcode.decodeByte? byte.toNat = some opcode) :
+    InterpreterLoop.loopFuel handler 1 state = handler opcode state := by
+  exact loopFuel_one_of_execSpecByte handler h_status h_pc h_code h_roundtrip.2
+
+theorem loopFuel_one_of_unsupported
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState} {byte : BitVec 8}
+    (h_status : state.status = .running)
+    (h_pc : state.pc < state.code.length)
+    (h_code : state.code[state.pc] = byte)
+    (h_decode : EvmOpcode.decodeByte? byte.toNat = none) :
+    InterpreterLoop.loopFuel handler 1 state = state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterLoop.stepWithHandler_of_unsupported handler (by
+    simp [InterpreterLoop.decodeCurrentOpcode?,
+      InterpreterLoop.fetchOpcodeByte?, h_pc, h_code, h_decode])
+
+theorem loopFuel_one_of_eof
+    (handler : InterpreterLoop.Handler)
+    {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.code.length ≤ state.pc) :
+    InterpreterLoop.loopFuel handler 1 state = state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  exact InterpreterLoop.stepWithHandler_eof_invalid handler h_pc
+
+end InterpreterExecutableStepBridge
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Stacked on #2510.

Adds GH #109 slice evm-asm-geyzi: a generic executable-spec byte bridge from fetch/decode into one running InterpreterLoop.loopFuel step.

Summary:
- adds EvmAsm.Evm64.InterpreterExecutableStepBridge
- proves loopFuel_one_of_execSpecByte and loopFuel_one_of_roundtrip
- adds unsupported-byte and EOF one-step invalid corollaries

Verification:
- lake build EvmAsm.Evm64.InterpreterExecutableStepBridge
- scripts/check-unimported.sh
- scripts/check-file-size.sh --report
- git diff --check
- lake build

Authored by @pirapira; implemented by Codex.