### PR TITLE
chore(noshake): flag Evm64.Basic Rv64.Basic notation-only false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -61,7 +61,7 @@
   "EvmAsm.Rv64.Tactics.XCancelStruct":
   ["EvmAsm.Rv64.SepLogic"],
  "EvmAsm.Evm64.Basic":
-  ["Std.Tactic.BVDecide"],
+  ["Std.Tactic.BVDecide", "EvmAsm.Rv64.Basic"],
  "EvmAsm.Evm64.CodeRegion":
   ["EvmAsm.Evm64.Basic", "EvmAsm.Rv64.ByteOps", "Mathlib.Tactic.Ring"],
  "EvmAsm.Evm64.Memory":


### PR DESCRIPTION
EvmAsm/Evm64/Basic.lean uses `Word`, which is defined as `notation "Word" => BitVec 64` in `EvmAsm.Rv64.Basic`. Shake does not track notation-only usage and reports `Rv64.Basic` as unused.

Add a `noshake.json` entry to silence this false positive. `lake build` is green (1600 jobs) and `lake exe shake EvmAsm` no longer flags `Evm64.Basic`.

Refs evm-asm-gbp6q, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).