### PR TITLE
feat(interpreter): add loop status lemmas

### DIFF
--- a/EvmAsm/Evm64.lean
+++ b/EvmAsm/Evm64.lean
@@ -94,6 +94,7 @@ import EvmAsm.Evm64.Dispatch
 import EvmAsm.Evm64.HandlerTable
 import EvmAsm.Evm64.TerminatingHandlers
 import EvmAsm.Evm64.InterpreterLoop
+import EvmAsm.Evm64.InterpreterLoopStatus
 import EvmAsm.Evm64.InterpreterSimulation
 import EvmAsm.Evm64.InterpreterLoopCompose
 

--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -1,0 +1,96 @@
+/-
+  EvmAsm.Evm64.InterpreterLoopStatus
+
+  Status/control lemmas for the pure interpreter loop (GH #108).
+-/
+
+import EvmAsm.Evm64.InterpreterLoop
+
+namespace EvmAsm.Evm64
+
+namespace InterpreterLoopStatus
+
+abbrev Handler := InterpreterLoop.Handler
+
+/-- Predicate for states that the fuel-bounded interpreter loop leaves fixed.
+    Distinctive token: InterpreterLoopStatus.loopFuel_nonRunning #108. -/
+def nonRunning (state : EvmState) : Prop :=
+  state.status ≠ .running
+
+theorem nonRunning_of_stopped {state : EvmState}
+    (h_status : state.status = .stopped) : nonRunning state := by
+  simp [nonRunning, h_status]
+
+theorem nonRunning_of_returned {state : EvmState} {data : List (BitVec 8)}
+    (h_status : state.status = .returned data) : nonRunning state := by
+  simp [nonRunning, h_status]
+
+theorem nonRunning_of_reverted {state : EvmState} {data : List (BitVec 8)}
+    (h_status : state.status = .reverted data) : nonRunning state := by
+  simp [nonRunning, h_status]
+
+theorem nonRunning_of_error {state : EvmState}
+    (h_status : state.status = .error) : nonRunning state := by
+  simp [nonRunning, h_status]
+
+theorem loopFuel_nonRunning
+    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (h_nonRunning : nonRunning state) :
+    InterpreterLoop.loopFuel handler fuel state = state := by
+  cases fuel with
+  | zero => rfl
+  | succ fuel =>
+      cases h_status : state.status <;>
+        simp [InterpreterLoop.loopFuel, h_status, nonRunning] at h_nonRunning ⊢
+
+theorem loopFuel_stopped
+    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (h_status : state.status = .stopped) :
+    InterpreterLoop.loopFuel handler fuel state = state :=
+  loopFuel_nonRunning handler fuel state (nonRunning_of_stopped h_status)
+
+theorem loopFuel_returned
+    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (h_status : state.status = .returned data) :
+    InterpreterLoop.loopFuel handler fuel state = state :=
+  loopFuel_nonRunning handler fuel state (nonRunning_of_returned h_status)
+
+theorem loopFuel_reverted
+    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (h_status : state.status = .reverted data) :
+    InterpreterLoop.loopFuel handler fuel state = state :=
+  loopFuel_nonRunning handler fuel state (nonRunning_of_reverted h_status)
+
+theorem loopFuel_error
+    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (h_status : state.status = .error) :
+    InterpreterLoop.loopFuel handler fuel state = state :=
+  loopFuel_nonRunning handler fuel state (nonRunning_of_error h_status)
+
+theorem loopFuel_one_eof_invalid
+    (handler : Handler) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_pc : state.code.length ≤ state.pc) :
+    InterpreterLoop.loopFuel handler 1 state = state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  simp [InterpreterLoop.stepWithHandler_eof_invalid handler h_pc]
+
+theorem loopFuel_one_unsupported_invalid
+    (handler : Handler) {state : EvmState}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
+    InterpreterLoop.loopFuel handler 1 state = state.invalid := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  simp [InterpreterLoop.stepWithHandler_of_unsupported handler h_decode]
+
+theorem loopFuel_one_decode
+    (handler : Handler) {state : EvmState} {opcode : EvmOpcode}
+    (h_status : state.status = .running)
+    (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
+    InterpreterLoop.loopFuel handler 1 state = handler opcode state := by
+  rw [InterpreterLoop.loopFuel_succ_running handler 0 state h_status]
+  simp [InterpreterLoop.stepWithHandler_of_decode handler h_decode]
+
+end InterpreterLoopStatus
+
+end EvmAsm.Evm64


### PR DESCRIPTION
Adds EvmAsm.Evm64.InterpreterLoopStatus for pure interpreter-loop control facts.\n\nThe new module proves non-running states are fixed for all fuel and provides one-step facts for EOF, unsupported decode, and successful decode under running status.\n\nLocal verification:\n- lake build EvmAsm.Evm64.InterpreterLoopStatus\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- lake build\n\nRefs evm-asm-lzeb2 and GH #108.