### PR TITLE
chore(shake): noshake LoopSemantic DivMulSubCarry+DivAddbackCarry false positives

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -236,6 +236,8 @@
  "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry": ["EvmAsm.Evm64.EvmWordArith.DivAddbackLimb"],
  "EvmAsm.Evm64.EvmWordArith.DivAddbackLimb": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
  "EvmAsm.Evm64.EvmWordArith.DivMulSubCarry": ["EvmAsm.Evm64.EvmWordArith.DivMulSubLimb"],
+ "EvmAsm.Evm64.DivMod.LoopSemantic":
+  ["EvmAsm.Evm64.EvmWordArith.DivMulSubCarry", "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry"],
  "EvmAsm.Evm64.EvmWordArith.DivAccumulate": ["EvmAsm.Evm64.EvmWordArith.DivRemainderBound"],
  "EvmAsm.Evm64.EvmWordArith.DivN4Overestimate": ["EvmAsm.Evm64.EvmWordArith.DivAccumulate"],
  "EvmAsm.Evm64.EvmWordArith.ModBridgeUtop": ["EvmAsm.Evm64.EvmWordArith.Val256ModBridge"],


### PR DESCRIPTION
Adds a `noshake.json` entry for `EvmAsm.Evm64.DivMod.LoopSemantic` covering `EvmWordArith.DivMulSubCarry` and `EvmWordArith.DivAddbackCarry`, both of which `lake exe shake` flags as unused.

Both imports are real: `LoopSemantic.lean` invokes `mulsub_register_4limb_val256` (from `DivMulSubCarry`) and `addback_register_4limb_val256` (from `DivAddbackCarry`). Verified false-positive by reverting the imports and observing the build break (`Unknown constant val256`, `simp made no progress`, `unsolved goals` at `addbackN4_val256_eq`).

Verified: `lake build` green; `lake exe shake EvmAsm | scripts/shake-filter.py` no longer flags these two imports for `LoopSemantic`.

Refs evm-asm-9tq / GH #1045 (import hygiene sweep), beads `evm-asm-6yjsk`.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).
