### PR TITLE
chore(shake): swap Dispatch import for Gas in HandlerTable

### DIFF
--- a/EvmAsm/Evm64/HandlerTable.lean
+++ b/EvmAsm/Evm64/HandlerTable.lean
@@ -4,7 +4,7 @@
   Pure opcode-handler table surface for the interpreter layer (GH #107).
 -/
 
-import EvmAsm.Evm64.Dispatch
+import EvmAsm.Evm64.Gas
 import EvmAsm.Evm64.Termination
 
 namespace EvmAsm.Evm64


### PR DESCRIPTION
Slice of #1045 (lake exe shake import-hygiene sweep).

`lake exe shake EvmAsm` reports `EvmAsm.Evm64.Dispatch` as unused in `EvmAsm/Evm64/HandlerTable.lean` and suggests `EvmAsm.Evm64.Gas` instead. HandlerTable references `EvmState` / `EvmOpcode` / `EvmState.invalid` which come (transitively) from Gas; Dispatch was only an indirect re-export.

Verified locally:
- `lake build` green (1600 jobs)
- `lake exe shake EvmAsm` no longer flags `HandlerTable.lean`

Beads: evm-asm-mhhoj (child of evm-asm-9tq / GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).