### PR TITLE
chore(interpreter): delete 4 dead loopFuel_succ_* theorems

### DIFF
--- a/EvmAsm/Evm64/InterpreterLoop.lean
+++ b/EvmAsm/Evm64/InterpreterLoop.lean
@@ -89,30 +89,6 @@ theorem loopFuel_succ_running
       loopFuel handler nSteps (stepWithHandler handler state) := by
   simp [loopFuel, h_status]
 
-theorem loopFuel_succ_stopped
-    (handler : Handler) (nSteps : Nat) (state : EvmState)
-    (h_status : state.status = .stopped) :
-    loopFuel handler (nSteps + 1) state = state := by
-  simp [loopFuel, h_status]
-
-theorem loopFuel_succ_returned
-    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
-    (h_status : state.status = .returned data) :
-    loopFuel handler (nSteps + 1) state = state := by
-  simp [loopFuel, h_status]
-
-theorem loopFuel_succ_reverted
-    (handler : Handler) (nSteps : Nat) (state : EvmState) (data : List (BitVec 8))
-    (h_status : state.status = .reverted data) :
-    loopFuel handler (nSteps + 1) state = state := by
-  simp [loopFuel, h_status]
-
-theorem loopFuel_succ_error
-    (handler : Handler) (nSteps : Nat) (state : EvmState)
-    (h_status : state.status = .error) :
-    loopFuel handler (nSteps + 1) state = state := by
-  simp [loopFuel, h_status]
-
 theorem stepWithHandler_eof_invalid
     (handler : Handler) {state : EvmState}
     (h_pc : state.code.length ≤ state.pc) :


### PR DESCRIPTION
Slice of evm-asm-sboz / parent issue #61 closure cleanup.

The four `loopFuel_succ_{stopped,returned,reverted,error}` theorems in `EvmAsm/Evm64/InterpreterLoop.lean` had no callers anywhere in `EvmAsm/`, `docs/`, or `scripts/` — verified via repo-wide grep with word boundaries. Each was a fuel-step bridge for a non-running `EvmState.status` that was never wired into a consumer. The companion `loopFuel_succ_running` stays (it is used by interpreter step proofs).

- -24 LOC
- `lake build` green (1634 jobs)
- 0 sorry

Refs evm-asm-shoq2 (parent evm-asm-sboz / DivMod cleanup).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).