### PR TITLE
chore(shake): noshake ModFullPathN3LoopUnified → ModFullPathN4

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -174,6 +174,8 @@
    "EvmAsm.Evm64.DivMod.LoopBody.MulsubCorrectionSkip"],
   "EvmAsm.Evm64.DivMod.Compose.ModFullPathN1LoopUnified":
  ["EvmAsm.Evm64.DivMod.Compose.ModFullPathN4"],
+  "EvmAsm.Evm64.DivMod.Compose.ModFullPathN3LoopUnified":
+ ["EvmAsm.Evm64.DivMod.Compose.ModFullPathN4"],
  "EvmAsm.Evm64.DivMod.LoopBodyN4":
   ["EvmAsm.Evm64.DivMod.LoopBody.TrialCall",
    "EvmAsm.Evm64.DivMod.LoopBody.TrialMax",


### PR DESCRIPTION
lake exe shake EvmAsm flags `EvmAsm.Evm64.DivMod.Compose.ModFullPathN4` as unused in `EvmAsm/Evm64/DivMod/Compose/ModFullPathN3LoopUnified.lean`. Verified false positive: removing the import breaks the build with `Unknown identifier evm_mod_preamble_denorm_epilogue_spec_within` (line 185).

Adds a `scripts/noshake.json` entry mirroring the existing `ModFullPathN1LoopUnified → ModFullPathN4` entry.

Refs evm-asm-xfu0n, GH #1045.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).