### PR TITLE
chore(shake): shift Stack import from Compare/LimbSpec to Lt/Gt/Slt/Sgt Spec.lean

### DIFF
--- a/EvmAsm/Evm64/Compare/LimbSpec.lean
+++ b/EvmAsm/Evm64/Compare/LimbSpec.lean
@@ -7,7 +7,6 @@
   - slt_msb_load_spec: MSB limb load (for SLT/SGT)
 -/
 
-import EvmAsm.Evm64.Stack
 import EvmAsm.Rv64.SyscallSpecs
 import EvmAsm.Rv64.Tactics.RunBlock
 

--- a/EvmAsm/Evm64/Gt/Spec.lean
+++ b/EvmAsm/Evm64/Gt/Spec.lean
@@ -7,6 +7,7 @@
 -/
 
 -- `Gt.Program → Stack → SpAddr`.
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Gt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison

--- a/EvmAsm/Evm64/Lt/Spec.lean
+++ b/EvmAsm/Evm64/Lt/Spec.lean
@@ -6,6 +6,7 @@
 -/
 
 -- `Lt.Program → Stack → SpAddr`.
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Lt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison

--- a/EvmAsm/Evm64/Sgt/Spec.lean
+++ b/EvmAsm/Evm64/Sgt/Spec.lean
@@ -10,6 +10,7 @@
 -/
 
 -- `Sgt.Program → Stack → SpAddr`.
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Sgt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison

--- a/EvmAsm/Evm64/Slt/Spec.lean
+++ b/EvmAsm/Evm64/Slt/Spec.lean
@@ -9,6 +9,7 @@
 -/
 
 -- `Slt.Program → Stack → SpAddr`.
+import EvmAsm.Evm64.Stack
 import EvmAsm.Evm64.Slt.Program
 import EvmAsm.Evm64.Compare.LimbSpec
 import EvmAsm.Evm64.EvmWordArith.Comparison


### PR DESCRIPTION
Small shake-hygiene slice for parent #1045 (beads evm-asm-9tq, child evm-asm-tw627).

`lake exe shake EvmAsm` flagged that `EvmAsm.Evm64.Compare.LimbSpec` doesn't itself need `EvmAsm.Evm64.Stack` — the four consumers (`Lt/Gt/Slt/Sgt Spec.lean`) were picking it up transitively. This PR:

- drops `import EvmAsm.Evm64.Stack` from `EvmAsm/Evm64/Compare/LimbSpec.lean`
- adds `import EvmAsm.Evm64.Stack` directly to `EvmAsm/Evm64/{Lt,Gt,Slt,Sgt}/Spec.lean`

Sibling shake suggestions for `Compare/LimbSpec` (drop `SyscallSpecs` / `Tactics.RunBlock`) are **false positives** — `RunBlock` is a tactic and `SyscallSpecs` provides the `@[spec_gen_rv64]` registry consumed by `runBlock`. Left alone, can be filed as separate noshake.json entries later.

`lake build` clean (0 errors). `lake exe shake EvmAsm` no longer reports `EvmAsm.Evm64.Stack` for these 5 files.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).