### PR TITLE
chore(divmod): delete dead fullDivN3QuotientWord_toNat

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean
@@ -63,19 +63,4 @@ theorem fullDivN3_hdivs_of_word_eq
     delta fullDivN3QuotientWord
     exact EvmWord.getLimbN_fromLimbs_3
 
-/-- The `toNat` of the packed quotient word equals the four-limb
-    `EvmWord.val256` of the per-limb results (with top two limbs zero). -/
-theorem fullDivN3QuotientWord_toNat
-    (bltu_1 bltu_0 : Bool)
-    (a0 a1 a2 a3 b0 b1 b2 b3 : Word) :
-    (fullDivN3QuotientWord bltu_1 bltu_0
-      a0 a1 a2 a3 b0 b1 b2 b3).toNat =
-    EvmWord.val256
-      (fullDivN3R0 bltu_1 bltu_0 a0 a1 a2 a3 b0 b1 b2 b3).1
-      (fullDivN3R1 bltu_1 a0 a1 a2 a3 b0 b1 b2 b3).1
-      (0 : Word) (0 : Word) := by
-  delta fullDivN3QuotientWord
-  rw [EvmWord.fromLimbs_toNat]
-  rfl
-
 end EvmAsm.Evm64


### PR DESCRIPTION
Single dead theorem `fullDivN3QuotientWord_toNat` in `EvmAsm/Evm64/DivMod/Spec/N3QuotientWord.lean` (lines 67-78) has zero references in the project. Likely leftover bridge from #61 closure work — sibling N3 toNat-bridge leaves were deleted in PRs #2579 / #2580.

- 15 LOC removed
- `lake build` green (1636 jobs)
- 0 new sorry

beads: `evm-asm-x5330` (parent `evm-asm-sboz`)

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).