### PR TITLE
chore(divmod): delete 3 dead defs in LoopDefs/{Post,Bundle}.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Bundle.lean
@@ -328,18 +328,9 @@ def loopBodyPre (n : Word)
   ((uBase + signExtend12 4064) ↦ₘ uTop) **
   (qAddr ↦ₘ qOld)
 
-/-- Precondition for a single-iteration loop body with scratch cells (call path).
-    Shared across call_skip, call_addback, and the unified call-path specs. -/
-@[irreducible]
-def loopBodyPreWithScratch (n : Word)
-    (sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-     v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld
-     retMem dMem dloMem scratch_un0 : Word) : Assertion :=
-  loopBodyPre n sp j jOld v5Old v6Old v7Old v10Old v11Old v2Old
-    v0 v1 v2 v3 u0 u1 u2 u3 uTop qOld **
-  (sp + signExtend12 3968 ↦ₘ retMem) **
-  (sp + signExtend12 3960 ↦ₘ dMem) **
-  (sp + signExtend12 3952 ↦ₘ dloMem) **
-  (sp + signExtend12 3944 ↦ₘ scratch_un0)
+-- (Removed dead def `loopBodyPreWithScratch`: a `loopBodyPre` extension with
+-- four scratch cells (ret/d/dlo/un0) for the call path. It had no consumers;
+-- call-path specs build the scratch chain inline. Authored by @pirapira;
+-- implemented by Hermes-bot (evm-hermes).)
 
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
+++ b/EvmAsm/Evm64/DivMod/LoopDefs/Post.lean
@@ -120,23 +120,9 @@ abbrev loopBodyN2AddbackBeqPost := loopBodyAddbackBeqPost (2 : Word)
 abbrev loopBodyN3AddbackBeqPost := loopBodyAddbackBeqPost (3 : Word)
 abbrev loopBodyN4AddbackBeqPost := loopBodyAddbackBeqPost (4 : Word)
 
--- ============================================================================
--- Unified (Bool-parameterized) loop body postcondition: skip/addback+BEQ
--- Issue #283: Unify skip/addback via `(borrow_zero : Bool)`.
--- `borrow_zero = true`  → skip path (borrow = 0, mulsub didn't underflow)
--- `borrow_zero = false` → addback+BEQ path (borrow ≠ 0, mulsub underflowed)
--- ============================================================================
-
-/-- Unified loop body postcondition parameterized on borrow condition.
-    `borrow_zero = true` selects the skip path;
-    `borrow_zero = false` selects the addback+BEQ (double-addback) path. -/
-@[irreducible]
-def loopBodyUnifiedPost (borrow_zero : Bool) (n : Word)
-    (sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  if borrow_zero then loopBodySkipPost n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  else loopBodyAddbackBeqPost n sp j qHat v0 v1 v2 v3 u0 u1 u2 u3 uTop
-
--- (Per-n unified-post abbreviations were removed as dead code.)
+-- (Bool-parameterized loopBodyUnifiedPost and per-n unified-post abbreviations
+-- were removed as dead code; callers use loopBodySkipPost / loopBodyAddbackBeqPost
+-- directly per execution path.)
 
 -- ============================================================================
 -- Call path postconditions for n=3 (includes div128 scratch cells)
@@ -411,10 +397,8 @@ theorem loopIterPostN3Call_skip {sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word}
         loopBodyN3CallSkipPostJ loopBodyN3SkipPost loopBodySkipPost loopExitPostN3 loopExitPost
   unfold mulsubN4_c3 at hb; simp only [if_neg hb]
 
-def loopIterPostN3 (bltu : Bool) (sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop : Word) : Assertion :=
-  match bltu with
-  | true => loopIterPostN3Call sp base j v0 v1 v2 v3 u0 u1 u2 u3 uTop
-  | false => loopIterPostN3Max sp j v0 v1 v2 v3 u0 u1 u2 u3 uTop ** empAssertion
+-- (Bool-dispatch wrapper loopIterPostN3 was removed as dead code; callers use
+-- loopIterPostN3Max / loopIterPostN3Call directly per execution path.)
 
 -- ============================================================================
 -- Two-iteration path postconditions with double addback for n=3


### PR DESCRIPTION
Three `@[irreducible]` defs in `EvmAsm/Evm64/DivMod/LoopDefs/` had no consumers anywhere in the codebase (verified via `.ilean` reference data + `grep -rwn`):

- `LoopDefs/Post.lean:134` — `loopBodyUnifiedPost` (Bool-parameterized skip/addback dispatch wrapper)
- `LoopDefs/Post.lean:400` — `loopIterPostN3` (Bool-dispatch wrapper around `loopIterPostN3{Max,Call}`)
- `LoopDefs/Bundle.lean:334` — `loopBodyPreWithScratch` (`loopBodyPre` extension with 4 scratch `↦ₘ` cells)

Leftover scaffolding from earlier closure attempts; production specs use the underlying `*Skip` / `*AddbackBeq` / `*Max` / `*Call` defs and inline scratch-cell chains directly. Each removed def was replaced with a one-line note pointing at the surviving alternatives.

Refs beads `evm-asm-3vawv` (slice of `evm-asm-sboz` — DivMod cleanup parent).

`lake build` green locally (1640 jobs); 0 new sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).