### PR TITLE
feat(exp): define exp_squaring_call_block per-iteration squaring composition

### DIFF
--- a/EvmAsm/Evm64/Exp/Program.lean
+++ b/EvmAsm/Evm64/Exp/Program.lean
@@ -558,6 +558,48 @@ theorem exp_loop_un_marshal_and_restore_byte_length :
     4 * exp_loop_un_marshal_and_restore.length = 36 := by
   rw [exp_loop_un_marshal_and_restore_length]
 
+-- ----------------------------------------------------------------------------
+-- Per-iteration squaring call (#92 slice 3-squaring-call, beads evm-asm-ywrjr)
+-- ----------------------------------------------------------------------------
+--
+-- Per docs/92-exp-frame-design.md §5 + §8, the per-iteration squaring step
+-- composes four already-merged sub-blocks:
+--
+--   exp_squaring_call_block mulOff :=
+--     exp_loop_marshal_factor1                ;;  -- 8 instr (32 bytes)
+--     exp_loop_marshal_result_to_factor2      ;;  -- 8 instr (32 bytes)
+--     exp_square_block mulOff                 ;;  -- 1 instr (4 bytes; JAL → mul)
+--     exp_loop_un_marshal_and_restore             -- 9 instr (36 bytes)
+--
+-- Total: 26 instructions = 104 bytes.
+-- Pure structural composition: marshalling specs land in the limb-level
+-- slice (`evm-asm-mtj3`) and the full-loop composition in `evm-asm-w5mk`.
+
+/-- Per-iteration squaring step: marshal factor1 + result→factor2, JAL into
+    `mul_callable`, then un-marshal and restore the scratch frame. 26
+    instructions. -/
+def exp_squaring_call_block (mulOff : BitVec 21) : Program :=
+  exp_loop_marshal_factor1 ;;
+  exp_loop_marshal_result_to_factor2 ;;
+  exp_square_block mulOff ;;
+  exp_loop_un_marshal_and_restore
+
+theorem exp_squaring_call_block_length (mulOff : BitVec 21) :
+    (exp_squaring_call_block mulOff).length = 26 := by
+  show (((exp_loop_marshal_factor1 ;;
+          exp_loop_marshal_result_to_factor2) ;;
+         exp_square_block mulOff) ;;
+        exp_loop_un_marshal_and_restore).length = 26
+  simp only [seq, Program.length_append,
+    exp_loop_marshal_factor1_length,
+    exp_loop_marshal_result_to_factor2_length,
+    exp_square_block_length,
+    exp_loop_un_marshal_and_restore_length]
+
+theorem exp_squaring_call_block_byte_length (mulOff : BitVec 21) :
+    4 * (exp_squaring_call_block mulOff).length = 104 := by
+  rw [exp_squaring_call_block_length]
+
 
 -- Placeholder: `evm_exp : Program` lands in slice 3 (evm-asm-ahaz).
 -- See `docs/92-exp-survey.md` for the algorithm and reuse points.


### PR DESCRIPTION
Per `docs/92-exp-frame-design.md` §5 + §8 the per-iteration squaring step composes four already-merged sub-blocks:

```
exp_squaring_call_block mulOff :=
  exp_loop_marshal_factor1            ;;  -- 8 instr (32 bytes)
  exp_loop_marshal_result_to_factor2  ;;  -- 8 instr (32 bytes)
  exp_square_block mulOff             ;;  -- 1 instr (4 bytes; JAL → mul)
  exp_loop_un_marshal_and_restore         -- 9 instr (36 bytes)
```

Total: 26 instructions = 104 bytes. Pure structural composition + length / byte-length lemmas. Marshalling specs follow in beads `evm-asm-mtj3`; full-loop composition in `evm-asm-w5mk`.

Refs: GH #92, beads `evm-asm-ywrjr` (slice of `evm-asm-ahaz` / `evm-asm-20z6`).

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).