### PR TITLE
chore(Rv64/SailEquiv): delete 2 dead align4_bit{0,1} helpers

### DIFF
--- a/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
+++ b/EvmAsm/Rv64/SailEquiv/MonadLemmas.lean
@@ -738,16 +738,6 @@ theorem runSail_get_next_pc {s : SailState} {v : BitVec 64}
 @[simp] private theorem sail_access_eq (v : BitVec w) (i : Nat) :
     Sail.BitVec.access v i = BitVec.ofBool v[i]! := rfl
 
-private theorem align4_bit0 (v : BitVec 64) (h : v &&& 3 = 0) :
-    v[0] = false := by
-  show v.getLsbD 0 = false
-  have := congrArg (·.getLsbD 0) h; simp at this; exact this
-
-private theorem align4_bit1 (v : BitVec 64) (h : v &&& 3 = 0) :
-    v[1] = false := by
-  show v.getLsbD 1 = false
-  have := congrArg (·.getLsbD 1) h; simp at this; exact this
-
 /-- currentlyEnabled Ext_Zca succeeds when misa is readable.
     Returns the MISA C-bit check result without modifying state. -/
 -- currentlyEnabled Ext_Zca → Ext_C → readReg misa. Both hartSupports are true.


### PR DESCRIPTION
Two private theorems in `EvmAsm/Rv64/SailEquiv/MonadLemmas.lean` are defined but never referenced anywhere in `EvmAsm/`:

- `align4_bit0` (L741)
- `align4_bit1` (L746)

Both were introduced in commit d8d251eb ("feat: add jump_to lemma stub + alignment helpers") as future helpers for `jump_to` alignment proofs, but the consumer never landed. Easy to resurrect from git history if needed later.

Verification:
- `lake build`: green (1634 jobs).
- `scripts/check-unimported.sh`: 571 modules / 571 reachable / 0 orphans.
- 0 new sorries.

Tracked by beads `evm-asm-ou0b3` (slice of `evm-asm-sboz` — DivMod/general dead-code cleanup parent).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).