### PR TITLE
chore(divmod): delete 3 dead v2 addback-borrow predicates and helper

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean
@@ -501,27 +501,6 @@ def isAddbackBorrowN4Call (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
   (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
    then (1 : Word) else 0) ≠ (0 : Word)
 
-/-- v2 mirror of `isAddbackBorrowN4Call` — same shape but uses
-    `div128Quot_v2` for the trial quotient. Required by the v2 closure
-    proof to match the predicate's internal use of `div128Quot_v2`.
-
-    Issue #1337 algorithm fix migration. -/
-def isAddbackBorrowN4Call_v2 (a0 a1 a2 a3 b0 b1 b2 b3 : Word) : Prop :=
-  let shift := (clzResult b3).1
-  let antiShift := signExtend12 (0 : BitVec 12) - shift
-  let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-  let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-  let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-  let b0' := b0 <<< (shift.toNat % 64)
-  let u4 := a3 >>> (antiShift.toNat % 64)
-  let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-  let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-  let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-  let u0 := a0 <<< (shift.toNat % 64)
-  let qHat := div128Quot_v2 u4 u3 b3'
-  (if BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
-   then (1 : Word) else 0) ≠ (0 : Word)
-
 /-- Loop body n=4, call+skip, j=0 with sp-relative addresses. -/
 theorem divK_loop_body_n4_call_skip_j0_norm (sp base : Word)
     (jOld v5Old v6Old v7Old v10Old v11Old v2Old : Word)

--- a/EvmAsm/Evm64/DivMod/SpecPredicates.lean
+++ b/EvmAsm/Evm64/DivMod/SpecPredicates.lean
@@ -86,10 +86,4 @@ theorem isAddbackCarry2NzN4CallEvm_def {a b : EvmWord} :
     isAddbackCarry2NzN4CallAb (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
                               (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3) := rfl
 
-/-- v2 mirror of `isAddbackBorrowN4CallEvm` — uses `div128Quot_v2` via
-    `isAddbackBorrowN4Call_v2`. Issue #1337 algorithm fix migration. -/
-def isAddbackBorrowN4CallEvm_v2 (a b : EvmWord) : Prop :=
-  isAddbackBorrowN4Call_v2 (a.getLimbN 0) (a.getLimbN 1) (a.getLimbN 2) (a.getLimbN 3)
-                           (b.getLimbN 0) (b.getLimbN 1) (b.getLimbN 2) (b.getLimbN 3)
-
 end EvmAsm.Evm64

--- a/EvmAsm/Evm64/EvmWordArith/AddbackBorrowExtract.lean
+++ b/EvmAsm/Evm64/EvmWordArith/AddbackBorrowExtract.lean
@@ -81,37 +81,6 @@ theorem u_top_lt_c3_of_addback_borrow_call (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
   · rw [if_neg hlt] at h
     exact absurd rfl h
 
-/-- v2 mirror of `u_top_lt_c3_of_addback_borrow_call` — extracts the same
-    Nat-level strict inequality but with `qHat = div128Quot_v2 u4 u3 b3'`
-    (the v2 fix).
-
-    Issue #1337 algorithm fix migration. -/
-theorem u_top_lt_c3_of_addback_borrow_call_v2 (a0 a1 a2 a3 b0 b1 b2 b3 : Word)
-    (h : isAddbackBorrowN4Call_v2 a0 a1 a2 a3 b0 b1 b2 b3) :
-    let shift := (clzResult b3).1
-    let antiShift := signExtend12 (0 : BitVec 12) - shift
-    let b3' := (b3 <<< (shift.toNat % 64)) ||| (b2 >>> (antiShift.toNat % 64))
-    let b2' := (b2 <<< (shift.toNat % 64)) ||| (b1 >>> (antiShift.toNat % 64))
-    let b1' := (b1 <<< (shift.toNat % 64)) ||| (b0 >>> (antiShift.toNat % 64))
-    let b0' := b0 <<< (shift.toNat % 64)
-    let u4 := a3 >>> (antiShift.toNat % 64)
-    let u3 := (a3 <<< (shift.toNat % 64)) ||| (a2 >>> (antiShift.toNat % 64))
-    let u2 := (a2 <<< (shift.toNat % 64)) ||| (a1 >>> (antiShift.toNat % 64))
-    let u1 := (a1 <<< (shift.toNat % 64)) ||| (a0 >>> (antiShift.toNat % 64))
-    let u0 := a0 <<< (shift.toNat % 64)
-    let qHat := div128Quot_v2 u4 u3 b3'
-    u4.toNat <
-    (mulsubN4 qHat b0' b1' b2' b3' u0 u1 u2 u3).2.2.2.2.toNat := by
-  intro shift antiShift b3' b2' b1' b0' u4 u3 u2 u1 u0 qHat
-  unfold isAddbackBorrowN4Call_v2 at h
-  simp only [] at h
-  by_cases hlt : BitVec.ult u4 (mulsubN4_c3 qHat b0' b1' b2' b3' u0 u1 u2 u3)
-  · rw [ult_iff] at hlt
-    unfold mulsubN4_c3 at hlt
-    exact hlt
-  · rw [if_neg hlt] at h
-    exact absurd rfl h
-
 end EvmWord
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Three v2-flavoured declarations from the #1337 algorithm-fix migration are no longer referenced by any live consumer (verified via `rg -wn` project-wide):

- `isAddbackBorrowN4CallEvm_v2` in `EvmAsm/Evm64/DivMod/SpecPredicates.lean`
- `u_top_lt_c3_of_addback_borrow_call_v2` in `EvmAsm/Evm64/EvmWordArith/AddbackBorrowExtract.lean`
- `isAddbackBorrowN4Call_v2` in `EvmAsm/Evm64/DivMod/Compose/FullPathN4.lean`

The first's `_def` rfl wrapper was already deleted in #2368 (bead `evm-asm-16ym`). The middle one was only used by the `qHat_*_shifted_under_runtime_v2` trio that was relocated in #2254 (`evm-asm-xr9t`) and later deleted as dead (`evm-asm-3ry3`). The Word-level `isAddbackBorrowN4Call_v2` is only consumed by the two v2 decls above, so it becomes dead once they are removed.

Slice of `evm-asm-sboz` (#61-closure DivMod cleanup parent).

- `lake build` green (1634 jobs, 0 sorry).
- No `maxHeartbeats` / `maxRecDepth` bumps.
- -58 LOC.

Beads: `evm-asm-62g8b`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).