### PR TITLE
chore(divmod): delete 4 dead helpers in FullPathN1{Conservation,LoopUnified}

### DIFF
--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean
@@ -120,20 +120,6 @@ def n1StepsTelescopeInput
   u.1.toNat + n1StepRemainderVal r1 * B =
     r0.1.toNat * V + n1StepRemainderVal r0 + n1StepTopVal r0 * B^4
 
-theorem n1StepsConservationNat_of_conservation
-    (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
-    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word)
-    (hsteps : n1StepsConservation v u r3 r2 r1 r0) :
-    n1StepsConservationNat v u r3 r2 r1 r0 := by
-  delta n1StepsConservation at hsteps
-  delta n1StepsConservationNat
-  rcases hsteps with ⟨h3, h2, h1, h0⟩
-  exact ⟨
-    n1StepConservationNat_of_conservation _ _ _ _ _ _ _ _ _ h3,
-    n1StepConservationNat_of_conservation _ _ _ _ _ _ _ _ _ h2,
-    n1StepConservationNat_of_conservation _ _ _ _ _ _ _ _ _ h1,
-    n1StepConservationNat_of_conservation _ _ _ _ _ _ _ _ _ h0⟩
-
 theorem n1TelescopeInput3_of_nat
     (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
     (r3 : Word × Word × Word × Word × Word × Word)
@@ -207,14 +193,6 @@ theorem n1StepsTelescoped_of_telescopeInput
   unfold EvmWord.val256 at ht ⊢
   ring_nf at ht ⊢
   exact ht
-
-theorem n1StepsTelescoped_of_nat_conservation
-    (v : Word × Word × Word × Word) (u : Word × Word × Word × Word × Word)
-    (r3 r2 r1 r0 : Word × Word × Word × Word × Word × Word)
-    (hsteps : n1StepsConservationNat v u r3 r2 r1 r0) :
-    n1StepsTelescoped v u r3 r2 r1 r0 :=
-  n1StepsTelescoped_of_telescopeInput v u r3 r2 r1 r0
-    (n1StepsTelescopeInput_of_nat_conservation v u r3 r2 r1 r0 hsteps)
 
 
 

--- a/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
+++ b/EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean
@@ -474,12 +474,6 @@ theorem fullDivN1NormV_unfold (b0 b1 b2 b3 : Word) :
   delta fullDivN1NormV
   rfl
 
-theorem fullDivN1NormV_v3_eq_zero_of_high_zero
-    (b0 b1 b2 b3 : Word) (hb3z : b3 = 0) (hb2z : b2 = 0) :
-    (fullDivN1NormV b0 b1 b2 b3).2.2.2 = 0 := by
-  rw [fullDivN1NormV_unfold]
-  simp [hb3z, hb2z]
-
 theorem fullDivN1NormV_v0_ge_pow63_of_high_zero
     (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
     (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
@@ -493,25 +487,6 @@ theorem fullDivN1NormV_v0_ge_pow63_of_high_zero
   rw [fullDivN1Shift_unfold]
   exact b3_shifted_ge_pow63 hb0nz
 
-theorem fullDivN1NormV_or_ne_zero_of_high_zero
-    (b0 b1 b2 b3 : Word) (hb1z : b1 = 0) (hb2z : b2 = 0) (hb3z : b3 = 0)
-    (hbnz : b0 ||| b1 ||| b2 ||| b3 ≠ 0) :
-    (fullDivN1NormV b0 b1 b2 b3).1 |||
-      (fullDivN1NormV b0 b1 b2 b3).2.1 |||
-      (fullDivN1NormV b0 b1 b2 b3).2.2.1 |||
-      (fullDivN1NormV b0 b1 b2 b3).2.2.2 ≠ 0 := by
-  have hge := fullDivN1NormV_v0_ge_pow63_of_high_zero b0 b1 b2 b3
-    hb1z hb2z hb3z hbnz
-  have hfirst_ne : (fullDivN1NormV b0 b1 b2 b3).1 ≠ 0 := by
-    intro hzero
-    have hto : ((fullDivN1NormV b0 b1 b2 b3).1).toNat = 0 := by
-      simp [hzero]
-    omega
-  intro hzero
-  have hz3 := BitVec.or_eq_zero_iff.mp hzero
-  have hz2 := BitVec.or_eq_zero_iff.mp hz3.1
-  have hz1 := BitVec.or_eq_zero_iff.mp hz2.1
-  exact hfirst_ne hz1.1
 theorem evm_div_n1_denorm_epilogue_bundled_spec
     (bltu_3 bltu_2 bltu_1 bltu_0 : Bool)
     (sp base a0 a1 a2 a3 b0 b1 b2 b3 : Word)


### PR DESCRIPTION
Removes 4 truly orphan declarations (zero external references in the EvmAsm tree) flagged by the dead-code audit on parent #61:

- `EvmAsm/Evm64/DivMod/Compose/FullPathN1Conservation.lean`:
  - `n1StepsConservationNat_of_conservation`
  - `n1StepsTelescoped_of_nat_conservation`
- `EvmAsm/Evm64/DivMod/Compose/FullPathN1LoopUnified.lean`:
  - `fullDivN1NormV_v3_eq_zero_of_high_zero`
  - `fullDivN1NormV_or_ne_zero_of_high_zero`

Verified via repo-wide grep that each name occurs only at its own declaration site. `lake build` passes with 0 errors / 0 sorries.

Beads: evm-asm-z3v2q (slice of evm-asm-sboz).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).