### PR TITLE
chore(divmod): delete dead callable length theorems

### DIFF
--- a/EvmAsm/Evm64/DivMod/Callable.lean
+++ b/EvmAsm/Evm64/DivMod/Callable.lean
@@ -79,17 +79,4 @@ def evm_mod_callable : Program :=
   cc_ret ;;            -- replaces the NOP at the exit slot
   divK_div128
 
--- ============================================================================
--- Length lemmas
--- ============================================================================
-
-/-- `evm_div_callable` has the same instruction count as `evm_div`
-    (1:1 NOP↔`cc_ret` swap). -/
-theorem evm_div_callable_length : evm_div_callable.length = 319 := by
-  native_decide
-
-/-- `evm_mod_callable` has the same instruction count as `evm_mod`. -/
-theorem evm_mod_callable_length : evm_mod_callable.length = 319 := by
-  native_decide
-
 end EvmAsm.Evm64


### PR DESCRIPTION
Slice of evm-asm-sboz / GH #61 follow-up DivMod cleanup.

`evm_div_callable_length` and `evm_mod_callable_length` in `EvmAsm/Evm64/DivMod/Callable.lean` are not referenced anywhere outside their own definitions (verified via grep across EvmAsm/scripts/docs). After PR #2653 removed the `*_byte_length` theorems that consumed them, these became dead. -13 LOC; `lake build` 1634 jobs green; 0 new sorry.

Beads: evm-asm-n9198.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).