### PR TITLE
chore(divmod): delete dead callable byte_length theorems

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -21,8 +21,8 @@
   NOP).
 
   This file is **prep slice A** for evm-asm-8pfe / GH #90: it
-  introduces only the Program definitions and length / byte_length
-  lemmas. Code-region helpers, sub-code lemmas and the
+  introduces only the Program definitions and length lemmas.
+  Code-region helpers, sub-code lemmas and the
   `_function_spec` round-trip will land in follow-up slices.
 
   Reference: GH #90 (parent evm-asm-34sg), beads slice evm-asm-0tnux.
@@ -80,7 +80,7 @@ def evm_mod_callable : Program :=
   divK_div128
 
 -- ============================================================================
--- Length / byte_length lemmas
+-- Length lemmas
 -- ============================================================================
 
 /-- `evm_div_callable` has the same instruction count as `evm_div`
@@ -91,11 +91,5 @@ theorem evm_div_callable_length : evm_div_callable.length = 319 := by
 /-- `evm_mod_callable` has the same instruction count as `evm_mod`. -/
 theorem evm_mod_callable_length : evm_mod_callable.length = 319 := by
   native_decide
-
-theorem evm_div_callable_byte_length : 4 * evm_div_callable.length = 1276 := by
-  rw [evm_div_callable_length]
-
-theorem evm_mod_callable_byte_length : 4 * evm_mod_callable.length = 1276 := by
-  rw [evm_mod_callable_length]
 
 end EvmAsm.Evm64


### PR DESCRIPTION
Two theorems in `EvmAsm/Evm64/DivMod/Callable.lean` had zero references project-wide outside their declaration sites:

- `evm_div_callable_byte_length` (L95)
- `evm_mod_callable_byte_length` (L98)

They mirrored the `mul_callable_byte_length` pattern from PR #2080, but DivMod's callable variant is never wired into EXP-style layout pinning, so the byte-length lemmas were dead on arrival. Verified via `rg -wn 'evm_div_callable_byte_length|evm_mod_callable_byte_length' EvmAsm/` (zero hits outside the file). The companion `*_callable_length` theorems remain — they ARE used.

Diff: -9/+3 LOC (theorems plus the now-stale comment header reference). `lake build` green (1634 jobs).

Slice of evm-asm-sboz; tracked as evm-asm-v3n19.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).