### PR TITLE
chore(shake): swap SpecCall → Spec.CallSkip in Shift0AddbackMod and SpecCallShift0

### DIFF
--- a/EvmAsm/Evm64/DivMod/Shift0AddbackMod.lean
+++ b/EvmAsm/Evm64/DivMod/Shift0AddbackMod.lean
@@ -6,7 +6,7 @@
 -/
 
 -- `SpecCall` transitively imports `EvmWordArith.Div128Shift0`.
-import EvmAsm.Evm64.DivMod.SpecCall
+import EvmAsm.Evm64.DivMod.Spec.CallSkip
 
 namespace EvmAsm.Evm64
 

--- a/EvmAsm/Evm64/DivMod/SpecCallShift0.lean
+++ b/EvmAsm/Evm64/DivMod/SpecCallShift0.lean
@@ -20,7 +20,7 @@
   proved there).
 -/
 
-import EvmAsm.Evm64.DivMod.SpecCall
+import EvmAsm.Evm64.DivMod.Spec.CallSkip
 
 namespace EvmAsm.Evm64
 


### PR DESCRIPTION
Two shake suggestions on DivMod Shift0 modules (parent evm-asm-6qj / #1045):

- `EvmAsm/Evm64/DivMod/Shift0AddbackMod.lean`
- `EvmAsm/Evm64/DivMod/SpecCallShift0.lean`

Both import the broad `EvmAsm.Evm64.DivMod.SpecCall` umbrella but only need
the narrower `EvmAsm.Evm64.DivMod.Spec.CallSkip`. Swap to the narrower
import in each file.

Verification:
- `lake build` green (1634 jobs, 0 errors).
- `lake exe shake EvmAsm` no longer flags these two files.

Beads: evm-asm-j5557 (parent evm-asm-6qj, #1045).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).