### PR TITLE
feat(evmwordarith): mulmod_eq_high_low_split bridge (#91 helper)

### DIFF
--- a/EvmAsm/Evm64/EvmWordArith/MulMod.lean
+++ b/EvmAsm/Evm64/EvmWordArith/MulMod.lean
@@ -21,6 +21,7 @@
 -/
 
 import EvmAsm.Evm64.Basic
+import EvmAsm.Evm64.EvmWordArith.MulHigh
 
 namespace EvmAsm.Evm64
 
@@ -57,6 +58,23 @@ theorem mulmod_correct (a b N : EvmWord) :
       have : (a.toNat * b.toNat) % N.toNat < N.toNat := Nat.mod_lt _ hNpos
       omega
     exact Nat.mod_eq_of_lt hlt
+
+/-- Algebraic bridge from the schoolbook split `(mulHigh, low)` to
+    `mulmod`. With `N ≠ 0`,
+
+      `(mulmod a b N).toNat =
+         ((mulHigh a b).toNat * 2^256 + (a * b).toNat) % N.toNat`.
+
+    Direct consequence of `mulHigh_mul_split` and `mulmod_correct`. The
+    future `evm_mulmod_stack_spec` (slice 5, beads `evm-asm-m4wu`) emits
+    a limb-level (high-256, low-256) pair from the 4×4 schoolbook
+    multiply and uses this bridge to close the algebraic side without
+    inlining the high/low split. Mirrors
+    `EvmWord.addmod_eq_carry_split` for the MULMOD side. -/
+theorem mulmod_eq_high_low_split (a b N : EvmWord) (h : N ≠ 0) :
+    (EvmWord.mulmod a b N).toNat =
+      ((EvmWord.mulHigh a b).toNat * 2 ^ 256 + (a * b).toNat) % N.toNat := by
+  rw [mulmod_correct, if_neg h, ← mulHigh_mul_split]
 
 end EvmWord
 


### PR DESCRIPTION
Algebraic bridge tying `EvmWord.mulHigh` + truncated mul to `EvmWord.mulmod_correct`: with `N ≠ 0`,

```
(mulmod a b N).toNat = ((mulHigh a b).toNat * 2^256 + (a * b).toNat) % N.toNat
```

Direct consequence of `mulHigh_mul_split` + `mulmod_correct`.

## Why
The future `evm_mulmod` runtime spec (slice 5, beads `evm-asm-m4wu`) will emit a limb-level (high-256, low-256) pair from the 4×4 schoolbook multiply and needs to bridge to the algebraic mod-`N` postcondition without re-proving / inlining the high/low split inline. Adding the named bridge now keeps slice 5's spec proof one rewrite wide. Mirrors `EvmWord.addmod_eq_carry_split` (PR #2570) for the MULMOD side.

## Verification
`lake build` green (1634 jobs). 0 sorry added. No `maxHeartbeats` / `maxRecDepth` bumps.

Beads: `evm-asm-rg1cz` (depends on parent `evm-asm-z7qm` / GH #91).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).