### PR TITLE
chore(shake): noshake CopyMemory/DivAddbackCarry false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -222,6 +222,8 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.XSimp", "EvmAsm.Rv64.Tactics.RunBlock"],
  "EvmAsm.Evm64.Push.Spec":
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
+ "EvmAsm.Evm64.Calldata.CopyMemory": ["Mathlib.Data.List.GetD"],
+ "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry": ["EvmAsm.Evm64.EvmWordArith.DivAddbackLimb"],
  "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"],
   "EvmAsm.Rv64.SailEquiv.ShiftProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
   "EvmAsm.Rv64.SailEquiv.ImmProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],


### PR DESCRIPTION
Two `lake exe shake EvmAsm` suggestions are false positives:

- `EvmAsm/Evm64/Calldata/CopyMemory.lean` uses `List.getD_eq_getElem` from `Mathlib.Data.List.GetD` (line 88).
- `EvmAsm/Evm64/EvmWordArith/DivAddbackCarry.lean` uses `addback_4limb_val256` from `EvmAsm.Evm64.EvmWordArith.DivAddbackLimb` (line 234).

Removing either breaks the build (verified locally). Recorded both in `scripts/noshake.json` so future shake slices and `scripts/shake-filter.py` consumers stop seeing them.

Refs evm-asm-i6g3j, parent evm-asm-6qj / GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).