### PR TITLE
chore(shake): flag MStore/MLoad LimbSpec SyscallSpecs/RunBlock/XSimp false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -84,6 +84,10 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Swap.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.MStore.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
+  "EvmAsm.Evm64.MLoad.LimbSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
   "EvmAsm.Evm64.Add.LimbSpec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Sub.LimbSpec":


### PR DESCRIPTION
lake exe shake EvmAsm flags SyscallSpecs / Tactics.RunBlock / Tactics.XSimp as unused in EvmAsm/Evm64/MStore/LimbSpec.lean and EvmAsm/Evm64/MLoad/LimbSpec.lean. Verified false positive: removing them produces 'unknown tactic' errors (e.g. MStore/LimbSpec.lean:105) and Unknown identifier ld_spec_gen_within / srli_spec_gen_within / lbu_spec_gen_within (declared in SyscallSpecs).

Adds noshake.json entries mirroring the Add/Sub/Eq/IsZero/And/Or/Xor LimbSpec pattern.

Beads: evm-asm-ycl1h
Parent beads: evm-asm-9tq (GH #1045)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).