### PR TITLE
chore(divmod): delete dead isAddbackBorrowN4Call_v4 in Spec/V4.lean

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/V4.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/V4.lean
@@ -107,26 +107,6 @@ is the canonical fix. -/
     else rhat2c
   div128Quot_phase2b_q0' q0' rhat2' dLo div_un0
 
-/-- **v4 mirror of `isAddbackBorrowN4Call`**: the addback BEQ runtime
-    gating, using `div128Quot_v4` for the trial quotient. The branch
-    fires when the borrow check on `mulsubN4_c3 qHat ...` is true,
-    indicating qHat overshoots q_true. -/
-def isAddbackBorrowN4Call_v4 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
-  let shift := (clzResult b3).1
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-  let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (antiShift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-  let u0 := a0 <<< (shift.toNat % 64)
-  let qHat := div128Quot_v4 u4 u3 b3'
-  (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
-   then (1 : Word) else 0) ≠ (0 : Word)
-
 /-- **div128Quot_v4 unfolds via the component accessors**: structural
     bridge to compose the proven sub-stubs. -/
 theorem div128Quot_v4_eq_components (uHi uLo vTop : Word) :


### PR DESCRIPTION
Slice of evm-asm-sboz (DivMod cleanup parent), tracked by beads evm-asm-4akou.

The Word-variant def `isAddbackBorrowN4Call_v4` (in `EvmAsm/Evm64/DivMod/Spec/V4.lean`) has zero references project-wide outside its declaration site, verified via `rg -nw isAddbackBorrowN4Call_v4`. Distinct from the recently-deleted EvmWord-variant `isAddbackBorrowN4CallEvm_v4` (shipped in PR #2619, beads evm-asm-vrheq).

Local `lake build` green: 1636 jobs, 0 errors, 0 sorry.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).