### PR TITLE
chore(shake): noshake Val256ModBridge → DivN4Overestimate

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -237,6 +237,7 @@
  "EvmAsm.Evm64.EvmWordArith.DivAddbackLimb": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
  "EvmAsm.Evm64.EvmWordArith.DivMulSubCarry": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
  "EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble": ["EvmAsm.Evm64.EvmWordArith.ModBridgeUtop"],
+"EvmAsm.Evm64.EvmWordArith.Val256ModBridge": ["EvmAsm.Evm64.EvmWordArith.DivN4Overestimate"],
  "EvmAsm.Rv64.SailEquiv.StateRel": ["LeanRV64D"],
   "EvmAsm.Rv64.SailEquiv.ShiftProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],
   "EvmAsm.Rv64.SailEquiv.ImmProofs": ["EvmAsm.Rv64.SailEquiv.ALUProofs"],


### PR DESCRIPTION
Slice of #1045 (parent beads `evm-asm-9tq`, slice `evm-asm-ol9ji`).

Shake suggests in `EvmAsm/Evm64/EvmWordArith/Val256ModBridge.lean`:

```
remove #[EvmAsm.Evm64.EvmWordArith.DivN4Overestimate]
add    #[EvmAsm.Evm64.EvmWordArith.MultiLimb, EvmAsm.Evm64.DivMod.LoopDefs.Iter]
```

This is a false positive: `Val256ModBridge.lean` uses `max_trial_overestimate_n4`
from `DivN4Overestimate` (line 53). Removing the import breaks the build.
Shake misses the usage because the lemma is referenced through term elaboration.

Added one `noshake.json` entry. Verified:
- `lake build` green.
- `lake exe shake EvmAsm` no longer flags `Val256ModBridge.lean`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
