### PR TITLE
chore(divmod): delete 3 dead defs (correction-skip alias + n3 max-after-skip predicates)

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
+++ b/EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean
@@ -100,11 +100,4 @@ theorem divK_mulsub_correction_skip_spec_within
     (fun h hq => by xperm_hyp hq)
     MSCS
 
-def divK_mulsub_correction_skip_spec
-    (sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word)
-    (v1Old v5Old v6Old v7Old v10Old v2Old : Word)
-    (base : Word) :=
-  divK_mulsub_correction_skip_spec_within sp qHat j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-    v1Old v5Old v6Old v7Old v10Old v2Old base
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean
@@ -496,18 +496,4 @@ def isAddbackBorrowN2Call (v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Prop :=
   (if BitVec.ult uTop (mulsubN4_c3 qHat v0 v1 v2 v3 u0 u1 u2 u3) then (1 : Word) else 0) ≠ (0 : Word)
 
 
-/-- j=0 BLTU condition for n=3 max path after j=1 max+skip: u3_j0 ≥ v2. -/
-def isMaxBltuN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 : Word) : Prop :=
-  let qHat : Word := signExtend12 4095
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  ¬BitVec.ult ms.2.2.1 v2
-
-/-- j=0 borrow=0 condition for n=3 max path after j=1 max+skip. -/
-def isSkipBorrowN3After_j1_skip (v0 v1 v2 v3 u0 u1 u2 u3 u0Orig : Word) : Prop :=
-  let qHat : Word := signExtend12 4095
-  let ms := mulsubN4 qHat v0 v1 v2 v3 u0 u1 u2 u3
-  (if BitVec.ult ms.2.2.2.1
-      (mulsubN4_c3 qHat v0 v1 v2 v3 u0Orig ms.1 ms.2.1 ms.2.2.1)
-    then (1 : Word) else 0) = (0 : Word)
-
 end EvmAsm.Evm64


### PR DESCRIPTION
Slice of evm-asm-sboz / GH #61 cleanup. Three never-referenced defs removed:

1. `EvmAsm/Evm64/DivMod/LoopBody/MulsubCorrectionSkip.lean` —
   `def divK_mulsub_correction_skip_spec` was a thin re-export of the
   `_within` form. Every consumer (LoopIterN1/{Max,Call}, LoopIterN2,
   LoopIterN3, LoopIterN4) calls the `_within` variant directly; the
   non-within alias has 0 references project-wide.

2. `EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean` —
   `def isMaxBltuN3After_j1_skip` (n=3 BLTU condition for j=0 after
   j=1 max+skip): 0 references.

3. `EvmAsm/Evm64/DivMod/LoopDefs/Iter.lean` —
   `def isSkipBorrowN3After_j1_skip` (companion borrow predicate):
   0 references.

`lake build` green locally, 1634 jobs, 0 new sorry, 21 LOC removed.

Refs beads evm-asm-g2evq, parent evm-asm-sboz, GH #61.
Authored by @pirapira; implemented by Hermes-bot (evm-hermes).