### PR TITLE
chore(shake): noshake Div128Lemmas + LoopSemantic in DivN4Overestimate

### DIFF
--- a/scripts/noshake.json
+++ b/scripts/noshake.json
@@ -238,7 +238,12 @@
  "EvmAsm.Evm64.DivMod.LoopSemantic":
   ["EvmAsm.Evm64.EvmWordArith.DivMulSubCarry", "EvmAsm.Evm64.EvmWordArith.DivAddbackCarry"],
  "EvmAsm.Evm64.EvmWordArith.DivAccumulate": ["EvmAsm.Evm64.EvmWordArith.DivRemainderBound"],
- "EvmAsm.Evm64.EvmWordArith.DivN4Overestimate": ["EvmAsm.Evm64.EvmWordArith.DivAccumulate"],
+ "EvmAsm.Evm64.EvmWordArith.DivN4Overestimate":
+  [
+    "EvmAsm.Evm64.EvmWordArith.DivAccumulate",
+    "EvmAsm.Evm64.EvmWordArith.Div128Lemmas",
+    "EvmAsm.Evm64.DivMod.LoopSemantic"
+  ],
  "EvmAsm.Evm64.EvmWordArith.ModBridgeUtop": ["EvmAsm.Evm64.EvmWordArith.Val256ModBridge"],
  "EvmAsm.Evm64.EvmWordArith.ModBridgeAssemble": ["EvmAsm.Evm64.EvmWordArith.ModBridgeUtop"],
 "EvmAsm.Evm64.EvmWordArith.Val256ModBridge": ["EvmAsm.Evm64.EvmWordArith.DivN4Overestimate"],


### PR DESCRIPTION
lake exe shake EvmAsm flags `EvmAsm.Evm64.EvmWordArith.Div128Lemmas` and `EvmAsm.Evm64.DivMod.LoopSemantic` as unused in `EvmAsm/Evm64/EvmWordArith/DivN4Overestimate.lean`. Both are false positives — removing either breaks the build (`mulsubN4` elaboration and a projection-2 access on `iter` results). Adding both to `scripts/noshake.json` under the existing `DivN4Overestimate` entry.

Verified locally: `lake build` green; `lake exe shake EvmAsm` no longer flags those two imports for DivN4Overestimate.

Refs GH #1045 (parent beads evm-asm-6qj). Closes beads evm-asm-vj4n0 once merged.

Authored by @pirapira; implemented by Hermes-bot (evm-hermes).