### PR TITLE
feat(evmwordarith): addmod_eq_carry_split bridge (#91 helper)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/AddMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/AddMod.lean
@@ -142,6 +142,24 @@ theorem modAdd_eq_addmod_of_ne_zero (a b N : EvmWord) (h : N ≠ 0) :
   unfold modAdd addmod
   rw [if_neg h]
 
+-- ============================================================================
+-- Carry-split bridge for ADDMOD
+-- ============================================================================
+
+/-- ADDMOD-via-carry-split: when `N ≠ 0`, the algebraic ADDMOD result is the
+    `mod N` of `addCarry`'s outputs combined as a 257-bit Nat.
+
+    This is the algebraic bridge used by the runtime spec (slice 3,
+    `evm-asm-sord`): the RISC-V add-with-carry pipeline returns a
+    `(carry-bit, truncated-256-bit-sum)` pair, and downstream code wants
+    to identify the post-condition with `EvmWord.addmod`. The lemma is a
+    direct consequence of `addCarry_spec` and `addmod_correct`. -/
+theorem addmod_eq_carry_split (a b N : EvmWord) (h : N ≠ 0) :
+    (EvmWord.addmod a b N).toNat =
+      ((if (addCarry a b).fst then 2 ^ 256 else 0) + (addCarry a b).snd.toNat)
+        % N.toNat := by
+  rw [addmod_correct, if_neg h, ← addCarry_spec]
+
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Algebraic bridge tying `EvmWord.addCarry` to `EvmWord.addmod_correct`: when `N ≠ 0`,

```
(addmod a b N).toNat = ((if c then 2^256 else 0) + r.toNat) % N.toNat
```

where `(c, r) = addCarry a b`. Direct consequence of `addCarry_spec` and `addmod_correct`.

## Why
The future `evm_addmod` runtime spec (slice 3, beads `evm-asm-sord`) emits a limb-level `(carry-bit, truncated-256-bit-sum)` pair from the RISC-V add-with-carry pipeline. Rather than inline a 5-line `addCarry_spec` / `addmod_correct` detour at the spec site, this lemma packages the bridge under a stable name. Slice 3 will close the algebraic step in one rewrite.

## Verification
`lake build` green (1613 jobs), 0 sorry added.

Beads: `evm-asm-0j4zm` (depends on parent `evm-asm-z7qm` / GH #91).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).