### PR TITLE
chore(divmod): delete dead modN4StackPre_unfold in Spec/Base.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/Base.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/Base.lean
@@ -247,23 +247,6 @@ instance (sp : Word) (a b : EvmWord) (v5 v6 v7 v10 v11 : Word)
 -- `modN4StackPreCall` (MOD-side call-trial pre-bundle) lives in
 -- `DivMod/SpecCall.lean` to stay under the Spec.lean file-size guardrail.
 
-/-- Named unfold for `modN4StackPre`. Mirror of `divN4StackPre_unfold`. -/
-theorem modN4StackPre_unfold {sp : Word} {a b : EvmWord}
-    {v5 v6 v7 v10 v11 : Word}
-    {q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-     shiftMem nMem jMem : Word} :
-    modN4StackPre sp a b v5 v6 v7 v10 v11
-        q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7 shiftMem nMem jMem =
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x10 ↦ᵣ v10) ** (.x0 ↦ᵣ (0 : Word)) **
-     (.x6 ↦ᵣ v6) ** (.x7 ↦ᵣ v7) **
-     (.x2 ↦ᵣ (clzResult (b.getLimbN 3)).2 >>> (63 : Nat)) **
-     (.x1 ↦ᵣ signExtend12 (4 : BitVec 12) - (4 : Word)) **
-     (.x11 ↦ᵣ v11) **
-     evmWordIs sp a ** evmWordIs (sp + 32) b **
-     divScratchValues sp q0 q1 q2 q3 u0 u1 u2 u3 u4 u5 u6 u7
-       shiftMem nMem jMem) := by
-  delta modN4StackPre; rfl
-
 /-- Named unfold for `divN4MaxSkipStackPost`. Restores access to the
     underlying definition once the `@[irreducible]` attribute has made
     `delta` the only way in at call sites. -/


### PR DESCRIPTION
Slice of #1338 / evm-asm-sboz cleanup (parent evm-asm-ciuob).

modN4StackPre_unfold (Spec/Base.lean) was the MOD-side mirror of divN4StackPre_unfold. The corresponding DIV-side _unfold_atoms variants were already removed in #2446 (evm-asm-sa0ks); this is the surviving MOD wrapper. `grep -rn modN4StackPre_unfold` across `EvmAsm/` shows zero references outside the declaration.

- 1 file changed, 17 deletions(-)
- `lake build` green (1634 jobs).
- 0 new sorry; no maxHeartbeats / maxRecDepth changes.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).