### PR TITLE
chore(shake): drop {Add,Sub}.Program import in Add/Sub LimbSpec.lean

### DIFF
--- a/EvmAsm/Evm64/Add/LimbSpec.lean
+++ b/EvmAsm/Evm64/Add/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb ADD specs (from Arithmetic.lean).
 -/
 
-import EvmAsm.Evm64.Add.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Add/Spec.lean
+++ b/EvmAsm/Evm64/Add/Spec.lean
@@ -7,6 +7,7 @@
 
 -- `Add.LimbSpec → Add.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Add.LimbSpec
+import EvmAsm.Evm64.Add.Program
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp

--- a/EvmAsm/Evm64/Sub/LimbSpec.lean
+++ b/EvmAsm/Evm64/Sub/LimbSpec.lean
@@ -4,7 +4,6 @@
   Per-limb SUB specs (from Arithmetic.lean).
 -/
 
-import EvmAsm.Evm64.Sub.Program
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Sub/Spec.lean
+++ b/EvmAsm/Evm64/Sub/Spec.lean
@@ -7,6 +7,7 @@
 
 -- `Sub.LimbSpec → Sub.Program → Stack → SpAddr`.
 import EvmAsm.Evm64.Sub.LimbSpec
+import EvmAsm.Evm64.Sub.Program
 import EvmAsm.Evm64.EvmWordArith.Arithmetic
 import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.Tactics.XSimp


### PR DESCRIPTION
## Summary

`lake exe shake EvmAsm` flags both `EvmAsm/Evm64/Add/LimbSpec.lean` and `EvmAsm/Evm64/Sub/LimbSpec.lean` as importing their respective `Program` module without using it. Verified: per-limb specs only use `LD`/`ADD`/`SUB`/`SLTU`/`SD`/`OR'` instruction constructors and never reference `evm_add` / `evm_sub`.

This is the direct analog of the `Not/LimbSpec` slice in #2623.

## Changes

- Drop `import EvmAsm.Evm64.Add.Program` from `EvmAsm/Evm64/Add/LimbSpec.lean`; add it to `EvmAsm/Evm64/Add/Spec.lean` (which uses `evm_add_code` via `CodeReq.ofProg`).
- Same for the `Sub` pair.

## Verification

- `lake build` green (1638 jobs).
- `lake exe shake EvmAsm` no longer flags those two LimbSpec files.

Refs #1045, beads evm-asm-5ed4p.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).