### PR TITLE
chore(shake): flag DivMulSubLimb false-positive in DivMulSubCarry

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -236,6 +236,7 @@
   ["EvmAsm.Rv64.SyscallSpecs", "EvmAsm.Rv64.Tactics.RunBlock", "EvmAsm.Rv64.Tactics.XSimp"],
  "EvmAsm.Evm64.Calldata.CopyMemory": ["Mathlib.Data.List.GetD"],
  "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry": ["EvmAsm.Evm64.EvmWordArith.DivAddbackLimb"],
+ "EvmAsm.Evm64.EvmWordArith.DivMulSubCarry": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
  "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"],
   "EvmAsm.Rv64.SailEquiv.ShiftProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
   "EvmAsm.Rv64.SailEquiv.ImmProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],


### PR DESCRIPTION
`lake exe shake EvmAsm` reports `EvmAsm.Evm64.EvmWordArith.DivMulSubLimb` unused in `EvmAsm/Evm64/EvmWordArith/DivMulSubCarry.lean` and suggests replacing it with `MultiLimb`. **False positive.**

`DivMulSubCarry.lean` uses the following declarations from `DivMulSubLimb`:
- `mulhu_toNat_le` (line 65)
- `mulsub_carry_word_eq` (line 134)
- `mulsub_limb_nat_eq` (line 156)
- `mulsub_chain_nat` (line 212)

`MultiLimb` does not transitively re-export them. Verified by attempting the swap: `lake build` fails with `Unknown identifier 'mulsub_chain_nat'` plus three other unification failures in the strict-carry-bound proof.

Add a `scripts/noshake.json` entry to suppress this suggestion.

Verification:
- `lake build` green (1638 jobs, 0 sorry)
- `lake exe shake EvmAsm` no longer flags `DivMulSubCarry.lean`

beads: evm-asm-77oh6
parent: evm-asm-9tq / GH #1045

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).