### PR TITLE
chore(divmod): delete 2 dead fullPath_mod_denorm_*_spec_within

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPath.lean
@@ -444,57 +444,6 @@ theorem evm_div_denorm_epilogue_spec (sp base : Word)
     hFull
 
 -- ============================================================================
--- Post-loop chain: Denorm → MOD Epilogue (base+916 → base+1068)
--- Denormalize u[] then load u'[] (remainder) to output.
--- ============================================================================
-
-/-- Post-loop chain for MOD: denormalize u[], then load u'[] to output.
-    base+916 → base+1068. Shift ≠ 0 case (denorm body executed). -/
-private theorem fullPath_mod_denorm_epilogue_spec_within (sp base : Word)
-    (u0 u1 u2 u3 v2 v5 v7 v10 shift : Word)
-    (m0 m8 m16 m24 : Word) :
-    cpsTripleWithin 33 (base + denormOff + 8) (base + nopOff) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x6 ↦ᵣ shift) ** (.x7 ↦ᵣ v7) **
-       (.x2 ↦ᵣ v2) ** (.x0 ↦ᵣ (0 : Word)) ** (.x10 ↦ᵣ v10) **
-       ((sp + signExtend12 4056) ↦ₘ u0) ** ((sp + signExtend12 4048) ↦ₘ u1) **
-       ((sp + signExtend12 4040) ↦ₘ u2) ** ((sp + signExtend12 4032) ↦ₘ u3) **
-       ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
-       ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-      (denormModPost sp shift u0 u1 u2 u3) := by
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  let u0' := (u0 >>> (shift.toNat % 64)) ||| (u1 <<< (antiShift.toNat % 64))
-  let u1' := (u1 >>> (shift.toNat % 64)) ||| (u2 <<< (antiShift.toNat % 64))
-  let u2' := (u2 >>> (shift.toNat % 64)) ||| (u3 <<< (antiShift.toNat % 64))
-  let u3' := u3 >>> (shift.toNat % 64)
-  -- Step 1: Denorm body (base+916 → base+1008, modCode)
-  have hDenorm := mod_denorm_body_spec_within sp u0 u1 u2 u3 v2 v5 v7 shift base
-
-  intro_lets at hDenorm
-  -- Frame denorm with x10, output memory
-  have hDenormF := cpsTripleWithin_frameR
-    ((.x10 ↦ᵣ v10) **
-     ((sp + 32) ↦ₘ m0) ** ((sp + 40) ↦ₘ m8) **
-     ((sp + 48) ↦ₘ m16) ** ((sp + 56) ↦ₘ m24))
-    (by pcFree) hDenorm
-  -- Step 2: MOD epilogue (base+1008 → base+1068, modCode)
-  -- After denorm: x5=u3', x6=shift, x7=(u3<<<antiShift%64), x10=v10
-  -- Epilogue loads u'[] from 4056..4032 (the denormalized values)
-  have hEpi := divK_mod_epilogue_spec_within sp base u0' u1' u2' u3'
-    u3' shift (u3 <<< (antiShift.toNat % 64)) v10 m0 m8 m16 m24
-
-  -- Frame epilogue with x2, x0
-  have hEpiF := cpsTripleWithin_frameR
-    ((.x2 ↦ᵣ antiShift) ** (.x0 ↦ᵣ (0 : Word)))
-    (by pcFree) hEpi
-  -- Compose denorm → epilogue
-  have hFull := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hDenormF hEpiF
-  exact cpsTripleWithin_mono_nSteps (by decide) <| cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by delta denormModPost; xperm_hyp hq)
-    hFull
-
--- ============================================================================
 -- Post-loop chain with preamble: Preamble → Denorm → DIV Epilogue (base+908 → base+1068)
 -- Loads shift from memory, denormalizes u[], then loads q[] to output.
 -- ============================================================================
@@ -544,8 +493,7 @@ theorem evm_div_preamble_denorm_epilogue_spec (sp base : Word)
     hFull
 
 -- ============================================================================
--- MOD Denorm preamble: LD shift + BEQ (base+908 → base+916) with modCode
--- Same instructions as divK_denorm_preamble_spec_within, but proved against modCode.
+-- Denorm code subsumption for modCode (re-proved here since private in ModEpilogue)
 -- ============================================================================
 
 /-- Denorm code (block 9) is subsumed by modCode.
@@ -556,60 +504,6 @@ private theorem divK_denorm_code_sub_modCode' (base : Word) :
   skipBlock; skipBlock; skipBlock; skipBlock; skipBlock
   skipBlock; skipBlock; skipBlock; skipBlock
   exact CodeReq.union_mono_left
-
-/-- Denorm preamble for shift≠0 with modCode: LD shift from memory + BEQ not taken.
-    base+908 → base+916. -/
-private theorem fullPath_mod_denorm_preamble_spec_within (sp shift v5 v6 v7 v2 v10 : Word) (base : Word)
-    (hshift_nz : shift ≠ 0) :
-    cpsTripleWithin 2 (base + denormOff) (base + denormOff + 8) (modCode base)
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ v6) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
-       ((sp + signExtend12 3992) ↦ₘ shift))
-      ((.x12 ↦ᵣ sp) ** (.x6 ↦ᵣ shift) ** (.x0 ↦ᵣ (0 : Word)) **
-       (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
-       ((sp + signExtend12 3992) ↦ₘ shift)) := by
-  -- 1. LD x6 x12 3992 at base+908 (denorm instr [0])
-  have hld := ld_spec_gen_within .x6 .x12 sp v6 shift (3992 : BitVec 12) (base + denormOff) (by nofun)
-  have hlde := cpsTripleWithin_extend_code (hmono := by
-    intro a i h
-    exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff) divK_denorm
-        [.LD .x6 .x12 3992] 0 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hld
-  -- 2. BEQ x6 x0 96 at base+912 (denorm instr [1])
-  have hbeq := beq_spec_gen_within .x6 .x0 (96 : BitVec 13) shift (0 : Word) (base + denormOff + 4)
-  rw [show (base + denormOff + 4 : Word) + signExtend13 (96 : BitVec 13) = base + epilogueOff from by rv64_addr,
-      show (base + denormOff + 4 : Word) + 4 = base + denormOff + 8 from by bv_addr] at hbeq
-  have hbeqe := cpsBranchWithin_extend_code (hmono := by
-    intro a i h
-    exact divK_denorm_code_sub_modCode' base a i
-      (CodeReq.ofProg_mono_sub (base + denormOff) (base + denormOff + 4) divK_denorm
-        [.BEQ .x6 .x0 96] 1 (by bv_addr) (by decide) (by decide) (by decide) a i h)) hbeq
-  -- 3. Eliminate taken branch: shift ≠ 0 means BEQ not taken
-  have hbeq_exit := cpsBranchWithin_ntakenPath hbeqe
-    (fun hp hQt => by
-      obtain ⟨_, _, _, _, _, ⟨_, _, _, _, _, ⟨_, hpure⟩⟩⟩ := hQt
-      exact hshift_nz hpure)
-  have hbeq_clean := cpsTripleWithin_weaken
-    (fun h hp => hp)
-    (fun h hp => sepConj_mono_right
-      (fun h' hp' => ((sepConj_pure_right h').1 hp').1) h hp)
-    hbeq_exit
-  -- 4. Frame LD with x0, x5, x7, x2, x10
-  have hldf := cpsTripleWithin_frameR
-    ((.x0 ↦ᵣ (0 : Word)) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10))
-    (by pcFree) hlde
-  -- 5. Frame BEQ exit with x12, x5, x7, x2, x10, shiftMem
-  have hbeqf := cpsTripleWithin_frameR
-    ((.x12 ↦ᵣ sp) ** (.x5 ↦ᵣ v5) ** (.x7 ↦ᵣ v7) ** (.x2 ↦ᵣ v2) ** (.x10 ↦ᵣ v10) **
-     ((sp + signExtend12 3992) ↦ₘ shift))
-    (by pcFree) hbeq_clean
-  -- 6. Compose LD → BEQ exit
-  have full := cpsTripleWithin_seq_perm_same_cr
-    (fun h hp => by xperm_hyp hp) hldf hbeqf
-  exact cpsTripleWithin_weaken
-    (fun h hp => by xperm_hyp hp)
-    (fun h hq => by xperm_hyp hq)
-    full
 
 -- ============================================================================
 -- Denorm code subsumption for divCode (re-proved here since private in Epilogue)


### PR DESCRIPTION
Two private theorems in `EvmAsm/Evm64/DivMod/Compose/FullPath.lean` had zero references anywhere in the project:

- `fullPath_mod_denorm_epilogue_spec_within` (post-loop chain for MOD denorm + epilogue, base+916 → base+1068)
- `fullPath_mod_denorm_preamble_spec_within` (LD shift + BEQ-not-taken preamble against modCode, base+908 → base+916)

Likely leftovers from #61 closure work. The companion subsumption helper `divK_denorm_code_sub_modCode'` is kept (still used by other theorems in this file).

- ~110 LOC removed (1 insertion, 107 deletions)
- `lake build` green locally (1640 jobs)
- 0 new sorry

Refs beads evm-asm-mczjf, parent evm-asm-sboz (DivMod cleanup after #61).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).