### PR TITLE
chore(divmod): delete 3 dead v4 helpers (batch 3)

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean
@@ -615,41 +615,6 @@ def fullDivN1CorrectedTrialVal_v4
   (qHat3.toNat - 2) * B^3 + (qHat2.toNat - 2) * B^2 +
     (qHat1.toNat - 2) * B + (qHat0.toNat - 2)
 
-@[irreducible]
-def fullDivN1LocalFloorVal_v4
-    (bltu_3 bltu_2 bltu_1 _bltu_0 : Bool)
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Nat :=
-  let B := 2^64
-  let v := fullDivN1NormV b0 b1 b2 b3
-  let u := fullDivN1NormU a0 a1 a2 a3 b0
-  let r3 := fullDivN1R3_v4 bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
-  let r2 := fullDivN1R2_v4 bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
-  let r1 := fullDivN1R1_v4 bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-  let local3 := n1LocalFloorDigit v.1 u.2.2.2.1 u.2.2.2.2
-  let local2 := n1LocalFloorDigit v.1 u.2.2.1 r3.2.1
-  let local1 := n1LocalFloorDigit v.1 u.2.1 r2.2.1
-  let local0 := n1LocalFloorDigit v.1 u.1 r1.2.1
-  (local3 - 2) * B^3 + (local2 - 2) * B^2 + (local1 - 2) * B + (local0 - 2)
-
-theorem fullDivN1CorrectedTrialVal_v4_le_quotientVal_v4
-    (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    fullDivN1CorrectedTrialVal_v4 bltu_3 bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3 ≤
-      fullDivN1QuotientVal_v4 bltu_3 bltu_2 bltu_1 bltu_0
-        a0 a1 a2 a3 b0 b1 b2 b3 := by
-  have h3 := fullDivN1R3_v4_qout_ge_trial_sub_two
-    bltu_3 a0 a1 a2 a3 b0 b1 b2 b3
-  have h2 := fullDivN1R2_v4_qout_ge_trial_sub_two
-    bltu_3 bltu_2 a0 a1 a2 a3 b0 b1 b2 b3
-  have h1 := fullDivN1R1_v4_qout_ge_trial_sub_two
-    bltu_3 bltu_2 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3
-  have h0 := fullDivN1R0_v4_qout_ge_trial_sub_two
-    bltu_3 bltu_2 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3
-  delta fullDivN1CorrectedTrialVal_v4 fullDivN1QuotientVal_v4
-  simp only [] at h3 h2 h1 h0 ⊢
-  nlinarith [h3, h2, h1, h0]
-
 theorem fullDivN1R3_v4_step_conservation
     (bltu_3 : Bool) (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
     (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)

--- a/EvmAsm/Evm64/DivMod/Spec/V4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/V4.lean
@@ -133,12 +133,6 @@ def isAddbackBorrowN4CallEvm_v4 (a b : EvmWord) : Prop :=
     (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
     (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
 
-theorem isAddbackBorrowN4CallEvm_v4_def {a b : EvmWord} :
-    isAddbackBorrowN4CallEvm_v4 a b =
-    isAddbackBorrowN4Call_v4
-      (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-      (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
-
 /-- **div128Quot_v4 unfolds via the component accessors**: structural
     bridge to compose the proven sub-stubs. -/
 theorem div128Quot_v4_eq_components (uHi uLo vTop : Word) :


### PR DESCRIPTION
Removes three v4 telescoping helpers with zero references outside their own declaration site (repo-wide grep verified):

* `EvmAsm/Evm64/DivMod/Spec/V4.lean` — `isAddbackBorrowN4CallEvm_v4_def` (rfl wrapper)
* `EvmAsm/Evm64/DivMod/Compose/FullPathN1ConservationV4.lean` — `fullDivN1LocalFloorVal_v4` (def) and `fullDivN1CorrectedTrialVal_v4_le_quotientVal_v4`

Companion to closed PRs #2424 / #2431 (earlier dead-v4-helper batches).

`lake build` green locally (1637 jobs). 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs evm-asm-9ihic; parent evm-asm-sboz (#61-closure dead-code sweep).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).