### PR TITLE
chore(divmod): delete dead conj2_arith in CallAddbackPureNat

### DIFF
--- a/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
+++ b/EvmAsm/Evm64/DivMod/Spec/CallAddbackPureNat.lean
@@ -305,70 +305,10 @@ theorem un21_toNat_untruncated_arith (A_trunc B k : ℕ)
     rw [Nat.mod_eq_of_lt (by omega : A_trunc + 2^64 - B < 2^64)]
     omega
 
-/-- **Pure-Nat helper for conj2 of `_no_wrap_under_call_addback_beq_untruncated`.**
+/-- **Pure-Nat helper for the un21 < vTop bridge.**
 
     Given the Phase-1 Euclidean (`q1'' * dHi + rhat'' = uHi`) and
     Knuth-A v2 (`q1'' ≥ (uHi*2^32 + div_un1) / vTop`) at the Nat level,
-    derives the untruncated phase-1 upper-bound conjunct:
-    `rhat'' * 2^32 + div_un1 - q1'' * dLo < 2^64`.
-
-    No Word reasoning — this is the algebraic combiner that the parent
-    stub's conj2 case will invoke once Knuth-A is closed.
-
-    Extracted from `Spec/CallAddback.lean` (sub-slice of evm-asm-ry8). -/
-theorem conj2_arith
-    (uHi div_un1 q1pp rhat_pp dHi dLo : ℕ)
-    (h_eucl : q1pp * dHi + rhat_pp = uHi)
-    (h_dHi_lt : dHi < 2^32)
-    (h_dLo_lt : dLo < 2^32)
-    (h_dHi_ge : dHi ≥ 2^31)
-    (h_knuthA : q1pp ≥ (uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo)) :
-    rhat_pp * 2^32 + div_un1 - q1pp * dLo < 2^64 := by
-  have h_vTop_pos : 0 < dHi * 2^32 + dLo := by
-    have h1 : dHi * 2^32 ≥ 2^31 * 2^32 := Nat.mul_le_mul_right _ h_dHi_ge
-    have h_pow : (2 ^ 31 * 2 ^ 32 : ℕ) = 2 ^ 63 := by decide
-    omega
-  have h_vTop_lt_pow64 : dHi * 2^32 + dLo < 2^64 := by
-    have h1 : dHi * 2^32 ≤ (2^32 - 1) * 2^32 :=
-      Nat.mul_le_mul_right _ (by omega : dHi ≤ 2^32 - 1)
-    have h_pow : ((2^32 - 1) * 2^32 + (2^32 - 1) : ℕ) = 2^64 - 1 := by decide
-    omega
-  rcases Nat.lt_or_ge (rhat_pp * 2^32 + div_un1) (q1pp * dLo) with h_neg | h_nonneg
-  · have h_zero : rhat_pp * 2^32 + div_un1 - q1pp * dLo = 0 := by omega
-    rw [h_zero]; decide
-  · have h_q1pp_dHi_le : q1pp * dHi ≤ uHi := by linarith [h_eucl]
-    have h_q1pp_dHi_2pow32_le : q1pp * dHi * 2^32 ≤ uHi * 2^32 :=
-      Nat.mul_le_mul_right _ h_q1pp_dHi_le
-    have h_rhat_2pow32 : rhat_pp * 2^32 = uHi * 2^32 - q1pp * dHi * 2^32 := by
-      have h_rhat_eq : rhat_pp = uHi - q1pp * dHi := by omega
-      rw [h_rhat_eq, Nat.sub_mul]
-    have h_q1pp_vTop : q1pp * (dHi * 2^32 + dLo) = q1pp * dHi * 2^32 + q1pp * dLo := by
-      ring
-    have h_lhs_eq :
-        rhat_pp * 2^32 + div_un1 - q1pp * dLo =
-        uHi * 2^32 + div_un1 - q1pp * (dHi * 2^32 + dLo) := by omega
-    rw [h_lhs_eq]
-    have h_div_mul :
-        (uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo) * (dHi * 2^32 + dLo) ≤
-        q1pp * (dHi * 2^32 + dLo) :=
-      Nat.mul_le_mul_right _ h_knuthA
-    have h_div_add_mod :
-        uHi * 2^32 + div_un1 =
-        (dHi * 2^32 + dLo) * ((uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo)) +
-        (uHi * 2^32 + div_un1) % (dHi * 2^32 + dLo) :=
-      (Nat.div_add_mod _ _).symm
-    have h_mod_lt :
-        (uHi * 2^32 + div_un1) % (dHi * 2^32 + dLo) < dHi * 2^32 + dLo :=
-      Nat.mod_lt _ h_vTop_pos
-    have h_div_mul' :
-        (uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo) * (dHi * 2^32 + dLo) =
-        (dHi * 2^32 + dLo) * ((uHi * 2^32 + div_un1) / (dHi * 2^32 + dLo)) :=
-      Nat.mul_comm _ _
-    omega
-
-/-- **Strengthened version of `conj2_arith`** — same hypotheses, but
-    bounds the untruncated subtraction by `vTop` instead of `2^64`.
-    Same algebraic argument, just keeps the tighter bound.
 
     The conclusion `(rhat'' * 2^32 + div_un1) - q1'' * dLo < vTop` is
     what the un21 < vTop bridge needs (combined with `_un21_toNat_untruncated`


### PR DESCRIPTION
Remove `conj2_arith` (`Spec/CallAddbackPureNat.lean`:319) which has zero references project-wide outside its declaration site (verified via `grep -rwn`).

Its strengthened sibling `un21_lt_vTop_arith` (L378, removed in PR #2649) is also dead — both were extracted from `Spec/CallAddback.lean` during the #61 closure / extract-pure-Nat-helpers slice (`evm-asm-ry8`), but the consumers were since deleted.

`lake build` green (1634 jobs, 0 sorry).

Refs `evm-asm-mu5l7`, `evm-asm-sboz`, GH #1078.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).