### PR TITLE
chore(shake): Env.StackSpec import swap + noshake false-positive entry

### DIFF
--- a/EvmAsm/Evm64/Env/StackSpec.lean
+++ b/EvmAsm/Evm64/Env/StackSpec.lean
@@ -18,7 +18,7 @@
   `EvmAsm/Evm64/Calldata/SizeSpec.lean`.
 -/
 
-import EvmAsm.Evm64.Env.Spec
+import EvmAsm.Evm64.Env.Program
 import EvmAsm.Evm64.Env.Field
 import EvmAsm.Evm64.Environment.Assertion
 import EvmAsm.Evm64.Stack

--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -212,6 +212,8 @@
  "EvmAsm.Evm64.EvmWordArith.Comparison": ["EvmAsm.Evm64.EvmWordArith.Common"],
  "EvmAsm.Evm64.Env.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.Env.StackSpec":
+  ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Env.Wrappers":
   ["EvmAsm.Evm64.Env.StackSpec"],
  "EvmAsm.Evm64.MStore8.Spec":


### PR DESCRIPTION
Slice of #1045 (beads evm-asm-33fj0 under parent evm-asm-9tq).

`lake exe shake EvmAsm` reports two issues for `EvmAsm/Evm64/Env/StackSpec.lean`:

1. `EvmAsm.Evm64.Env.Spec` is unused — only referenced in a docstring. The
   file actually depends on `EvmAsm.Evm64.Env.Program` (for `evm_env_load_code`).
   Swap the import.
2. After (1), shake flags `SyscallSpecs` / `Tactics.RunBlock` / `Tactics.XSimp`
   as removable, but they are real direct usages — `runBlock` tactic,
   `xperm_hyp` tactic, `signExtend12_neg32`, and the `*_spec_gen_within`
   family from the `SyscallSpecs` registry. Add a `noshake.json` entry
   to silence the false positives.

`lake build` green; `lake exe shake EvmAsm` no longer flags `Env.StackSpec`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).