### PR TITLE
chore(rlp): rename 'fuel' → 'nDepth' in EL/RLP/*

### DIFF
--- a/EvmAsm/EL/RLP/Decode.lean
+++ b/EvmAsm/EL/RLP/Decode.lean
@@ -27,16 +27,16 @@ def readLength (bs : List Byte) (n : Nat) : Option (Nat × List Byte) := do
 
 /-! ## Decoding
 
-Both `decodeAux` and `decodeItems` structurally recurse on `fuel`.
-Each item decode consumes 2 units of fuel (one in `decodeAux`, one in
-`decodeItems`), so we use `2 * bs.length` as the initial fuel. -/
+Both `decodeAux` and `decodeItems` structurally recurse on `nDepth`.
+Each item decode consumes 2 units of nDepth (one in `decodeAux`, one in
+`decodeItems`), so we use `2 * bs.length` as the initial nDepth. -/
 
 mutual
 /-- Decode one RLP item from the byte stream. -/
-def decodeAux (fuel : Nat) (bs : List Byte) : Option (RLPItem × List Byte) :=
-  match fuel with
+def decodeAux (nDepth : Nat) (bs : List Byte) : Option (RLPItem × List Byte) :=
+  match nDepth with
   | 0 => none
-  | fuel + 1 =>
+  | nDepth + 1 =>
   match bs with
   | [] => none
   | pfx :: rest =>
@@ -65,7 +65,7 @@ def decodeAux (fuel : Nat) (bs : List Byte) : Option (RLPItem × List Byte) :=
       -- Short list: prefix = 0xC0 + len
       let len := p - 0xC0
       do let (payload, rest') ← takeBytes rest len
-         let (items, leftover) ← decodeItems fuel payload
+         let (items, leftover) ← decodeItems nDepth payload
          if List.isEmpty leftover then some (.list items, rest')
          else none
     else
@@ -76,20 +76,20 @@ def decodeAux (fuel : Nat) (bs : List Byte) : Option (RLPItem × List Byte) :=
          if lenVal ≤ 55 then none
          else do
            let (payload, rest'') ← takeBytes rest' lenVal
-           let (items, leftover) ← decodeItems fuel payload
+           let (items, leftover) ← decodeItems nDepth payload
            if List.isEmpty leftover then some (.list items, rest'')
            else none
 
 /-- Decode consecutive items from a byte stream until empty. -/
-def decodeItems (fuel : Nat) (bs : List Byte) : Option (List RLPItem × List Byte) :=
+def decodeItems (nDepth : Nat) (bs : List Byte) : Option (List RLPItem × List Byte) :=
   match bs with
   | [] => some ([], [])
   | _ =>
-    match fuel with
+    match nDepth with
     | 0 => none
-    | fuel + 1 => do
-      let (item, rest) ← decodeAux fuel bs
-      let (items, rest') ← decodeItems fuel rest
+    | nDepth + 1 => do
+      let (item, rest) ← decodeAux nDepth bs
+      let (items, rest') ← decodeItems nDepth rest
       some (item :: items, rest')
 end
 
@@ -97,12 +97,12 @@ end
 def decode (bs : List Byte) : Option (RLPItem × List Byte) :=
   decodeAux (2 * bs.length) bs
 
-/-- Expose the exact fuel budget used by the top-level decode wrapper. -/
+/-- Expose the exact nDepth budget used by the top-level decode wrapper. -/
 theorem decode_eq_decodeAux_length (bs : List Byte) :
     decode bs = decodeAux (2 * bs.length) bs := by
   rfl
 
-/-- Top-level decode on a nonempty stream uses two fuel units for the head byte
+/-- Top-level decode on a nonempty stream uses two nDepth units for the head byte
     plus twice the tail length. -/
 theorem decode_cons_eq_decodeAux_fuel (pfx : Byte) (rest : List Byte) :
     decode (pfx :: rest) = decodeAux (2 * rest.length + 2) (pfx :: rest) := by

--- a/EvmAsm/EL/RLP/ListDecodeBridge.lean
+++ b/EvmAsm/EL/RLP/ListDecodeBridge.lean
@@ -13,27 +13,27 @@ namespace ListDecodeBridge
 /-- Decode an RLP list payload and require that the payload decoder consumes
     the payload exactly. Distinctive token: ListDecodeBridge.decodeListPayload
     #120. -/
-def decodeListPayload (fuel : Nat) (payload : List Byte) : Option (List RLPItem) := do
-  let (items, leftover) ← decodeItems fuel payload
+def decodeListPayload (nDepth : Nat) (payload : List Byte) : Option (List RLPItem) := do
+  let (items, leftover) ← decodeItems nDepth payload
   if List.isEmpty leftover then some items else none
 
 theorem decodeListPayload_eq_some_of_decodeItems_empty
-    {fuel : Nat} {payload : List Byte} {items : List RLPItem}
-    (h_decode : decodeItems fuel payload = some (items, [])) :
-    decodeListPayload fuel payload = some items := by
+    {nDepth : Nat} {payload : List Byte} {items : List RLPItem}
+    (h_decode : decodeItems nDepth payload = some (items, [])) :
+    decodeListPayload nDepth payload = some items := by
   simp [decodeListPayload, h_decode]
 
 theorem decodeListPayload_eq_none_of_decodeItems_none
-    {fuel : Nat} {payload : List Byte}
-    (h_decode : decodeItems fuel payload = none) :
-    decodeListPayload fuel payload = none := by
+    {nDepth : Nat} {payload : List Byte}
+    (h_decode : decodeItems nDepth payload = none) :
+    decodeListPayload nDepth payload = none := by
   simp [decodeListPayload, h_decode]
 
 theorem decodeListPayload_eq_none_of_leftover
-    {fuel : Nat} {payload : List Byte} {items : List RLPItem} {leftover : List Byte}
-    (h_decode : decodeItems fuel payload = some (items, leftover))
+    {nDepth : Nat} {payload : List Byte} {items : List RLPItem} {leftover : List Byte}
+    (h_decode : decodeItems nDepth payload = some (items, leftover))
     (h_leftover : leftover ≠ []) :
-    decodeListPayload fuel payload = none := by
+    decodeListPayload nDepth payload = none := by
   cases leftover with
   | nil =>
       contradiction
@@ -41,20 +41,20 @@ theorem decodeListPayload_eq_none_of_leftover
       simp [decodeListPayload, h_decode]
 
 theorem decodeAux_cons_shortList_eq_decodeListPayload
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h_class : classifyPrefix pfx = .shortList) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (payload, rest') ← takeBytes rest (rlpPrefixShortListPayloadLen pfx)
-        let items ← decodeListPayload fuel payload
+        let items ← decodeListPayload nDepth payload
         some (.list items, rest')) := by
-  rw [decodeAux_cons_shortList_of_classifyPrefix fuel pfx rest h_class]
+  rw [decodeAux_cons_shortList_of_classifyPrefix nDepth pfx rest h_class]
   cases h_take : takeBytes rest (rlpPrefixShortListPayloadLen pfx) with
   | none =>
       simp [decodeListPayload]
   | some pair =>
       rcases pair with ⟨payload, rest'⟩
-      cases h_decode : decodeItems fuel payload with
+      cases h_decode : decodeItems nDepth payload with
       | none =>
           simp [decodeListPayload, h_decode]
       | some pair' =>
@@ -62,17 +62,17 @@ theorem decodeAux_cons_shortList_eq_decodeListPayload
           cases leftover <;> simp [decodeListPayload, h_decode]
 
 theorem decodeAux_cons_longList_eq_decodeListPayload
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h_class : classifyPrefix pfx = .longList) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (lenVal, rest') ← readLength rest (rlpPrefixLongListLenOfLen pfx)
         if lenVal ≤ 55 then none
         else do
           let (payload, rest'') ← takeBytes rest' lenVal
-          let items ← decodeListPayload fuel payload
+          let items ← decodeListPayload nDepth payload
           some (.list items, rest'')) := by
-  rw [decodeAux_cons_longList_of_classifyPrefix fuel pfx rest h_class]
+  rw [decodeAux_cons_longList_of_classifyPrefix nDepth pfx rest h_class]
   cases h_read : readLength rest (rlpPrefixLongListLenOfLen pfx) with
   | none =>
       simp [decodeListPayload]
@@ -85,7 +85,7 @@ theorem decodeAux_cons_longList_eq_decodeListPayload
             simp [decodeListPayload, h_short, h_take]
         | some pair' =>
             rcases pair' with ⟨payload, rest''⟩
-            cases h_decode : decodeItems fuel payload with
+            cases h_decode : decodeItems nDepth payload with
             | none =>
                 simp [decodeListPayload, h_short, h_take, h_decode]
             | some pair'' =>

--- a/EvmAsm/EL/RLP/PrefixDecode.lean
+++ b/EvmAsm/EL/RLP/PrefixDecode.lean
@@ -11,17 +11,17 @@ namespace EvmAsm.EL.RLP
 
 /-- A classified single-byte prefix selects the single-byte `decodeAux` branch. -/
 theorem decodeAux_cons_singleByte_of_classifyPrefix
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : classifyPrefix pfx = .singleByte) :
-    decodeAux (fuel + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
+    decodeAux (nDepth + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
   have h_lt := (classifyPrefix_singleByte_iff pfx).mp h
   simp [decodeAux, h_lt]
 
 /-- A classified short-byte-string prefix selects the short-string branch. -/
 theorem decodeAux_cons_shortBytes_of_classifyPrefix
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : classifyPrefix pfx = .shortBytes) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (data, rest') ← takeBytes rest (rlpPrefixShortBytesPayloadLen pfx)
         match data with
@@ -34,9 +34,9 @@ theorem decodeAux_cons_shortBytes_of_classifyPrefix
 
 /-- A classified long-byte-string prefix selects the long-string branch. -/
 theorem decodeAux_cons_longBytes_of_classifyPrefix
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : classifyPrefix pfx = .longBytes) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (lenVal, rest') ← readLength rest (rlpPrefixLongBytesLenOfLen pfx)
         if lenVal ≤ 55 then none
@@ -51,12 +51,12 @@ theorem decodeAux_cons_longBytes_of_classifyPrefix
 
 /-- A classified short-list prefix selects the short-list branch. -/
 theorem decodeAux_cons_shortList_of_classifyPrefix
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : classifyPrefix pfx = .shortList) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (payload, rest') ← takeBytes rest (rlpPrefixShortListPayloadLen pfx)
-        let (items, leftover) ← decodeItems fuel payload
+        let (items, leftover) ← decodeItems nDepth payload
         if List.isEmpty leftover then some (.list items, rest') else none) := by
   have h_range := (classifyPrefix_shortList_iff pfx).mp h
   have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
@@ -67,15 +67,15 @@ theorem decodeAux_cons_shortList_of_classifyPrefix
 
 /-- A classified long-list prefix selects the long-list branch. -/
 theorem decodeAux_cons_longList_of_classifyPrefix
-    (fuel : Nat) (pfx : Byte) (rest : List Byte)
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : classifyPrefix pfx = .longList) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    decodeAux (nDepth + 1) (pfx :: rest) =
       (do
         let (lenVal, rest') ← readLength rest (rlpPrefixLongListLenOfLen pfx)
         if lenVal ≤ 55 then none
         else do
           let (payload, rest'') ← takeBytes rest' lenVal
-          let (items, leftover) ← decodeItems fuel payload
+          let (items, leftover) ← decodeItems nDepth payload
           if List.isEmpty leftover then some (.list items, rest'') else none) := by
   have h_range := (classifyPrefix_longList_iff pfx).mp h
   have h_not_lt : ¬ pfx.toNat < 0x80 := by omega
@@ -91,8 +91,8 @@ theorem decodeAux_cons_longList_of_classifyPrefix
   executable prefix classifiers.
 -/
 theorem decodeAux_cons_eq_classifyPrefix_match
-    (fuel : Nat) (pfx : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1) (pfx :: rest) =
+    (nDepth : Nat) (pfx : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1) (pfx :: rest) =
       match classifyPrefix pfx with
       | .singleByte => some (.bytes [pfx], rest)
       | .shortBytes =>
@@ -111,7 +111,7 @@ theorem decodeAux_cons_eq_classifyPrefix_match
       | .shortList =>
           (do
             let (payload, rest') ← takeBytes rest (rlpPrefixShortListPayloadLen pfx)
-            let (items, leftover) ← decodeItems fuel payload
+            let (items, leftover) ← decodeItems nDepth payload
             if List.isEmpty leftover then some (.list items, rest') else none)
       | .longList =>
           (do
@@ -119,14 +119,14 @@ theorem decodeAux_cons_eq_classifyPrefix_match
             if lenVal ≤ 55 then none
             else do
               let (payload, rest'') ← takeBytes rest' lenVal
-              let (items, leftover) ← decodeItems fuel payload
+              let (items, leftover) ← decodeItems nDepth payload
               if List.isEmpty leftover then some (.list items, rest'') else none) := by
   cases h : classifyPrefix pfx
-  · rw [decodeAux_cons_singleByte_of_classifyPrefix fuel pfx rest h]
-  · rw [decodeAux_cons_shortBytes_of_classifyPrefix fuel pfx rest h]
-  · rw [decodeAux_cons_longBytes_of_classifyPrefix fuel pfx rest h]
-  · rw [decodeAux_cons_shortList_of_classifyPrefix fuel pfx rest h]
-  · rw [decodeAux_cons_longList_of_classifyPrefix fuel pfx rest h]
+  · rw [decodeAux_cons_singleByte_of_classifyPrefix nDepth pfx rest h]
+  · rw [decodeAux_cons_shortBytes_of_classifyPrefix nDepth pfx rest h]
+  · rw [decodeAux_cons_longBytes_of_classifyPrefix nDepth pfx rest h]
+  · rw [decodeAux_cons_shortList_of_classifyPrefix nDepth pfx rest h]
+  · rw [decodeAux_cons_longList_of_classifyPrefix nDepth pfx rest h]
 
 /--
   Top-level `decode` wrapper version of `decodeAux_cons_eq_classifyPrefix_match`.

--- a/EvmAsm/EL/RLP/Properties.lean
+++ b/EvmAsm/EL/RLP/Properties.lean
@@ -48,44 +48,44 @@ theorem readLength_length_lt {bs : List Byte} {n : Nat} (h : bs.length < n) :
 
 /-! ## decodeAux trivial cases -/
 
-/-- `decodeAux 0` always returns `none` (no fuel). -/
+/-- `decodeAux 0` always returns `none` (no nDepth). -/
 theorem decodeAux_zero_fuel (bs : List Byte) :
     decodeAux 0 bs = none := by
   simp [decodeAux]
 
-/-- `decodeAux` on an empty stream returns `none` regardless of fuel. -/
-theorem decodeAux_nil (fuel : Nat) :
-    decodeAux fuel [] = none := by
-  cases fuel <;> simp [decodeAux]
+/-- `decodeAux` on an empty stream returns `none` regardless of nDepth. -/
+theorem decodeAux_nil (nDepth : Nat) :
+    decodeAux nDepth [] = none := by
+  cases nDepth <;> simp [decodeAux]
 
 /-- Single-byte items: when the prefix `p` satisfies `p < 0x80`, `decodeAux`
     succeeds and returns `(.bytes [p], rest)` consuming one byte. -/
-theorem decodeAux_single_byte (fuel : Nat) (pfx : Byte) (rest : List Byte)
+theorem decodeAux_single_byte (nDepth : Nat) (pfx : Byte) (rest : List Byte)
     (h : pfx.toNat < 0x80) :
-    decodeAux (fuel + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
+    decodeAux (nDepth + 1) (pfx :: rest) = some (.bytes [pfx], rest) := by
   simp [decodeAux, h]
 
 /-- Empty short byte string (prefix `0x80`): `decodeAux` returns `(.bytes [], rest)`
     consuming only the prefix byte. -/
-theorem decodeAux_empty_string (fuel : Nat) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0x80 : Byte) :: rest) = some (.bytes [], rest) := by
+theorem decodeAux_empty_string (nDepth : Nat) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0x80 : Byte) :: rest) = some (.bytes [], rest) := by
   simp [decodeAux, takeBytes]
 
 /-- Empty list (prefix `0xC0`): `decodeAux` returns `(.list [], rest)`
     consuming exactly the prefix byte. The short-list branch fires with
     `len = 0`, so `takeBytes rest 0 = some ([], rest)` and the recursive
-    `decodeItems fuel []` returns `some ([], [])` which has empty
+    `decodeItems nDepth []` returns `some ([], [])` which has empty
     leftover. -/
-theorem decodeAux_empty_list (fuel : Nat) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0xC0 : Byte) :: rest) = some (.list [], rest) := by
+theorem decodeAux_empty_list (nDepth : Nat) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0xC0 : Byte) :: rest) = some (.list [], rest) := by
   simp [decodeAux, takeBytes, decodeItems]
 
 /-- Two-byte short string (prefix `0x82`): `decodeAux` returns
     `(.bytes [b1, b2], rest)` consuming three bytes (prefix + 2 payload).
     The two-byte payload is multi-byte, so the canonical-form check
     (which only fires for single-byte strings) is bypassed. -/
-theorem decodeAux_two_byte_string (fuel : Nat) (b1 b2 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0x82 : Byte) :: b1 :: b2 :: rest) =
+theorem decodeAux_two_byte_string (nDepth : Nat) (b1 b2 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0x82 : Byte) :: b1 :: b2 :: rest) =
       some (.bytes [b1, b2], rest) := by
   simp [decodeAux, takeBytes]
 
@@ -93,32 +93,32 @@ theorem decodeAux_two_byte_string (fuel : Nat) (b1 b2 : Byte) (rest : List Byte)
     `(.bytes [b1, b2, b3], rest)` consuming four bytes (prefix + 3
     payload). Multi-byte payload bypasses the canonical-form check. -/
 theorem decodeAux_three_byte_string
-    (fuel : Nat) (b1 b2 b3 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0x83 : Byte) :: b1 :: b2 :: b3 :: rest) =
+    (nDepth : Nat) (b1 b2 b3 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0x83 : Byte) :: b1 :: b2 :: b3 :: rest) =
       some (.bytes [b1, b2, b3], rest) := by
   simp [decodeAux, takeBytes]
 
 /-- Four-byte short string (prefix `0x84`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_four_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0x84 : Byte) :: b1 :: b2 :: b3 :: b4 :: rest) =
+    (nDepth : Nat) (b1 b2 b3 b4 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0x84 : Byte) :: b1 :: b2 :: b3 :: b4 :: rest) =
       some (.bytes [b1, b2, b3, b4], rest) := by
   simp [decodeAux, takeBytes]
 
 /-- Five-byte short string (prefix `0x85`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_five_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1) ((0x85 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: rest) =
+    (nDepth : Nat) (b1 b2 b3 b4 b5 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1) ((0x85 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5], rest) := by
   simp [decodeAux, takeBytes]
 
 /-- Six-byte short string (prefix `0x86`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_six_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x86 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6], rest) := by
   simp [decodeAux, takeBytes]
@@ -126,8 +126,8 @@ theorem decodeAux_six_byte_string
 /-- Seven-byte short string (prefix `0x87`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_seven_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x87 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7], rest) := by
   simp [decodeAux, takeBytes]
@@ -135,8 +135,8 @@ theorem decodeAux_seven_byte_string
 /-- Eight-byte short string (prefix `0x88`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_eight_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x88 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8], rest) := by
   simp [decodeAux, takeBytes]
@@ -144,8 +144,8 @@ theorem decodeAux_eight_byte_string
 /-- Nine-byte short string (prefix `0x89`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_nine_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x89 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9], rest) := by
   simp [decodeAux, takeBytes]
@@ -153,8 +153,8 @@ theorem decodeAux_nine_byte_string
 /-- Ten-byte short string (prefix `0x8A`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_ten_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x8A : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10], rest) := by
   simp [decodeAux, takeBytes]
@@ -162,8 +162,8 @@ theorem decodeAux_ten_byte_string
 /-- Eleven-byte short string (prefix `0x8B`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_eleven_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 : Byte) (rest : List Byte) :
-    decodeAux (fuel + 1)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 : Byte) (rest : List Byte) :
+    decodeAux (nDepth + 1)
         ((0x8B : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11], rest) := by
@@ -172,9 +172,9 @@ theorem decodeAux_eleven_byte_string
 /-- Twelve-byte short string (prefix `0x8C`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twelve_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x8C : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12], rest) := by
@@ -183,9 +183,9 @@ theorem decodeAux_twelve_byte_string
 /-- Thirteen-byte short string (prefix `0x8D`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirteen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x8D : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13], rest) := by
@@ -194,9 +194,9 @@ theorem decodeAux_thirteen_byte_string
 /-- Fourteen-byte short string (prefix `0x8E`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_fourteen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x8E : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14],
@@ -206,9 +206,9 @@ theorem decodeAux_fourteen_byte_string
 /-- Fifteen-byte short string (prefix `0x8F`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_fifteen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x8F : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: rest) =
       some (.bytes [b1, b2, b3, b4, b5, b6, b7, b8, b9, b10, b11, b12, b13, b14, b15],
@@ -218,9 +218,9 @@ theorem decodeAux_fifteen_byte_string
 /-- Sixteen-byte short string (prefix `0x90`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_sixteen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x90 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: rest) =
       some (.bytes
@@ -231,9 +231,9 @@ theorem decodeAux_sixteen_byte_string
 /-- Seventeen-byte short string (prefix `0x91`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_seventeen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x91 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: rest) =
       some (.bytes
@@ -244,9 +244,9 @@ theorem decodeAux_seventeen_byte_string
 /-- Eighteen-byte short string (prefix `0x92`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_eighteen_byte_string
-    (fuel : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 : Byte)
+    (nDepth : Nat) (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x92 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: rest) =
       some (.bytes
@@ -258,10 +258,10 @@ theorem decodeAux_eighteen_byte_string
 /-- Nineteen-byte short string (prefix `0x93`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_nineteen_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x93 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: rest) =
       some (.bytes
@@ -273,10 +273,10 @@ theorem decodeAux_nineteen_byte_string
 /-- Twenty-byte short string (prefix `0x94`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x94 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: rest) =
       some (.bytes
@@ -288,10 +288,10 @@ theorem decodeAux_twenty_byte_string
 /-- Twenty-one-byte short string (prefix `0x95`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_one_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x95 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           rest) =
@@ -304,11 +304,11 @@ theorem decodeAux_twenty_one_byte_string
 /-- Twenty-two-byte short string (prefix `0x96`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_two_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22 :
       Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x96 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: rest) =
@@ -321,11 +321,11 @@ theorem decodeAux_twenty_two_byte_string
 /-- Twenty-three-byte short string (prefix `0x97`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_three_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x97 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: rest) =
@@ -338,11 +338,11 @@ theorem decodeAux_twenty_three_byte_string
 /-- Twenty-four-byte short string (prefix `0x98`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_four_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x98 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: rest) =
@@ -355,11 +355,11 @@ theorem decodeAux_twenty_four_byte_string
 /-- Twenty-five-byte short string (prefix `0x99`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_five_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x99 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: rest) =
@@ -372,11 +372,11 @@ theorem decodeAux_twenty_five_byte_string
 /-- Twenty-six-byte short string (prefix `0x9A`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_six_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9A : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: rest) =
@@ -389,11 +389,11 @@ theorem decodeAux_twenty_six_byte_string
 /-- Twenty-seven-byte short string (prefix `0x9B`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_seven_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9B : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: rest) =
@@ -406,11 +406,11 @@ theorem decodeAux_twenty_seven_byte_string
 /-- Twenty-eight-byte short string (prefix `0x9C`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_eight_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9C : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: rest) =
@@ -423,11 +423,11 @@ theorem decodeAux_twenty_eight_byte_string
 /-- Twenty-nine-byte short string (prefix `0x9D`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_twenty_nine_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9D : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: rest) =
@@ -440,11 +440,11 @@ theorem decodeAux_twenty_nine_byte_string
 /-- Thirty-byte short string (prefix `0x9E`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9E : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: rest) =
@@ -457,11 +457,11 @@ theorem decodeAux_thirty_byte_string
 /-- Thirty-one-byte short string (prefix `0x9F`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_one_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0x9F : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -475,11 +475,11 @@ theorem decodeAux_thirty_one_byte_string
 /-- Thirty-two-byte short string (prefix `0xA0`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_two_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA0 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -493,11 +493,11 @@ theorem decodeAux_thirty_two_byte_string
 /-- Thirty-three-byte short string (prefix `0xA1`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_three_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA1 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -512,11 +512,11 @@ theorem decodeAux_thirty_three_byte_string
 /-- Thirty-four-byte short string (prefix `0xA2`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_four_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA2 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -531,11 +531,11 @@ theorem decodeAux_thirty_four_byte_string
 /-- Thirty-five-byte short string (prefix `0xA3`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_five_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA3 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -550,11 +550,11 @@ theorem decodeAux_thirty_five_byte_string
 /-- Thirty-six-byte short string (prefix `0xA4`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_six_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA4 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -569,11 +569,11 @@ theorem decodeAux_thirty_six_byte_string
 /-- Thirty-seven-byte short string (prefix `0xA5`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_seven_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA5 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -588,11 +588,11 @@ theorem decodeAux_thirty_seven_byte_string
 /-- Thirty-eight-byte short string (prefix `0xA6`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_eight_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA6 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -607,11 +607,11 @@ theorem decodeAux_thirty_eight_byte_string
 /-- Thirty-nine-byte short string (prefix `0xA7`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_thirty_nine_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA7 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -626,12 +626,12 @@ theorem decodeAux_thirty_nine_byte_string
 /-- Forty-byte short string (prefix `0xA8`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_forty_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 :
       Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA8 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -646,12 +646,12 @@ theorem decodeAux_forty_byte_string
 /-- Forty-one-byte short string (prefix `0xA9`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_forty_one_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 b41 :
       Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xA9 : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -667,12 +667,12 @@ theorem decodeAux_forty_one_byte_string
 /-- Forty-two-byte short string (prefix `0xAA`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_forty_two_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 b41 b42 :
       Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xAA : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -688,12 +688,12 @@ theorem decodeAux_forty_two_byte_string
 /-- Forty-three-byte short string (prefix `0xAB`). Multi-byte payload
     bypasses the canonical-form check. -/
 theorem decodeAux_forty_three_byte_string
-    (fuel : Nat)
+    (nDepth : Nat)
     (b1 b2 b3 b4 b5 b6 b7 b8 b9 b10 b11 b12 b13 b14 b15 b16 b17 b18 b19 b20 b21 b22
       b23 b24 b25 b26 b27 b28 b29 b30 b31 b32 b33 b34 b35 b36 b37 b38 b39 b40 b41 b42
       b43 : Byte)
     (rest : List Byte) :
-    decodeAux (fuel + 1)
+    decodeAux (nDepth + 1)
         ((0xAB : Byte) :: b1 :: b2 :: b3 :: b4 :: b5 :: b6 :: b7 :: b8 :: b9 :: b10 ::
           b11 :: b12 :: b13 :: b14 :: b15 :: b16 :: b17 :: b18 :: b19 :: b20 :: b21 ::
           b22 :: b23 :: b24 :: b25 :: b26 :: b27 :: b28 :: b29 :: b30 :: b31 ::
@@ -711,8 +711,8 @@ theorem decodeAux_forty_three_byte_string
     been encoded as itself, not under prefix `0x81`), so `decodeAux`
     returns `none`. -/
 theorem decodeAux_canonical_rejection_single
-    (fuel : Nat) (b : Byte) (rest : List Byte) (h : b.toNat < 0x80) :
-    decodeAux (fuel + 1) ((0x81 : Byte) :: b :: rest) = none := by
+    (nDepth : Nat) (b : Byte) (rest : List Byte) (h : b.toNat < 0x80) :
+    decodeAux (nDepth + 1) ((0x81 : Byte) :: b :: rest) = none := by
   simp [decodeAux, takeBytes, h]
 
 /-- Singleton list containing one small byte: top-level `decode` of
@@ -910,18 +910,18 @@ theorem decode_nil : decode ([] : List Byte) = none := by
   simp [decode, decodeAux]
 
 /-- `decode [pfx]` returns `(.bytes [pfx], [])` whenever `pfx < 0x80`.
-    Specializes `decodeAux_single_byte` at the top-level fuel. -/
+    Specializes `decodeAux_single_byte` at the top-level nDepth. -/
 theorem decode_single_byte (pfx : Byte) (h : pfx.toNat < 0x80) :
     decode [pfx] = some (.bytes [pfx], []) := by
   simp [decode, decodeAux, h]
 
 /-- `decode [0x80] = some (.bytes [], [])` — the canonical empty-string
-    encoding. Specializes `decodeAux_empty_string` at the top-level fuel. -/
+    encoding. Specializes `decodeAux_empty_string` at the top-level nDepth. -/
 theorem decode_empty_string : decode [(0x80 : Byte)] = some (.bytes [], []) := by
   simp [decode, decodeAux, takeBytes]
 
 /-- `decode [0xC0] = some (.list [], [])` — the canonical empty-list
-    encoding. Specializes `decodeAux_empty_list` at the top-level fuel. -/
+    encoding. Specializes `decodeAux_empty_list` at the top-level nDepth. -/
 theorem decode_empty_list : decode [(0xC0 : Byte)] = some (.list [], []) := by
   simp [decode, decodeAux, takeBytes, decodeItems]
 


### PR DESCRIPTION
The `fuel` parameter in RLP decoding is a structural-recursion bound on parsing depth, not a RISC-V step count or EVM gas. Rename to `nDepth` to disambiguate from both EVM gas and the RISC-V-step `nSteps` rename tracked in evm-asm-1tpvq.

Affected files (all in `EvmAsm/EL/RLP/`):
- `Decode.lean` (15 occurrences)
- `ListDecodeBridge.lean` (21)
- `PrefixDecode.lean` (21)
- `Properties.lean` (101)

Disjoint from the `Evm64/` `fuel` (RISC-V steps) usage tracked in evm-asm-1tpvq, so no merge conflict expected.

`lake build` clean locally.

Closes evm-asm-5bxv4.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).