### PR TITLE
chore(shake): move Not.Program import from Not/LimbSpec.lean to Not/Spec.lean

### DIFF
--- a/EvmAsm/Evm64/Not/LimbSpec.lean
+++ b/EvmAsm/Evm64/Not/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb NOT spec.
 -/
 
-import EvmAsm.Evm64.Not.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Not/Spec.lean
+++ b/EvmAsm/Evm64/Not/Spec.lean
@@ -5,6 +5,7 @@
 -/
 
 import EvmAsm.Evm64.Not.LimbSpec
+import EvmAsm.Evm64.Not.Program
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp
 


### PR DESCRIPTION
Slice of #1045 (evm-asm-vke75 / parent evm-asm-9tq).

`lake exe shake EvmAsm` flagged `EvmAsm/Evm64/Not/LimbSpec.lean` as importing `EvmAsm.Evm64.Not.Program` without using it. Verified: `LimbSpec` defines `not_limb_spec_within` using only LD/XORI/SD instruction constructors and never references `evm_not`. Moved the import to `Not/Spec.lean`, which uses `evm_not` directly in `evm_not_code` (`CodeReq.ofProg base evm_not`) and previously got it transitively through `LimbSpec`.

Verification:
- `lake build`: green.
- `lake exe shake EvmAsm`: no longer flags `Not/LimbSpec.lean` for the `Not.Program` import.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).