### PR TITLE
chore(interp): rename binder `fuel` → `nSteps` in interpreter/handler loop cluster

### DIFF
--- a/EvmAsm/Evm64/HandlerLoopBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopBridge.lean
@@ -48,22 +48,22 @@ theorem stepWithTableHandler_empty_of_decode
   exact stepWithTableHandler_missing_invalid h_decode (HandlerTable.empty_apply opcode)
 
 theorem loopFuel_succ_running_decode
-    (table : HandlerTable) (fuel : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (table : HandlerTable) (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
-    InterpreterLoop.loopFuel (toLoopHandler table) (fuel + 1) state =
-      InterpreterLoop.loopFuel (toLoopHandler table) fuel
+    InterpreterLoop.loopFuel (toLoopHandler table) (nSteps + 1) state =
+      InterpreterLoop.loopFuel (toLoopHandler table) nSteps
         (HandlerTable.dispatchOpcode table opcode state) := by
-  rw [InterpreterLoop.loopFuel_succ_running (toLoopHandler table) fuel state h_status]
+  rw [InterpreterLoop.loopFuel_succ_running (toLoopHandler table) nSteps state h_status]
   rw [stepWithTableHandler_of_decode table h_decode]
 
 theorem loopFuel_empty_succ_running_decode
-    (fuel : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
-    InterpreterLoop.loopFuel (toLoopHandler HandlerTable.empty) (fuel + 1) state =
-      InterpreterLoop.loopFuel (toLoopHandler HandlerTable.empty) fuel state.invalid := by
-  rw [loopFuel_succ_running_decode HandlerTable.empty fuel h_status h_decode]
+    InterpreterLoop.loopFuel (toLoopHandler HandlerTable.empty) (nSteps + 1) state =
+      InterpreterLoop.loopFuel (toLoopHandler HandlerTable.empty) nSteps state.invalid := by
+  rw [loopFuel_succ_running_decode HandlerTable.empty nSteps h_status h_decode]
   simp [HandlerTable.dispatchOpcode]
 
 theorem handlerMatchesSpec_of_dispatch_eq

--- a/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
+++ b/EvmAsm/Evm64/HandlerLoopSimulationBridge.lean
@@ -14,7 +14,7 @@ namespace HandlerLoopSimulationBridge
 /--
 If a handler table dispatches each decoded opcode like the executable-spec
 handler, then the table-backed interpreter loop matches the executable-spec
-loop for every fuel budget.
+loop for every nSteps budget.
 
 Distinctive token: HandlerLoopSimulationBridge.loopFuel_table_matchesSpec #107 #109.
 -/
@@ -23,9 +23,9 @@ theorem loopFuel_table_matchesSpec
     (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
       InterpreterLoop.decodeCurrentOpcode? state = some opcode →
         HandlerTable.dispatchOpcode table opcode state = spec opcode state) :
-    ∀ (fuel : Nat) (state : EvmState),
-      InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) fuel state =
-        InterpreterLoop.loopFuel spec fuel state := by
+    ∀ (nSteps : Nat) (state : EvmState),
+      InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) nSteps state =
+        InterpreterLoop.loopFuel spec nSteps state := by
   exact InterpreterSimulation.loopFuel_matchesSpec
     (HandlerLoopBridge.handlerMatchesSpec_of_dispatch_eq table spec h_dispatch)
 
@@ -45,10 +45,10 @@ theorem loopFuel_table_matchesSpec_at
     (h_dispatch : ∀ (opcode : EvmOpcode) (state : EvmState),
       InterpreterLoop.decodeCurrentOpcode? state = some opcode →
         HandlerTable.dispatchOpcode table opcode state = spec opcode state)
-    (fuel : Nat) (state : EvmState) :
-    InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) fuel state =
-      InterpreterLoop.loopFuel spec fuel state := by
-  exact loopFuel_table_matchesSpec table spec h_dispatch fuel state
+    (nSteps : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel (HandlerLoopBridge.toLoopHandler table) nSteps state =
+      InterpreterLoop.loopFuel spec nSteps state := by
+  exact loopFuel_table_matchesSpec table spec h_dispatch nSteps state
 
 end HandlerLoopSimulationBridge
 

--- a/EvmAsm/Evm64/InterpreterLoop.lean
+++ b/EvmAsm/Evm64/InterpreterLoop.lean
@@ -36,14 +36,14 @@ def stepWithHandler (handler : Handler) (state : EvmState) : EvmState :=
   | some opcode => handler opcode state
   | none => state.invalid
 
-/-- Fuel-bounded interpreter loop. Non-running states are returned unchanged;
-    running states take at most `fuel` fetch/decode/dispatch steps.
+/-- Step-bounded interpreter loop. Non-running states are returned unchanged;
+    running states take at most `nSteps` fetch/decode/dispatch steps.
     Distinctive token: InterpreterLoop.loopFuel. -/
 def loopFuel (handler : Handler) : Nat → EvmState → EvmState
   | 0, state => state
-  | fuel + 1, state =>
+  | nSteps + 1, state =>
       match state.status with
-      | .running => loopFuel handler fuel (stepWithHandler handler state)
+      | .running => loopFuel handler nSteps (stepWithHandler handler state)
       | _ => state
 
 theorem fetchOpcodeByte?_of_lt
@@ -83,34 +83,34 @@ theorem stepWithHandler_of_unsupported
     loopFuel handler 0 state = state := rfl
 
 theorem loopFuel_succ_running
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .running) :
-    loopFuel handler (fuel + 1) state =
-      loopFuel handler fuel (stepWithHandler handler state) := by
+    loopFuel handler (nSteps + 1) state =
+      loopFuel handler nSteps (stepWithHandler handler state) := by
   simp [loopFuel, h_status]
 
 theorem loopFuel_succ_stopped
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .stopped) :
-    loopFuel handler (fuel + 1) state = state := by
+    loopFuel handler (nSteps + 1) state = state := by
   simp [loopFuel, h_status]
 
 theorem loopFuel_succ_returned
-    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
     (h_status : state.status = .returned data) :
-    loopFuel handler (fuel + 1) state = state := by
+    loopFuel handler (nSteps + 1) state = state := by
   simp [loopFuel, h_status]
 
 theorem loopFuel_succ_reverted
-    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
     (h_status : state.status = .reverted data) :
-    loopFuel handler (fuel + 1) state = state := by
+    loopFuel handler (nSteps + 1) state = state := by
   simp [loopFuel, h_status]
 
 theorem loopFuel_succ_error
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .error) :
-    loopFuel handler (fuel + 1) state = state := by
+    loopFuel handler (nSteps + 1) state = state := by
   simp [loopFuel, h_status]
 
 theorem stepWithHandler_eof_invalid

--- a/EvmAsm/Evm64/InterpreterLoopCompose.lean
+++ b/EvmAsm/Evm64/InterpreterLoopCompose.lean
@@ -12,25 +12,25 @@ namespace InterpreterLoopCompose
 
 abbrev Handler := InterpreterLoop.Handler
 
-/-- Non-running states are fixed points for every fuel budget. -/
+/-- Non-running states are fixed points for every nSteps budget. -/
 theorem loopFuel_of_not_running
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status ≠ .running) :
-    InterpreterLoop.loopFuel handler fuel state = state := by
-  cases fuel with
+    InterpreterLoop.loopFuel handler nSteps state = state := by
+  cases nSteps with
   | zero => rfl
   | succ _ =>
       cases h : state.status <;> simp [InterpreterLoop.loopFuel, h] at h_status ⊢
 
 /-- Distinctive token: InterpreterLoopCompose.loopFuel_add #109. -/
 theorem loopFuel_add
-    (handler : Handler) (fuelA fuelB : Nat) (state : EvmState) :
-    InterpreterLoop.loopFuel handler (fuelA + fuelB) state =
-      InterpreterLoop.loopFuel handler fuelB
-        (InterpreterLoop.loopFuel handler fuelA state) := by
-  induction fuelA generalizing state with
+    (handler : Handler) (nStepsA nStepsB : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (nStepsA + nStepsB) state =
+      InterpreterLoop.loopFuel handler nStepsB
+        (InterpreterLoop.loopFuel handler nStepsA state) := by
+  induction nStepsA generalizing state with
   | zero => simp
-  | succ fuelA ih =>
+  | succ nStepsA ih =>
       rw [Nat.succ_add]
       cases h_status : state.status
       · simp [InterpreterLoop.loopFuel, h_status]
@@ -41,18 +41,18 @@ theorem loopFuel_add
       · simp [InterpreterLoop.loopFuel, h_status, loopFuel_of_not_running]
 
 theorem loopFuel_one_add
-    (handler : Handler) (fuel : Nat) (state : EvmState) :
-    InterpreterLoop.loopFuel handler (1 + fuel) state =
-      InterpreterLoop.loopFuel handler fuel
+    (handler : Handler) (nSteps : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (1 + nSteps) state =
+      InterpreterLoop.loopFuel handler nSteps
         (InterpreterLoop.loopFuel handler 1 state) := by
-  exact loopFuel_add handler 1 fuel state
+  exact loopFuel_add handler 1 nSteps state
 
 theorem loopFuel_add_one
-    (handler : Handler) (fuel : Nat) (state : EvmState) :
-    InterpreterLoop.loopFuel handler (fuel + 1) state =
+    (handler : Handler) (nSteps : Nat) (state : EvmState) :
+    InterpreterLoop.loopFuel handler (nSteps + 1) state =
       InterpreterLoop.loopFuel handler 1
-        (InterpreterLoop.loopFuel handler fuel state) := by
-  exact loopFuel_add handler fuel 1 state
+        (InterpreterLoop.loopFuel handler nSteps state) := by
+  exact loopFuel_add handler nSteps 1 state
 
 end InterpreterLoopCompose
 

--- a/EvmAsm/Evm64/InterpreterLoopStatus.lean
+++ b/EvmAsm/Evm64/InterpreterLoopStatus.lean
@@ -12,7 +12,7 @@ namespace InterpreterLoopStatus
 
 abbrev Handler := InterpreterLoop.Handler
 
-/-- Predicate for states that the fuel-bounded interpreter loop leaves fixed.
+/-- Predicate for states that the nSteps-bounded interpreter loop leaves fixed.
     Distinctive token: InterpreterLoopStatus.loopFuel_nonRunning #108. -/
 def nonRunning (state : EvmState) : Prop :=
   state.status ≠ .running
@@ -34,38 +34,38 @@ theorem nonRunning_of_error {state : EvmState}
   simp [nonRunning, h_status]
 
 theorem loopFuel_nonRunning
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_nonRunning : nonRunning state) :
-    InterpreterLoop.loopFuel handler fuel state = state := by
-  cases fuel with
+    InterpreterLoop.loopFuel handler nSteps state = state := by
+  cases nSteps with
   | zero => rfl
-  | succ fuel =>
+  | succ nSteps =>
       cases h_status : state.status <;>
         simp [InterpreterLoop.loopFuel, h_status, nonRunning] at h_nonRunning ⊢
 
 theorem loopFuel_stopped
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .stopped) :
-    InterpreterLoop.loopFuel handler fuel state = state :=
-  loopFuel_nonRunning handler fuel state (nonRunning_of_stopped h_status)
+    InterpreterLoop.loopFuel handler nSteps state = state :=
+  loopFuel_nonRunning handler nSteps state (nonRunning_of_stopped h_status)
 
 theorem loopFuel_returned
-    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
     (h_status : state.status = .returned data) :
-    InterpreterLoop.loopFuel handler fuel state = state :=
-  loopFuel_nonRunning handler fuel state (nonRunning_of_returned h_status)
+    InterpreterLoop.loopFuel handler nSteps state = state :=
+  loopFuel_nonRunning handler nSteps state (nonRunning_of_returned h_status)
 
 theorem loopFuel_reverted
-    (handler : Handler) (fuel : Nat) (state : EvmState) (data : List (BitVec 8))
+    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
     (h_status : state.status = .reverted data) :
-    InterpreterLoop.loopFuel handler fuel state = state :=
-  loopFuel_nonRunning handler fuel state (nonRunning_of_reverted h_status)
+    InterpreterLoop.loopFuel handler nSteps state = state :=
+  loopFuel_nonRunning handler nSteps state (nonRunning_of_reverted h_status)
 
 theorem loopFuel_error
-    (handler : Handler) (fuel : Nat) (state : EvmState)
+    (handler : Handler) (nSteps : Nat) (state : EvmState)
     (h_status : state.status = .error) :
-    InterpreterLoop.loopFuel handler fuel state = state :=
-  loopFuel_nonRunning handler fuel state (nonRunning_of_error h_status)
+    InterpreterLoop.loopFuel handler nSteps state = state :=
+  loopFuel_nonRunning handler nSteps state (nonRunning_of_error h_status)
 
 theorem loopFuel_one_eof_invalid
     (handler : Handler) {state : EvmState}

--- a/EvmAsm/Evm64/InterpreterSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterSimulation.lean
@@ -52,15 +52,15 @@ theorem stepWithHandler_matchesSpec
 /-- Distinctive token: InterpreterSimulation.loopFuel_matchesSpec #109. -/
 theorem loopFuel_matchesSpec
     {impl spec : Handler} (h_match : HandlerMatchesSpec impl spec) :
-    ∀ (fuel : Nat) (state : EvmState),
-      InterpreterLoop.loopFuel impl fuel state =
-        InterpreterLoop.loopFuel spec fuel state
+    ∀ (nSteps : Nat) (state : EvmState),
+      InterpreterLoop.loopFuel impl nSteps state =
+        InterpreterLoop.loopFuel spec nSteps state
   | 0, _ => rfl
-  | fuel + 1, state => by
+  | nSteps + 1, state => by
       cases h_status : state.status <;>
         simp [InterpreterLoop.loopFuel, h_status]
       rw [stepWithHandler_matchesSpec h_match]
-      exact loopFuel_matchesSpec h_match fuel (InterpreterLoop.stepWithHandler spec state)
+      exact loopFuel_matchesSpec h_match nSteps (InterpreterLoop.stepWithHandler spec state)
 
 end InterpreterSimulation
 

--- a/EvmAsm/Evm64/InterpreterTrace.lean
+++ b/EvmAsm/Evm64/InterpreterTrace.lean
@@ -21,12 +21,12 @@ Distinctive token: InterpreterTrace.loopTrace #108.
 -/
 def loopTrace (handler : Handler) : Nat → EvmState → List EvmOpcode
   | 0, _ => []
-  | fuel + 1, state =>
+  | nSteps + 1, state =>
       match state.status with
       | .running =>
           match InterpreterLoop.decodeCurrentOpcode? state with
           | some opcode =>
-              opcode :: loopTrace handler fuel (InterpreterLoop.stepWithHandler handler state)
+              opcode :: loopTrace handler nSteps (InterpreterLoop.stepWithHandler handler state)
           | none => []
       | _ => []
 
@@ -34,48 +34,48 @@ def loopTrace (handler : Handler) : Nat → EvmState → List EvmOpcode
     loopTrace handler 0 state = [] := rfl
 
 theorem loopTrace_succ_decode
-    (handler : Handler) (fuel : Nat) {state : EvmState} {opcode : EvmOpcode}
+    (handler : Handler) (nSteps : Nat) {state : EvmState} {opcode : EvmOpcode}
     (h_status : state.status = .running)
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = some opcode) :
-    loopTrace handler (fuel + 1) state =
-      opcode :: loopTrace handler fuel (InterpreterLoop.stepWithHandler handler state) := by
+    loopTrace handler (nSteps + 1) state =
+      opcode :: loopTrace handler nSteps (InterpreterLoop.stepWithHandler handler state) := by
   simp [loopTrace, h_status, h_decode]
 
 theorem loopTrace_succ_unsupported
-    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (handler : Handler) (nSteps : Nat) {state : EvmState}
     (h_status : state.status = .running)
     (h_decode : InterpreterLoop.decodeCurrentOpcode? state = none) :
-    loopTrace handler (fuel + 1) state = [] := by
+    loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status, h_decode]
 
 theorem loopTrace_succ_stopped
-    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (handler : Handler) (nSteps : Nat) {state : EvmState}
     (h_status : state.status = .stopped) :
-    loopTrace handler (fuel + 1) state = [] := by
+    loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status]
 
 theorem loopTrace_succ_returned
-    (handler : Handler) (fuel : Nat) {state : EvmState} {data : List (BitVec 8)}
+    (handler : Handler) (nSteps : Nat) {state : EvmState} {data : List (BitVec 8)}
     (h_status : state.status = .returned data) :
-    loopTrace handler (fuel + 1) state = [] := by
+    loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status]
 
 theorem loopTrace_succ_reverted
-    (handler : Handler) (fuel : Nat) {state : EvmState} {data : List (BitVec 8)}
+    (handler : Handler) (nSteps : Nat) {state : EvmState} {data : List (BitVec 8)}
     (h_status : state.status = .reverted data) :
-    loopTrace handler (fuel + 1) state = [] := by
+    loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status]
 
 theorem loopTrace_succ_error
-    (handler : Handler) (fuel : Nat) {state : EvmState}
+    (handler : Handler) (nSteps : Nat) {state : EvmState}
     (h_status : state.status = .error) :
-    loopTrace handler (fuel + 1) state = [] := by
+    loopTrace handler (nSteps + 1) state = [] := by
   simp [loopTrace, h_status]
 
 theorem loopTrace_length_le_fuel (handler : Handler) :
-    ∀ (fuel : Nat) (state : EvmState), (loopTrace handler fuel state).length ≤ fuel
+    ∀ (nSteps : Nat) (state : EvmState), (loopTrace handler nSteps state).length ≤ nSteps
   | 0, _ => Nat.zero_le 0
-  | fuel + 1, state => by
+  | nSteps + 1, state => by
       cases h_status : state.status <;>
         simp [loopTrace, h_status]
       cases h_decode : InterpreterLoop.decodeCurrentOpcode? state with
@@ -83,7 +83,7 @@ theorem loopTrace_length_le_fuel (handler : Handler) :
           simp
       | some opcode =>
           simp [
-            Nat.succ_le_succ (loopTrace_length_le_fuel handler fuel
+            Nat.succ_le_succ (loopTrace_length_le_fuel handler nSteps
               (InterpreterLoop.stepWithHandler handler state))]
 
 end InterpreterTrace

--- a/EvmAsm/Evm64/InterpreterTraceSimulation.lean
+++ b/EvmAsm/Evm64/InterpreterTraceSimulation.lean
@@ -13,18 +13,18 @@ namespace InterpreterTraceSimulation
 
 /--
 Per-opcode handler agreement preserves the decoded-opcode trace of the
-executable fuel loop.
+executable nSteps loop.
 
 Distinctive token: InterpreterTraceSimulation.loopTrace_matchesSpec #109.
 -/
 theorem loopTrace_matchesSpec
     {impl spec : InterpreterLoop.Handler}
     (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec) :
-    ∀ (fuel : Nat) (state : EvmState),
-      InterpreterTrace.loopTrace impl fuel state =
-        InterpreterTrace.loopTrace spec fuel state
+    ∀ (nSteps : Nat) (state : EvmState),
+      InterpreterTrace.loopTrace impl nSteps state =
+        InterpreterTrace.loopTrace spec nSteps state
   | 0, _ => rfl
-  | fuel + 1, state => by
+  | nSteps + 1, state => by
       cases h_status : state.status <;>
         simp [InterpreterTrace.loopTrace, h_status]
       cases h_decode : InterpreterLoop.decodeCurrentOpcode? state with
@@ -32,22 +32,22 @@ theorem loopTrace_matchesSpec
           simp
       | some opcode =>
           rw [InterpreterSimulation.stepWithHandler_matchesSpec h_match state]
-          simp [loopTrace_matchesSpec h_match fuel
+          simp [loopTrace_matchesSpec h_match nSteps
             (InterpreterLoop.stepWithHandler spec state)]
 
-/-- Handler agreement preserves both the final fuel-loop state and its decoded
+/-- Handler agreement preserves both the final nSteps-loop state and its decoded
     trace. -/
 theorem loopFuelAndTrace_matchesSpec
     {impl spec : InterpreterLoop.Handler}
     (h_match : InterpreterSimulation.HandlerMatchesSpec impl spec)
-    (fuel : Nat) (state : EvmState) :
-    (InterpreterLoop.loopFuel impl fuel state,
-      InterpreterTrace.loopTrace impl fuel state) =
-    (InterpreterLoop.loopFuel spec fuel state,
-      InterpreterTrace.loopTrace spec fuel state) := by
+    (nSteps : Nat) (state : EvmState) :
+    (InterpreterLoop.loopFuel impl nSteps state,
+      InterpreterTrace.loopTrace impl nSteps state) =
+    (InterpreterLoop.loopFuel spec nSteps state,
+      InterpreterTrace.loopTrace spec nSteps state) := by
   simp [
-    InterpreterSimulation.loopFuel_matchesSpec h_match fuel state,
-    loopTrace_matchesSpec h_match fuel state]
+    InterpreterSimulation.loopFuel_matchesSpec h_match nSteps state,
+    loopTrace_matchesSpec h_match nSteps state]
 
 end InterpreterTraceSimulation
 


### PR DESCRIPTION
Disambiguates the RISC-V step-budget parameter from EVM gas (per beads evm-asm-1tpvq).

Renames the parameter binder `fuel`/`fuelA`/`fuelB` → `nSteps`/`nStepsA`/`nStepsB` in the 8-file interpreter/handler-loop cluster:
- `EvmAsm/Evm64/InterpreterLoop.lean`
- `EvmAsm/Evm64/InterpreterLoopStatus.lean`
- `EvmAsm/Evm64/InterpreterLoopCompose.lean`
- `EvmAsm/Evm64/InterpreterTrace.lean`
- `EvmAsm/Evm64/InterpreterTraceSimulation.lean`
- `EvmAsm/Evm64/InterpreterSimulation.lean`
- `EvmAsm/Evm64/HandlerLoopBridge.lean`
- `EvmAsm/Evm64/HandlerLoopSimulationBridge.lean`

Scope choices:
- Function/theorem names (`loopFuel`, `loopFuel_succ_running`, `loopTrace_length_le_fuel`, …) and the `InterpreterLoop` namespace token are **intentionally left untouched** — those form a public interface and renaming them is a strictly larger change that would touch every downstream caller.
- RLP/* files are **excluded** per the beads task (their `fuel` is a parsing-recursion bound, not a RISC-V step count; possibly renamed separately to `nDepth` per evm-asm-5bxv4).

`lake build` clean.

Refs evm-asm-1tpvq.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).