### PR TITLE
chore(shake): noshake EL.RLP.ListDecodeBridge → PrefixDecode

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -248,4 +248,5 @@
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
  ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"],
 "EvmAsm.Evm64.ExecutableSpecOpcodeBridge": ["Mathlib.Tactic.IntervalCases"],
+"EvmAsm.EL.RLP.ListDecodeBridge": ["EvmAsm.EL.RLP.PrefixDecode"],
 "EvmAsm.EL.CallOutputMemory": ["Mathlib.Data.List.GetD"]}}


### PR DESCRIPTION
shake flags EvmAsm.EL.RLP.PrefixDecode as unused in EvmAsm/EL/RLP/ListDecodeBridge.lean, but the import is genuinely needed: ListDecodeBridge references classifyPrefix and decodeAux_cons_{shortList,longList}_of_classifyPrefix from PrefixDecode (lines 45, 51, 66, 75). Removing it breaks the build with 'Unknown identifier' / 'Function expected at'.

Verified locally:
- removing the import: lake build FAILS with 'Unknown identifier classifyPrefix' etc.
- adding the noshake entry: lake build green; lake exe shake EvmAsm no longer flags ListDecodeBridge.

Refs evm-asm-c3u0q (parent evm-asm-9tq, GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).