### PR TITLE
chore(shake): noshake InterpreterExecutableStepBridge → InterpreterExecutableFetchBridge

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -255,5 +255,6 @@
 "EvmAsm.Evm64.DivMod.Spec.CallAddbackPureNat":
  ["Mathlib.Tactic.Ring", "Mathlib.Tactic.Linarith"],
 "EvmAsm.Evm64.ExecutableSpecOpcodeBridge": ["Mathlib.Tactic.IntervalCases"],
+"EvmAsm.Evm64.InterpreterExecutableStepBridge": ["EvmAsm.Evm64.InterpreterExecutableFetchBridge"],
 "EvmAsm.EL.RLP.ListDecodeBridge": ["EvmAsm.EL.RLP.PrefixDecode"],
 "EvmAsm.EL.CallOutputMemory": ["Mathlib.Data.List.GetD"]}}


### PR DESCRIPTION
shake flags `EvmAsm.Evm64.InterpreterExecutableFetchBridge` as unused in `EvmAsm/Evm64/InterpreterExecutableStepBridge.lean` and suggests swapping it for `EvmAsm.Evm64.InterpreterLoop`. The import is genuinely needed: the proof of `InterpreterExecutableStepBridge.loopFuel_one_of_execSpecByte` references `InterpreterExecutableFetchBridge.stepWithHandler_of_execSpecByte` on line 29.

Verified locally:
- removing the import: `lake build EvmAsm.Evm64.InterpreterExecutableStepBridge` FAILS with `Unknown identifier InterpreterExecutableFetchBridge.stepWithHandler_of_execSpecByte`.
- adding the noshake entry: `lake build` green; `lake exe shake EvmAsm` no longer flags `InterpreterExecutableStepBridge`.

Refs evm-asm-0g507 (parent evm-asm-9tq, GH #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).