### PR TITLE
chore(multiply): delete 2 dead evm_mul_*_byte_off/length theorems

### DIFF
--- a/EvmAsm/Evm64/Multiply/Program.lean
+++ b/EvmAsm/Evm64/Multiply/Program.lean
@@ -158,15 +158,6 @@ def evm_mul : Program :=
 /-- `evm_mul` has exactly 63 instructions. -/
 theorem evm_mul_length : evm_mul.length = 63 := by decide
 
-/-- The epilogue starts at byte offset 248 within `evm_mul`. -/
-theorem evm_mul_epilogue_byte_off :
-    4 * (mul_col0.length + mul_col1.length + mul_col2.length + mul_col3.length) = 248 := by
-  native_decide
-
-/-- `evm_mul` occupies exactly 252 bytes. -/
-theorem evm_mul_byte_length : 4 * evm_mul.length = 252 := by
-  rw [evm_mul_length]
-
 -- ============================================================================
 -- Test infrastructure
 -- ============================================================================


### PR DESCRIPTION
Slice of evm-asm-sboz (DivMod cleanup parent) / beads evm-asm-1r5xw.

`evm_mul_epilogue_byte_off` and `evm_mul_byte_length` in
`EvmAsm/Evm64/Multiply/Program.lean` had zero references project-wide
(verified via `rg -wn` across `EvmAsm/`, `docs/`, `scripts/` — only the
declaration lines themselves). They were added in PR #2082 (evm-asm-elqw,
MUL program layout helpers for EXP) but the EXP-MUL composition ended
up not consuming them.

-9 LOC, lake build green (1634 jobs), 0 sorry.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).