### PR TITLE
feat(keccak): add stack decode bridge

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -106,6 +106,7 @@ import EvmAsm.Evm64.PrecompileDispatch
 import EvmAsm.Evm64.Memory
 import EvmAsm.Evm64.MemoryGas
 import EvmAsm.Evm64.KeccakArgs
+import EvmAsm.Evm64.KeccakArgsStackDecode
 import EvmAsm.Evm64.LogGas
 import EvmAsm.Evm64.LogArgsGas
 import EvmAsm.Evm64.TerminatingGas

--- a/EvmAsm/Evm64/KeccakArgsStackDecode.lean
+++ b/EvmAsm/Evm64/KeccakArgsStackDecode.lean
@@ -1,0 +1,48 @@
+/-
+  EvmAsm.Evm64.KeccakArgsStackDecode
+
+  Pure top-of-stack decoder for KECCAK256/SHA3 arguments (GH #111).
+-/
+
+import EvmAsm.Evm64.KeccakArgs
+
+namespace EvmAsm.Evm64
+
+namespace KeccakArgsStackDecode
+
+open KeccakArgs
+
+/--
+Decode KECCAK256/SHA3 stack arguments from the top-of-stack list order:
+`offset, size`.
+
+Distinctive token: KeccakArgsStackDecode.decodeKeccakStack? #111.
+-/
+def decodeKeccakStack? : List EvmWord → Option Args
+  | offset :: size :: _ => some (keccakArgs offset size)
+  | _ => none
+
+theorem decodeKeccakStack?_some
+    (offset size : EvmWord) (rest : List EvmWord) :
+    decodeKeccakStack? (offset :: size :: rest) =
+      some (keccakArgs offset size) := rfl
+
+theorem decoded_inputRange (offset size : EvmWord) :
+    inputRange (keccakArgs offset size) =
+      { offset := offset, size := size } := rfl
+
+theorem decoded_inputOffsetNat (offset size : EvmWord) :
+    inputOffsetNat (keccakArgs offset size) = offset.toNat := rfl
+
+theorem decoded_inputSizeNat (offset size : EvmWord) :
+    inputSizeNat (keccakArgs offset size) = size.toNat := rfl
+
+theorem decoded_stackArgumentCount :
+    stackArgumentCount = 2 := rfl
+
+theorem decoded_resultCount :
+    resultCount = 1 := rfl
+
+end KeccakArgsStackDecode
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds a pure executable-spec bridge for KECCAK256/SHA3 stack argument decoding.\n\nThis introduces EvmAsm.Evm64.KeccakArgsStackDecode with a top-of-stack decoder for [offset, size] and projection lemmas for input range, Nat offsets/sizes, and stack/result arity.\n\nLocal verification:\n- lake build EvmAsm.Evm64.KeccakArgsStackDecode\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- lake build\n\nRefs evm-asm-qxclt and GH #111.