### PR TITLE
chore(noshake): flag Div128Step1v2 DropPure tactic-macro false-positive

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -135,7 +135,7 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.ControlFlow",
    "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1v2":
-  ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1"],
+  ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Step1", "EvmAsm.Rv64.Tactics.DropPure"],
   "EvmAsm.Evm64.DivMod.LimbSpec.Div128Step2":
   ["EvmAsm.Evm64.DivMod.LimbSpec.Div128Clamp", "EvmAsm.Evm64.DivMod.LimbSpec.Div128Tail"],
   "EvmAsm.Evm64.DivMod.Compose.Offsets":


### PR DESCRIPTION
Slice of #1045 (import hygiene sweep). Tracks beads evm-asm-yz796.

`lake exe shake EvmAsm` reports `EvmAsm.Rv64.Tactics.DropPure` as unused in `EvmAsm/Evm64/DivMod/LimbSpec/Div128Step1v2.lean`, but the file invokes the `drop_pure` tactic macro at lines 423 and 463. Shake doesn't track tactic-macro usage, so this is a false positive analogous to PR #2260 (XPermPure/DropPure noshake entries).

Append `EvmAsm.Rv64.Tactics.DropPure` to the existing `Div128Step1v2` noshake entry.

Verification:
- `lake build` succeeds (1600 jobs).
- `lake exe shake EvmAsm | grep Div128Step1v2` → no output.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).