### PR TITLE
chore(shake): noshake entry for N4StackSpecWithin -> N4StackSpec

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -42,8 +42,10 @@
   ["EvmAsm.Evm64.DivMod.Compose.FullPathN2Bundle.Branches"],
   "EvmAsm.Evm64.DivMod.Shift0Dispatcher":
   ["EvmAsm.Evm64.DivMod.Shift0AddbackMod", "EvmAsm.Evm64.DivMod.SpecCallShift0"],
-  "EvmAsm.Evm64.DivMod.N4StackSpec":
+ "EvmAsm.Evm64.DivMod.N4StackSpec":
   ["EvmAsm.Evm64.DivMod.Spec.CallAddbackMod"],
+ "EvmAsm.Evm64.DivMod.N4StackSpecWithin":
+  ["EvmAsm.Evm64.DivMod.N4StackSpec"],
   "EvmAsm.Evm64.EvmWordArith.DivBridge":
   ["EvmAsm.Evm64.EvmWordArith.Normalization"],
   "EvmAsm.Rv64.AddrNorm": ["EvmAsm.Rv64.AddrNormAttr"],


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags `EvmAsm.Evm64.DivMod.N4StackSpec` as unused in `EvmAsm/Evm64/DivMod/N4StackSpecWithin.lean`. This is a false positive: the wrapper file uses `evm_div_n4_stack_spec`, `evm_mod_n4_stack_spec_within`, and the `{div,mod}N4CallSkipStackPost_unfold` lemmas, all defined in `N4StackSpec`. Removing the import breaks `lake build` with unsolved goals at the dispatcher-surface theorems (verified locally).

Add a one-line `scripts/noshake.json` entry alongside the existing `N4StackSpec` exemption.

## Test

- `lake build` ✅
- `lake exe shake EvmAsm` no longer flags `N4StackSpecWithin` as a key

Refs: GH #1045 (parent `evm-asm-9tq`), beads `evm-asm-2xd28`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).