### PR TITLE
chore(shake): noshake EvmWordArith.DivN4Lemmas → DivBridge

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -247,6 +247,7 @@
 "EvmAsm.Evm64.EvmWordArith.MulCorrect":
  ["EvmAsm.Evm64.EvmWordArith.MultiLimb", "EvmAsm.Evm64.EvmWordArith.Arithmetic"],
 "EvmAsm.Evm64.EvmWordArith.Div": ["EvmAsm.Evm64.EvmWordArith.Common"],
+"EvmAsm.Evm64.EvmWordArith.DivN4Lemmas": ["EvmAsm.Evm64.EvmWordArith.DivBridge"],
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
  ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"],
 "EvmAsm.Evm64.ExecutableSpecOpcodeBridge": ["Mathlib.Tactic.IntervalCases"],


### PR DESCRIPTION
shake flags `EvmAsm.Evm64.EvmWordArith.DivBridge` as unused in `EvmAsm/Evm64/EvmWordArith/DivN4Lemmas.lean`, but the import is genuinely needed: `DivN4Lemmas` references `div_of_nat_euclidean` and `mod_of_nat_euclidean` (defined in `DivBridge.lean` lines 52, 63). Removing the import breaks the build with 'Unknown identifier'.

Verified locally:
- removing the import: `lake build` FAILS with 'Unknown identifier div_of_nat_euclidean' / 'mod_of_nat_euclidean'.
- adding the noshake entry: `lake build` green; `lake exe shake EvmAsm` no longer flags DivN4Lemmas.

Refs evm-asm-gawe0 (parent evm-asm-9tq, GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).