### PR TITLE
chore(noshake): silence ExecSpecOpcodeBridge IntervalCases + CallOutputMemory List.GetD

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -240,4 +240,6 @@
  ["EvmAsm.Evm64.EvmWordArith.MultiLimb", "EvmAsm.Evm64.EvmWordArith.Arithmetic"],
 "EvmAsm.Evm64.EvmWordArith.Div": ["EvmAsm.Evm64.EvmWordArith.Common"],
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
- ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"]}}
+ ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"],
+"EvmAsm.Evm64.ExecutableSpecOpcodeBridge": ["Mathlib.Tactic.IntervalCases"],
+"EvmAsm.EL.CallOutputMemory": ["Mathlib.Data.List.GetD"]}}


### PR DESCRIPTION
lake exe shake EvmAsm currently flags two false positives that this PR silences via scripts/noshake.json:

- EvmAsm/Evm64/ExecutableSpecOpcodeBridge.lean uses 'interval_cases n' tactic at lines 48 and 54 — needs Mathlib.Tactic.IntervalCases. Shake doesn't track tactic-imported declarations.
- EvmAsm/EL/CallOutputMemory.lean uses 'List.getD' (line 44) and 'List.getD_eq_getElem' (line 91) — needs Mathlib.Data.List.GetD.

Verified locally:
- Removing either import breaks lake build with 'unknown tactic interval_cases' / 'Unknown constant List.getD_eq_getElem' errors.
- After the noshake entries, lake build succeeds (1617 jobs) and shake no longer flags these two files.

Beads: evm-asm-07yav (parent evm-asm-9tq, tracking GH #1045 import hygiene sweep).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).