### PR TITLE
chore(exp): delete 4 dead exp_loop_*_byte_length theorems

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -394,10 +394,6 @@ def exp_loop_marshal_factor1 : Program :=
 theorem exp_loop_marshal_factor1_length :
     exp_loop_marshal_factor1.length = 8 := by decide
 
-theorem exp_loop_marshal_factor1_byte_length :
-    4 * exp_loop_marshal_factor1.length = 32 := by
-  rw [exp_loop_marshal_factor1_length]
-
 -- ----------------------------------------------------------------------------
 -- Per-iteration marshalling helpers (#92 slice 3-marshal-result-to-factor2,
 -- beads evm-asm-z5yv)
@@ -440,10 +436,6 @@ def exp_loop_marshal_result_to_factor2 : Program :=
 
 theorem exp_loop_marshal_result_to_factor2_length :
     exp_loop_marshal_result_to_factor2.length = 8 := by decide
-
-theorem exp_loop_marshal_result_to_factor2_byte_length :
-    4 * exp_loop_marshal_result_to_factor2.length = 32 := by
-  rw [exp_loop_marshal_result_to_factor2_length]
 
 -- ----------------------------------------------------------------------------
 -- Per-iteration marshalling helpers (#92 slice 3-marshal-a-to-factor2,
@@ -491,10 +483,6 @@ def exp_loop_marshal_a_to_factor2 : Program :=
 
 theorem exp_loop_marshal_a_to_factor2_length :
     exp_loop_marshal_a_to_factor2.length = 8 := by decide
-
-theorem exp_loop_marshal_a_to_factor2_byte_length :
-    4 * exp_loop_marshal_a_to_factor2.length = 32 := by
-  rw [exp_loop_marshal_a_to_factor2_length]
 
 
 -- ----------------------------------------------------------------------------
@@ -553,10 +541,6 @@ def exp_loop_un_marshal_and_restore : Program :=
 
 theorem exp_loop_un_marshal_and_restore_length :
     exp_loop_un_marshal_and_restore.length = 9 := by decide
-
-theorem exp_loop_un_marshal_and_restore_byte_length :
-    4 * exp_loop_un_marshal_and_restore.length = 36 := by
-  rw [exp_loop_un_marshal_and_restore_length]
 
 
 -- Placeholder: `evm_exp : Program` lands in slice 3 (evm-asm-ahaz).


### PR DESCRIPTION
Slice of evm-asm-sboz / beads evm-asm-fzkhj.

Four byte_length wrappers in `EvmAsm/Evm64/Exp/Program.lean` had no callers anywhere in `EvmAsm/`, `docs/`, or `scripts/` — verified via repo-wide rg with word boundaries:

- `exp_loop_marshal_factor1_byte_length`
- `exp_loop_marshal_result_to_factor2_byte_length`
- `exp_loop_marshal_a_to_factor2_byte_length`
- `exp_loop_un_marshal_and_restore_byte_length`

Each was a thin `4 * X.length = N` wrapper around a corresponding `_length` theorem, which remains in place for downstream use.

`lake build` green (1634 jobs, 0 sorry); -16 LOC.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).