### PR TITLE
chore(divmod): delete 2 dead fullDivN1NormV_v{1,2}_eq_zero_of_high_zero

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -531,25 +531,6 @@ theorem fullDivN1NormV_v3_eq_zero_of_high_zero
   rw [fullDivN1NormV_unfold]
   simp [hb3z, hb2z]
 
-theorem fullDivN1NormV_v1_eq_zero_of_high_zero
-    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hshift_nz : fullDivN1Shift b0 ≠ 0) :
-    (fullDivN1NormV b0 b1 b2 b3).2.1 = 0 := by
-  rw [fullDivN1NormV_unfold]
-  simp only [hb1z]
-  rw [fullDivN1AntiShift_unfold]
-  rw [fullDivN1AntiShift_toNat_mod_eq hshift_nz]
-  rw [fullDivN1Shift_unfold]
-  have hz : b0 >>> (64 - (clzResult b0).1.toNat) = 0 :=
-    (ushiftRight_eq_zero_iff (64 - (clzResult b0).1.toNat)).mpr
-      (clzResult_fst_top_bound b0)
-  simp [hz]
-
-theorem fullDivN1NormV_v2_eq_zero_of_high_zero
-    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) :
-    (fullDivN1NormV b0 b1 b2 b3).2.2.1 = 0 := by
-  rw [fullDivN1NormV_unfold]
-  simp [hb1z, hb2z]
-
 theorem fullDivN1NormV_v0_ge_pow63_of_high_zero
     (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :


### PR DESCRIPTION
Removes two theorems in `EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean` with zero references outside their declaration site (verified via repo-wide grep):

- `fullDivN1NormV_v1_eq_zero_of_high_zero` (formerly line 534)
- `fullDivN1NormV_v2_eq_zero_of_high_zero` (formerly line 547)

Sibling `fullDivN1NormV_v3_eq_zero_of_high_zero` remains in active use (7 callers across FullPathN1ConservationV4.lean, FullPathN1Conservation.lean, FullPathN1LoopUnified.lean) and is kept untouched.

`lake build` green locally; 0 sorry; no `maxHeartbeats` / `maxRecDepth` bumps.

Refs evm-asm-40xra, parent evm-asm-sboz (DivMod cleanup umbrella).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).