### PR TITLE
chore(extract-pure): delete dead sepConj_pure_mid_{left,right}_eq

### DIFF
--- a/EvmAsm/Rv64/Tactics/ExtractPure.lean
+++ b/EvmAsm/Rv64/Tactics/ExtractPure.lean
@@ -72,21 +72,6 @@ fires at the outer `s` and converts it to a `∧`.
 Tracked under beads `evm-asm-22a` / GH #1435.
 -/
 
-/-- Bubble a pure leaf one step left through an associated chain
-    `P ** ⌜Q⌝ ** R = ⌜Q⌝ ** P ** R`. Stated as `Assertion = Assertion` so
-    `simp only` will apply it at any depth inside a nested `**` chain. -/
-theorem sepConj_pure_mid_left_eq {P : Assertion} {Q : Prop} {R : Assertion} :
-    (P ** ⌜Q⌝ ** R) = (⌜Q⌝ ** P ** R) := by
-  rw [← sepConj_assoc', ← sepConj_assoc', sepConj_comm' P (⌜Q⌝)]
-
-/-- Bubble a pure leaf at the right end of a chain leftward past one
-    resource: `P ** R ** ⌜Q⌝ = ⌜Q⌝ ** P ** R`. Sibling of
-    `sepConj_pure_mid_left_eq` for the trailing-pure case. -/
-theorem sepConj_pure_mid_right_eq {P R : Assertion} {Q : Prop} :
-    (P ** R ** ⌜Q⌝) = (⌜Q⌝ ** P ** R) := by
-  rw [sepConj_comm' R (⌜Q⌝), ← sepConj_assoc',
-      sepConj_comm' P (⌜Q⌝), sepConj_assoc']
-
 /-- `extract_pure h` rewrites a separation-logic hypothesis
     `h : (A₁ ** … ** Aₙ) s` into a `∧`-chain whose left conjuncts are
     the pure atoms (`⌜P⌝`) extracted from the chain and whose tail is


### PR DESCRIPTION
Two Assertion-equality variants in `EvmAsm/Rv64/Tactics/ExtractPure.lean` (`sepConj_pure_mid_left_eq` and `sepConj_pure_mid_right_eq`, originally added under evm-asm-22a / GH #1435) are unreferenced anywhere in the tree. The active `extract_pure` macro instead uses the non-`_eq` lemmas `sepConj_pure_mid_left` / `sepConj_pure_mid_right` from SepLogic.lean. Deleting the dead pair drops 15 LOC with no behavior change.

Acceptance:
- `lake build` green (verified locally).
- No new sorry, no API surface used downstream.

Refs beads `evm-asm-jvuh0` (parent: dead-code sweep `evm-asm-sboz` is DivMod-scoped; this is a separate Rv64/Tactics finding).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).