### PR TITLE
chore(shake): noshake entry for FullPathN1ConservationV4 → Spec.V4

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -202,6 +202,8 @@
   ["EvmAsm.Evm64.DivMod.LoopBodyN3"],
  "EvmAsm.Evm64.DivMod.Compose.FullPathN1Conservation":
   ["EvmAsm.Evm64.EvmWordArith.CallSkipLowerBoundV2.CompensationCases", "EvmAsm.Evm64.EvmWordArith.DivN4DoubleAddback", "EvmAsm.Evm64.EvmWordArith.ModBridgeUtop"],
+ "EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationV4":
+  ["EvmAsm.Evm64.DivMod.Spec.V4"],
  "EvmAsm.Evm64.DivMod.Spec.Dispatcher":
   ["EvmAsm.Evm64.DivMod.Spec.Base", "EvmAsm.Evm64.DivMod.Spec.CallSkipOverestimateBridge", "EvmAsm.Evm64.DivMod.Compose.FullPathN1ConservationRuntime"],
  "EvmAsm.Rv64.RLP.Phase2LongLoopTwo":   ["EvmAsm.Rv64.RLP.Phase2LongLoopOne"],


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags `EvmAsm.Evm64.DivMod.Spec.V4` as unused in
`EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean`. This is a
false positive: removing the import breaks `lake build` with two
unknown-identifier errors:

- `div128Quot_v4_ge_q_true_normalized_of_lt` at line 48
- `div128Quot_v4_eq_q_true_normalized_of_lt` at line 168

Both are theorems in `EvmAsm/Evm64/DivMod/Spec/V4.lean`. Adding a
`scripts/noshake.json` entry so future shake slicers don't re-attempt
the drop.

## Verification

- `lake build` green (1640 jobs).
- `lake exe shake EvmAsm | grep FullPathN1ConservationV4` is empty after the change.

## Refs

GH #1045 (import hygiene sweep). Beads parent `evm-asm-9tq`, slice `evm-asm-8z0cx`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).