### PR TITLE
feat(create): bridge collision to failed result

### DIFF
--- a/EvmAsm/EL.lean
+++ b/EvmAsm/EL.lean
@@ -10,6 +10,7 @@ import EvmAsm.EL.CreateArgsBridge
 import EvmAsm.EL.CreateInitcodeBridge
 import EvmAsm.EL.CreateEffects
 import EvmAsm.EL.CreateCollision
+import EvmAsm.EL.CreateCollisionResult
 import EvmAsm.EL.CreateResultBridge
 import EvmAsm.EL.Logs
 import EvmAsm.EL.LogArgsBridge

--- a/EvmAsm/EL/CreateCollisionResult.lean
+++ b/EvmAsm/EL/CreateCollisionResult.lean
@@ -1,0 +1,59 @@
+/-
+  EvmAsm.EL.CreateCollisionResult
+
+  CREATE/CREATE2 collision result bridge for GH #115.
+-/
+
+import EvmAsm.EL.CreateCollision
+import EvmAsm.EL.CreateResultBridge
+
+namespace EvmAsm.EL
+namespace CreateCollisionResult
+
+/-- Result shape for the executable-spec CREATE collision branch.
+
+When the derived target already has code or nonce, CREATE/CREATE2 fails,
+pushes zero, preserves the caller-visible world state, and returns no created
+address. Distinctive token: `CreateCollisionResult.collisionResult`. -/
+def collisionResult (state : WorldState) (gasRemaining : Nat) : CreateResult :=
+  { status := .failed
+    address? := none
+    state := state
+    returndata := []
+    gasRemaining := gasRemaining }
+
+theorem collisionResult_status (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).status = .failed := rfl
+
+theorem collisionResult_address? (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).address? = none := rfl
+
+theorem collisionResult_state (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).state = state := rfl
+
+theorem collisionResult_returndata (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).returndata = [] := rfl
+
+theorem collisionResult_gasRemaining (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).gasRemaining = gasRemaining := rfl
+
+theorem collisionResult_failed (state : WorldState) (gasRemaining : Nat) :
+    (collisionResult state gasRemaining).failed := rfl
+
+theorem collisionResult_stackWord (state : WorldState) (gasRemaining : Nat) :
+    CreateResultBridge.createResultStackWord (collisionResult state gasRemaining) = 0 := rfl
+
+theorem not_createAddressAvailable_of_collision
+    {state : WorldState} {addr : Address}
+    (h_collision : CreateCollision.accountHasCodeOrNonce state addr) :
+    ¬ CreateCollision.createAddressAvailable state addr :=
+  fun h_available => h_available h_collision
+
+theorem collisionResult_stackWord_of_collision
+    {state : WorldState} {addr : Address} {gasRemaining : Nat}
+    (_h_collision : CreateCollision.accountHasCodeOrNonce state addr) :
+    CreateResultBridge.createResultStackWord (collisionResult state gasRemaining) = 0 :=
+  collisionResult_stackWord state gasRemaining
+
+end CreateCollisionResult
+end EvmAsm.EL


### PR DESCRIPTION
Stacked on #2550.\n\nAdds a CREATE/CREATE2 collision failure result bridge for GH #115, connecting the collision predicate from #2550 to the failed result and zero stack-word surface.\n\nBead: evm-asm-30tce\nGH issue: #115\nDependency: #2550 / evm-asm-gefvq\n\nLocal verification on stacked branch:\n- lake build EvmAsm.EL.CreateCollisionResult\n- scripts/check-unimported.sh\n- scripts/check-file-size.sh --report\n- git diff --check\n- rg -n "sorry|set_option maxHeartbeats|set_option maxRecDepth|file-size-exception" EvmAsm/EL/CreateCollisionResult.lean EvmAsm/EL.lean\n- lake build\n\nAuthored by @pirapira; implemented by Codex.