### PR TITLE
feat(el): add world-state frame lemmas

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -21,6 +21,7 @@ import EvmAsm.EL.Conformance.Calldata
 import EvmAsm.EL.Conformance.RLP
 import EvmAsm.EL.WorldState
 import EvmAsm.EL.WorldStateAccount
+import EvmAsm.EL.WorldStateFrame
 import EvmAsm.EL.Storage
 import EvmAsm.EL.StorageAccessBridge
 import EvmAsm.EL.StorageEcallBridge

--- a/EvmAsm/EL/WorldStateFrame.lean
+++ b/EvmAsm/EL/WorldStateFrame.lean
@@ -1,0 +1,72 @@
+/-
+  EvmAsm.EL.WorldStateFrame
+
+  Frame lemmas for independent account and storage updates (GH #123).
+-/
+
+import EvmAsm.EL.WorldState
+
+namespace EvmAsm.EL
+
+namespace WorldState
+
+/-- Storage writes do not change account lookup.
+    Distinctive token: WorldStateFrame.getAccount_setStorage #123. -/
+theorem getAccount_setStorage
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) (value : Word256) :
+    getAccount (setStorage state storageAddr key value) addr = getAccount state addr := rfl
+
+theorem accountCode?_setStorage
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) (value : Word256) :
+    accountCode? (setStorage state storageAddr key value) addr = accountCode? state addr := rfl
+
+theorem accountCodeHash?_setStorage
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) (value : Word256) :
+    accountCodeHash? (setStorage state storageAddr key value) addr =
+      accountCodeHash? state addr := rfl
+
+theorem accountBalance?_setStorage
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) (value : Word256) :
+    accountBalance? (setStorage state storageAddr key value) addr =
+      accountBalance? state addr := rfl
+
+theorem accountNonce?_setStorage
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) (value : Word256) :
+    accountNonce? (setStorage state storageAddr key value) addr = accountNonce? state addr := rfl
+
+/-- Account writes do not change storage lookup. -/
+theorem getStorage_setAccount
+    (state : WorldState) (addr storageAddr : Address) (account : Account) (key : StorageKey) :
+    getStorage (setAccount state addr account) storageAddr key =
+      getStorage state storageAddr key := rfl
+
+theorem getStorage_deleteAccount
+    (state : WorldState) (addr storageAddr : Address) (key : StorageKey) :
+    getStorage (deleteAccount state addr) storageAddr key =
+      getStorage state storageAddr key := rfl
+
+theorem getStorage_setAccountCode
+    (state : WorldState) (addr storageAddr : Address) (codeHash : Hash256) (code : List Byte)
+    (key : StorageKey) :
+    getStorage (setAccountCode state addr codeHash code) storageAddr key =
+      getStorage state storageAddr key := by
+  unfold setAccountCode
+  cases getAccount state addr <;> rfl
+
+theorem getStorage_setAccountBalance
+    (state : WorldState) (addr storageAddr : Address) (balance : Word256) (key : StorageKey) :
+    getStorage (setAccountBalance state addr balance) storageAddr key =
+      getStorage state storageAddr key := by
+  unfold setAccountBalance
+  cases getAccount state addr <;> rfl
+
+theorem getStorage_setAccountNonce
+    (state : WorldState) (addr storageAddr : Address) (nonce : Nat) (key : StorageKey) :
+    getStorage (setAccountNonce state addr nonce) storageAddr key =
+      getStorage state storageAddr key := by
+  unfold setAccountNonce
+  cases getAccount state addr <;> rfl
+
+end WorldState
+
+end EvmAsm.EL


### PR DESCRIPTION
Adds GH #123 slice evm-asm-sxc8g: EvmAsm.EL.WorldStateFrame with generic account/storage frame lemmas.

Local verification:
- lake build EvmAsm.EL.WorldStateFrame
- scripts/check-unimported.sh
- scripts/check-file-size.sh --report
- git diff --check
- rg forbidden-token scan on touched files
- lake build

Full build only showed the pre-existing LeanRV64D/RiscvExtras.lean extension.toCtorIdx deprecation warning.

Authored by @pirapira; implemented by Codex.